### PR TITLE
fix: accept "disable" as PG sslmode as documented

### DIFF
--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -577,12 +577,12 @@ impl FromStr for PgSslMode {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_ref() {
-            "disabled" => Ok(Self::Disable),
+            "disabled" | "disable" => Ok(Self::Disable),
             "allow" => Ok(Self::Allow),
             "prefer" => Ok(Self::Prefer),
             "require" => Ok(Self::Require),
-            "verifyca" => Ok(Self::VerifyCa),
-            "verifyfull" => Ok(Self::VerifyFull),
+            "verifyca" | "verify-ca" | "verify_ca" => Ok(Self::VerifyCa),
+            "verifyfull" | "verify-full" | "verify_full" => Ok(Self::VerifyFull),
             _ => Err(anyhow!("PgSslMode not supported: '{}'", s)),
         }
     }
@@ -800,6 +800,18 @@ mod test {
         });
         figment::Jail::expect_with(|jail| {
             jail.set_env("LAKEKEEPER_TEST__PG_SSL_MODE", "disabled");
+            let config = get_config();
+            assert_eq!(config.pg_ssl_mode, Some(PgSslMode::Disable));
+            Ok(())
+        });
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__PG_SSL_MODE", "disable");
+            let config = get_config();
+            assert_eq!(config.pg_ssl_mode, Some(PgSslMode::Disable));
+            Ok(())
+        });
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__PG_SSL_MODE", "Disable");
             let config = get_config();
             assert_eq!(config.pg_ssl_mode, Some(PgSslMode::Disable));
             Ok(())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now accepts additional aliases for database SSL modes. “disable/disabled”, “verifyca/verify-ca/verify_ca”, and “verifyfull/verify-full/verify_full” are recognized case-insensitively, reducing setup friction and typos.
* **Tests**
  * Expanded test coverage for the new SSL mode aliases and case-insensitive parsing to ensure consistent behavior across accepted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->