### PR TITLE
feat(ci): add nextest profile ci_no_secrets for external PRs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,6 +24,9 @@ failure-output = "immediate-final"
 fail-fast = false
 retries = 0
 
+[profile.ci.junit] # this can be some other profile, too
+path = "junit.xml"
+
 # Can require external services but no secrets.
 [profile.ci_no_secrets]
 default-filter = """
@@ -41,5 +44,5 @@ failure-output = "immediate-final"
 fail-fast = false
 retries = 0
 
-[profile.ci.junit] # this can be some other profile, too
+[profile.ci_no_secrets.junit] # this can be some other profile, too
 path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -35,6 +35,7 @@ default-filter = """
     and not test(::gcs_integration_tests::)
     and not test(::gcs_hns_integration_tests::)
     and not test(::gcp_system_credentials_integration_tests::)
+    and not test(::r2_integration_tests::)
 """
 failure-output = "immediate-final"
 fail-fast = false

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,4 @@
+# Tests that can run without secrets and external services.
 [profile.default]
 default-filter = """
     not (package(lakekeeper-io) and binary(integration_tests))
@@ -23,6 +24,21 @@ failure-output = "immediate-final"
 fail-fast = false
 retries = 0
 
+# Can require external services but no secrets.
+[profile.ci_no_secrets]
+default-filter = """
+    not (package(lakekeeper-io) and binary(integration_tests))
+    and not test(::aws_integration_tests::)
+    and not test(::aws_kms_integration_tests::)
+    and not test(::azure_integration_tests::)
+    and not test(::azure_system_credentials_integration_tests::)
+    and not test(::gcs_integration_tests::)
+    and not test(::gcs_hns_integration_tests::)
+    and not test(::gcp_system_credentials_integration_tests::)
+"""
+failure-output = "immediate-final"
+fail-fast = false
+retries = 0
 
 [profile.ci.junit] # this can be some other profile, too
 path = "junit.xml"

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -177,6 +177,17 @@ jobs:
         with:
           tool: cargo-nextest
 
+      - name: Determine nextest profile
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+            # PR is made off this repo, so workflows have access to secrets and the entire suite
+            # can be run.
+            echo "NEXTEST_PROFILE=ci" >> $GITHUB_ENV
+          else
+            # PR is made off a fork, so secrets are not available in ci workflows.
+            echo "NEXTEST_PROFILE=ci_no_secrets" >> $GITHUB_ENV
+          fi
+
       - name: Migrate database
         run: |
           export DEBIAN_FRONTEND=noninteractive 
@@ -208,7 +219,7 @@ jobs:
         run: docker run -d -p 35081:8081 openfga/openfga:v1.8 run
 
       - name: Test
-        run: cargo nextest run --profile ci --all-targets --all-features --workspace
+        run: cargo nextest run --profile ${{ env.NEXTEST_PROFILE }} --all-targets --all-features --workspace
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
           LAKEKEEPER_TEST__KV2__URL: http://localhost:8200


### PR DESCRIPTION
Making this PR from a fork to verify the profile works for external PRs.

After merging we should check that internal PRs are still executed with `--profile ci`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test filters to exclude integration tests that require external secrets; added a new no-secrets CI profile with immediate-final failure output, no retries, and fail-fast disabled.

* **Chores**
  * CI now automatically selects the appropriate test profile for in-repo vs. forked pull requests to improve safety and consistency of test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->