### PR TITLE
chore: Remove bitnami images

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -148,7 +148,7 @@ jobs:
         ports:
           - 5432:5432
       minio:
-        image: bitnami/minio:2025.4.22
+        image: bitnami/minio:latest
         env:
           MINIO_ROOT_USER: minio-root-user
           MINIO_ROOT_PASSWORD: minio-root-password

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -41,11 +41,10 @@ services:
       iceberg_net:
 
   db:
-    image: bitnami/postgresql:16.6.0
+    image: postgres:16
     environment:
-      - POSTGRESQL_USERNAME=postgres
-      - POSTGRESQL_PASSWORD=postgres
-      - POSTGRESQL_DATABASE=postgres
+      - POSTGRES_PASSWORD=postgres
+      - PGDATA=/var/lib/postgresql/data/pgdata
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres" ]
       interval: 2s
@@ -53,7 +52,7 @@ services:
       retries: 2
       start_period: 10s
     volumes:
-      - volume-lakekeeper:/bitnami/postgresql
+      - volume-lakekeeper:/var/lib/postgresql/data
     networks:
       iceberg_net:
 

--- a/docker-compose/openfga-overlay.yaml
+++ b/docker-compose/openfga-overlay.yaml
@@ -54,11 +54,10 @@ services:
         condition: service_healthy
 
   openfga-db:
-    image: bitnami/postgresql:16.3.0
+    image: postgres:16
     environment:
-      - POSTGRESQL_USERNAME=postgres
-      - POSTGRESQL_PASSWORD=postgres
-      - POSTGRESQL_DATABASE=postgres
+      - POSTGRES_PASSWORD=postgres
+      - PGDATA=/var/lib/postgresql/data/pgdata
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres"]
       interval: 2s
@@ -66,7 +65,7 @@ services:
       retries: 2
       start_period: 10s
     volumes:
-      - volume-openfga:/bitnami/postgresql
+      - volume-openfga:/var/lib/postgresql/data
     networks:
       iceberg_net:
 

--- a/examples/access-control-advanced/docker-compose.yaml
+++ b/examples/access-control-advanced/docker-compose.yaml
@@ -138,15 +138,17 @@ services:
         condition: service_healthy
       keycloak:
         condition: service_healthy
+      minio:
+        condition: service_healthy
+      createbuckets:
+        condition: service_completed_successfully
     networks:
       iceberg_net:
 
   db:
-    image: bitnami/postgresql:16.3.0
+    image: postgres:16
     environment:
-      - POSTGRESQL_USERNAME=postgres
-      - POSTGRESQL_PASSWORD=postgres
-      - POSTGRESQL_DATABASE=postgres
+      - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres" ]
       interval: 2s
@@ -157,11 +159,9 @@ services:
       iceberg_net:
 
   openfga-db:
-    image: bitnami/postgresql:16.3.0
+    image: postgres:16
     environment:
-      - POSTGRESQL_USERNAME=postgres
-      - POSTGRESQL_PASSWORD=postgres
-      - POSTGRESQL_DATABASE=postgres
+      - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres" ]
       interval: 2s
@@ -172,22 +172,33 @@ services:
       iceberg_net:
 
   minio:
-    image: bitnami/minio:2025.4.22
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     environment:
       - MINIO_ROOT_USER=minio-root-user
       - MINIO_ROOT_PASSWORD=minio-root-password
-      - MINIO_API_PORT_NUMBER=9000
-      - MINIO_CONSOLE_PORT_NUMBER=9001
-      - MINIO_SCHEME=http
-      - MINIO_DEFAULT_BUCKETS=examples
+    command: [ "server", "--console-address", ":9001", "/data" ]
     healthcheck:
-      test: [ "CMD", "mc", "ls", "local", "|", "grep", "examples" ]
+      test: [ "CMD", "mc", "ready", "local" ]
       interval: 2s
       timeout: 10s
       retries: 2
       start_period: 15s
     networks:
       iceberg_net:
+
+  createbuckets:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    restart: on-failure
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5;
+      /usr/bin/mc alias set dockerminio http://minio:9000 minio-root-user minio-root-password;
+      /usr/bin/mc mb dockerminio/examples;
+      exit 0;
+      "
 
   openfga-migrate:
     image: openfga/openfga:v1.8

