### PR TITLE
fix: ignore multiple writes of same permissions

### DIFF
--- a/crates/iceberg-catalog/src/service/authz/implementations/openfga/error.rs
+++ b/crates/iceberg-catalog/src/service/authz/implementations/openfga/error.rs
@@ -89,6 +89,19 @@ impl OpenFGAError {
         }
     }
 
+    pub(crate) fn ignore_duplicate_writes(self) -> Result<(), Self> {
+        match &self {
+            OpenFGAError::WriteFailed { source, .. }
+                if source
+                    .message()
+                    .starts_with("cannot write a tuple which already exists") =>
+            {
+                Ok(())
+            }
+            _ => Err(self),
+        }
+    }
+
     pub(crate) fn store_creation(status: tonic::Status) -> Self {
         Self::known_status(&status).unwrap_or(OpenFGAError::StoreCreationFailed(status))
     }

--- a/crates/iceberg-catalog/src/service/authz/implementations/openfga/mod.rs
+++ b/crates/iceberg-catalog/src/service/authz/implementations/openfga/mod.rs
@@ -714,6 +714,7 @@ impl OpenFGAAuthorizer {
                 source: e,
             })
             .map(|_| ())
+            .or_else(OpenFGAError::ignore_duplicate_writes)
     }
 
     /// A convenience wrapper around read that handles error conversion

--- a/crates/iceberg-catalog/src/service/authz/implementations/openfga/mod.rs
+++ b/crates/iceberg-catalog/src/service/authz/implementations/openfga/mod.rs
@@ -714,7 +714,6 @@ impl OpenFGAAuthorizer {
                 source: e,
             })
             .map(|_| ())
-            .or_else(OpenFGAError::ignore_duplicate_writes)
     }
 
     /// A convenience wrapper around read that handles error conversion

--- a/examples/access-control/docker-compose-build.yaml
+++ b/examples/access-control/docker-compose-build.yaml
@@ -23,3 +23,7 @@ services:
   openfga-db:
     ports:
       - "2346:5432"
+  openfga:
+    ports:
+      - "35081:8081"
+

--- a/examples/access-control/docker-compose-build.yaml
+++ b/examples/access-control/docker-compose-build.yaml
@@ -9,6 +9,7 @@ services:
       dockerfile: docker/full.Dockerfile
     environment:
       - LAKEKEEPER__ALLOW_ORIGIN="*"
+      - RUST_LOG=info,axum=trace,iceberg-catalog=trace,iceberg-catalog-bin=trace,iceberg-ext=trace
   migrate:
     image: localhost/iceberg-catalog-local:latest
     pull_policy: never


### PR DESCRIPTION
also re-enables logs for the build docker-compose overlay in access-controls example