### PR TITLE
feat: enable native-tls-root-certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,6 +2760,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.12",
+ "rustls-native-certs 0.7.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -4469,6 +4470,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.12",
+ "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "serde",
@@ -4742,6 +4744,19 @@ name = "rustls-native-certs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ uuid = { version = "^1.6", features = ["serde", "v4", "v5", "v7"] }
 reqwest = { version = "^0.12", default-features = false, features = [
     "json",
     "rustls-tls",
+    "rustls-tls-native-roots",
 ] }
 iceberg = { git = "https://github.com/hansetag/iceberg-rust.git", rev = "2b6263a6c998df75444f7feb54bd37144354a071", features = [
     "storage-all",

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Following options are global and apply to all warehouses:
 | `ICEBERG_REST__SECRET_BACKEND`                     | `postgres`                             | The secret backend to use. If `kv2` is chosen, you need to provide additional parameters found under []() Default: `postgres`, one-of: [`postgres`, `kv2`]                                                                     |
 | `ICEBERG_DEFAULT_TABULAR_EXPIRATION_DELAY_SECONDS` | `86400`                                | Time after which a tabular, i.e. View or Table which has been dropped is going to be deleted. Default: `86400` \[7 days\]                                                                                                      |
 
+### Self-signed certificates in dependencies (e.g. minio)
+
+You may be running Lakekeeper in your own environment which uses self-signed certificates for e.g. minio. Lakekeeper is built with reqwest's `rustls-tls-native-roots` feature activated, this means `SSL_CERT_FILE` and `SSL_CERT_DIR` are respected. If both are not set, the system's default CA store is used. If you want to use a custom CA store, set `SSL_CERT_FILE` to the path of the CA file or `SSL_CERT_DIR` to the path of the CA directory. The certificate used by the server cannot be a CA. It needs to be an end entity certificate, else you may run into `CaUsedAsEndEntity` errors.
+
 ### Task queues
 
 Currently, the catalog uses two task queues, one to ultimately delete soft-deleted tabulars and another to purge tabulars which have been deleted with the `purgeRequested=True` query parameter. The task queues are configured as follows:


### PR DESCRIPTION
This should fix self-signed certs. Tested locally with minio with a certificate generated via [certgen](https://github.com/minio/certgen) `./certgen-darwin-arm64 -host "127.0.0.1,localhost,minio" --no-ca`, discovered the following quirks:


- the cert cannot be a CA (client will fail with `CaUsedAsEndEntity`, see https://github.com/lightningnetwork/lnd/issues/5450#issuecomment-2419544062):
 > The error CaUsedAsEndEntity indicates that Rustls is rejecting the server’s certificate because it is a CA certificate being used as an end-entity certificate, which is not allowed by default in TLS protocols. Rustls adheres strictly to the TLS specification and security best practices, so it flags this usage as invalid.
In TLS, the server certificate presented during the handshake should be an end-entity certificate (CA:FALSE). Using a CA certificate as a server certificate violates the specification.

- minio won't start if there's no CA in `certs/CAs/` (https://github.com/bitnami/containers/issues/29356#issuecomment-1501503357)