--- a/examples/access-control-advanced/docker-compose.yaml
+++ b/examples/access-control-advanced/docker-compose.yaml
@@ -199,6 +199,8 @@ services:
       /usr/bin/mc mb dockerminio/examples;
       exit 0;
       "
+    networks:
+      iceberg_net:
 
   openfga-migrate:
     image: openfga/openfga:v1.8

--- a/examples/access-control-simple/docker-compose.yaml
+++ b/examples/access-control-simple/docker-compose.yaml
@@ -168,6 +168,8 @@ services:
       /usr/bin/mc mb dockerminio/examples;
       exit 0;
       "
+    networks:
+      iceberg_net:
 
   openfga-migrate:
     image: openfga/openfga:v1.8

--- a/examples/access-control-simple/docker-compose.yaml
+++ b/examples/access-control-simple/docker-compose.yaml
@@ -63,6 +63,8 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
+      createbuckets:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
       minio:
@@ -113,11 +115,9 @@ services:
       iceberg_net:
 
   db:
-    image: bitnami/postgresql:16.3.0
+    image: postgres:16
     environment:
-      - POSTGRESQL_USERNAME=postgres
-      - POSTGRESQL_PASSWORD=postgres
-      - POSTGRESQL_DATABASE=postgres
+      - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres" ]
       interval: 2s
@@ -128,11 +128,9 @@ services:
       iceberg_net:
 
   openfga-db:
-    image: bitnami/postgresql:16.3.0
+    image: postgres:16
     environment:
-      - POSTGRESQL_USERNAME=postgres
-      - POSTGRESQL_PASSWORD=postgres
-      - POSTGRESQL_DATABASE=postgres
+      - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres" ]
       interval: 2s
@@ -143,22 +141,33 @@ services:
       iceberg_net:
 
   minio:
-    image: bitnami/minio:2025.4.22
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     environment:
       - MINIO_ROOT_USER=minio-root-user
       - MINIO_ROOT_PASSWORD=minio-root-password
-      - MINIO_API_PORT_NUMBER=9000
-      - MINIO_CONSOLE_PORT_NUMBER=9001
-      - MINIO_SCHEME=http
-      - MINIO_DEFAULT_BUCKETS=examples
+    command: [ "server", "--console-address", ":9001", "/data" ]
     healthcheck:
-      test: [ "CMD", "mc", "ls", "local", "|", "grep", "examples" ]
+      test: [ "CMD", "mc", "ready", "local" ]
       interval: 2s
       timeout: 10s
       retries: 2
       start_period: 15s
     networks:
       iceberg_net:
+
+  createbuckets:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    restart: on-failure
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5;
+      /usr/bin/mc alias set dockerminio http://minio:9000 minio-root-user minio-root-password;
+      /usr/bin/mc mb dockerminio/examples;
+      exit 0;
+      "
 
   openfga-migrate:
     image: openfga/openfga:v1.8

--- a/examples/minimal/docker-compose.yaml
+++ b/examples/minimal/docker-compose.yaml
@@ -40,6 +40,8 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+      createbuckets:
+        condition: service_completed_successfully
     networks:
       iceberg_net:
     ports:
@@ -112,11 +114,9 @@ services:
       iceberg_net:
 
   db:
-    image: bitnami/postgresql:16.3.0
+    image: postgres:16
     environment:
-      - POSTGRESQL_USERNAME=postgres
-      - POSTGRESQL_PASSWORD=postgres
-      - POSTGRESQL_DATABASE=postgres
+      - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres" ]
       interval: 2s
@@ -127,16 +127,13 @@ services:
       iceberg_net:
 
   minio:
-    image: bitnami/minio:2025.4.22
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     environment:
       - MINIO_ROOT_USER=minio-root-user
       - MINIO_ROOT_PASSWORD=minio-root-password
-      - MINIO_API_PORT_NUMBER=9000
-      - MINIO_CONSOLE_PORT_NUMBER=9001
-      - MINIO_SCHEME=http
-      - MINIO_DEFAULT_BUCKETS=examples
+    command: [ "server", "--console-address", ":9001", "/data" ]
     healthcheck:
