### PR TITLE
fix!: drop duplicate sequence numbers in table snapshots & add index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2860,7 +2860,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.4.0"
-source = "git+https://github.com/lakekeeper/iceberg-rust.git?rev=7ca94329#7ca9432930268b051523aa46b27e5bdca6ee4cea"
+source = "git+https://github.com/lakekeeper/iceberg-rust.git?rev=f3b7dd2#f3b7dd2e9a6fb726db065aeb6822db1091fc7040"
 dependencies = [
  "anyhow",
  "apache-avro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ reqwest = { version = "^0.12", default-features = false, features = [
     "rustls-tls",
     "rustls-tls-native-roots",
 ] }
-iceberg = { git = "https://github.com/lakekeeper/iceberg-rust.git", rev = "7ca94329", features = [
+iceberg = { git = "https://github.com/lakekeeper/iceberg-rust.git", rev = "f3b7dd2", features = [
     "storage-all",
 ] }
 iso8601 = "0.6.2"

--- a/crates/iceberg-catalog/migrations/20250328131139_fix_sequence_number.sql
+++ b/crates/iceberg-catalog/migrations/20250328131139_fix_sequence_number.sql
@@ -1,9 +1,25 @@
 DELETE
 FROM table_snapshot t1
     USING table_snapshot t2
-WHERE t1.created_at > t2.created_at
+        JOIN "table" ON t2.table_id = "table".table_id
+WHERE t1.created_at < t2.created_at
   AND t1.table_id = t2.table_id
-  AND t1.sequence_number = t2.sequence_number;
+  AND t1.sequence_number = t2.sequence_number
+  AND "table".table_format_version != '1';
 
-alter table table_snapshot
-    add constraint unique_table_snapshot_sequence_number unique (table_id, sequence_number);
+-- table fmt version 1 has no sequence number, hence we only enforce the unique constraint via a partial unique index
+CREATE OR REPLACE FUNCTION is_table_format_v2(table_id_param uuid)
+    RETURNS BOOLEAN
+    IMMUTABLE AS
+$$
+BEGIN
+    RETURN EXISTS (SELECT 1
+                   FROM "table" t
+                   WHERE t.table_id = table_id_param
+                     AND t.table_format_version != '1');
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE UNIQUE INDEX unique_table_snapshot_sequence_number
+    ON table_snapshot (table_id, sequence_number)
+    WHERE is_table_format_v2(table_id);

--- a/crates/iceberg-catalog/migrations/20250328131139_fix_sequence_number.sql
+++ b/crates/iceberg-catalog/migrations/20250328131139_fix_sequence_number.sql
@@ -8,7 +8,7 @@ WHERE t1.created_at < t2.created_at
   AND "table".table_format_version != '1';
 
 -- table fmt version 1 has no sequence number, hence we only enforce the unique constraint via a partial unique index
-CREATE OR REPLACE FUNCTION is_table_format_v2(table_id_param uuid)
+CREATE OR REPLACE FUNCTION is_not_table_format_v1(table_id_param uuid)
     RETURNS BOOLEAN
     IMMUTABLE AS
 $$

--- a/crates/iceberg-catalog/migrations/20250328131139_fix_sequence_number.sql
+++ b/crates/iceberg-catalog/migrations/20250328131139_fix_sequence_number.sql
@@ -1,0 +1,9 @@
+DELETE
+FROM table_snapshot t1
+    USING table_snapshot t2
+WHERE t1.created_at > t2.created_at
+  AND t1.table_id = t2.table_id
+  AND t1.sequence_number = t2.sequence_number;
+
+alter table table_snapshot
+    add constraint unique_table_snapshot_sequence_number unique (table_id, sequence_number);

--- a/crates/iceberg-catalog/migrations/20250328131139_fix_sequence_number.sql
+++ b/crates/iceberg-catalog/migrations/20250328131139_fix_sequence_number.sql
@@ -22,4 +22,4 @@ $$ LANGUAGE plpgsql;
 
 CREATE UNIQUE INDEX unique_table_snapshot_sequence_number
     ON table_snapshot (table_id, sequence_number)
-    WHERE is_table_format_v2(table_id);
+    WHERE is_not_table_format_v1(table_id);


### PR DESCRIPTION
Caution: this is a destructive change. Currently, it's possible through concurrent writes to get duplicate `table_id, sequence_number` tuples into `table_snapshot` by:

1. node A: load table
2. node B: load table
3. node A: add snapshot with sequence number incremented by one
4. node B: add snapshot with sequence number incremented by one
5. node A: commit
6. node B: commit

In general, this should not have happened often, since it's only possible when not sending a `RefSnapshotIdMatch` requirement:

```rust
#[serde(rename = "assert-ref-snapshot-id")]
    RefSnapshotIdMatch {
        /// The reference of the table to assert.
        r#ref: String,
        /// The snapshot id of the table to assert.
        /// If the id is `None`, the ref must not already exist.
        #[serde(rename = "snapshot-id")]
        snapshot_id: Option<i64>,
    },
```
