### PR TITLE
feat: Store table metrics delivered to /metrics endpoint

### DIFF
--- a/crates/iceberg-catalog/migrations/20250522081615_create_table_metrics.sql
+++ b/crates/iceberg-catalog/migrations/20250522081615_create_table_metrics.sql
@@ -1,0 +1,25 @@
+-- UP script to create the table_metrics table
+
+CREATE TABLE table_metrics (
+    table_id UUID NOT NULL REFERENCES "table"(table_id) ON DELETE CASCADE,
+    total_records BIGINT NOT NULL,
+    total_files_size_bytes BIGINT NOT NULL,
+    total_data_files BIGINT NOT NULL,
+    total_delete_files BIGINT NOT NULL,
+    total_position_deletes BIGINT NOT NULL,
+    total_equality_deletes BIGINT NOT NULL,
+    reported_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (table_id, reported_at) -- Composite key to store metrics over time
+);
+
+-- Index for efficient querying by table_id
+CREATE INDEX idx_table_metrics_table_id ON table_metrics(table_id);
+
+-- Apply the updated_at trigger (if it exists and is conventional)
+-- SELECT trigger_updated_at('table_metrics');
+
+-- Add time columns (if a helper function like add_time_columns exists and is conventional)
+-- CALL add_time_columns('table_metrics');
+
+-- DOWN script (for manual rollback if needed)
+-- DROP TABLE table_metrics;

--- a/crates/iceberg-catalog/src/catalog/metrics.rs
+++ b/crates/iceberg-catalog/src/catalog/metrics.rs
@@ -1,20 +1,64 @@
 use super::CatalogServer;
 use crate::{
-    api::iceberg::v1::{ApiContext, Result, TableParameters},
+    api::iceberg::v1::{ApiContext, ErrorModel, Result, TableParameters},
+    catalog::require_warehouse_id,
     request_metadata::RequestMetadata,
-    service::{authz::Authorizer, secrets::SecretStore, Catalog, State},
+    service::{
+        authz::Authorizer, secrets::SecretStore, Catalog, ListFlags, State, Transaction as _,
+    },
 };
+use iceberg_ext::spec::Metrics as ExtMetrics;
 
 #[async_trait::async_trait]
 impl<C: Catalog, A: Authorizer + Clone, S: SecretStore>
     crate::api::iceberg::v1::metrics::Service<State<A, C, S>> for CatalogServer<C, A, S>
 {
     async fn report_metrics(
-        _: TableParameters,
-        _: serde_json::Value,
-        _: ApiContext<State<A, C, S>>,
-        _: RequestMetadata,
+        params: TableParameters,
+        metrics_value: serde_json::Value,
+        api_context: ApiContext<State<A, C, S>>,
+        _request_metadata: RequestMetadata,
     ) -> Result<()> {
+        let parsed_metrics: ExtMetrics = serde_json::from_value(metrics_value).map_err(|e| {
+            ErrorModel::bad_request(
+                format!("Failed to parse metrics JSON: {}", e),
+                "MetricsParsingFailed",
+                Some(Box::new(e)),
+            )
+        })?;
+
+        let warehouse_id = require_warehouse_id(params.prefix)?;
+
+        let mut catalog_transaction =
+            C::Transaction::begin_write(api_context.inner().catalog.clone()).await?;
+
+        let table_id = C::table_to_id(
+            warehouse_id,
+            &params.table,
+            ListFlags::default(),
+            catalog_transaction.transaction(),
+        )
+        .await?
+        .ok_or_else(|| {
+            ErrorModel::not_found(
+                format!(
+                    "Table {} not found in warehouse {}",
+                    params.table, warehouse_id
+                ),
+                "TableNotFound",
+                None,
+            )
+        })?;
+
+        C::report_table_metrics(
+            table_id,
+            parsed_metrics,
+            catalog_transaction.transaction(),
+        )
+        .await?;
+
+        catalog_transaction.commit().await?;
+
         Ok(())
     }
 }

--- a/crates/iceberg-catalog/src/service/catalog.rs
+++ b/crates/iceberg-catalog/src/service/catalog.rs
@@ -8,6 +8,7 @@ pub use iceberg_ext::catalog::rest::{CommitTableResponse, CreateTableRequest};
 use iceberg_ext::{
     catalog::rest::{CatalogConfig, ErrorModel},
     configs::Location,
+    spec::Metrics as ExtMetrics,
 };
 
 use super::{
@@ -785,6 +786,12 @@ where
         protect: bool,
         transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'_>,
     ) -> Result<ProtectionResponse>;
