### PR TITLE
chore: ignore proc-macro-error & rustls advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,4 +5,5 @@ ignore = [
     "RUSTSEC-2024-0373", # we're not using http3 in reqwest, we end up getting quinn due to a bug in cargo, it's not being compiled: https://github.com/seanmonstar/reqwest/issues/2318 / https://github.com/rust-lang/cargo/issues/10802
     "RUSTSEC-2024-0370", # we are aware of the issue, once we migrate to utoipa 0.5 the dependency will be gone, it is also "only" an unmaintained dependency without direct harm.
     "RUSTSEC-2024-0399", # we are using tls only in clients
+    "RUSTSEC-2024-0384", # unmaintained without direct harm
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,4 +4,5 @@ ignore = [
     "RUSTSEC-2023-0071", # we're using postgres, this is likely a false positive: https://github.com/launchbadge/sqlx/issues/2911
     "RUSTSEC-2024-0373", # we're not using http3 in reqwest, we end up getting quinn due to a bug in cargo, it's not being compiled: https://github.com/seanmonstar/reqwest/issues/2318 / https://github.com/rust-lang/cargo/issues/10802
     "RUSTSEC-2024-0370", # we are aware of the issue, once we migrate to utoipa 0.5 the dependency will be gone, it is also "only" an unmaintained dependency without direct harm.
+    "RUSTSEC-2024-0399", # we are using tls only in clients
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,7 +1,7 @@
 # See https://github.com/rustsec/rustsec/blob/main/cargo-audit/audit.toml.example
-
 [advisories]
 ignore = [
     "RUSTSEC-2023-0071", # we're using postgres, this is likely a false positive: https://github.com/launchbadge/sqlx/issues/2911
     "RUSTSEC-2024-0373", # we're not using http3 in reqwest, we end up getting quinn due to a bug in cargo, it's not being compiled: https://github.com/seanmonstar/reqwest/issues/2318 / https://github.com/rust-lang/cargo/issues/10802
+    "RUSTSEC-2024-0370", # we are aware of the issue, once we migrate to utoipa 0.5 the dependency will be gone, it is also "only" an unmaintained dependency without direct harm.
 ]


### PR DESCRIPTION
1. We depend on proc-macro-error through utoipa < 0.5, upgrading to utoipa 0.5 is blocked by #563, since it's just an unmaintained dependency without direct security implications, we should ignore the advisory for now to unblock other PRs here and target upgrading utoipa to 0.5 in the near future.


2. [RUSTSEC-2024-0399](https://rustsec.org/advisories/RUSTSEC-2024-0399) shouldn't apply to us since we are not terminating tls but are just using rustls in various clients

3.  [RUSTSEC-2024-0384](https://rustsec.org/advisories/RUSTSEC-2024-0384) considered unmaintained but no known harm, we should update azure through which we depend once they upgrade their dependencies