-      test: [ "CMD", "mc", "ls", "local", "|", "grep", "examples" ]
+      test: [ "CMD", "mc", "ready", "local" ]
       interval: 2s
       timeout: 10s
       retries: 2
@@ -146,7 +143,21 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
-  
+
+  createbuckets:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    restart: on-failure
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5;
+      /usr/bin/mc alias set dockerminio http://minio:9000 minio-root-user minio-root-password;
+      /usr/bin/mc mb dockerminio/examples;
+      exit 0;
+      "
+
   trino:
     image: trinodb/trino:467
     environment:

--- a/examples/minimal/docker-compose.yaml
+++ b/examples/minimal/docker-compose.yaml
@@ -93,6 +93,8 @@ services:
         condition: service_healthy
       bootstrap:
         condition: service_completed_successfully
+      createbuckets:
+        condition: service_completed_successfully
     restart: "no"
     command:
       - -w
@@ -157,6 +159,8 @@ services:
       /usr/bin/mc mb dockerminio/examples;
       exit 0;
       "
+    networks:
+      iceberg_net:
 
   trino:
     image: trinodb/trino:467

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -160,6 +160,8 @@ services:
       /usr/bin/mc mb dockerminio/tests;
       exit 0;
       "
+    networks:
+      iceberg_net:
 
   nats:
     image: nats:latest

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -122,13 +122,13 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -p 2345 -d postgres"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres"]
       interval: 2s
       timeout: 10s
       retries: 2
       start_period: 20s
     ports:
-      - "31102:2345"
+      - "31102:5432"
     networks:
       - iceberg_rest_tests
 

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -63,8 +63,8 @@ services:
     image: ${LAKEKEEPER_TEST__SERVER_IMAGE}
     environment:
       - ICEBERG_REST__PG_ENCRYPTION_KEY=abc
-      - ICEBERG_REST__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:2345/postgres
-      - ICEBERG_REST__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@db:2345/postgres
+      - ICEBERG_REST__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:5432/postgres
+      - ICEBERG_REST__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@db:5432/postgres
       - RUST_LOG=trace,axum=trace
     restart: "no"
     command: ["migrate"]
@@ -78,8 +78,8 @@ services:
     image: ${LAKEKEEPER_TEST__SERVER_IMAGE}
     environment:
       - ICEBERG_REST__PG_ENCRYPTION_KEY=abc
-      - ICEBERG_REST__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:2345/postgres
-      - ICEBERG_REST__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@db:2345/postgres
+      - ICEBERG_REST__PG_DATABASE_URL_READ=postgresql://postgres:postgres@db:5432/postgres
+      - ICEBERG_REST__PG_DATABASE_URL_WRITE=postgresql://postgres:postgres@db:5432/postgres
       - ICEBERG_REST__NATS_ADDRESS=nats://nats:4222
       - ICEBERG_REST__NATS_TOPIC=changes
       - ICEBERG_REST__NATS_USER=test
@@ -165,7 +165,7 @@ services:
 
   nats:
     image: nats:latest
-    command: [ "nats-server",  "-m=8222", "--user=test", "--pass=test" ]
+    command: [ "-m=8222", "--user=test", "--pass=test" ]
     ports:
       - "31105:4222"
     healthcheck:

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -161,7 +161,7 @@ services:
       exit 0;
       "
     networks:
-      iceberg_net:
+      - iceberg_rest_tests
 
   nats:
     image: nats:latest

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -108,6 +108,8 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+      createbuckets:
+        condition: service_completed_successfully
       nats:
         condition: service_started
       keycloak:
@@ -116,13 +118,9 @@ services:
       - iceberg_rest_tests
 
   db:
-    image: bitnami/postgresql:16.3.0
+    image: postgres:16
     environment:
-      - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=postgres
-      - PGUSER=postgres
-      - POSTGRESQL_PORT_NUMBER=2345
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -p 2345 -d postgres"]
       interval: 2s
@@ -135,16 +133,13 @@ services:
       - iceberg_rest_tests
 
   minio:
