### PR TITLE
feat(gcs): Add option to disable STS downscoping for HNS compatibility

### DIFF
--- a/crates/iceberg-catalog/src/service/storage/mod.rs
+++ b/crates/iceberg-catalog/src/service/storage/mod.rs
@@ -53,7 +53,7 @@ pub enum StorageProfile {
     Test(TestProfile),
     #[serde(rename = "gcs")]
     #[schema(title = "StorageProfileGcs")]
-    Gcs(GcsProfile),
+    Gcs(#[schema(inline)] GcsProfile),
 }
 
 #[derive(Debug, Clone, strum_macros::Display)]

--- a/docs/docs/storage.md
+++ b/docs/docs/storage.md
@@ -422,20 +422,11 @@ The following table describes all configuration parameters for a GCS storage pro
 | `bucket`     | String | Yes      | -       | Name of the GCS bucket.         |
 | `key-prefix` | String | No       | None    | Subpath in the bucket to use for this warehouse. |
 
-For GCS, the bucket should have hierarchical namespaces disabled and the service account should have appropriate permissions (such as Storage Admin role) on the bucket.
+For GCS, the bucket should have hierarchical namespaces (HNS) disabled and the service account (SA) should have appropriate permissions (such as Storage Admin role) on the bucket.
 
-### Authentication Options
+**Note on (HNS):** Using GCS buckets with HNS enabled can cause permission errors with Lakekeeper's default credential downscoping mechanism due to issues authorizing implicit folder creation. A workaround flag is available (see below), but the most compatible setup currently is to use buckets with HNS disabled if prefix-scoped credentials are required.
 
-Lakekeeper supports two primary authentication methods for GCS:
-
-##### Service Account Key
-
-You can provide a service account key directly when creating a warehouse. This is the most straightforward way to give Lakekeeper access to your GCS bucket:
-When configuring a GCS warehouse, ensure the Service Account (SA) used has sufficient permissions (e.g., `roles/storage.objectAdmin` or potentially a custom role, often granted at the bucket or project level).
-
-**Note on Hierarchical Namespace (HNS):** Using GCS buckets with HNS enabled can cause permission errors with Lakekeeper's default credential downscoping mechanism due to issues authorizing implicit folder creation. A workaround flag is available (see below), but the most compatible setup currently is to use buckets with HNS disabled if prefix-scoped credentials are required.
-
-### GCS STS Downscoping and HNS Compatibility
+#### GCS STS Downscoping and HNS Compatibility
 
 By default, Lakekeeper uses Google's Security Token Service (STS) to create downscoped, prefix-limited credentials when vending credentials for GCS (`vended_credentials: true` in data access requests). This enhances security by limiting the token's access to the specific `key-prefix` defined in the storage profile.
 
@@ -456,6 +447,15 @@ To enable the use of HNS buckets as a **short-term workaround**, you can add an 
     3. The source credential used by Lakekeeper already follows the principle of least privilege as much as possible (e.g., scoped to necessary buckets rather than project-wide admin roles).
 
     The recommended long-term solution involves resolving the underlying STS `availabilityCondition` incompatibility with HNS. Please consult Lakekeeper community resources or GCP support for potential updates on this issue.
+
+### Authentication Options
+
+Lakekeeper supports two primary authentication methods for GCS:
+
+##### Service Account Key
+
+You can provide a service account key directly when creating a warehouse. This is the most straightforward way to give Lakekeeper access to your GCS bucket:
+When configuring a GCS warehouse, ensure the Service Account (SA) used has sufficient permissions (e.g., `roles/storage.objectAdmin` or potentially a custom role, often granted at the bucket or project level).
 
 A sample storage profile could look like this (see flag description below):
 

--- a/docs/docs/storage.md
+++ b/docs/docs/storage.md
@@ -411,7 +411,6 @@ When enabled, Lakekeeper will use the managed identity of the virtual machine or
 
 ## Google Cloud Storage
 
-<<<<<<< HEAD
 Google Cloud Storage can be used to store Iceberg tables through the `gs://` protocol.
 
 ### Configuration Parameters
@@ -432,7 +431,6 @@ Lakekeeper supports two primary authentication methods for GCS:
 ##### Service Account Key
 
 You can provide a service account key directly when creating a warehouse. This is the most straightforward way to give Lakekeeper access to your GCS bucket:
-=======
 When configuring a GCS warehouse, ensure the Service Account (SA) used has sufficient permissions (e.g., `roles/storage.objectAdmin` or potentially a custom role, often granted at the bucket or project level).
 
 **Note on Hierarchical Namespace (HNS):** Using GCS buckets with HNS enabled can cause permission errors with Lakekeeper's default credential downscoping mechanism due to issues authorizing implicit folder creation. A workaround flag is available (see below), but the most compatible setup currently is to use buckets with HNS disabled if prefix-scoped credentials are required.
@@ -460,7 +458,6 @@ To enable the use of HNS buckets as a **short-term workaround**, you can add an 
     The recommended long-term solution involves resolving the underlying STS `availabilityCondition` incompatibility with HNS. Please consult Lakekeeper community resources or GCP support for potential updates on this issue.
 
 A sample storage profile could look like this (see flag description below):
->>>>>>> a24e40f3 (docs(gcs): Add documentation for disable_sts_downscoping flag)
 
 ```json
 {


### PR DESCRIPTION
# Context
Lakekeeper currently doesn't support GCS buckets w/ hierarchical namespace (HNS) enabled when STS downscoping is active (which is the default for generating scoped table credentials).  Attempts to create warehouses or perform initial writes on HNS buckets fail with a 403 Forbidden error, specifically citing missing `storage.folders.create` permissions, even when the source SA has `storage.admin` role.

This issue stems from `availabilityCondition` used in the STS Access Boundary.  Standard conditions (based on `resource.name.startsWith` and `api.getAttribute`) fail to evaluate correctly during the implicit folder creation steps inherent in HNS operations.  While requesting broader roles like `roles/storage.objectUser` or `roles/storage.objectAdmin` was attempted, the operations still failed due to the condition blocking the permission.  **Removing the condition entirely (expression: "true")** allowed operations to succeed, confirming the condition logic is the root cause.

# Proposed Workaround
To enable the use of HNS buckets in scenarios where the security trade-off is acceptable (e.g., trusted internal environments), this PR introduces a workaround similar to how it was handled in Apache Polaris ([Issue #379](https://github.com/apache/polaris/issues/379), [PR #400](https://github.com/apache/polaris/pull/400)).

A new optional boolean flag, `disable_sts_downscoping`, is added to the `GcsProfile` struct.

If false (default) or omitted: Lakekeeper attempts STS downscoping as before (currently failing for HNS).
If true: Lakekeeper bypasses the `sts::downscope` call entirely and instead acquires a standard, non-downscoped OAuth token from the source credential.  This allows users to explicitly opt-out of downscoping for specific HNS warehouses

# Testing
- Manual testing confirmed that setting `disable_sts_downscoping: true` via a modified API call allows successful warehouse creation on HNS-enabled buckets.
```
➜  lakekeeper git:(main) ✗ docker build --build-arg ARCH=arm64 -t lakekeeper-local:hns-fix -f docker/full.Dockerfile .
[+] Building 104.4s (23/23) FINISHED                                                                                                                 docker:desktop-linux
 => [internal] load build definition from full.Dockerfile                                                                                                            0.0s
 => => transferring dockerfile: 2.43kB
...
➜  lakekeeper git:(main) ✗ cd docker-compose
➜  docker-compose git:(main) ✗ docker-compose down
[+] Running 4/4
 ✔ Container docker-compose-lakekeeper-1  Removed                                                                                                                    0.3s
 ✔ Container docker-compose-migrate-1     Removed                                                                                                                    0.0s
 ✔ Container docker-compose-db-1          Removed                                                                                                                    0.1s
 ✔ Network docker-compose_iceberg_net     Removed                                                                                                                    0.0s
➜  docker-compose git:(main) ✗ docker-compose up -d
[+] Running 4/4
 ✔ Network docker-compose_iceberg_net     Created                                                                                                                    0.0s
 ✔ Container docker-compose-db-1          Healthy                                                                                                                    5.8s
 ✔ Container docker-compose-migrate-1     Exited                                                                                                                     6.4s
 ✔ Container docker-compose-lakekeeper-1  Started                                                                                                                    6.4s
```
```
➜  docker-compose git:(main) ✗ curl -i -X POST "http://127.0.0.1:8181/management/v1/project" \
                                        -H "Content-Type: application/json" \
                                        -d '{
                                         "project-id": "<redacted>",
                                         "project-name": "<redacted>"
                                       }'
                               echo
