### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We have prepared a self-contained docker-compose file to demonstrate the usage o
 
 ```sh
 git clone https://github.com/lakekeeper/lakekeeper.git
-cd iceberg-catalog/examples/self-contained
+cd lakekeeper/examples/self-contained
 docker compose up
 ```
 


### PR DESCRIPTION
Was referencing iceberg-catalog instead of the new repo lakekeeper