### PR TITLE
fix: `partition_statistics` deletion

### DIFF
--- a/.sqlx/query-1e8987175061207564b8f7dc762ba047ef581a31fefddc5172f794a25954f32b.json
+++ b/.sqlx/query-1e8987175061207564b8f7dc762ba047ef581a31fefddc5172f794a25954f32b.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM partition_statistics WHERE table_id = $1 AND snapshot_id = ANY($2::BIGINT[])",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1e8987175061207564b8f7dc762ba047ef581a31fefddc5172f794a25954f32b"
+}

--- a/crates/lakekeeper/src/implementations/postgres/tabular/table/common.rs
+++ b/crates/lakekeeper/src/implementations/postgres/tabular/table/common.rs
@@ -584,18 +584,18 @@ pub(super) async fn insert_partition_statistics(
 
 pub(super) async fn remove_partition_statistics(
     table_id: Uuid,
-    statistics_ids: Vec<i64>,
+    snapshot_ids: Vec<i64>,
     transaction: &mut Transaction<'_, Postgres>,
 ) -> api::Result<()> {
     let _ = sqlx::query!(
-        r#"DELETE FROM table_statistics WHERE table_id = $1 AND snapshot_id = ANY($2::BIGINT[])"#,
+        r#"DELETE FROM partition_statistics WHERE table_id = $1 AND snapshot_id = ANY($2::BIGINT[])"#,
         table_id,
-        &statistics_ids,
+        &snapshot_ids,
     )
     .execute(&mut **transaction)
     .await
     .map_err(|err| {
-        tracing::warn!("Error creating table: {}", err);
+        tracing::warn!("Error deleting table statistics: {}", err);
         err.into_error_model("Error deleting table statistics".to_string())
     })?;
 

--- a/crates/lakekeeper/src/implementations/postgres/tabular/table/common.rs
+++ b/crates/lakekeeper/src/implementations/postgres/tabular/table/common.rs
@@ -595,8 +595,8 @@ pub(super) async fn remove_partition_statistics(
     .execute(&mut **transaction)
     .await
     .map_err(|err| {
-        tracing::warn!("Error deleting table statistics: {}", err);
-        err.into_error_model("Error deleting table statistics".to_string())
+        tracing::warn!("Error deleting partition statistics for table {table_id}: {err}");
+        err.into_error_model("Error deleting partition statistics".to_string())
     })?;
 
     Ok(())


### PR DESCRIPTION
Previously rows where deleted from `table_statistics` instead of `partition_statistics`. My understanding of what happened:

- `remove_partition_statistics` gets only ever called after `remove_table_statistics` with [the same](https://github.com/lakekeeper/lakekeeper/blob/cfaad2861dce3998ad7514dc464c5320f7dadee6/crates/lakekeeper/src/catalog/tables.rs#L1527-L1547) snapshot ids.
- In that case the call of `remove_partition_statistics` should be a no-op and there are probably some orphan `partition_statistics` rows out there. To remove them, should we add a migration?