### PR TITLE
feat: Optionally disable the use of `x-forwarded-` headers

### DIFF
--- a/crates/iceberg-catalog/src/config.rs
+++ b/crates/iceberg-catalog/src/config.rs
@@ -97,6 +97,9 @@ pub struct DynAppConfig {
     /// Bind IP the server listens on.
     /// Defaults to 0.0.0.0
     pub bind_ip: IpAddr,
+    /// If x-forwarded-x headers should be respected.
+    /// Defaults to true
+    pub use_x_forwarded_headers: bool,
     /// If true (default), the NIL uuid is used as default project id.
     pub enable_default_project: bool,
     /// Template to obtain the "prefix" for a warehouse,
@@ -441,6 +444,7 @@ impl Default for DynAppConfig {
             base_uri: None,
             metrics_port: 9000,
             enable_default_project: true,
+            use_x_forwarded_headers: true,
             prefix_template: "{warehouse_id}".to_string(),
             allow_origin: None,
             reserved_namespaces: ReservedNamespaces(HashSet::from([
@@ -1070,6 +1074,23 @@ mod test {
             let config = get_config();
             assert!(config.enable_aws_system_credentials);
             assert!(!config.s3_enable_direct_system_credentials);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_use_x_forwarded_headers() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__USE_X_FORWARDED_HEADERS", "true");
+            let config = get_config();
+            assert!(config.use_x_forwarded_headers);
+            Ok(())
+        });
+
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__USE_X_FORWARDED_HEADERS", "false");
+            let config = get_config();
+            assert!(!config.use_x_forwarded_headers);
             Ok(())
         });
     }

--- a/crates/iceberg-catalog/src/implementations/postgres/migrations/mod.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/migrations/mod.rs
@@ -120,7 +120,7 @@ async fn run_checks(
 pub async fn check_migration_status(pool: &sqlx::PgPool) -> anyhow::Result<MigrationState> {
     let mut conn = pool.acquire().await?;
     let m = sqlx::migrate!();
-    let mut sha_patches = get_sha_patches();
+    let sha_patches = get_sha_patches();
     tracing::info!("SHA patches: {:?}", sha_patches.iter().collect::<Vec<_>>());
 
     let applied_migrations = match conn.list_applied_migrations().await {

--- a/crates/iceberg-catalog/src/implementations/postgres/migrations/mod.rs
+++ b/crates/iceberg-catalog/src/implementations/postgres/migrations/mod.rs
@@ -120,6 +120,9 @@ async fn run_checks(
 pub async fn check_migration_status(pool: &sqlx::PgPool) -> anyhow::Result<MigrationState> {
     let mut conn = pool.acquire().await?;
     let m = sqlx::migrate!();
+    let mut sha_patches = get_sha_patches();
+    tracing::info!("SHA patches: {:?}", sha_patches.iter().collect::<Vec<_>>());
+
     let applied_migrations = match conn.list_applied_migrations().await {
         Ok(migrations) => migrations,
         Err(e) => {
@@ -140,10 +143,12 @@ pub async fn check_migration_status(pool: &sqlx::PgPool) -> anyhow::Result<Migra
         .migrations
         .iter()
         .map(|mig| (mig.version, &*mig.checksum))
+        .filter(|(v, _)| !sha_patches.contains(v))
         .collect::<HashSet<_>>();
     let applied = applied_migrations
         .iter()
         .map(|mig| (mig.version, &*mig.checksum))
+        .filter(|(v, _)| !sha_patches.contains(v))
         .collect::<HashSet<_>>();
     let missing = to_be_applied.difference(&applied).collect::<HashSet<_>>();
 

--- a/crates/iceberg-catalog/src/lib.rs
+++ b/crates/iceberg-catalog/src/lib.rs
@@ -19,7 +19,7 @@ pub mod api;
 mod request_metadata;
 
 pub(crate) use request_metadata::{
-    X_FORWARDED_FOR_HEADER, X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER,
+    X_FORWARDED_HOST_HEADER, X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER,
 };
 
 #[cfg(feature = "router")]

--- a/crates/iceberg-catalog/src/request_metadata.rs
+++ b/crates/iceberg-catalog/src/request_metadata.rs
@@ -8,7 +8,6 @@ use axum::{
 use http::{HeaderMap, Method};
 use iceberg_ext::catalog::rest::{ErrorModel, IcebergErrorResponse};
 use limes::Authentication;
-use rand::rand_core::le;
 use uuid::Uuid;
 
 use crate::{service::authn::Actor, ProjectId, WarehouseIdent, CONFIG, DEFAULT_PROJECT_ID};
@@ -266,8 +265,7 @@ fn determine_base_uri(headers: &HeaderMap) -> Option<String> {
 
     let host_header = headers
         .get(http::header::HOST)
-        .map(|hv| hv.to_str().ok())
-        .flatten();
+        .and_then(|hv| hv.to_str().ok());
 
     if CONFIG.use_x_forwarded_headers {
         let any_x_forwarded_header_present = headers

--- a/crates/iceberg-catalog/src/request_metadata.rs
+++ b/crates/iceberg-catalog/src/request_metadata.rs
@@ -8,6 +8,7 @@ use axum::{
 use http::{HeaderMap, Method};
 use iceberg_ext::catalog::rest::{ErrorModel, IcebergErrorResponse};
 use limes::Authentication;
+use rand::rand_core::le;
 use uuid::Uuid;
 
 use crate::{service::authn::Actor, ProjectId, WarehouseIdent, CONFIG, DEFAULT_PROJECT_ID};
@@ -16,7 +17,7 @@ const PROJECT_ID_HEADER_DEPRECATED: &str = "x-project-ident";
 pub const X_PROJECT_ID_HEADER: &str = "x-project-id";
 pub const X_REQUEST_ID_HEADER: &str = "x-request-id";
 
-pub(crate) const X_FORWARDED_FOR_HEADER: &str = "x-forwarded-for";
+pub(crate) const X_FORWARDED_HOST_HEADER: &str = "x-forwarded-host";
 pub(crate) const X_FORWARDED_PROTO_HEADER: &str = "x-forwarded-proto";
 pub(crate) const X_FORWARDED_PORT_HEADER: &str = "x-forwarded-port";
 
@@ -174,7 +175,7 @@ impl RequestMetadata {
     /// Get the host that the request was made to.
     ///
     /// Contains the value of `CONFIG.base_uri` if configered, else the
-    /// (`x-forward-proto`|https)://`x-forwarded-for`:`x-forwarded-port` headers if present,
+    /// (`x-forward-proto`|https)://`x-forwarded-host`:`x-forwarded-port` headers if present,
     /// otherwise the `host` header.
     #[must_use]
     pub fn base_url(&self) -> &str {
@@ -221,7 +222,7 @@ pub(crate) async fn create_request_metadata_with_trace_and_project_fn(
 
     let Some(host) = determine_base_uri(&headers) else {
         return IcebergErrorResponse::from(ErrorModel::bad_request(
-            "base_uri is not set and neither x-forwarded-for nor host header are set. Either send the appropriate headers or configure the base_uri according to the documentation.".to_string(),
+            "base_uri is not set and neither x-forwarded-host nor host header are set. Either send the appropriate headers or configure the base_uri according to the documentation.".to_string(),
             "NoHostHeader",
             None,
         ))
@@ -263,10 +264,23 @@ fn determine_base_uri(headers: &HeaderMap) -> Option<String> {
         return Some(uri.to_string());
     }
 
-    let x_forwarded_host = if CONFIG.use_x_forwarded_headers {
-        let x_forwarded_for = headers
-            .get(X_FORWARDED_FOR_HEADER)
-            .and_then(|hv| hv.to_str().ok());
+    let host_header = headers
+        .get(http::header::HOST)
+        .map(|hv| hv.to_str().ok())
+        .flatten();
+
+    if CONFIG.use_x_forwarded_headers {
+        let any_x_forwarded_header_present = headers
+            .get(X_FORWARDED_HOST_HEADER)
+            .or(headers.get(X_FORWARDED_PROTO_HEADER))
+            .or(headers.get(X_FORWARDED_PORT_HEADER))
+            .is_some();
+
+        let host = headers
+            .get(X_FORWARDED_HOST_HEADER)
+            .and_then(|hv| hv.to_str().ok())
+            .or(host_header)?;
+
         let x_forwarded_proto = headers
             .get(X_FORWARDED_PROTO_HEADER)
             .and_then(|hv| hv.to_str().ok());
@@ -274,44 +288,31 @@ fn determine_base_uri(headers: &HeaderMap) -> Option<String> {
             .get(X_FORWARDED_PORT_HEADER)
             .and_then(|hv| hv.to_str().ok());
 
-        if let Some(forwarded_for) = x_forwarded_for {
-            let mut x_forwarded_host = String::new();
-            if let Some(proto) = x_forwarded_proto {
-                x_forwarded_host.push_str(proto);
-                x_forwarded_host.push_str("://");
-            } else {
-                // we default to https since we assume that a reverse proxy did tls termination
-                // leaving out protocol would break at least iceberg java which requires a protocol.
-                x_forwarded_host.push_str("https://");
-            }
-
-            x_forwarded_host.push_str(forwarded_for);
-            if let Some(port) = x_forwarded_port {
-                x_forwarded_host.push(':');
-                x_forwarded_host.push_str(port);
-            }
-            Some(x_forwarded_host)
+        let mut base_uri = String::new();
+        if let Some(proto) = x_forwarded_proto {
+            base_uri.push_str(proto);
+            base_uri.push_str("://");
         } else {
-            None
-        }
-    } else {
-        None
-    };
-
-    let host = x_forwarded_host.or(headers
-        .get(http::header::HOST)
-        .map(|hv| hv.to_str().map(ToString::to_string))
-        .transpose()
-        .ok()
-        .flatten()
-        .map(|host| {
-            if host.starts_with("http://") || host.starts_with("https://") {
-                host
+            // In the unlikely case that x-forwarded headers are present, but the proto header
+            // is missing, we assume https.
+            if any_x_forwarded_header_present {
+                base_uri.push_str("https://");
             } else {
-                format!("http://{host}")
+                // Lakekeeper does not terminate TLS. Any external entity that terminates TLS should set the x-forwarded- headers.
+                base_uri.push_str("http://");
             }
-        }));
-    host
+        }
+        base_uri.push_str(host);
+        if let Some(port) = x_forwarded_port {
+            base_uri.push(':');
+            base_uri.push_str(port);
+        }
+        Some(base_uri)
+    } else {
+        // If no BASE_URI is set and no x-forwarded headers are present, the encryption is unencrypted,
+        // as lakekeeper does not terminate TLS. Any external entity that terminates TLS should set the x-forwarded headers.
+        host_header.map(|host| format!("http://{host}"))
+    }
 }
 
 #[cfg(test)]
@@ -319,7 +320,7 @@ mod test {
     use http::{header::HeaderValue, HeaderMap};
 
     use crate::request_metadata::{
-        determine_base_uri, X_FORWARDED_FOR_HEADER, X_FORWARDED_PORT_HEADER,
+        determine_base_uri, X_FORWARDED_HOST_HEADER, X_FORWARDED_PORT_HEADER,
         X_FORWARDED_PROTO_HEADER,
     };
 
@@ -365,7 +366,7 @@ mod test {
             jail.set_env("LAKEKEEPER_TEST__BASE_URI", "https://localhost:8181/a/b/");
             let mut headers = HeaderMap::new();
             headers.insert(
-                X_FORWARDED_FOR_HEADER,
+                X_FORWARDED_HOST_HEADER,
                 HeaderValue::from_static("example.com"),
             );
             let host = determine_base_uri(&headers);
@@ -376,7 +377,7 @@ mod test {
             jail.set_env("LAKEKEEPER_TEST__BASE_URI", "https://localhost:8181/a/b");
             let mut headers = HeaderMap::new();
             headers.insert(
-                X_FORWARDED_FOR_HEADER,
+                X_FORWARDED_HOST_HEADER,
                 HeaderValue::from_static("example.com"),
             );
             let host = determine_base_uri(&headers);
@@ -386,10 +387,10 @@ mod test {
     }
 
     #[test]
-    fn test_determine_host_with_x_forwarded_complete() {
+    fn test_determine_host_with_x_forwarded_https() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            X_FORWARDED_FOR_HEADER,
+            X_FORWARDED_HOST_HEADER,
             HeaderValue::from_static("example.com"),
         );
         headers.insert(X_FORWARDED_PROTO_HEADER, HeaderValue::from_static("https"));
@@ -400,10 +401,24 @@ mod test {
     }
 
     #[test]
+    fn test_determine_host_with_x_forwarded_http() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            X_FORWARDED_HOST_HEADER,
+            HeaderValue::from_static("example.com"),
+        );
+        headers.insert(X_FORWARDED_PROTO_HEADER, HeaderValue::from_static("http"));
+        headers.insert(X_FORWARDED_PORT_HEADER, HeaderValue::from_static("8080"));
+
+        let result = determine_base_uri(&headers);
+        assert_eq!(result, Some("http://example.com:8080".to_string()));
+    }
+
+    #[test]
     fn test_determine_host_with_x_forwarded_no_port() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            X_FORWARDED_FOR_HEADER,
+            X_FORWARDED_HOST_HEADER,
             HeaderValue::from_static("example.com"),
         );
         headers.insert(X_FORWARDED_PROTO_HEADER, HeaderValue::from_static("https"));
@@ -416,7 +431,7 @@ mod test {
     fn test_determine_host_with_x_forwarded_no_proto() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            X_FORWARDED_FOR_HEADER,
+            X_FORWARDED_HOST_HEADER,
             HeaderValue::from_static("example.com"),
         );
         headers.insert("x-forwarded-port", HeaderValue::from_static("8080"));
@@ -429,7 +444,7 @@ mod test {
     fn test_determine_host_with_only_x_forwarded_for() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            X_FORWARDED_FOR_HEADER,
+            X_FORWARDED_HOST_HEADER,
             HeaderValue::from_static("example.com"),
         );
 
@@ -447,18 +462,6 @@ mod test {
     }
 
     #[test]
-    fn test_determine_host_with_host_header_with_protocol() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            http::header::HOST,
-            HeaderValue::from_static("https://example.com"),
-        );
-
-        let result = determine_base_uri(&headers);
-        assert_eq!(result, Some("https://example.com".to_string()));
-    }
-
-    #[test]
     fn test_determine_host_empty_headers() {
         let headers = HeaderMap::new();
         let result = determine_base_uri(&headers);
@@ -470,7 +473,7 @@ mod test {
         let mut headers = HeaderMap::new();
         // Insert an invalid UTF-8 sequence as header value
         headers.insert(
-            X_FORWARDED_FOR_HEADER,
+            X_FORWARDED_HOST_HEADER,
             HeaderValue::from_bytes(&[0xFF]).unwrap(),
         );
 
@@ -482,7 +485,7 @@ mod test {
     fn test_determine_host_prefers_x_forwarded() {
         let mut headers = HeaderMap::new();
         headers.insert(
-            X_FORWARDED_FOR_HEADER,
+            X_FORWARDED_HOST_HEADER,
             HeaderValue::from_static("forwarded.example.com"),
         );
         headers.insert(X_FORWARDED_PROTO_HEADER, HeaderValue::from_static("https"));

--- a/crates/iceberg-catalog/src/tracing.rs
+++ b/crates/iceberg-catalog/src/tracing.rs
@@ -7,7 +7,7 @@ use tracing::{Level, Span};
 use uuid::Uuid;
 
 use crate::{
-    api::X_REQUEST_ID_HEADER, X_FORWARDED_FOR_HEADER, X_FORWARDED_PORT_HEADER,
+    api::X_REQUEST_ID_HEADER, X_FORWARDED_HOST_HEADER, X_FORWARDED_PORT_HEADER,
     X_FORWARDED_PROTO_HEADER,
 };
 
@@ -40,7 +40,7 @@ impl<B> MakeSpan<B> for RestMakeSpan {
                         "request",
                         method = %request.method(),
                         host = %request.headers().get("host").and_then(|v| v.to_str().ok()).unwrap_or("not set"),
-                        "x-forwarded-for" = %request.headers().get(X_FORWARDED_FOR_HEADER).and_then(|v| v.to_str().ok()).unwrap_or("not set"),
+                        "x-forwarded-host" = %request.headers().get(X_FORWARDED_HOST_HEADER).and_then(|v| v.to_str().ok()).unwrap_or("not set"),
                         "x-forwarded-proto" = %request.headers().get(X_FORWARDED_PROTO_HEADER).and_then(|v| v.to_str().ok()).unwrap_or("not set"),
                         "x-forwarded-port" = %request.headers().get(X_FORWARDED_PORT_HEADER).and_then(|v| v.to_str().ok()).unwrap_or("not set"),
                         uri = %request.uri(),

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -6,7 +6,7 @@ For most deployments, we recommend to set at least the following variables: `LAK
 
 ## Routing and Base-URL
 
-Some Lakekeeper endpoints return links pointing at Lakekeeper itself. By default, these links are generated using the `x-forwarded-for`, `x-forwarded-proto` and `x-forwarded-port` headers, if these are not present, the `host` header is used. If these heuristics are not working for you, you may set the `LAKEKEEPER_BASE_URI` environment variable to the base-URL where Lakekeeper is externally reachable. This may be necessary if Lakekeeper runs behind a reverse proxy or load balancer, and you cannot set the headers accordingly. In general, we recommend relying on the headers. To respect the `host` header but not the `x-forwarded-` headers, set `LAKEKEEPER__USE_X_FORWARDED_HEADERS` to `false`.
+Some Lakekeeper endpoints return links pointing at Lakekeeper itself. By default, these links are generated using the `x-forwarded-host`, `x-forwarded-proto` and `x-forwarded-port` headers, if these are not present, the `host` header is used. If these heuristics are not working for you, you may set the `LAKEKEEPER_BASE_URI` environment variable to the base-URL where Lakekeeper is externally reachable. This may be necessary if Lakekeeper runs behind a reverse proxy or load balancer, and you cannot set the headers accordingly. In general, we recommend relying on the headers. To respect the `host` header but not the `x-forwarded-` headers, set `LAKEKEEPER__USE_X_FORWARDED_HEADERS` to `false`.
 
 ### General
 
@@ -20,7 +20,7 @@ Some Lakekeeper endpoints return links pointing at Lakekeeper itself. By default
 | `LAKEKEEPER__BIND_IP`                              | `0.0.0.0`, `::1`, `::`                 | IP Address Lakekeeper binds to. Default: `0.0.0.0` (listen to all incoming IPv4 packages) |
 | `LAKEKEEPER__SECRET_BACKEND`                       | `postgres`                             | The secret backend to use. If `kv2` (Hashicorp KV Version 2) is chosen, you need to provide [additional parameters](#vault-kv-version-2) Default: `postgres`, one-of: [`postgres`, `kv2`] |
 | `LAKEKEEPER__ALLOW_ORIGIN`                         | `*`                                    | A comma separated list of allowed origins for CORS. |
-| <nobr>`LAKEKEEPER__USE_X_FORWARDED_HEADERS`</nobr> | <nobr>`false`<nobr>                    | If true, Lakekeeper respects the `x-forwarded-for`, `x-forwarded-proto` and `x-forwarded-port` headers in incoming requests. This is mostly relevant for the `/config` endpoint. Default: `true` (Headers are respected.) |
+| <nobr>`LAKEKEEPER__USE_X_FORWARDED_HEADERS`</nobr> | <nobr>`false`<nobr>                    | If true, Lakekeeper respects the `x-forwarded-host`, `x-forwarded-proto` and `x-forwarded-port` headers in incoming requests. This is mostly relevant for the `/config` endpoint. Default: `true` (Headers are respected.) |
 
 ### Storage
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -6,20 +6,21 @@ For most deployments, we recommend to set at least the following variables: `LAK
 
 ## Routing and Base-URL
 
-Some Lakekeeper endpoints return links pointing at Lakekeeper itself. By default, these links are generated using the `x-forwarded-for`, `x-forwarded-proto` and `x-forwarded-port` headers, if these are not present, the `host` header is used. If these heuristics are not working for you, you may set the `LAKEKEEPER_BASE_URI` environment variable to the base-URL where Lakekeeper is externally reachable. This may be necessary if Lakekeeper runs behind a reverse proxy or load balancer, and you cannot set the headers accordingly. In general, we recommend relying on the headers.
+Some Lakekeeper endpoints return links pointing at Lakekeeper itself. By default, these links are generated using the `x-forwarded-for`, `x-forwarded-proto` and `x-forwarded-port` headers, if these are not present, the `host` header is used. If these heuristics are not working for you, you may set the `LAKEKEEPER_BASE_URI` environment variable to the base-URL where Lakekeeper is externally reachable. This may be necessary if Lakekeeper runs behind a reverse proxy or load balancer, and you cannot set the headers accordingly. In general, we recommend relying on the headers. To respect the `host` header but not the `x-forwarded-` headers, set `LAKEKEEPER__USE_X_FORWARDED_HEADERS` to `false`.
 
 ### General
 
-| Variable                                         | Example                                | Description |
-|--------------------------------------------------|----------------------------------------|-----|
-| <nobr>`LAKEKEEPER__BASE_URI`</nobr>              | <nobr>`https://example.com:8181`<nobr> | Optional base-URL where the catalog is externally reachable. Default: `None`. See [Routing and Base-URL](#routing-and-base-url). |
-| <nobr>`LAKEKEEPER__ENABLE_DEFAULT_PROJECT`<nobr> | `true`                                 | If `true`, the NIL Project ID ("00000000-0000-0000-0000-000000000000") is used as a default if the user does not specify a project when connecting. This option is enabled by default, which we recommend for all single-project (single-tenant) setups. Default: `true`. |
-| `LAKEKEEPER__RESERVED_NAMESPACES`                | `system,examples,information_schema`   | Reserved Namespaces that cannot be created via the REST interface |
-| `LAKEKEEPER__METRICS_PORT`                       | `9000`                                 | Port where the Prometheus metrics endpoint is reachable. Default: `9000` |
-| `LAKEKEEPER__LISTEN_PORT`                        | `8181`                                 | Port Lakekeeper listens on. Default: `8181` |
-| `LAKEKEEPER__BIND_IP`                            | `0.0.0.0`, `::1`, `::`                 | IP Address Lakekeeper binds to. Default: `0.0.0.0` (listen to all incoming IPv4 packages) |
-| `LAKEKEEPER__SECRET_BACKEND`                     | `postgres`                             | The secret backend to use. If `kv2` (Hashicorp KV Version 2) is chosen, you need to provide [additional parameters](#vault-kv-version-2) Default: `postgres`, one-of: [`postgres`, `kv2`] |
-| `LAKEKEEPER__ALLOW_ORIGIN`                       | `*`                                    | A comma separated list of allowed origins for CORS. |
+| Variable                                           | Example                                | Description |
+|----------------------------------------------------|----------------------------------------|-----|
+| <nobr>`LAKEKEEPER__BASE_URI`</nobr>                | <nobr>`https://example.com:8181`<nobr> | Optional base-URL where the catalog is externally reachable. Default: `None`. See [Routing and Base-URL](#routing-and-base-url). |
+| <nobr>`LAKEKEEPER__ENABLE_DEFAULT_PROJECT`<nobr>   | `true`                                 | If `true`, the NIL Project ID ("00000000-0000-0000-0000-000000000000") is used as a default if the user does not specify a project when connecting. This option is enabled by default, which we recommend for all single-project (single-tenant) setups. Default: `true`. |
+| `LAKEKEEPER__RESERVED_NAMESPACES`                  | `system,examples,information_schema`   | Reserved Namespaces that cannot be created via the REST interface |
+| `LAKEKEEPER__METRICS_PORT`                         | `9000`                                 | Port where the Prometheus metrics endpoint is reachable. Default: `9000` |
+| `LAKEKEEPER__LISTEN_PORT`                          | `8181`                                 | Port Lakekeeper listens on. Default: `8181` |
+| `LAKEKEEPER__BIND_IP`                              | `0.0.0.0`, `::1`, `::`                 | IP Address Lakekeeper binds to. Default: `0.0.0.0` (listen to all incoming IPv4 packages) |
+| `LAKEKEEPER__SECRET_BACKEND`                       | `postgres`                             | The secret backend to use. If `kv2` (Hashicorp KV Version 2) is chosen, you need to provide [additional parameters](#vault-kv-version-2) Default: `postgres`, one-of: [`postgres`, `kv2`] |
+| `LAKEKEEPER__ALLOW_ORIGIN`                         | `*`                                    | A comma separated list of allowed origins for CORS. |
+| <nobr>`LAKEKEEPER__USE_X_FORWARDED_HEADERS`</nobr> | <nobr>`false`<nobr>                    | If true, Lakekeeper respects the `x-forwarded-for`, `x-forwarded-proto` and `x-forwarded-port` headers in incoming requests. This is mostly relevant for the `/config` endpoint. Default: `true` (Headers are respected.) |
 
 ### Storage
 


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Use X-Forwarded-Host header for response in /config Endpoint

feat: Optionally disable the use of x-forwarded- headers
END_COMMIT_OVERRIDE