### PR TITLE
doc: fix typo

### DIFF
--- a/examples/access-control/README.md
+++ b/examples/access-control/README.md
@@ -25,4 +25,4 @@ You can also login to Keycloak using:
 * Username: admin
 * Password: admin
 
-The Keycloak Ream "iceberg" is pre-configured.
+The Keycloak Realm "iceberg" is pre-configured.

--- a/examples/trino-opa/README.md
+++ b/examples/trino-opa/README.md
@@ -36,4 +36,4 @@ You can also login to Keycloak using:
 * Username: admin
 * Password: admin
 
-The Keycloak Ream "iceberg" is pre-configured.
+The Keycloak Realm "iceberg" is pre-configured.


### PR DESCRIPTION
Fixed typo. Changed `Ream` to `Realm` in examples.