### PR TITLE
Make developer guide clearer

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,1 +1,1 @@
-For more information, please refer to the [developer guide](docs/docs/developer-guide.md).
+For more information, please refer to the [developer guide](docs/docs/developer-guide.md) or the [nightly doc](https://docs.lakekeeper.io/docs/nightly/developer-guide/)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,18 +1,1 @@
-
-# Integration tests
-
-## OpenFGA
-
-Some tests are run against an OpenFGA server.
-
-```bash
-# Start an OpenFGA server in a docker container
-docker rm --force openfga-client && docker run -d --name openfga-client -p 36080:8080 -p 36081:8081 -p 36300:3000 openfga/openfga:v1.8 run
-
-# Set Lakekeeper's OpenFGA endpoint
-export LAKEKEEPER_TEST__OPENFGA__ENDPOINT="http://localhost:36081"
-
-# Enable and run the tests
-export TEST_OPENFGA=1
-cargo nextest run --all-features --lib openfga
-```
+For more information, please refer to the [developer guide](docs/docs/developer-guide.md).

--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -21,6 +21,9 @@ echo 'export ICEBERG_REST__PG_DATABASE_URL_READ="postgresql://postgres:postgres@
 echo 'export ICEBERG_REST__PG_DATABASE_URL_WRITE="postgresql://postgres:postgres@localhost/postgres"' >> .env
 source .env
 
+cd crates/lakekeeper
+sqlx database create && sqlx migrate run
+cd ../..
 # Run tests (make sure you have cargo nextest installed, `cargo install cargo-nextest`)
 cargo nextest run --all-features
 
@@ -28,9 +31,6 @@ cargo nextest run --all-features
 just check-clippy
 # formatting the code. You may have to install nightly rust toolchain
 just fix-format
-
-# linting
-just check-clippy
 ```
 Keep in mind that some tests are gated by `TEST_*` env vars. You can find a list of them in the [Testing section](#test-cloud-storage-profiles) below or by searching for `needs_env_var` within files ending with `.rs`.
 There are a few cargo commands we run on CI. You may install [just](https://crates.io/crates/just) to run them conveniently.
@@ -78,11 +78,12 @@ If your database credentials used differ, please modify the `.env` accordingly a
 
 Run:
 ```sh
-# Migrate db. Make sure you have sqlx-install with `cargo install sqlx-cli`
+# Migrate db. Make sure you have sqlx-cli install with `cargo install sqlx-cli`
 # Run this locally if you change the db schema via `crates/lakekeeper/migrations`,
 # e.g. after adding a table or dropping a column.
 cd crates/lakekeeper
 sqlx database create && sqlx migrate run
+cd ../..
 
 # If you changed any of the SQL statements embedded in Rust code, run this before pushing to GitHub.
 just sqlx-prepare

--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -79,7 +79,8 @@ If your database credentials used differ, please modify the `.env` accordingly a
 Run:
 ```sh
 # Migrate db. Make sure you have sqlx-install with `cargo install sqlx-cli`
-# Run this locally if you change the db schema via crates/lakekeeper/migrations (e.g. after adding a table or dropping a column`).
+# Run this locally if you change the db schema via `crates/lakekeeper/migrations`,
+# e.g. after adding a table or dropping a column.
 cd crates/lakekeeper
 sqlx database create && sqlx migrate run
 

--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -21,9 +21,11 @@ echo 'export ICEBERG_REST__PG_DATABASE_URL_READ="postgresql://postgres:postgres@
 echo 'export ICEBERG_REST__PG_DATABASE_URL_WRITE="postgresql://postgres:postgres@localhost/postgres"' >> .env
 source .env
 
+# Migrate db
 cd crates/lakekeeper
 sqlx database create && sqlx migrate run
 cd ../..
+
 # Run tests (make sure you have cargo nextest installed, `cargo install cargo-nextest`)
 cargo nextest run --all-features
 

--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -156,9 +156,9 @@ cargo test service::storage::s3::test::aws::test_can_validate
 
 Our integration tests are written in Python and use pytest. They are located in the `tests` folder. The integration tests spin up Lakekeeper and all the dependencies via `docker compose`. Please check the [Integration Test Docs](https://github.com/lakekeeper/lakekeeper/tree/main/tests) for more information.
 
-### OpenFGA
+### Running Authorization unit tests
 
-Some tests are run against an OpenFGA server.
+Some authorization unit tests need to be run against an OpenFGA server. They are enabled only if TEST_OPENFGA is set. The workflow for executing them is:
 
 ```bash
 # Start an OpenFGA server in a docker container

--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -21,7 +21,7 @@ echo 'export ICEBERG_REST__PG_DATABASE_URL_READ="postgresql://postgres:postgres@
 echo 'export ICEBERG_REST__PG_DATABASE_URL_WRITE="postgresql://postgres:postgres@localhost/postgres"' >> .env
 source .env
 
-# Once you have made some changes to the code, run tests (make sure you have cargo nextest installed, `cargo install cargo-nextest`)
+# Run tests (make sure you have cargo nextest installed, `cargo install cargo-nextest`)
 cargo nextest run --all-features
 
 # run clippy


### PR DESCRIPTION
Hi team,

As I was working on this issue https://github.com/lakekeeper/lakekeeper/issues/812 and get to work with SQLx. I see that there are areas where the developer guide can be clearer, hence the PR.

I also notice there is another development doc (mostly geared towards openFGA). I'm not sure if it is still valid and should we combine it with the existing `docs/docs/developer-guide.md` file.
https://github.com/lakekeeper/lakekeeper/blob/cc03bc3acb97990f4da9ad74d3189bfa7dffd63f/DEVELOPMENT.md?plain=1#L1-L18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced detailed integration-test instructions with a pointer to the developer guide/nightly docs for running tests.
  * Reorganized developer guide: renamed "First steps" to "Initial Setup" and clarified setup, DB, and test workflows.
  * Moved SQLx preparation and migration guidance into a dedicated section with clearer warnings and steps.
  * Added instructions for running authorization unit tests against an OpenFGA server and minor wording fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->