### PR TITLE
chore: refactor 'docker-compose' -> 'docker compose'

### DIFF
--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -38,7 +38,7 @@ The following shell snippet will start a full development environment including 
 
 ```sh
 $ cd examples
-$ docker-compose -f docker-compose.yaml -f docker-compose-latest.yaml up -d --build
+$ docker compose -f docker-compose.yaml -f docker-compose-latest.yaml up -d --build
 ```
 
 You may then head to `localhost:8888` and try out one of the notebooks.

--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -37,8 +37,8 @@ This quickstart does not run tests against cloud-storage providers or KV2. For t
 The following shell snippet will start a full development environment including the catalog plus its dependencies and a jupyter server with spark. The iceberg-catalog and its migrations will be built from source. This can be useful for development and testing.
 
 ```sh
-$ cd examples
-$ docker compose -f docker-compose.yaml -f docker-compose-latest.yaml up -d --build
+cd examples/minimal
+docker compose -f docker-compose.yaml -f docker-compose-build.yaml up -d --build
 ```
 
 You may then head to `localhost:8888` and try out one of the notebooks.
@@ -139,6 +139,7 @@ When adding a new endpoint, you may need to extend the authorization model. Plea
 1. apply your changes, e.g. add `define can_undrop: modify` to the `view` type in `authz/openfga/v2.2/schema.fga`
 1. regenerate `schema.json` via `./fga model transform --file authz/openfga/v2.2/schema.fga > authz/openfga/v2.2/schema.json` (download the `fga` binary from the [OpenFGA repo](https://github.com/openfga/cli/releases/))
 1. Head to `crate::service::authz::implementations::openfga::migration.rs`, modify `ACTIVE_MODEL_VERSION` to the newer version. For backwards compatible changes, change the `add_model` section. For changes that require migrations, add an additional `add_model` section that includes the migration fn.
+
 ```rust
 pub(super) static ACTIVE_MODEL_VERSION: LazyLock<AuthorizationModelVersion> =
     LazyLock::new(|| AuthorizationModelVersion::new(3, 0)); // <- Change this for every change in the model

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -21,7 +21,7 @@ All docker compose examples come with batteries included (Identity Provider, Sto
     ```bash
     git clone https://github.com/lakekeeper/lakekeeper
     cd examples/access-control-advanced
-    docker-compose up -d
+    docker compose up -d
     ```
 
 === "🐳 With Authentication & Authorization - Simple"
@@ -30,7 +30,7 @@ All docker compose examples come with batteries included (Identity Provider, Sto
     ```bash
     git clone https://github.com/lakekeeper/lakekeeper
     cd examples/access-control-simple
-    docker-compose up -d
+    docker compose up -d
     ```
 
 === "🐳 Unsecured"
@@ -38,7 +38,7 @@ All docker compose examples come with batteries included (Identity Provider, Sto
     ```bash
     git clone https://github.com/lakekeeper/lakekeeper
     cd examples/minimal
-    docker-compose up -d
+    docker compose up -d
     ```
 
 Then open your browser and head to `localhost:8888` to load the example Jupyter notebooks or head to `localhost:8181` for the Lakekeeper UI.
@@ -54,7 +54,7 @@ While you can start the "🐳 Unsecured" variant without any external dependenci
     ```bash
     git clone https://github.com/lakekeeper/lakekeeper
     cd docker-compose
-    docker-compose up -d
+    docker compose up -d
     ```
 
 === "🐳 Authentication & Authorization"


### PR DESCRIPTION
 * Refactored to `docker compose`
 * fixed docker compose development setup to be `examples/minimal`