### PR TITLE
feat: Provide `ApiContext` to externally registered tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ itertools = "0.14.0"
 mockall = "0.13.0"
 needs_env_var = "1.1.0"
 http = "^1.1"
-derive_more = { version = "^2.0.0", features = ["from"] }
+derive_more = { version = "^2.0.0", features = ["from", "debug"] }
 flate2 = "^1.0"
 lazy_static = "^1.4"
 futures = "^0.3"

--- a/crates/lakekeeper/src/api/management/v1/bootstrap.rs
+++ b/crates/lakekeeper/src/api/management/v1/bootstrap.rs
@@ -203,14 +203,11 @@ pub(crate) trait Service<C: Catalog, A: Authorizer, S: SecretStore> {
             aws_system_identities_enabled: CONFIG.enable_aws_system_credentials,
             azure_system_identities_enabled: CONFIG.enable_azure_system_credentials,
             gcp_system_identities_enabled: CONFIG.enable_gcp_system_credentials,
-            queues: state
-                .v1_state
-                .registered_task_queues
-                .queue_names()
-                .await
-                .into_iter()
-                .map(ToString::to_string)
-                .collect(),
+            queues: {
+                let mut names = state.v1_state.registered_task_queues.queue_names().await;
+                names.sort_unstable();
+                names.into_iter().map(ToString::to_string).collect()
+            },
         })
     }
 }

