### PR TITLE
fix: potential deadlock in load-table

### DIFF
--- a/crates/iceberg-catalog/src/catalog/tables.rs
+++ b/crates/iceberg-catalog/src/catalog/tables.rs
@@ -427,6 +427,7 @@ impl<C: Catalog, A: Authorizer + Clone, S: SecretStore>
             t.transaction(),
         )
         .await?;
+        t.commit().await?;
         let CatalogLoadTableResult {
             table_id: _,
             namespace_id: _,


### PR DESCRIPTION
Likely fix of #623.

We're creating a read-transaction in load-table, the read transaction is not committed but dropped at the end of the handler. We're also fetching a secret for non-staged tables. If we have 2x max pool connections requests, we can run into a scenario where all read pool connections are in the transaction while all handlers are hanging on acquiring the connection to read the secret.

This change commits the transaction before reading the secret.