### PR TITLE
fix: nats in tests

### DIFF
--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -78,7 +78,7 @@ services:
       - ICEBERG_REST__PG_ENCRYPTION_KEY=abc
       - ICEBERG_REST__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:2345/postgres
       - ICEBERG_REST__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@db:2345/postgres
-      - ICEBERG_REST__NATS_URI=nats://nats:4222
+      - ICEBERG_REST__NATS_ADDRESS=nats://nats:4222
       - ICEBERG_REST__NATS_TOPIC=changes
       - ICEBERG_REST__NATS_USER=test
       - ICEBERG_REST__NATS_PASSWORD=test


### PR DESCRIPTION
There was a wrong key in `tests/docker-compose.yaml`