### PR TITLE
fix: prepend a version count to metadata files

### DIFF
--- a/crates/iceberg-catalog/src/catalog/tables.rs
+++ b/crates/iceberg-catalog/src/catalog/tables.rs
@@ -537,7 +537,7 @@ impl<C: Catalog, A: Authorizer + Clone, S: SecretStore>
             updates,
         )?;
         let location = previous_table.metadata_location;
-        let next_metadata_count = if let Some(loc) = location {
+        let next_metadata_count = if let Some(loc) = location.as_ref() {
             extract_count_from_metadata_location(loc)? + 1
         } else {
             0
@@ -1054,11 +1054,12 @@ impl<C: Catalog, A: Authorizer + Clone, S: SecretStore>
                     expired_metadata_logs.extend(this_expired);
                 }
 
-                let next_metadata_count = if let Some(loc) = previous_table.metadata_location {
-                    extract_count_from_metadata_location(loc)? + 1
-                } else {
-                    0
-                };
+                let next_metadata_count =
+                    if let Some(loc) = previous_table.metadata_location.as_ref() {
+                        extract_count_from_metadata_location(loc)? + 1
+                    } else {
+                        0
+                    };
 
                 let new_table_location =
                     parse_location(new_metadata.location(), StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -1168,7 +1169,7 @@ impl<C: Catalog, A: Authorizer + Clone, S: SecretStore>
     }
 }
 
