### PR TITLE
(docs) add ignore changes lifecycle to lakekeeper app

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -226,6 +226,11 @@ Alternatively, the following snippets will setup the resources mentioned above:
         user_consent_display_name  = "Access Lakekeeper API"
       }
     }
+    lifecycle {
+      ignore_changes = [
+        identifier_uris,
+      ]
+    }
   }
 
   resource "azuread_application_identifier_uri" "lakekeeper" {


### PR DESCRIPTION
Missed this in my initial PR, as per the [docs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_identifier_uri):

> This resource is analogous to the identifier_uris property in the azuread_application resource. When using these resources together, you should use the ignore_changes [lifecycle meta-argument](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle).

This caused the identifier url to be removed on our end upon rerolling