### PR TITLE
chore(tests): Test with Iceberg 1.9.2 & 1.10.0

### DIFF
--- a/.github/workflows/integration_test_matrix.yml
+++ b/.github/workflows/integration_test_matrix.yml
@@ -37,41 +37,38 @@ jobs:
           - starrocks
           - trino
           - trino_opa
-          - spark_openfga-1.6.1
           - spark_openfga-1.7.1
           - spark_openfga-1.8.0
           - spark_openfga-1.9.2
+          - spark_openfga-1.10.0
           - spark_kv2-1.7.1
-          - spark_adls-1.6.1
           - spark_adls-1.8.0
           - spark_adls-1.9.2
+          - spark_adls-1.10.0
           - spark_wasbs-1.8.1
-          # - spark_adls-1.7.1 adls is currently broken with 1.7.1 due to https://lists.apache.org/thread/xc0ddyjkwdl8rhp072fcydl4rondogx6
-          - spark_aws_remote_signing-1.6.1
           - spark_aws_remote_signing-1.7.1
           - spark_aws_remote_signing-1.8.0
           - spark_aws_remote_signing-1.9.2
-          - spark_aws_sts-1.6.1
+          - spark_aws_remote_signing-1.10.0
           - spark_aws_sts-1.7.1
           - spark_aws_sts-1.8.0
           - spark_aws_sts-1.9.2
-          - spark_gcs-1.6.1
+          - spark_aws_sts-1.10.0
           - spark_gcs-1.7.1
           - spark_gcs-1.8.0
           - spark_gcs-1.9.2
-          - spark_minio_sts-1.5.2
-          - spark_minio_sts-1.6.1
+          - spark_gcs-1.10.0
           - spark_minio_sts-1.7.1
           - spark_minio_sts-1.8.0
           - spark_minio_sts-1.9.2
-          - spark_minio_remote_signing-1.5.2
-          - spark_minio_remote_signing-1.6.1
+          - spark_minio_sts-1.10.0
           - spark_minio_remote_signing-1.7.1
           - spark_minio_remote_signing-1.8.0
           - spark_minio_remote_signing-1.9.2
-          - spark_minio_s3a-1.9.2
-          - spark_aws_system_identity_sts-1.9.2
-          - spark_aws_system_identity_remote_signing-1.9.2
+          - spark_minio_remote_signing-1.10.0
+          - spark_minio_s3a-1.10.0
+          - spark_aws_system_identity_sts-1.10.0
+          - spark_aws_system_identity_remote_signing-1.10.0
     uses: ./.github/workflows/integration_test_workflow.yml
     with:
         test_name: ${{ matrix.names }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded integration test coverage to include Spark 1.9.2 across supported connectors and identity flows.
  - Removed legacy 1.5.x entries; retained 1.6.1, 1.7.1, and 1.8.0 coverage.
  - Improves confidence in compatibility across versions.

- Chores
  - CI maintenance to streamline the test matrix and reduce outdated configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->