--- a/crates/lakekeeper/src/api/management/v1/bootstrap.rs
+++ b/crates/lakekeeper/src/api/management/v1/bootstrap.rs
@@ -207,6 +207,7 @@ pub(crate) trait Service<C: Catalog, A: Authorizer, S: SecretStore> {
                 .v1_state
                 .registered_task_queues
                 .queue_names()
+                .await
                 .into_iter()
                 .map(ToString::to_string)
                 .collect(),

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -991,7 +991,9 @@ pub trait Service<C: Catalog, A: Authorizer, S: SecretStore> {
             existing_queue_names.sort_unstable();
             let existing_queue_names = existing_queue_names.join(", ");
             return Err(ErrorModel::bad_request(
-                format!("Queue '{queue_name}' not found! Existing queues: [{existing_queue_names}]"),
+                format!(
+                    "Queue '{queue_name}' not found! Existing queues: [{existing_queue_names}]"
+                ),
                 "QueueNotFound",
                 None,
             )

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -976,7 +976,7 @@ pub trait Service<C: Catalog, A: Authorizer, S: SecretStore> {
         // ------------------- Business Logic -------------------
         let task_queues = context.v1_state.registered_task_queues;
 
-        if let Some(validate_config_fn) = task_queues.validate_config_fn(&queue_name) {
+        if let Some(validate_config_fn) = task_queues.validate_config_fn(&queue_name).await {
             validate_config_fn(request.queue_config.0.clone()).map_err(|e| {
                 ErrorModel::bad_request(
                     format!(
@@ -987,7 +987,7 @@ pub trait Service<C: Catalog, A: Authorizer, S: SecretStore> {
                 )
             })?;
         } else {
-            let existing_queue_names = task_queues.queue_names();
+            let existing_queue_names = task_queues.queue_names().await;
             return Err(ErrorModel::bad_request(
                 format!(
                     "Queue '{queue_name}' not found! Existing queues: [{existing_queue_names:?}]"

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -987,11 +987,11 @@ pub trait Service<C: Catalog, A: Authorizer, S: SecretStore> {
                 )
             })?;
         } else {
-            let existing_queue_names = task_queues.queue_names().await;
+            let mut existing_queue_names = task_queues.queue_names().await;
+            existing_queue_names.sort_unstable();
+            let existing_queue_names = existing_queue_names.join(", ");
             return Err(ErrorModel::bad_request(
-                format!(
-                    "Queue '{queue_name}' not found! Existing queues: [{existing_queue_names:?}]"
-                ),
+                format!("Queue '{queue_name}' not found! Existing queues: [{existing_queue_names}]"),
                 "QueueNotFound",
                 None,
             )

--- a/crates/lakekeeper/src/api/router.rs
+++ b/crates/lakekeeper/src/api/router.rs
@@ -84,7 +84,7 @@ impl<C: Catalog, A: Authorizer + Clone, S: SecretStore, N: Authenticator + Debug
 ///
 /// # Errors
 /// - Fails if the token verifier chain cannot be created
-pub fn new_full_router<
+pub async fn new_full_router<
     C: Catalog,
     A: Authorizer + Clone,
     S: SecretStore,
@@ -136,7 +136,8 @@ pub fn new_full_router<
                 Json(health).into_response()
             }),
         );
-    let router = maybe_merge_swagger_router(router, registered_task_queues.api_config())
+    let registered_api_config = registered_task_queues.api_config().await;
+    let router = maybe_merge_swagger_router(router, registered_api_config.iter().collect())
         .layer(axum::middleware::from_fn(
             create_request_metadata_with_trace_and_project_fn,
         ))

--- a/crates/lakekeeper/src/catalog/views.rs
+++ b/crates/lakekeeper/src/catalog/views.rs
@@ -164,7 +164,7 @@ mod test {
         NamespaceIdent,
         WarehouseId,
     ) {
-        let api_context = crate::tests::get_api_context(&pool, AllowAllAuthorizer);
+        let api_context = crate::tests::get_api_context(&pool, AllowAllAuthorizer).await;
         let state = api_context.v1_state.catalog.clone();
         let warehouse_id = initialize_warehouse(
             state.clone(),

--- a/crates/lakekeeper/src/serve.rs
+++ b/crates/lakekeeper/src/serve.rs
@@ -64,11 +64,11 @@ fn log_service_completion<H: ::std::hash::BuildHasher>(
                     if during_shutdown {
                         let msg =
                             format!("Service '{task_name}' finished gracefully during shutdown");
-                        tracing::info!(msg);
+                        tracing::info!("{msg}");
                         msg
                     } else {
                         let msg = format!("Service '{task_name}' finished successfully but was supposed to run indefinitely");
-                        tracing::info!(msg);
+                        tracing::info!("{msg}");
                         msg
                     }
                 }
@@ -76,11 +76,11 @@ fn log_service_completion<H: ::std::hash::BuildHasher>(
                     if during_shutdown {
                         let msg =
                             format!("Service '{task_name}' exited with error during shutdown: {e}");
-                        tracing::warn!(msg);
+                        tracing::warn!("{msg}");
                         msg
                     } else {
                         let msg = format!("Service '{task_name}' exited with error: {e}");
-                        tracing::error!(msg);
+                        tracing::error!("{msg}");
                         msg
                     }
                 }
@@ -89,11 +89,11 @@ fn log_service_completion<H: ::std::hash::BuildHasher>(
         Err(join_err) => {
             if during_shutdown {
                 let msg = format!("Service join error during shutdown: {join_err}");
-                tracing::warn!(msg);
+                tracing::warn!("{msg}");
                 msg
             } else {
                 let msg = format!("Service join error: {join_err}");
-                tracing::error!(msg);
+                tracing::error!("{msg}");
                 msg
             }
         }
@@ -196,8 +196,6 @@ pub async fn serve<C: Catalog, S: SecretStore, A: Authorizer, N: Authenticator +
     .await;
 
     // Handle shutdown if serve_inner returned (e.g. due to error)
-    cancellation_token.cancel();
-
     tracing::debug!("Sending shutdown signal to threads");
     cancellation_token.cancel();
 

--- a/crates/lakekeeper/src/serve.rs
+++ b/crates/lakekeeper/src/serve.rs
@@ -46,7 +46,7 @@ pub type RegisterBackgroundServiceFn<A, C, S> = std::sync::Arc<
 >;
 
 pub type RegisterTaskQueueFn<A, C, S> = std::sync::Arc<
-    dyn Fn(&mut TaskQueueRegistry, ApiContext<State<A, C, S>>) -> anyhow::Result<()> + Send + Sync,
+    dyn Fn(&TaskQueueRegistry, ApiContext<State<A, C, S>>) -> anyhow::Result<()> + Send + Sync,
 >;
 
 /// Helper function to process the result of a service task completion
@@ -215,7 +215,7 @@ pub async fn serve<C: Catalog, S: SecretStore, A: Authorizer, N: Authenticator +
     hooks.append(Arc::new(CloudEventsPublisher::new(cloud_events_tx.clone())));
 
     // Task queues
-    let mut task_queue_registry = TaskQueueRegistry::new();
+    let task_queue_registry = TaskQueueRegistry::new();
     if enable_built_in_queues {
         task_queue_registry
             .register_built_in_queues::<C, _, _>(
@@ -243,7 +243,7 @@ pub async fn serve<C: Catalog, S: SecretStore, A: Authorizer, N: Authenticator +
     };
 
     for register_fn in register_additional_task_queues_fn {
-        register_fn(&mut task_queue_registry, state.clone())?;
+        register_fn(&task_queue_registry, state.clone())?;
     }
 
     // Router

--- a/crates/lakekeeper/src/service/task_queue/mod.rs
+++ b/crates/lakekeeper/src/service/task_queue/mod.rs
@@ -12,6 +12,7 @@ use futures::future::BoxFuture;
 use iceberg_ext::catalog::rest::IcebergErrorResponse;
 use serde::{de::DeserializeOwned, Serialize};
 use strum::EnumIter;
+use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -69,7 +70,7 @@ pub trait TaskData: Clone + Serialize + DeserializeOwned {}
 #[derive(Clone, Default, Debug)]
 pub struct RegisteredTaskQueues {
     // Mapping of queue names to their configurations
-    queues: Arc<HashMap<&'static str, RegisteredQueue>>,
+    queues: Arc<RwLock<HashMap<&'static str, RegisteredQueue>>>,
 }
 
 impl RegisteredTaskQueues {
@@ -78,22 +79,29 @@ impl RegisteredTaskQueues {
     /// # Returns
     /// Some(ValidatorFn) if the queue exists, None otherwise
     #[must_use]
-    pub fn validate_config_fn(&self, queue_name: &str) -> Option<ValidatorFn> {
+    pub async fn validate_config_fn(&self, queue_name: &str) -> Option<ValidatorFn> {
         self.queues
+            .read()
+            .await
             .get(queue_name)
             .map(|q| Arc::clone(&q.schema_validator_fn))
     }
 
     /// Get the API configuration for all registered queues
     #[must_use]
-    pub fn api_config(&self) -> Vec<&QueueApiConfig> {
-        self.queues.values().map(|q| &q.api_config).collect()
+    pub async fn api_config(&self) -> Vec<QueueApiConfig> {
+        self.queues
+            .read()
+            .await
+            .values()
+            .map(|q| q.api_config.clone())
+            .collect()
     }
 
     /// Get the names of all registered queues
     #[must_use]
-    pub fn queue_names(&self) -> Vec<&'static str> {
-        self.queues.keys().copied().collect()
+    pub async fn queue_names(&self) -> Vec<&'static str> {
+        self.queues.read().await.keys().copied().collect()
     }
 }
 
@@ -135,9 +143,9 @@ impl Debug for RegisteredTaskQueueWorker {
 #[derive(Debug)]
 pub struct TaskQueueRegistry {
     // Mapping of queue names to their configurations
-    registered_queues: HashMap<&'static str, RegisteredQueue>,
+    registered_queues: Arc<RwLock<HashMap<&'static str, RegisteredQueue>>>,
     // Mapping of queue names to their worker configuration
-    task_workers: HashMap<&'static str, RegisteredTaskQueueWorker>,
+    task_workers: Arc<RwLock<HashMap<&'static str, RegisteredTaskQueueWorker>>>,
 }
 
 impl Default for TaskQueueRegistry {
@@ -170,12 +178,15 @@ impl TaskQueueRegistry {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            registered_queues: HashMap::new(),
-            task_workers: HashMap::new(),
+            registered_queues: Arc::new(RwLock::new(HashMap::new())),
+            task_workers: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
-    pub fn register_queue<T: QueueConfig>(&mut self, task_queue: QueueRegistration) -> &mut Self {
+    pub async fn register_queue<T: QueueConfig>(
+        &mut self,
+        task_queue: QueueRegistration,
+    ) -> &mut Self {
         let QueueRegistration {
             queue_name,
             worker_fn,
@@ -191,7 +202,7 @@ impl TaskQueueRegistry {
             )),
         };
 
-        self.registered_queues.insert(
+        self.registered_queues.write().await.insert(
             queue_name,
             RegisteredQueue {
                 api_config,
@@ -199,7 +210,7 @@ impl TaskQueueRegistry {
             },
         );
 
-        self.task_workers.insert(
+        self.task_workers.write().await.insert(
             queue_name,
             RegisteredTaskQueueWorker {
                 worker_fn,
@@ -209,7 +220,7 @@ impl TaskQueueRegistry {
         self
     }
 
-    pub fn register_built_in_queues<C: Catalog, S: SecretStore, A: Authorizer>(
+    pub async fn register_built_in_queues<C: Catalog, S: SecretStore, A: Authorizer>(
         &mut self,
         catalog_state: C::State,
         secret_store: S,
@@ -235,7 +246,8 @@ impl TaskQueueRegistry {
                 })
             }),
             num_workers: 2,
-        });
+        })
+        .await;
 
         self.register_queue::<PurgeQueueConfig>(QueueRegistration {
             queue_name: tabular_purge_queue::QUEUE_NAME,
@@ -253,7 +265,8 @@ impl TaskQueueRegistry {
                 })
             }),
             num_workers: 2,
-        });
+        })
+        .await;
 
         self
     }
@@ -262,27 +275,33 @@ impl TaskQueueRegistry {
     #[must_use]
     pub fn registered_task_queues(&self) -> RegisteredTaskQueues {
         RegisteredTaskQueues {
-            queues: Arc::new(self.registered_queues.clone()),
+            // It is important to share the interior mutable state,
+            // so that tasks that register later are reflected to the state
+            // that previously registered tasks have a reference to.
+            queues: self.registered_queues.clone(),
         }
     }
 
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.registered_queues.len()
+    pub async fn len(&self) -> usize {
+        self.registered_queues.read().await.len()
     }
 
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.registered_queues.is_empty()
+    pub async fn is_empty(&self) -> bool {
+        self.registered_queues.read().await.is_empty()
     }
 
     /// Creates a [`TaskQueuesRunner`] that can be used to start the task queue workers
     #[must_use]
-    pub fn task_queues_runner(&self, cancellation_token: CancellationToken) -> TaskQueuesRunner {
+    pub async fn task_queues_runner(
+        &self,
+        cancellation_token: CancellationToken,
+    ) -> TaskQueuesRunner {
         let mut registered_task_queues = HashMap::new();
 
-        for name in self.registered_queues.keys() {
-            if let Some(worker) = self.task_workers.get(name) {
+        for name in self.registered_queues.read().await.keys() {
+            if let Some(worker) = self.task_workers.read().await.get(name) {
                 registered_task_queues.insert(
                     *name,
                     QueueWorkerConfig {
@@ -1005,6 +1024,116 @@ mod test {
         },
     };
 
+    #[tokio::test]
+    async fn test_shared_interior_mutable_state() {
+        // This test verifies that RegisteredTaskQueues instances share the same
+        // interior mutable state, so that tasks registered later are reflected
+        // in previously created RegisteredTaskQueues instances.
+        
+        let mut registry = crate::service::task_queue::TaskQueueRegistry::new();
+        
+        // Create an initial RegisteredTaskQueues instance before registering any queues
+        let initial_queues = registry.registered_task_queues();
+        
+        // Verify registry starts empty and initial_queues reflects this
+        assert_eq!(registry.len().await, 0);
+        assert!(registry.is_empty().await);
+        assert!(initial_queues.api_config().await.is_empty());
+        
+        // Register a test queue
+        use super::QueueConfig;
+        use serde::{Deserialize, Serialize};
+        use utoipa::ToSchema;
+        
+        #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+        struct TestQueueConfig {
+            test_field: String,
+        }
+        
+        impl QueueConfig for TestQueueConfig {
+            fn queue_name() -> &'static str {
+                "test-queue"
+            }
+        }
+        
+        registry.register_queue::<TestQueueConfig>(super::QueueRegistration {
+            queue_name: "test-queue",
+            worker_fn: std::sync::Arc::new(move |_cancellation_token| {
+                Box::pin(async {
+                    // Empty worker for testing
+                })
+            }),
+            num_workers: 1,
+        }).await;
+        
+        // Create another RegisteredTaskQueues instance after registration
+        let later_queues = registry.registered_task_queues();
+        
+        // Registry should now show the registered queue
+        assert_eq!(registry.len().await, 1);
+        assert!(!registry.is_empty().await);
+        
+        // Both RegisteredTaskQueues instances should now see the registered queue due to shared state
+        let initial_api_config = initial_queues.api_config().await;
+        let later_api_config = later_queues.api_config().await;
+        assert_eq!(initial_api_config.len(), 1);
+        assert_eq!(later_api_config.len(), 1);
+        assert_eq!(initial_api_config[0].queue_name, "test-queue");
+        assert_eq!(later_api_config[0].queue_name, "test-queue");
+        
+        // Both should have access to the validator function
+        assert!(initial_queues.validate_config_fn("test-queue").await.is_some());
+        assert!(later_queues.validate_config_fn("test-queue").await.is_some());
+        assert!(initial_queues.validate_config_fn("non-existent").await.is_none());
+        assert!(later_queues.validate_config_fn("non-existent").await.is_none());
+        
+        // Register another queue and verify both instances see it
+        #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+        struct SecondTestQueueConfig {
+            other_field: i32,
+        }
+        
+        impl QueueConfig for SecondTestQueueConfig {
+            fn queue_name() -> &'static str {
+                "second-test-queue"
+            }
+        }
+        
+        registry.register_queue::<SecondTestQueueConfig>(super::QueueRegistration {
+            queue_name: "second-test-queue",
+            worker_fn: std::sync::Arc::new(move |_cancellation_token| {
+                Box::pin(async {
+                    // Empty worker for testing
+                })
+            }),
+            num_workers: 2,
+        }).await;
+        
+        // Registry should now show both queues
+        assert_eq!(registry.len().await, 2);
+        
+        // Both RegisteredTaskQueues instances should now see both queues due to shared interior mutable state
+        let initial_api_config = initial_queues.api_config().await;
+        let later_api_config = later_queues.api_config().await;
+        assert_eq!(initial_api_config.len(), 2);
+        assert_eq!(later_api_config.len(), 2);
+        
+        // Check that both queues are accessible from both instances
+        assert!(initial_queues.validate_config_fn("test-queue").await.is_some());
+        assert!(initial_queues.validate_config_fn("second-test-queue").await.is_some());
+        assert!(later_queues.validate_config_fn("test-queue").await.is_some());
+        assert!(later_queues.validate_config_fn("second-test-queue").await.is_some());
+        
+        // Verify that the queue names are correctly registered in both instances
+        let mut initial_queue_names: Vec<_> = initial_api_config.iter().map(|q| q.queue_name).collect();
+        let mut later_queue_names: Vec<_> = later_api_config.iter().map(|q| q.queue_name).collect();
+        initial_queue_names.sort();
+        later_queue_names.sort();
+        
+        assert_eq!(initial_queue_names, vec!["second-test-queue", "test-queue"]);
+        assert_eq!(later_queue_names, vec!["second-test-queue", "test-queue"]);
+    }
+
     #[sqlx::test]
     #[traced_test]
     async fn test_queue_expiration_queue_task(pool: PgPool) {
@@ -1017,14 +1146,16 @@ mod test {
         let cat = catalog_state.clone();
         let sec = secrets.clone();
         let auth = AllowAllAuthorizer;
-        queues.register_built_in_queues::<PostgresCatalog, SecretsState, AllowAllAuthorizer>(
-            cat,
-            sec,
-            auth,
-            Duration::from_millis(100),
-        );
+        queues
+            .register_built_in_queues::<PostgresCatalog, SecretsState, AllowAllAuthorizer>(
+                cat,
+                sec,
+                auth,
+                Duration::from_millis(100),
+            )
+            .await;
         let cancellation_token = tokio_util::sync::CancellationToken::new();
-        let runner = queues.task_queues_runner(cancellation_token.clone());
+        let runner = queues.task_queues_runner(cancellation_token.clone()).await;
         let _queue_task = tokio::task::spawn(runner.run_queue_workers(true));
 
         let warehouse = initialize_warehouse(

--- a/crates/lakekeeper/src/service/task_queue/mod.rs
+++ b/crates/lakekeeper/src/service/task_queue/mod.rs
@@ -183,10 +183,7 @@ impl TaskQueueRegistry {
         }
     }
 
-    pub async fn register_queue<T: QueueConfig>(
-        &mut self,
-        task_queue: QueueRegistration,
-    ) -> &mut Self {
+    pub async fn register_queue<T: QueueConfig>(&self, task_queue: QueueRegistration) -> &Self {
         let QueueRegistration {
             queue_name,
             worker_fn,
@@ -221,12 +218,12 @@ impl TaskQueueRegistry {
     }
 
     pub async fn register_built_in_queues<C: Catalog, S: SecretStore, A: Authorizer>(
-        &mut self,
+        &self,
         catalog_state: C::State,
         secret_store: S,
         authorizer: A,
         poll_interval: Duration,
-    ) -> &mut Self {
+    ) -> &Self {
         let catalog_state_clone = catalog_state.clone();
         self.register_queue::<ExpirationQueueConfig>(QueueRegistration {
             queue_name: tabular_expiration_queue::QUEUE_NAME,
@@ -1059,7 +1056,7 @@ mod test {
             }
         }
 
-        let mut registry = crate::service::task_queue::TaskQueueRegistry::new();
+        let registry = crate::service::task_queue::TaskQueueRegistry::new();
 
         // Create an initial RegisteredTaskQueues instance before registering any queues
         let initial_queues = registry.registered_task_queues();
@@ -1169,7 +1166,7 @@ mod test {
     async fn test_queue_expiration_queue_task(pool: PgPool) {
         let catalog_state = CatalogState::from_pools(pool.clone(), pool.clone());
 
-        let mut queues = crate::service::task_queue::TaskQueueRegistry::new();
+        let queues = crate::service::task_queue::TaskQueueRegistry::new();
 
         let secrets =
             crate::implementations::postgres::SecretsState::from_pools(pool.clone(), pool);

--- a/crates/lakekeeper/src/service/task_queue/mod.rs
+++ b/crates/lakekeeper/src/service/task_queue/mod.rs
@@ -1000,14 +1000,14 @@ pub const fn valid_max_time_since_last_heartbeat(num: i64) -> chrono::Duration {
 #[cfg(test)]
 mod test {
 
-    use super::*;
+    use std::time::Duration;
 
     use serde::{Deserialize, Serialize};
     use sqlx::PgPool;
-    use std::time::Duration;
     use tracing_test::traced_test;
     use utoipa::ToSchema;
 
+    use super::*;
     use crate::{
         api::{
             iceberg::v1::PaginationQuery,

--- a/crates/lakekeeper/src/service/task_queue/mod.rs
+++ b/crates/lakekeeper/src/service/task_queue/mod.rs
@@ -554,8 +554,8 @@ pub struct SpecializedTask<C: QueueConfig, P: TaskData> {
     pub status: TaskStatus,
     pub picked_up_at: Option<chrono::DateTime<Utc>>,
     pub attempt: i32,
-    pub(crate) config: Option<C>,
-    pub(crate) data: P,
+    pub config: Option<C>,
+    pub data: P,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/lakekeeper/src/service/task_queue/mod.rs
+++ b/crates/lakekeeper/src/service/task_queue/mod.rs
@@ -13,6 +13,7 @@ use iceberg_ext::catalog::rest::IcebergErrorResponse;
 use serde::{de::DeserializeOwned, Serialize};
 use strum::EnumIter;
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -26,7 +27,6 @@ use crate::service::{
 
 pub mod tabular_expiration_queue;
 pub mod tabular_purge_queue;
-pub use crate::CancellationToken;
 
 pub(crate) const DEFAULT_MAX_TIME_SINCE_LAST_HEARTBEAT: chrono::Duration =
     valid_max_time_since_last_heartbeat(3600);
@@ -42,8 +42,9 @@ pub static BUILT_IN_API_CONFIGS: LazyLock<Vec<QueueApiConfig>> = LazyLock::new(|
 
 /// Infinitely running task worker loop function that polls tasks from a queue and
 /// processes. Accepts a cancellation token for graceful shutdown.
-pub type TaskQueueWorker =
-    Arc<dyn Fn(CancellationToken) -> BoxFuture<'static, ()> + Send + Sync + 'static>;
+pub type TaskQueueWorker = Arc<
+    dyn Fn(tokio_util::sync::CancellationToken) -> BoxFuture<'static, ()> + Send + Sync + 'static,
+>;
 type ValidatorFn = Arc<dyn Fn(serde_json::Value) -> serde_json::Result<()> + Send + Sync>;
 
 /// Warehouse specific configuration for a task queue.
@@ -299,8 +300,11 @@ impl TaskQueueRegistry {
     ) -> TaskQueuesRunner {
         let mut registered_task_queues = HashMap::new();
 
-        for name in self.registered_queues.read().await.keys() {
-            if let Some(worker) = self.task_workers.read().await.get(name) {
+        let queues = self.registered_queues.read().await;
+        let workers = self.task_workers.read().await;
+
+        for name in queues.keys() {
+            if let Some(worker) = workers.get(name) {
                 registered_task_queues.insert(
                     *name,
                     QueueWorkerConfig {
@@ -550,8 +554,8 @@ pub struct SpecializedTask<C: QueueConfig, P: TaskData> {
     pub status: TaskStatus,
     pub picked_up_at: Option<chrono::DateTime<Utc>>,
     pub attempt: i32,
-    pub config: Option<C>,
-    pub data: P,
+    pub(crate) config: Option<C>,
+    pub(crate) data: P,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -663,7 +667,7 @@ impl<Q: QueueConfig, D: TaskData> SpecializedTask<Q, D> {
     pub async fn poll_for_new_task<C: Catalog>(
         catalog_state: C::State,
         poll_interval: &Duration,
-        cancellation_token: crate::CancellationToken,
+        cancellation_token: tokio_util::sync::CancellationToken,
     ) -> Option<Self> {
         loop {
             tokio::select! {

--- a/crates/lakekeeper/src/service/task_queue/tabular_purge_queue.rs
+++ b/crates/lakekeeper/src/service/task_queue/tabular_purge_queue.rs
@@ -56,7 +56,7 @@ pub(crate) async fn tabular_purge_worker<C: Catalog, S: SecretStore>(
             .await;
 
         let Some(task) = task else {
-            tracing::info!("Graceful shutdown: exiting tabular purge worker");
+            tracing::info!("Graceful shutdown: exiting `{QUEUE_NAME}` worker");
             return;
         };
 

--- a/crates/lakekeeper/src/tests/drop_warehouse.rs
+++ b/crates/lakekeeper/src/tests/drop_warehouse.rs
@@ -28,7 +28,7 @@ async fn test_cannot_drop_warehouse_before_purge_tasks_completed(pool: PgPool) {
     let storage_profile = crate::tests::memory_io_profile();
     let authorizer = AllowAllAuthorizer {};
 
-    let api_context = get_api_context(&pool, authorizer);
+    let api_context = get_api_context(&pool, authorizer).await;
 
     // Bootstrap
     ApiServer::bootstrap(
@@ -110,7 +110,8 @@ async fn test_cannot_drop_warehouse_before_purge_tasks_completed(pool: PgPool) {
         &api_context,
         Some(std::time::Duration::from_secs(1)),
         cancellation_token.clone(),
-    );
+    )
+    .await;
 
     // Drop warehouse — poll until purge tasks complete to avoid flakiness
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);

--- a/crates/lakekeeper/src/tests/drop_warehouse.rs
+++ b/crates/lakekeeper/src/tests/drop_warehouse.rs
@@ -106,7 +106,7 @@ async fn test_cannot_drop_warehouse_before_purge_tasks_completed(pool: PgPool) {
 
     // Spawn task queue workers
     let cancellation_token = crate::CancellationToken::new();
-    let queues_future = spawn_build_in_queues(
+    let queues_handle = spawn_build_in_queues(
         &api_context,
         Some(std::time::Duration::from_secs(1)),
         cancellation_token.clone(),
@@ -132,5 +132,5 @@ async fn test_cannot_drop_warehouse_before_purge_tasks_completed(pool: PgPool) {
         }
     }
     cancellation_token.cancel();
-    queues_future.await.unwrap();
+    queues_handle.await.unwrap();
 }

--- a/crates/lakekeeper/src/tests/mod.rs
+++ b/crates/lakekeeper/src/tests/mod.rs
@@ -275,8 +275,8 @@ pub(crate) async fn get_api_context<T: Authorizer>(
     let mut task_queues = TaskQueueRegistry::new();
     task_queues
         .register_built_in_queues::<PostgresCatalog, _, _>(
-            catalog_state,
-            secret_store,
+            catalog_state.clone(),
+            secret_store.clone(),
             auth.clone(),
             CONFIG.task_poll_interval,
         )
@@ -285,8 +285,8 @@ pub(crate) async fn get_api_context<T: Authorizer>(
     ApiContext {
         v1_state: State {
             authz: auth,
-            catalog: CatalogState::from_pools(pool.clone(), pool.clone()),
-            secrets: SecretsState::from_pools(pool.clone(), pool.clone()),
+            catalog: catalog_state,
+            secrets: secret_store,
             contract_verifiers: ContractVerifiers::new(vec![]),
             hooks: EndpointHookCollection::new(vec![]),
             registered_task_queues,
@@ -303,8 +303,6 @@ pub(crate) async fn spawn_build_in_queues<T: Authorizer>(
     poll_interval: Option<std::time::Duration>,
     cancellation_token: crate::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
-    let ctx = ctx.clone();
-
     let mut task_queues = TaskQueueRegistry::new();
     task_queues
         .register_built_in_queues::<PostgresCatalog, _, _>(

--- a/crates/lakekeeper/src/tests/mod.rs
+++ b/crates/lakekeeper/src/tests/mod.rs
@@ -272,7 +272,7 @@ pub(crate) async fn get_api_context<T: Authorizer>(
     let catalog_state = CatalogState::from_pools(pool.clone(), pool.clone());
     let secret_store = SecretsState::from_pools(pool.clone(), pool.clone());
 
-    let mut task_queues = TaskQueueRegistry::new();
+    let task_queues = TaskQueueRegistry::new();
     task_queues
         .register_built_in_queues::<PostgresCatalog, _, _>(
             catalog_state.clone(),
@@ -303,7 +303,7 @@ pub(crate) async fn spawn_build_in_queues<T: Authorizer>(
     poll_interval: Option<std::time::Duration>,
     cancellation_token: crate::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
-    let mut task_queues = TaskQueueRegistry::new();
+    let task_queues = TaskQueueRegistry::new();
     task_queues
         .register_built_in_queues::<PostgresCatalog, _, _>(
             ctx.v1_state.catalog.clone(),

--- a/crates/lakekeeper/src/tests/stats.rs
+++ b/crates/lakekeeper/src/tests/stats.rs
@@ -27,7 +27,8 @@ mod test {
     async fn test_stats_task_produces_correct_values(pool: PgPool) {
         let setup = super::setup_stats_test(pool, 1, 1).await;
         let cancellation_token = tokio_util::sync::CancellationToken::new();
-        let queues_handle = spawn_build_in_queues(&setup.ctx, None, cancellation_token.clone());
+        let queues_handle =
+            spawn_build_in_queues(&setup.ctx, None, cancellation_token.clone()).await;
         let whi = setup.warehouse.warehouse_id;
         let stats = ApiServer::get_warehouse_statistics(
             whi,

--- a/crates/lakekeeper/src/tests/tasks.rs
+++ b/crates/lakekeeper/src/tests/tasks.rs
@@ -60,7 +60,7 @@ mod test {
         let result = Arc::new(Mutex::new(false));
         let result_clone = result.clone();
 
-        let mut task_queue_registry = TaskQueueRegistry::new();
+        let task_queue_registry = TaskQueueRegistry::new();
         task_queue_registry
             .register_queue::<Config>(QueueRegistration {
                 queue_name: QUEUE_NAME,

--- a/crates/lakekeeper/src/tests/tasks.rs
+++ b/crates/lakekeeper/src/tests/tasks.rs
@@ -61,35 +61,37 @@ mod test {
         let result_clone = result.clone();
 
         let mut task_queue_registry = TaskQueueRegistry::new();
-        task_queue_registry.register_queue::<Config>(QueueRegistration {
-            queue_name: QUEUE_NAME,
-            worker_fn: Arc::new(move |_| {
-                let ctx = ctx_clone.clone();
-                let rx = rx.clone();
-                let result_clone = result_clone.clone();
-                Box::pin(async move {
-                    let task_id = rx.recv().await.unwrap();
+        task_queue_registry
+            .register_queue::<Config>(QueueRegistration {
+                queue_name: QUEUE_NAME,
+                worker_fn: Arc::new(move |_| {
+                    let ctx = ctx_clone.clone();
+                    let rx = rx.clone();
+                    let result_clone = result_clone.clone();
+                    Box::pin(async move {
+                        let task_id = rx.recv().await.unwrap();
 
-                    let task = PostgresCatalog::pick_new_task(
-                        QUEUE_NAME,
-                        DEFAULT_MAX_TIME_SINCE_LAST_HEARTBEAT,
-                        ctx.v1_state.catalog.clone(),
-                    )
-                    .await
-                    .unwrap()
-                    .unwrap();
-                    let config = task.queue_config::<Config>().unwrap().unwrap();
-                    assert_eq!(config.some_val, "test_value");
+                        let task = PostgresCatalog::pick_new_task(
+                            QUEUE_NAME,
+                            DEFAULT_MAX_TIME_SINCE_LAST_HEARTBEAT,
+                            ctx.v1_state.catalog.clone(),
+                        )
+                        .await
+                        .unwrap()
+                        .unwrap();
+                        let config = task.queue_config::<Config>().unwrap().unwrap();
+                        assert_eq!(config.some_val, "test_value");
 
-                    assert_eq!(task_id, task.task_id);
+                        assert_eq!(task_id, task.task_id);
 
-                    let task = task.task_data::<TestTaskData>().unwrap();
-                    assert_eq!(task, task_state);
-                    *result_clone.lock().unwrap() = true;
-                })
-            }),
-            num_workers: 1,
-        });
+                        let task = task.task_data::<TestTaskData>().unwrap();
+                        assert_eq!(task, task_state);
+                        *result_clone.lock().unwrap() = true;
+                    })
+                }),
+                num_workers: 1,
+            })
+            .await;
         let mut transaction =
             <PostgresCatalog as Catalog>::Transaction::begin_write(catalog_state.clone())
                 .await
@@ -139,6 +141,7 @@ mod test {
         let task_handle = tokio::task::spawn(
             task_queue_registry
                 .task_queues_runner(cancellation_token.clone())
+                .await
                 .run_queue_workers(false),
         );
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improvements
  - Task queues are now concurrency-safe and fully asynchronous; registration, discovery, and runners await operations and error messages list existing queues. Shutdown logs include queue names.
- Refactor
  - Routing and server wiring unified around a single application state/context; background services and lifecycle are coordinated via the shared state.
- Documentation
  - OpenAPI/Swagger now incorporates current task-queue configs.
- Tests
  - Test harness and cases updated for async initialization and queue handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->