-pub(crate) fn extract_count_from_metadata_location(location: Location) -> Result<usize> {
+pub(crate) fn extract_count_from_metadata_location(location: &Location) -> Result<usize> {
     let last_segment = location.as_str().trim_end_matches('/').split('/').last();
     let Some(last_segment) = last_segment else {
         return Err(ErrorModel::internal(

--- a/crates/iceberg-catalog/src/catalog/tables.rs
+++ b/crates/iceberg-catalog/src/catalog/tables.rs
@@ -1188,9 +1188,9 @@ pub(crate) fn extract_count_from_metadata_location(location: Location) -> Result
     ))?;
     usize::from_str(front).map_err(|e| {
         ErrorModel::internal(
-            format!("Failed to parse integer counter in filename: {}", e),
+            format!("Failed to parse integer counter in filename: {e}"),
             "InvalidTableFileName",
-            None,
+            Some(Box::new(e)),
         )
         .into()
     })

--- a/crates/iceberg-catalog/src/catalog/views/commit.rs
+++ b/crates/iceberg-catalog/src/catalog/views/commit.rs
@@ -6,8 +6,8 @@ use crate::catalog::compression_codec::CompressionCodec;
 use crate::catalog::io::write_metadata_file;
 use crate::catalog::require_warehouse_id;
 use crate::catalog::tables::{
-    determine_table_ident, maybe_body_to_json, require_active_warehouse,
-    validate_table_or_view_ident,
+    determine_table_ident, extract_count_from_metadata_location, maybe_body_to_json,
+    require_active_warehouse, validate_table_or_view_ident,
 };
 use crate::catalog::views::{parse_view_location, validate_view_updates};
 use crate::request_metadata::RequestMetadata;
@@ -94,10 +94,11 @@ pub(crate) async fn commit_view<C: Catalog, A: Authorizer + Clone, S: SecretStor
     check_asserts(requirements, view_id)?;
 
     let ViewMetadataWithLocation {
-        metadata_location: _,
+        metadata_location: before_update_metadata_location,
         metadata: before_update_metadata,
     } = C::load_view(view_id, false, t.transaction()).await?;
     let view_location = parse_view_location(&before_update_metadata.location)?;
+    let before_update_metadata_location = parse_view_location(&before_update_metadata_location)?;
 
     state
         .v1_state
@@ -115,6 +116,7 @@ pub(crate) async fn commit_view<C: Catalog, A: Authorizer + Clone, S: SecretStor
         &view_location,
         &CompressionCodec::try_from_properties(requested_update_metadata.properties())?,
         Uuid::now_v7(),
+        extract_count_from_metadata_location(before_update_metadata_location)? + 1,
     );
 
     C::update_view_metadata(

--- a/crates/iceberg-catalog/src/catalog/views/commit.rs
+++ b/crates/iceberg-catalog/src/catalog/views/commit.rs
@@ -116,7 +116,7 @@ pub(crate) async fn commit_view<C: Catalog, A: Authorizer + Clone, S: SecretStor
         &view_location,
         &CompressionCodec::try_from_properties(requested_update_metadata.properties())?,
         Uuid::now_v7(),
-        extract_count_from_metadata_location(&before_update_metadata_location)? + 1,
+        extract_count_from_metadata_location(&before_update_metadata_location).map_or(0, |v| v + 1),
     );
 
     C::update_view_metadata(

--- a/crates/iceberg-catalog/src/catalog/views/commit.rs
+++ b/crates/iceberg-catalog/src/catalog/views/commit.rs
@@ -116,7 +116,7 @@ pub(crate) async fn commit_view<C: Catalog, A: Authorizer + Clone, S: SecretStor
         &view_location,
         &CompressionCodec::try_from_properties(requested_update_metadata.properties())?,
         Uuid::now_v7(),
-        extract_count_from_metadata_location(before_update_metadata_location)? + 1,
+        extract_count_from_metadata_location(&before_update_metadata_location)? + 1,
     );
 
     C::update_view_metadata(

--- a/crates/iceberg-catalog/src/catalog/views/create.rs
+++ b/crates/iceberg-catalog/src/catalog/views/create.rs
@@ -92,6 +92,7 @@ pub(crate) async fn create_view<C: Catalog, A: Authorizer + Clone, S: SecretStor
         &view_location,
         &CompressionCodec::try_from_properties(&request.properties)?,
         *view_id,
+        0,
     );
 
     // serialize body before moving it

--- a/crates/iceberg-catalog/src/service/storage/mod.rs
+++ b/crates/iceberg-catalog/src/service/storage/mod.rs
@@ -342,8 +342,12 @@ impl StorageProfile {
     ) -> Result<(), ValidationError> {
         let compression_codec = CompressionCodec::Gzip;
 
-        let mut test_file_write =
-            self.default_metadata_location(test_location, &compression_codec, uuid::Uuid::now_v7());
+        let mut test_file_write = self.default_metadata_location(
+            test_location,
+            &compression_codec,
+            uuid::Uuid::now_v7(),
+            0,
+        );
         if is_vended_credentials {
             let f = test_file_write
                 .url()
@@ -454,9 +458,12 @@ pub trait StorageLocations {
         table_location: &Location,
         compression_codec: &CompressionCodec,
         metadata_id: uuid::Uuid,
+        metadata_count: usize,
     ) -> Location {
         let filename_extension_compression = compression_codec.as_file_extension();
-        let filename = format!("{metadata_id}{filename_extension_compression}.metadata.json",);
+        let filename = format!(
+            "{metadata_count:05}-{metadata_id}{filename_extension_compression}.metadata.json",
+        );
         let mut l = table_location.clone();
 
         l.without_trailing_slash().extend(&["metadata", &filename]);


### PR DESCRIPTION
we're going for the string parsing route here, we could also store the version number in the db, wdyt @c-thiel?

Python is parsing strings:

```py
    @staticmethod
    def _parse_metadata_version(metadata_location: str) -> int:
        """Parse the version from the metadata location.

        The version is the first part of the file name, before the first dash.
        For example, the version of the metadata file
        `s3://bucket/db/tb/metadata/00001-6c97e413-d51b-4538-ac70-12fe2a85cb83.metadata.json`
        is 1.
        If the path does not comply with the pattern, the version is defaulted to be -1, ensuring
        that the next metadata file is treated as having version 0.

        Args:
            metadata_location (str): The location of the metadata file.

        Returns:
            int: The version of the metadata file. -1 if the file name does not have valid version string
        """
        file_name = metadata_location.split("/")[-1]
        if file_name_match := TABLE_METADATA_FILE_NAME_REGEX.fullmatch(file_name):
            try:
                uuid.UUID(file_name_match.group(2))
            except ValueError:
                return -1
            return int(file_name_match.group(1))
        else:
            return -1
```

Currently, this PR will fail any metadata file that's not a uuid (len 36) /  uuid with prepended parsable usize

closes #522 