### PR TITLE
fix: release please

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Regenerate management openapi
         run: just update-management-openapi
       - name: Fail on diff
-        run: git diff --exit-code openapi Cargo.lock
+        run: git diff -w --ignore-blank-lines --exit-code Cargo.lock openapi/
       - name: Build TS Client
         run: npx @hey-api/openapi-ts -i openapi/management-open-api.yaml -o src/gen/management -c @hey-api/client-fetch
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -71,7 +71,7 @@ jobs:
           TEST_KV2: 1
           TEST_MINIO: 1
 
-  check-management-openapi:
+  check-generated-cotents-match:
     runs-on: ubuntu-latest
     steps:
       - run: sudo snap install --edge --classic just
@@ -85,7 +85,7 @@ jobs:
       - name: Regenerate management openapi
         run: just update-management-openapi
       - name: Fail on diff
-        run: git diff --exit-code
+        run: git diff --exit-code openapi Cargo.lock
       - name: Build TS Client
         run: npx @hey-api/openapi-ts -i openapi/management-open-api.yaml -o src/gen/management -c @hey-api/client-fetch
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7475,3 +7475,4 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+

--- a/openapi/management-open-api.yaml
+++ b/openapi/management-open-api.yaml
@@ -3120,3 +3120,4 @@ tags:
 - name: permissions
   description: Manage Permissions
 
+


### PR DESCRIPTION
release please PR currently fails due to incremented version number being detected as diff

this changes the diff to just care about openapi & cargo.lock, Cargo.lock was added since it broke main build from time to time