### PR TITLE
test(HidingAuthorizer): enable blocking actions

### DIFF
--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -694,8 +694,7 @@ pub(crate) mod tests {
             self.blocked_actions.read().unwrap().contains(action)
         }
 
-        // `namespace:can_list_everything`
-        fn block_action(&mut self, object: &str) {
+        pub(crate) fn block_action(&self, object: &str) {
             self.blocked_actions
                 .write()
                 .unwrap()
@@ -939,7 +938,7 @@ pub(crate) mod tests {
             paste! {
                 #[tokio::test]
                 async fn [<test_block_ $entity _action>]() {
-                    let mut authz = HidingAuthorizer::new();
+                    let authz = HidingAuthorizer::new();
 
                     // Nothing is hidden, so the action is allowed.
                     assert!(authz

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -585,6 +585,8 @@ pub(crate) mod tests {
         sync::{Arc, RwLock},
     };
 
+    use paste::paste;
+
     use super::*;
     use crate::service::health::Health;
 
@@ -659,16 +661,24 @@ pub(crate) mod tests {
     /// A mock of the [`Authorizer`] that allows to hide objects.
     /// This is useful to test the behavior of the authorizer when objects are hidden.
     ///
-    /// Objects that have been hidden will return `allowed: false`
-    /// for any check request.
+    /// Objects that have been hidden will return `allowed: false` for any check request. This
+    /// means all checks for an object that was *not* hidden return `allowed: true`.
+    ///
+    /// Some tests require blocking certain actions without hiding the object, for instance
+    /// forbid an action on a namespace without hiding the namespace. This can be achieved by
+    /// blocking the action.
     pub(crate) struct HidingAuthorizer {
+        /// Strings encode `object_type:object_id` e.g. `namespace:id_of_namespace_to_hide`.
         pub(crate) hidden: Arc<RwLock<HashSet<String>>>,
+        /// Strings encode `object_type:action` e.g. `namespace:can_create_table`.
+        blocked_actions: Arc<RwLock<HashSet<String>>>,
     }
 
     impl HidingAuthorizer {
         pub(crate) fn new() -> Self {
             Self {
                 hidden: Arc::new(RwLock::new(HashSet::new())),
+                blocked_actions: Arc::new(RwLock::new(HashSet::new())),
             }
         }
 
@@ -678,6 +688,18 @@ pub(crate) mod tests {
 
         pub(crate) fn hide(&self, object: &str) {
             self.hidden.write().unwrap().insert(object.to_string());
+        }
+
+        fn action_is_blocked(&self, action: &str) -> bool {
+            self.blocked_actions.read().unwrap().contains(action)
+        }
+
+        // `namespace:can_list_everything`
+        fn block_action(&mut self, object: &str) {
+            self.blocked_actions
+                .write()
+                .unwrap()
+                .insert(object.to_string());
         }
     }
 
@@ -733,8 +755,11 @@ pub(crate) mod tests {
             &self,
             _metadata: &RequestMetadata,
             role_id: RoleId,
-            _action: CatalogRoleAction,
+            action: CatalogRoleAction,
         ) -> Result<bool> {
+            if self.action_is_blocked(format!("role:{action}").as_str()) {
+                return Ok(false);
+            }
             Ok(self.check_available(format!("role:{role_id}").as_str()))
         }
 
@@ -750,8 +775,11 @@ pub(crate) mod tests {
             &self,
             _metadata: &RequestMetadata,
             project_id: &ProjectId,
-            _action: CatalogProjectAction,
+            action: CatalogProjectAction,
         ) -> Result<bool> {
+            if self.action_is_blocked(format!("project:{action}").as_str()) {
+                return Ok(false);
+            }
             Ok(self.check_available(format!("project:{project_id}").as_str()))
         }
 
@@ -759,8 +787,11 @@ pub(crate) mod tests {
             &self,
             _metadata: &RequestMetadata,
             warehouse_id: WarehouseId,
-            _action: CatalogWarehouseAction,
+            action: CatalogWarehouseAction,
         ) -> Result<bool> {
+            if self.action_is_blocked(format!("warehouse:{action}").as_str()) {
+                return Ok(false);
+            }
             Ok(self.check_available(format!("warehouse:{warehouse_id}").as_str()))
         }
 
@@ -768,11 +799,14 @@ pub(crate) mod tests {
             &self,
             _metadata: &RequestMetadata,
             namespace_id: NamespaceId,
-            _action: A,
+            action: A,
         ) -> Result<bool>
         where
             A: From<CatalogNamespaceAction> + std::fmt::Display + Send,
         {
+            if self.action_is_blocked(format!("namespace:{action}").as_str()) {
+                return Ok(false);
+            }
             Ok(self.check_available(format!("namespace:{namespace_id}").as_str()))
         }
 
@@ -780,11 +814,14 @@ pub(crate) mod tests {
             &self,
             _metadata: &RequestMetadata,
             table_id: TableId,
-            _action: A,
+            action: A,
         ) -> Result<bool>
         where
             A: From<CatalogTableAction> + std::fmt::Display + Send,
         {
+            if self.action_is_blocked(format!("table:{action}").as_str()) {
+                return Ok(false);
+            }
             Ok(self.check_available(format!("table:{table_id}").as_str()))
         }
 
@@ -792,11 +829,14 @@ pub(crate) mod tests {
             &self,
             _metadata: &RequestMetadata,
             view_id: ViewId,
-            _action: A,
+            action: A,
         ) -> Result<bool>
         where
             A: From<CatalogViewAction> + std::fmt::Display + Send,
         {
+            if self.action_is_blocked(format!("view:{action}").as_str()) {
+                return Ok(false);
+            }
             Ok(self.check_available(format!("view:{view_id}").as_str()))
         }
 
@@ -893,4 +933,58 @@ pub(crate) mod tests {
             Ok(())
         }
     }
+
+    macro_rules! test_block_action {
+        ($entity:ident, $action:path, $object_id:expr) => {
+            paste! {
+                #[tokio::test]
+                async fn [<test_block_ $entity _action>]() {
+                    let mut authz = HidingAuthorizer::new();
+
+                    // Nothing is hidden, so the action is allowed.
+                    assert!(authz
+                        .[<is_allowed_ $entity _action>](
+                            &RequestMetadata::new_unauthenticated(),
+                            $object_id,
+                            $action
+                        )
+                        .await
+                        .unwrap());
+
+                    // Generates "namespace:can_list_everything" for macro invoked with
+                    // (namespace, CatalogNamespaceAction::CanListEverything)
+                    authz.block_action(format!("{}:{}", stringify!($entity), $action).as_str());
+
+                    // After blocking the action it must not be allowed anymore.
+                    assert!(!authz
+                        .[<is_allowed_ $entity _action>](
+                            &RequestMetadata::new_unauthenticated(),
+                            $object_id,
+                            $action
+                        )
+                        .await
+                        .unwrap());
+                }
+            }
+        };
+    }
+
+    test_block_action!(role, CatalogRoleAction::CanDelete, RoleId::new_random());
+    test_block_action!(
+        project,
+        CatalogProjectAction::CanRename,
+        &ProjectId::new_random()
+    );
+    test_block_action!(
+        warehouse,
+        CatalogWarehouseAction::CanCreateNamespace,
+        WarehouseId::new_random()
+    );
+    test_block_action!(
+        namespace,
+        CatalogNamespaceAction::CanListViews,
+        NamespaceId::new_random()
+    );
+    test_block_action!(table, CatalogTableAction::CanDrop, TableId::new_random());
+    test_block_action!(view, CatalogViewAction::CanDrop, ViewId::new_random());
 }

--- a/crates/lakekeeper/src/service/mod.rs
+++ b/crates/lakekeeper/src/service/mod.rs
@@ -103,6 +103,13 @@ impl WarehouseId {
     }
 }
 
+impl ViewId {
+    #[must_use]
+    pub fn new_random() -> Self {
+        Self(uuid::Uuid::now_v7())
+    }
+}
+
 /// Status of a warehouse
 #[derive(
     Debug,


### PR DESCRIPTION
Adresses #1152

Slightly deviates from [this proposal](https://github.com/lakekeeper/lakekeeper/issues/1152#issuecomment-2939838153) because after adding `can_list_everything` to `warehouse` I suppose `HidingAuthorizer` would need not only a new field `allowed_namespace_actions` but also `allowed_warehouse_actions`.

I think this can be simplified by instead adding `blocked_actions` to `HidingAuthorizer`, which can then be used to block `warehouse:can_list_everything`, `namespace:can_list_everything`, and potentially actions on other objects later on. This also feels like a more natural extension of `HidingAuhorizer`.

With this in place the problem described in #1152 should be fixed by:

```Rust
authz.block_action(format!("warehouse:{}", CatalogWarehouseAction::CanListEverything));
authz.block_action(format!("namespace:{}", CatalogNamespaceAction::CanListEverything));
```