HTTP/1.1 201 Created
content-type: application/json
x-request-id: <redacted>
content-length: 29
date: Wed, 16 Apr 2025 18:19:34 GMT

{"project-id":"<redacted>"}
➜  docker-compose git:(main) ✗ curl -i -X POST "http://127.0.0.1:8181/management/v1/warehouse" \
                                       -H "Content-Type: application/json" \
                                       -d '{
                                       "project-id": "<redacted>",
                                       "warehouse-name": "test_hns",
                                       "storage-profile": {
                                           "type": "gcs",
                                           "bucket": "test-data-us-central1-hns",
                                           "key-prefix": "",
                                           "disable-sts-downscoping": true
                                       },
                                       "storage-credential": {
                                           "type": "gcs",
                                           "credential-type": "service-account-key",
                                           "key": {
                                               "type": "service_account",
                                               "project_id": "<redacted>",
                                               "private_key_id": "<redacted>",
                                               "private_key": "-----BEGIN PRIVATE KEY-----\n<redacted>=\n-----END PRIVATE KEY-----\n",
                                               "client_email": "lakekeeper@<redacted>.iam.gserviceaccount.com",
                                               "client_id": "<redacted>",
                                               "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                                               "token_uri": "https://oauth2.googleapis.com/token",
                                               "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
                                               "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/lakekeeper%40<redacted>.iam.gserviceaccount.com",
                                               "universe_domain": "googleapis.com"
                               }
                                       }
                                   }'
HTTP/1.1 201 Created
content-type: application/json
x-request-id: <redacted>
vary: accept-encoding
content-length: 55
date: Wed, 16 Apr 2025 18:19:43 GMT

{"warehouse-id":"<redacted>"}⏎
```
- Functionality for non-HNS buckets or when the flag is false remains unchanged (downscoping is attempted, fails for HNS as before).

- Generated OpenAPI schema was verified to correctly show the optional flag after the `#[schema(inline)]` change
<img width="1020" alt="Screenshot 2025-04-16 at 11 45 37" src="https://github.com/user-attachments/assets/7dd0b497-fe32-4596-a30e-9c9b0f9273ab" />