+
+    async fn report_table_metrics<'a>(
+        table_id: TableId,
+        metrics: ExtMetrics,
+        transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'a>,
+    ) -> Result<()>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/iceberg-catalog/src/tests/metrics_api_test.rs
+++ b/crates/iceberg-catalog/src/tests/metrics_api_test.rs
@@ -1,0 +1,236 @@
+use iceberg::TableIdent;
+use iceberg_ext::{spec::Metrics as ExtMetrics, NamespaceIdent};
+use serde_json::json;
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::{
+    api::{
+        iceberg::{types::Prefix, v1::TableParameters},
+        management::v1::warehouse::TabularDeleteProfile,
+        ApiContext,
+    },
+    catalog::CatalogServer,
+    implementations::postgres::{CatalogState, PostgresCatalog, SecretsState},
+    request_metadata::RequestMetadata,
+    service::{authz::AllowAllAuthorizer, Catalog, State, UserId},
+    tests::{create_ns, create_table, get_api_context, random_request_metadata, setup},
+};
+
+#[sqlx::test]
+async fn test_report_table_metrics_success_and_fetch(pool: sqlx::PgPool) {
+    let auth = AllowAllAuthorizer;
+    let (api_context, wh_response) = setup(
+        pool.clone(),
+        crate::tests::test_io_profile(),
+        None,
+        auth,
+        TabularDeleteProfile::Hard {},
+        Some(UserId::new_unchecked("test_user", "test_user")),
+        None,
+        1,
+    )
+    .await;
+
+    let ns_ident = NamespaceIdent::new("my_namespace".to_string());
+    create_ns(
+        api_context.clone(),
+        wh_response.warehouse_id.to_string(),
+        ns_ident.name().to_string(),
+    )
+    .await;
+
+    let table_ident = TableIdent::new(ns_ident.clone(), "my_table".to_string());
+    let create_table_response = create_table(
+        api_context.clone(),
+        wh_response.warehouse_id.to_string(),
+        ns_ident.name().to_string(),
+        table_ident.name().to_string(),
+        false, // Not staged
+    )
+    .await
+    .expect("Failed to create table");
+
+    let table_id = create_table_response.table_metadata.table_uuid;
+
+    let table_params = TableParameters {
+        prefix: Some(Prefix(wh_response.warehouse_id.to_string())),
+        table: table_ident.clone(),
+    };
+
+    let metrics_data = ExtMetrics {
+        total_records: 12345,
+        total_files_size_bytes: 67890,
+        total_data_files: 10,
+        total_delete_files: 1,
+        total_position_deletes: 5,
+        total_equality_deletes: 0,
+    };
+    let metrics_json_value =
+        serde_json::to_value(&metrics_data).expect("Failed to serialize metrics to JSON");
+
+    let report_result = CatalogServer::report_metrics(
+        table_params,
+        metrics_json_value,
+        api_context.clone(),
+        random_request_metadata(),
+    )
+    .await;
+
+    assert!(report_result.is_ok(), "Report metrics failed: {:?}", report_result.err());
+
+    // Verify data in table_metrics
+    let row = sqlx::query(
+        r#"
+        SELECT table_id, total_records, total_files_size_bytes, total_data_files,
+               total_delete_files, total_position_deletes, total_equality_deletes
+        FROM table_metrics
+        WHERE table_id = $1
+        ORDER BY reported_at DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(table_id)
+    .fetch_one(&pool)
+    .await
+    .expect("Failed to fetch from table_metrics");
+
+    let fetched_table_id: Uuid = row.get("table_id");
+    let total_records: i64 = row.get("total_records");
+    let total_files_size_bytes: i64 = row.get("total_files_size_bytes");
+    let total_data_files: i64 = row.get("total_data_files");
+    let total_delete_files: i64 = row.get("total_delete_files");
+    let total_position_deletes: i64 = row.get("total_position_deletes");
+    let total_equality_deletes: i64 = row.get("total_equality_deletes");
+
+    assert_eq!(fetched_table_id, table_id);
+    assert_eq!(total_records, metrics_data.total_records);
+    assert_eq!(total_files_size_bytes, metrics_data.total_files_size_bytes);
+    assert_eq!(total_data_files, metrics_data.total_data_files);
+    assert_eq!(total_delete_files, metrics_data.total_delete_files);
+    assert_eq!(total_position_deletes, metrics_data.total_position_deletes);
+    assert_eq!(total_equality_deletes, metrics_data.total_equality_deletes);
+}
+
+#[sqlx::test]
+async fn test_report_table_metrics_table_not_found(pool: sqlx::PgPool) {
+    let auth = AllowAllAuthorizer;
+    let (api_context, wh_response) = setup(
+        pool.clone(),
+        crate::tests::test_io_profile(),
+        None,
+        auth,
+        TabularDeleteProfile::Hard {},
+        Some(UserId::new_unchecked("test_user", "test_user")),
+        None,
+        1,
+    )
+    .await;
+
+    let non_existent_table_ident = TableIdent::new(
+        NamespaceIdent::new("my_namespace".to_string()),
+        "non_existent_table".to_string(),
+    );
+
+    let table_params = TableParameters {
+        prefix: Some(Prefix(wh_response.warehouse_id.to_string())),
+        table: non_existent_table_ident,
+    };
+
+    let metrics_data = ExtMetrics {
+        total_records: 100,
+        total_files_size_bytes: 200,
+        total_data_files: 3,
+        total_delete_files: 0,
+        total_position_deletes: 0,
+        total_equality_deletes: 0,
+    };
+    let metrics_json_value =
+        serde_json::to_value(&metrics_data).expect("Failed to serialize metrics to JSON");
+
+    let report_result = CatalogServer::report_metrics(
+        table_params,
+        metrics_json_value,
+        api_context.clone(),
+        random_request_metadata(),
+    )
+    .await;
+
+    assert!(report_result.is_err());
+    let error = report_result.err().unwrap();
+    // Error response from report_metrics is ErrorModel
+    // We need to check the type and message if possible.
+    // For now, checking if it's an error is sufficient for this test structure.
+    // A more precise check would involve inspecting error.error.error_type or similar.
+    // Based on the implementation, it should be a "TableNotFound" error.
+    // Example: assert_eq!(error.error.error_type, "TableNotFound");
+    // However, direct comparison of ErrorModel is complex due to its structure.
+     assert_eq!(error.error.code, 404); // Not Found
+     assert!(error.error.message.contains("Table"));
+     assert!(error.error.message.contains("not found"));
+}
+
+#[sqlx::test]
+async fn test_report_table_metrics_malformed_json(pool: sqlx::PgPool) {
+    let auth = AllowAllAuthorizer;
+    let (api_context, wh_response) = setup(
+        pool.clone(),
+        crate::tests::test_io_profile(),
+        None,
+        auth,
+        TabularDeleteProfile::Hard {},
+        Some(UserId::new_unchecked("test_user", "test_user")),
+        None,
+        1,
+    )
+    .await;
+    
+    let ns_ident = NamespaceIdent::new("my_namespace_json".to_string());
+    create_ns(
+        api_context.clone(),
+        wh_response.warehouse_id.to_string(),
+        ns_ident.name().to_string(),
+    )
+    .await;
+
+    let table_ident = TableIdent::new(ns_ident.clone(), "my_table_json".to_string());
+    let _ = create_table(
+        api_context.clone(),
+        wh_response.warehouse_id.to_string(),
+        ns_ident.name().to_string(),
+        table_ident.name().to_string(),
+        false, // Not staged
+    )
+    .await
+    .expect("Failed to create table");
+
+    let table_params = TableParameters {
+        prefix: Some(Prefix(wh_response.warehouse_id.to_string())),
+        table: table_ident.clone(),
+    };
+
+    // Malformed JSON: total_records is a string instead of a number
+    let malformed_json_value = json!({
+        "total_records": "not_a_number",
+        "total_files_size_bytes": 67890,
+        "total_data_files": 10,
+        "total_delete_files": 1,
+        "total_position_deletes": 5,
+        "total_equality_deletes": 0,
+    });
+
+    let report_result = CatalogServer::report_metrics(
+        table_params,
+        malformed_json_value,
+        api_context.clone(),
+        random_request_metadata(),
+    )
+    .await;
+
+    assert!(report_result.is_err());
+    let error = report_result.err().unwrap();
+    // Check for bad request and specific error type related to parsing
+    assert_eq!(error.error.code, 400); // Bad Request
+    assert!(error.error.message.contains("Failed to parse metrics JSON"));
+    assert_eq!(error.error.r#type, "MetricsParsingFailed");
+}

--- a/crates/iceberg-catalog/src/tests/mod.rs
+++ b/crates/iceberg-catalog/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod drop_recursive;
 mod drop_warehouse;
 mod endpoint_stats;
+mod metrics_api_test;
 mod stats;
 
 use std::sync::Arc;

--- a/crates/iceberg-ext/src/spec/metrics.rs
+++ b/crates/iceberg-ext/src/spec/metrics.rs
@@ -1,0 +1,82 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Metrics {
+    pub total_records: i64,
+    pub total_files_size_bytes: i64,
+    pub total_data_files: i64,
+    pub total_delete_files: i64,
+    pub total_position_deletes: i64,
+    pub total_equality_deletes: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metrics_serialization_deserialization() {
+        let original_metrics = Metrics {
+            total_records: 1000,
+            total_files_size_bytes: 1024000,
+            total_data_files: 10,
+            total_delete_files: 2,
+            total_position_deletes: 50,
+            total_equality_deletes: 5,
+        };
+
+        // Serialize to JSON
+        let json_string = serde_json::to_string(&original_metrics).expect("Serialization failed");
+
+        // Deserialize from JSON
+        let deserialized_metrics: Metrics =
+            serde_json::from_str(&json_string).expect("Deserialization failed");
+
+        // Assert equality
+        assert_eq!(original_metrics, deserialized_metrics);
+
+        // Test with a known valid JSON string
+        let valid_json = r#"
+        {
+            "total_records": 2000,
+            "total_files_size_bytes": 2048000,
+            "total_data_files": 20,
+            "total_delete_files": 4,
+            "total_position_deletes": 100,
+            "total_equality_deletes": 10
+        }
+        "#;
+        let metrics_from_valid_json: Metrics =
+            serde_json::from_str(valid_json).expect("Deserialization of valid JSON failed");
+        assert_eq!(metrics_from_valid_json.total_records, 2000);
+
+        // Test with missing fields (should fail as no default attribute is set)
+        let json_missing_fields = r#"
+        {
+            "total_records": 1000
+        }
+        "#;
+        let result_missing: Result<Metrics, _> = serde_json::from_str(json_missing_fields);
+        assert!(
+            result_missing.is_err(),
+            "Deserialization should fail for missing fields"
+        );
+
+        // Test with incorrect type (should fail)
+        let json_incorrect_type = r#"
+        {
+            "total_records": "not_a_number",
+            "total_files_size_bytes": 1024000,
+            "total_data_files": 10,
+            "total_delete_files": 2,
+            "total_position_deletes": 50,
+            "total_equality_deletes": 5
+        }
+        "#;
+        let result_incorrect_type: Result<Metrics, _> = serde_json::from_str(json_incorrect_type);
+        assert!(
+            result_incorrect_type.is_err(),
+            "Deserialization should fail for incorrect type"
+        );
+    }
+}

--- a/crates/iceberg-ext/src/spec/mod.rs
+++ b/crates/iceberg-ext/src/spec/mod.rs
@@ -5,3 +5,6 @@ pub use iceberg::spec::{
     SortDirection, SortField, SortOrder, StatisticsFile, TableMetadata, TableMetadataBuildResult,
     TableMetadataBuilder, UnboundPartitionField, UnboundPartitionSpec, ViewMetadata, ViewVersion,
 };
+
+mod metrics;
+pub use metrics::Metrics;


### PR DESCRIPTION
This commit introduces the capability to store metrics reported to the `/v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics` endpoint.

Key changes include:

- Definition of a `Metrics` struct in `iceberg-ext` for metrics data.
- A new PostgreSQL table `table_metrics` to persist these metrics, linked to the respective tables.
- Extension of the `Catalog` trait with a `report_table_metrics` method.
- Implementation of this method for `PostgresCatalog` to handle database insertion.
- Modification of the API endpoint handler in `iceberg-catalog` to parse the incoming JSON metrics, use the new trait method for storage, and manage database transactions.
- Comprehensive unit tests for `Metrics` struct (de)serialization.
- Integration tests for the `/metrics` endpoint, verifying successful data storage in the database and proper error handling for cases like non-existent tables or malformed JSON.

This addresses issue #9 by enabling the persistence of table metrics, which can be used for future table optimizations.