-    image: bitnami/minio:2025.4.22
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     environment:
       - MINIO_ROOT_USER=minio-root-user
       - MINIO_ROOT_PASSWORD=minio-root-password
-      - MINIO_API_PORT_NUMBER=9000
-      - MINIO_CONSOLE_PORT_NUMBER=9001
-      - MINIO_SCHEME=http
-      - MINIO_DEFAULT_BUCKETS=tests
+    command: [ "server", "--console-address", ":9001", "/data" ]
     healthcheck:
-      test: ["CMD", "curl", "-I", "http://localhost:9000/minio/health/live"]
+      test: [ "CMD", "mc", "ready", "local" ]
       interval: 2s
       timeout: 10s
       retries: 2
@@ -152,8 +147,22 @@ services:
     networks:
       - iceberg_rest_tests
 
+  createbuckets:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    restart: on-failure
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5;
+      /usr/bin/mc alias set dockerminio http://minio:9000 minio-root-user minio-root-password;
+      /usr/bin/mc mb dockerminio/tests;
+      exit 0;
+      "
+
   nats:
-    image: bitnami/nats:2.10.23
+    image: nats:latest
     command: [ "nats-server",  "-m=8222", "--user=test", "--pass=test" ]
     ports:
       - "31105:4222"

--- a/tests/migrations/docker-compose.yaml
+++ b/tests/migrations/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+      createbuckets:
+        condition: service_completed_successfully
     networks:
       iceberg_net:
     ports:
@@ -53,6 +55,8 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+      createbuckets:
+        condition: service_completed_successfully
     networks:
       iceberg_net:
     ports:
@@ -71,11 +75,9 @@ services:
       iceberg_net:
 
   db:
-    image: bitnami/postgresql:16.3.0
+    image: postgres:16
     environment:
-      - POSTGRESQL_USERNAME=postgres
-      - POSTGRESQL_PASSWORD=postgres
-      - POSTGRESQL_DATABASE=postgres
+      - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres -p 5432 -d postgres" ]
       interval: 2s
@@ -86,16 +88,13 @@ services:
       iceberg_net:
 
   minio:
-    image: bitnami/minio:2025.4.22
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     environment:
       - MINIO_ROOT_USER=minio-root-user
       - MINIO_ROOT_PASSWORD=minio-root-password
-      - MINIO_API_PORT_NUMBER=9000
-      - MINIO_CONSOLE_PORT_NUMBER=9001
-      - MINIO_SCHEME=http
-      - MINIO_DEFAULT_BUCKETS=examples
+    command: [ "server", "--console-address", ":9001", "/data" ]
     healthcheck:
-      test: [ "CMD", "mc", "ls", "local", "|", "grep", "examples" ]
+      test: [ "CMD", "mc", "ready", "local" ]
       interval: 2s
       timeout: 10s
       retries: 2
@@ -105,6 +104,20 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
+
+  createbuckets:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    restart: on-failure
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5;
+      /usr/bin/mc alias set dockerminio http://minio:9000 minio-root-user minio-root-password;
+      /usr/bin/mc mb dockerminio/examples;
+      exit 0;
+      "
 
   bootstrap:
     image: curlimages/curl

--- a/tests/migrations/docker-compose.yaml
+++ b/tests/migrations/docker-compose.yaml
@@ -118,6 +118,8 @@ services:
       /usr/bin/mc mb dockerminio/examples;
       exit 0;
       "
+    networks:
+      iceberg_net:
 
   bootstrap:
     image: curlimages/curl
@@ -148,6 +150,8 @@ services:
       lakekeeper_initial:
         condition: service_healthy
       bootstrap:
+        condition: service_completed_successfully
+      createbuckets:
         condition: service_completed_successfully
     restart: "no"
     command:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a service to auto-create MinIO buckets; dependent services now wait for bucket creation before starting.

- Chores
  - Migrated to official Postgres 16 images and simplified DB environment variables.
  - Upgraded MinIO to newer official releases, standardized server+console startup, data paths, and healthchecks.
  - Upgraded NATS image.
  - CI MinIO image tag updated in unit test workflow.

- Tests
  - Test compose setups now pre-create buckets and use updated images/healthchecks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->