### PR TITLE
chore(ci): add configuration for CodeRabbit reviews + exclude `.sqlx`

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+reviews:
+  profile: chill
+  high_level_summary: true
+  auto_review:
+    enabled: true
+    # Auto review after every push can be too noisy.
+    # To manually request a review, comment
+    # - @coderabbitai review # new changes only
+    # - @coderabbitai full review # full review from scratch
+    auto_incremental_review: false
+    drafts: false
+  tools:
+    gitleaks:
+      enabled: true
+  path_filters:
+    - "!.sqlx/"


### PR DESCRIPTION
AFAIK files in `.sqlx` are generated based on queries in `.rs` files. Then it should be sufficient to have coderabbit review the `.rs` files to cover what's in `.sqlx`.

## Warning

Adding `.coderabbit.yaml` overrides this repo's coderabbit settings in other places.

Having the config in the repo would make it more explicit and allow collaborating on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration to enable automated code reviews for pull requests.
  * Enabled automated secret/leak scanning to improve security.
  * Applied path filtering to limit unnecessary checks.
  * No user-facing changes; improves development workflow and code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->