### PR TITLE
chore(docs): Architecture clarify Secret Store

### DIFF
--- a/docs/docs/concepts.md
+++ b/docs/docs/concepts.md
@@ -13,7 +13,7 @@ Lakekeeper is an implementation of the Apache Iceberg REST Catalog API.  Lakekee
 * **Warehouse Storage** (required): When a new Warehouse is created, storage credentials are required.
 * **Identity Provider** (optional): Lakekeeper can authenticate incoming requests using any OIDC capable Identity Provider (IdP). Lakekeeper can also natively authenticate kubernetes service accounts.
 * **Authorization System** (optional): For permission management, Lakekeeper uses the wonderful [OpenFGA](http://openfga.dev) Project. OpenFGA is automatically deployed in our docker-compose and helm installations. Authorization can only be used if Lakekeeper is connected to an Identity Provider.
-* **Secret Store** (optional): By default, Lakekeeper stores all secrets (i.e. S3 access credentials) encrypted in the Persistence Backend. To increase security, Lakekeeper can also use external systems to store secrets. Currently all Hashicorp-Vault like stores are supported.
+* **Secret Store** (required): Lakekeeper requires a Secret Store to stores secrets such as Warehouse credentials. By default, Lakekeeper uses the default Postgres connection to store encrypted secrets. To increase security, Lakekeeper can also use external systems to store secrets. Currently all Hashicorp-Vault like stores are supported.
 * **Event Store** (optional): Lakekeeper can send Change Events to an Event Store. We support [NATS](http://nats.io) and [Apache Kafka](http://kafka.apache.org)
 * **Data Contract System** (optional): Lakekeeper can interface with external data contract systems to prohibit breaking changes to your tables.
 


### PR DESCRIPTION
Closes https://github.com/lakekeeper/lakekeeper/issues/1276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated concepts to clarify that a Secret Store is now required.
  * Documented default behavior: secrets are stored encrypted using the existing database connection.
  * Reaffirmed support for external secret managers (e.g., HashiCorp Vault–like solutions).
  * No changes to Event Store or Data Contract System descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->