### PR TITLE
Remove useless startup check

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -192,9 +192,7 @@ jobs:
             "$MANAGEMENT_URL/v1/bootstrap" \
             -H "Authorization: Bearer $ACCESS_TOKEN" \
             -H "Content-Type: application/json" \
-            -d '{
-              "accept-terms-of-use": true
-            }' \
+            -d '{}' \
             || echo "Bootstrap may have already been completed"
 
       - name: Dump docker logs on failure

--- a/crates/lakekeeper/src/implementations/postgres/catalog.rs
+++ b/crates/lakekeeper/src/implementations/postgres/catalog.rs
@@ -86,10 +86,9 @@ impl Catalog for super::PostgresCatalog {
 
     // ---------------- Bootstrap ----------------
     async fn bootstrap<'a>(
-        terms_accepted: bool,
         transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'a>,
     ) -> Result<bool> {
-        bootstrap(terms_accepted, &mut **transaction).await
+        bootstrap(&mut **transaction).await
     }
 
     async fn get_warehouse_by_name(

--- a/crates/lakekeeper/src/serve.rs
+++ b/crates/lakekeeper/src/serve.rs
@@ -233,13 +233,8 @@ fn validate_server_info(server_info: &ServerInfo) -> anyhow::Result<()> {
         }
         ServerInfo::Bootstrapped {
             server_id,
-            terms_accepted,
         } => {
-            if !terms_accepted {
-                Err(anyhow!(
-                    "The terms of service have not been accepted on bootstrap."
-                ))
-            } else if *server_id != CONFIG.server_id {
+            if *server_id != CONFIG.server_id {
                 Err(anyhow!(
                     "The server ID during bootstrap {} does not match the server ID in the configuration {}.",
                     server_id, CONFIG.server_id

--- a/crates/lakekeeper/src/service/catalog.rs
+++ b/crates/lakekeeper/src/service/catalog.rs
@@ -203,8 +203,6 @@ pub enum ServerInfo {
     Bootstrapped {
         /// Server ID of the catalog at the time of bootstrapping
         server_id: uuid::Uuid,
-        /// Whether the terms have been accepted
-        terms_accepted: bool,
     },
 }
 
@@ -280,7 +278,6 @@ where
     /// If bootstrapped succeeded, return Ok(true).
     /// If the catalog is already bootstrapped, return Ok(false).
     async fn bootstrap<'a>(
-        terms_accepted: bool,
         transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'a>,
     ) -> Result<bool>;
 

--- a/crates/lakekeeper/src/tests/drop_warehouse.rs
+++ b/crates/lakekeeper/src/tests/drop_warehouse.rs
@@ -34,7 +34,7 @@ async fn test_cannot_drop_warehouse_before_purge_tasks_completed(pool: PgPool) {
     ApiServer::bootstrap(
         api_context.clone(),
         random_request_metadata(),
-        BootstrapRequest::builder().accept_terms_of_use().build(),
+        BootstrapRequest::builder().build(),
     )
     .await
     .unwrap();

--- a/crates/lakekeeper/src/tests/mod.rs
+++ b/crates/lakekeeper/src/tests/mod.rs
@@ -214,7 +214,6 @@ pub(crate) async fn setup<T: Authorizer>(
         api_context.clone(),
         metadata.clone(),
         BootstrapRequest {
-            accept_terms_of_use: true,
             is_operator: true,
             user_name: None,
             user_email: None,

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -2454,12 +2454,7 @@ components:
                 - azure-system-identity
     BootstrapRequest:
       type: object
-      required:
-        - accept-terms-of-use
       properties:
-        accept-terms-of-use:
-          type: boolean
-          description: Set to true if you accept LAKEKEEPER terms of use.
         is-operator:
           type: boolean
           description: |-

--- a/docs/docs/bootstrap.md
+++ b/docs/docs/bootstrap.md
@@ -5,9 +5,7 @@ After the initial deployment, Lakekeeper needs to be bootstrapped. This can be d
 curl --location 'https://<lakekeeper-url>/management/v1/bootstrap' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer <my-bearer-token>' \
---data '{
-    "accept-terms-of-use": true
-}'
+--data '{}'
 ```
 
 `<my-bearer-token>` is obtained by logging into the IdP before bootstrapping Lakekeeper. If authentication is disabled, no token is required. Lakekeeper can only be bootstrapped once.
@@ -16,7 +14,6 @@ During bootstrapping, Lakekeeper performs the following actions:
 
 * Grants the server's `admin` role to the user performing the POST request. The user is identified by their token. If authentication is disabled, the `Authorization` header is not required, and no `admin` is set, as permissions are disabled in this case.
 * Stores the current [Server ID](./concepts.md#server) to prevent unwanted future changes of the Server ID that would break permissions.
-* Accepts terms of use as defined by our [License](../../about/license.md).
 * If `LAKEKEEPER__ENABLE_DEFAULT_PROJECT` is enabled (default), a default project with the NIL Project ID ("00000000-0000-0000-0000-000000000000") is created.
 
 If the initial user is a technical user (e.g., a Kubernetes Operator) managing the Lakekeeper deployment, the `admin` role might not be sufficient as it limits access to projects until the `admin` grants themselves permission. For technical users, the `operator` role grants full access to all APIs and can be obtained by adding `"is-operator": true` to the JSON body of the bootstrap request.

--- a/examples/access-control-advanced/notebooks/01-Bootstrap.ipynb
+++ b/examples/access-control-advanced/notebooks/01-Bootstrap.ipynb
@@ -102,18 +102,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "response = requests.post(\n",
-    "    url=f\"{MANAGEMENT_URL}/v1/bootstrap\",\n",
-    "    headers={\n",
-    "        \"Authorization\": f\"Bearer {access_token}\"\n",
-    "    },\n",
-    "    json={\n",
-    "        \"accept-terms-of-use\": True,\n",
-    "    },\n",
-    ")\n",
-    "response.raise_for_status()"
-   ]
+   "source": "response = requests.post(\n    url=f\"{MANAGEMENT_URL}/v1/bootstrap\",\n    headers={\n        \"Authorization\": f\"Bearer {access_token}\"\n    },\n    json={},\n)\nresponse.raise_for_status()"
   },
   {
    "cell_type": "markdown",

--- a/examples/access-control-simple/notebooks/01-Bootstrap.ipynb
+++ b/examples/access-control-simple/notebooks/01-Bootstrap.ipynb
@@ -107,22 +107,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "response = requests.post(\n",
-    "    url=f\"{MANAGEMENT_URL}/v1/bootstrap\",\n",
-    "    headers={\n",
-    "        \"Authorization\": f\"Bearer {access_token}\"\n",
-    "    },\n",
-    "    json={\n",
-    "        \"accept-terms-of-use\": True,\n",
-    "        # Optionally, we can override the name / type of the user:\n",
-    "        # \"user-email\": \"user@example.com\",\n",
-    "        # \"user-name\": \"Roald Amundsen\",\n",
-    "        # \"user-type\": \"human\"\n",
-    "    },\n",
-    ")\n",
-    "response.raise_for_status()"
-   ]
+   "source": "response = requests.post(\n    url=f\"{MANAGEMENT_URL}/v1/bootstrap\",\n    headers={\n        \"Authorization\": f\"Bearer {access_token}\"\n    },\n    json={\n        # Optionally, we can override the name / type of the user:\n        # \"user-email\": \"user@example.com\",\n        # \"user-name\": \"Roald Amundsen\",\n        # \"user-type\": \"human\"\n    },\n)\nresponse.raise_for_status()"
   },
   {
    "cell_type": "markdown",

--- a/examples/minimal/docker-compose.yaml
+++ b/examples/minimal/docker-compose.yaml
@@ -77,7 +77,7 @@ services:
       - "-H"
       - "Content-Type: application/json"
       - "--data"
-      - '{"accept-terms-of-use": true}'
+      - '{}'
       - "-o"
       - "/dev/null"
       # - "--fail-with-body"

--- a/tests/kube-auth/bootstrap.sh
+++ b/tests/kube-auth/bootstrap.sh
@@ -2,4 +2,4 @@
 
 set -eu
 
-curl -f -H "Content-Type: application/json" -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" my-lakekeeper:8181/management/v1/bootstrap -d '{"accept-terms-of-use": true}'
+curl -f -H "Content-Type: application/json" -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" my-lakekeeper:8181/management/v1/bootstrap -d '{}'

--- a/tests/migrations/docker-compose.yaml
+++ b/tests/migrations/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
       - "-H"
       - "Content-Type: application/json"
       - "--data"
-      - '{"accept-terms-of-use": true}'
+      - '{}'
       - "-o"
       - "/dev/null"
       # - "--fail-with-body"

--- a/tests/python/tests/conftest.py
+++ b/tests/python/tests/conftest.py
@@ -471,7 +471,7 @@ def server(access_token) -> Server:
         response = requests.post(
             management_url + "v1/bootstrap",
             headers={"Authorization": f"Bearer {access_token}"},
-            json={"accept-terms-of-use": True},
+            json={},
         )
         response.raise_for_status()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified bootstrap API: no longer requires an accept-terms-of-use field; send an empty JSON body ({}) instead.
- Documentation
  - Updated OpenAPI spec and bootstrap guide to remove the terms-of-use requirement and reflect the new request payload.
- Chores
  - Updated examples, notebooks, test scripts, and docker-compose to use the new bootstrap payload.
  - Adjusted CI/workflows to align with the updated bootstrap request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->