### PR TITLE
fix(aws): deal with closed connections via retries

### DIFF
--- a/.github/workflows/integration_test_workflow.yml
+++ b/.github/workflows/integration_test_workflow.yml
@@ -70,5 +70,5 @@ jobs:
               name: db-dump-${{ inputs.test_name }}
               path: dump.sql.gz
           - name: Dump docker logs on failure
-            if: failure()
+            if: always()
             uses: jwalton/gh-docker-logs@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3049,6 +3049,7 @@ dependencies = [
  "tower-http 0.6.2",
  "tracing",
  "tracing-subscriber",
+ "tryhard",
  "url",
  "urlencoding",
  "utoipa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ tower-http = { version = "^0.6", features = [
 ] }
 tracing = { version = "^0.1", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
+tryhard = { version = "0.5.1" }
 urlencoding = "^2.1"
 async-stream = "0.3.6"
 utoipa = { version = "4.2.3", features = [

--- a/crates/iceberg-catalog/Cargo.toml
+++ b/crates/iceberg-catalog/Cargo.toml
@@ -86,6 +86,7 @@ tower-http = { workspace = true, optional = true, features = [
     "cors",
 ] }
 tracing = { workspace = true }
+tryhard = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 utoipa = { workspace = true, features = ["uuid"] }

--- a/crates/iceberg-catalog/src/lib.rs
+++ b/crates/iceberg-catalog/src/lib.rs
@@ -21,6 +21,7 @@ pub mod api;
 
 #[cfg(feature = "router")]
 pub mod metrics;
+mod retry;
 #[cfg(feature = "router")]
 pub(crate) mod tracing;
 

--- a/crates/iceberg-catalog/src/retry.rs
+++ b/crates/iceberg-catalog/src/retry.rs
@@ -1,0 +1,12 @@
+use std::time::Duration;
+
+pub(crate) async fn retry_fn<T, Z, E>(f: impl Fn() -> T) -> crate::api::Result<Z, E>
+where
+    T: std::future::Future<Output = crate::api::Result<Z, E>>,
+{
+    tryhard::retry_fn(f)
+        .retries(3)
+        .exponential_backoff(Duration::from_millis(100))
+        .max_delay(Duration::from_secs(1))
+        .await
+}

--- a/crates/iceberg-catalog/src/service/storage/mod.rs
+++ b/crates/iceberg-catalog/src/service/storage/mod.rs
@@ -352,15 +352,7 @@ impl StorageProfile {
                 }
             }
         })
-        .await
-        .map_err(|e| {
-            tracing::warn!("Outer Error: {e:?}");
-            e
-        })?
-        .map_err(|e| {
-            tracing::warn!("Inner error: {e:?}");
-            e
-        })?;
+        .await??;
         tracing::info!("checked location is empty");
         Ok(())
     }

--- a/crates/iceberg-catalog/src/service/storage/mod.rs
+++ b/crates/iceberg-catalog/src/service/storage/mod.rs
@@ -21,6 +21,7 @@ use iceberg_ext::configs::table::TableProperties;
 use iceberg_ext::configs::Location;
 pub use s3::{S3Credential, S3Flavor, S3Location, S3Profile};
 
+use crate::retry::retry_fn;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -324,16 +325,22 @@ impl StorageProfile {
             .map_err(|e| ValidationError::IoOperationFailed(e, Box::new(self.clone())))?;
 
         tracing::info!("Cleanup finished");
-
-        check_location_is_empty(&file_io, &test_location, self, || {
-            ValidationError::InvalidLocation {
-                reason: "Files are left after remove_all on test location".to_string(),
-                source: None,
-                location: test_location.to_string(),
-                storage_type: self.storage_type(),
+        retry_fn(|| async {
+            match check_location_is_empty(&file_io, &test_location, self, || {
+                ValidationError::InvalidLocation {
+                    reason: "Files are left after remove_all on test location".to_string(),
+                    source: None,
+                    location: test_location.to_string(),
+                    storage_type: self.storage_type(),
+                }
+            })
+            .await
+            {
+                Err(e @ ValidationError::IoOperationFailed(_, _)) => Err(e),
+                other => Ok(other),
             }
         })
-        .await?;
+        .await??;
         tracing::info!("checked location is empty");
         Ok(())
     }

--- a/crates/iceberg-catalog/src/service/storage/mod.rs
+++ b/crates/iceberg-catalog/src/service/storage/mod.rs
@@ -352,7 +352,15 @@ impl StorageProfile {
                 }
             }
         })
-        .await??;
+        .await
+        .map_err(|e| {
+            tracing::warn!("Outer Error: {e:?}");
+            e
+        })?
+        .map_err(|e| {
+            tracing::warn!("Inner error: {e:?}");
+            e
+        })?;
         tracing::info!("checked location is empty");
         Ok(())
     }

--- a/crates/iceberg-catalog/src/service/storage/mod.rs
+++ b/crates/iceberg-catalog/src/service/storage/mod.rs
@@ -342,7 +342,14 @@ impl StorageProfile {
                     );
                     Err(e)
                 }
-                other => Ok(other),
+                Ok(()) => {
+                    tracing::debug!("Location is empty");
+                    Ok(Ok(()))
+                }
+                Err(other) => {
+                    tracing::error!("Unrecoverable error: {other:?}");
+                    Ok(Err(other))
+                }
             }
         })
         .await??;

--- a/crates/iceberg-catalog/src/service/storage/s3.rs
+++ b/crates/iceberg-catalog/src/service/storage/s3.rs
@@ -20,12 +20,7 @@ use veil::Redact;
 
 use super::StorageType;
 
-static S3_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
-    reqwest::ClientBuilder::new()
-        .pool_idle_timeout(Duration::from_millis(18500))
-        .build()
-        .expect("This should never fail since we are just setting timeout to 18500 which does not populate config.error")
-});
+static S3_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 
 #[derive(Debug, Eq, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/iceberg-catalog/src/service/storage/s3.rs
+++ b/crates/iceberg-catalog/src/service/storage/s3.rs
@@ -15,7 +15,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::LazyLock;
-use std::time::Duration;
 use veil::Redact;
 
 use super::StorageType;


### PR DESCRIPTION
Wraps every fileio operation in retry_fn which will retry 3 times with exp backoff, removes the keep idle connections time on pool since we're going to retry anyways.

closes #567 