### PR TITLE
fix: case insensitivity of catalog endpoints

### DIFF
--- a/crates/lakekeeper/migrations/20250916082614_jsonb_to_textarr.sql
+++ b/crates/lakekeeper/migrations/20250916082614_jsonb_to_textarr.sql
@@ -1,0 +1,3 @@
+CREATE FUNCTION jsonb_to_textarr(jsonb) RETURNS text[] AS $$
+    SELECT array_agg(txt) FROM jsonb_array_elements_text($1) txt;
+$$ LANGUAGE SQL;

--- a/crates/lakekeeper/src/implementations/postgres/tabular/mod.rs
+++ b/crates/lakekeeper/src/implementations/postgres/tabular/mod.rs
@@ -12,7 +12,7 @@ use http::StatusCode;
 use iceberg::ErrorKind;
 use iceberg_ext::NamespaceIdent;
 use lakekeeper_io::Location;
-use sqlx::{postgres::PgArguments, Arguments, Execute, FromRow, Postgres, QueryBuilder};
+use sqlx::FromRow;
 use uuid::Uuid;
 
 use super::dbutils::DBErrorHandler as _;
@@ -31,8 +31,6 @@ use crate::{
     },
     WarehouseId, CONFIG,
 };
-
-const MAX_PARAMETERS: usize = 30000;
 
 #[derive(Debug, sqlx::Type, Copy, Clone, strum::Display)]
 #[sqlx(type_name = "tabular_type", rename_all = "kebab-case")]
@@ -183,14 +181,27 @@ where
 #[derive(Debug, FromRow)]
 struct TabularRow {
     tabular_id: Uuid,
-    namespace: Vec<String>,
-    tabular_name: String,
+    // Despite `IS NOT NULL` filter sqlx thinks column selected from input is nullable.
+    namespace: Option<Vec<String>>,
+    // Despite `IS NOT NULL` filter sqlx thinks column selected from input is nullable.
+    tabular_name: Option<String>,
     // apparently this is needed, we need 'as "typ: TabularType"' in the query else the select won't
     // work, but that apparently aliases the whole column to "typ: TabularType"
     #[sqlx(rename = "typ: TabularType")]
     typ: TabularType,
 }
 
+/// The keys in the returned map correspond to the input identifiers in the `tables` parameter.
+///
+/// These may differ in case from identifiers stored in the db, since case insensitivity is achieved
+/// by collation. For example:
+///
+/// - Table name in the db is `table1`
+/// - The input parameter is `TABLE1`
+/// - `table1` and `TABLE1` match due to collation and the key in the returned map is `TABLE1`
+///
+/// In line with that, querying both `table1` and `TABLE1` returns a map with two entries, both
+/// both being the same table id.
 pub(crate) async fn tabular_idents_to_ids<'e, 'c: 'e, E>(
     warehouse_id: WarehouseId,
     tables: HashSet<TabularIdentBorrowed<'_>>,
@@ -200,76 +211,91 @@ pub(crate) async fn tabular_idents_to_ids<'e, 'c: 'e, E>(
 where
     E: 'e + sqlx::Executor<'c, Database = sqlx::Postgres>,
 {
-    let batch_tables = tables
-        .iter()
-        .map(|t| {
-            let TableIdent { namespace, name } = t.to_table_ident_tuple();
-            let typ: TabularType = t.into();
-            (namespace, name, typ)
-        })
-        .collect::<Vec<_>>();
-
-    if batch_tables.is_empty() {
+    if tables.is_empty() {
         return Ok(HashMap::new());
     }
+    let (ns_names, t_names, t_typs) = tables.iter().fold(
+        (
+            Vec::with_capacity(tables.len()),
+            Vec::with_capacity(tables.len()),
+            Vec::with_capacity(tables.len()),
+        ),
+        |(mut ns_names, mut t_names, mut t_typs), t| {
+            let TableIdent { namespace, name } = t.to_table_ident_tuple();
+            let typ: TabularType = t.into();
+            ns_names.push(namespace.as_ref());
+            t_names.push(name);
+            t_typs.push(typ);
+            (ns_names, t_names, t_typs)
+        },
+    );
 
-    if batch_tables.len() > (MAX_PARAMETERS / 2) {
-        return Err(ErrorModel::bad_request(
-            "Too many tables or views to fetch",
-            "TooManyTablesOrViews",
-            None,
+    // Encoding `ns_names` as json is a workaround for `sqlx` not supporting `Vec<Vec<String>>`.
+    let ns_names_json = serde_json::to_value(&ns_names).map_err(|e| {
+        ErrorModel::internal(
+            "Error json encoding namespace names",
+            "EncodingError",
+            Some(Box::new(e)),
         )
-        .into());
-    }
+    })?;
 
-    // This query is statically verified against our DB, we then take it apart to do some dynamic
-    // extension further down before reconstructing it.
-    let mut statically_checked_query = sqlx::query_as!(
+    // For columns with collation, the query must return the value as in input `tables`.
+    let rows = sqlx::query_as!(
         TabularRow,
         r#"
         SELECT t.tabular_id,
-               n.namespace_name as "namespace",
-               t.name as tabular_name,
-               t.typ as "typ: TabularType"
-        FROM tabular t
-        INNER JOIN namespace n ON t.namespace_id = n.namespace_id
+            in_ns.name as "namespace",
+            in_t.name as tabular_name,
+            t.typ as "typ: TabularType"
+        FROM LATERAL (
+            SELECT jsonb_to_textarr(name) AS name, idx
+            FROM jsonb_array_elements($2) WITH ORDINALITY AS t(name, idx)
+        ) in_ns
+        INNER JOIN LATERAL UNNEST($3::text[], $4::tabular_type[])
+            WITH ORDINALITY AS in_t(name, typ, idx)
+            ON in_ns.idx = in_t.idx
+        INNER JOIN tabular t ON t.name = in_t.name AND t.typ = in_t.typ
+        INNER JOIN namespace n ON t.namespace_id = n.namespace_id AND n.namespace_name = in_ns.name
         INNER JOIN warehouse w ON n.warehouse_id = w.warehouse_id
-        WHERE w.status = 'active' and n."warehouse_id" = $1
-            AND (t.deleted_at is NULL OR $2)
-            AND (t.metadata_location is not NULL OR $3) "#,
+        WHERE in_t.name IS NOT NULL AND in_ns.name IS NOT NULL
+            AND w.status = 'active' and n."warehouse_id" = $1
+            AND (t.deleted_at is NULL OR $5)
+            AND (t.metadata_location is not NULL OR $6) "#,
         *warehouse_id,
+        ns_names_json as _,
+        t_names.as_slice() as _,
+        t_typs.as_slice() as _,
         list_flags.include_deleted,
         list_flags.include_staged
-    );
-    let checked_sql = statically_checked_query.sql();
-
-    let mut query_builder: QueryBuilder<'_, Postgres> = sqlx::QueryBuilder::new(checked_sql);
-
-    let mut args = statically_checked_query
-        .take_arguments()
-        .map_err(|e| {
-            ErrorModel::internal("Failed to build dynamic query", "DatabaseError", Some(e))
-        })?
-        .unwrap_or_default();
-
-    append_dynamic_filters(batch_tables.as_slice(), &mut query_builder, &mut args)?;
-
-    let query = query_builder.build();
-
-    let rows: Vec<TabularRow> = sqlx::query_as_with(query.sql(), args)
-        .fetch_all(catalog_state)
-        .await
-        .map_err(|e| e.into_error_model("Error fetching tables or views".to_string()))?;
+    )
+    .fetch_all(catalog_state)
+    .await
+    .map_err(|e| e.into_error_model("Error fetching tables or views".to_string()))?;
 
     let mut table_map = HashMap::with_capacity(tables.len());
     for TabularRow {
         tabular_id,
-        namespace,
-        tabular_name: name,
+        namespace: in_namespace,
+        tabular_name: in_tabular_name,
         typ,
     } in rows
     {
+        let namespace = in_namespace.ok_or_else(|| {
+            ErrorModel::internal(
+                "Namespace name should not be null",
+                "InternalDatabaseError",
+                None,
+            )
+        })?;
+        let name = in_tabular_name.ok_or_else(|| {
+            ErrorModel::internal(
+                "Tabular name should not be null",
+                "InternalDatabaseError",
+                None,
+            )
+        })?;
         let namespace = try_parse_namespace_ident(namespace)?;
+
         match typ {
             TabularType::Table => {
                 table_map.insert(
@@ -287,51 +313,13 @@ where
     }
 
     // Missing tables are added with None
-    for table in tables {
-        table_map.entry(table.into()).or_insert(None);
+    if table_map.len() < tables.len() {
+        for table in tables {
+            table_map.entry(table.into()).or_insert(None);
+        }
     }
 
     Ok(table_map)
-}
-
-fn append_dynamic_filters(
-    batch_tables: &[(&NamespaceIdent, &String, TabularType)],
-    query_builder: &mut QueryBuilder<'_, Postgres>,
-    args: &mut PgArguments,
-) -> Result<()> {
-    query_builder.push(r" AND (n.namespace_name, t.name, t.typ) IN ");
-    query_builder.push("(");
-
-    let mut arg_idx = args.len() + 1;
-    for (i, (ns_ident, name, typ)) in batch_tables.iter().enumerate() {
-        query_builder.push(format!("(${arg_idx}"));
-        arg_idx += 1;
-        args.add(ns_ident.as_ref()).map_err(|e| {
-            ErrorModel::internal("Failed to add namespace to query", "DatabaseError", Some(e))
-        })?;
-
-        query_builder.push(", ");
-
-        query_builder.push(format!("${arg_idx}"));
-        arg_idx += 1;
-        args.add(name).map_err(|e| {
-            ErrorModel::internal("Failed to add name to query", "DatabaseError", Some(e))
-        })?;
-        query_builder.push(", ");
-
-        query_builder.push(format!("${arg_idx}"));
-        arg_idx += 1;
-        args.add(*typ).map_err(|e| {
-            ErrorModel::internal("Failed to add type to query", "DatabaseError", Some(e))
-        })?;
-
-        query_builder.push(")");
-        if i != batch_tables.len() - 1 {
-            query_builder.push(", ");
-        }
-    }
-    query_builder.push(")");
-    Ok(())
 }
 
 pub(crate) struct CreateTabular<'a> {

--- a/crates/lakekeeper/src/implementations/postgres/tabular/table/mod.rs
+++ b/crates/lakekeeper/src/implementations/postgres/tabular/table/mod.rs
@@ -1376,6 +1376,74 @@ pub(crate) mod tests {
     }
 
     #[sqlx::test]
+    async fn test_to_ids_case_insensitivity(pool: sqlx::PgPool) {
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
+
+        let warehouse_id = initialize_warehouse(state.clone(), None, None, None, true).await;
+        let namespace_lower =
+            NamespaceIdent::from_vec(vec!["my_namespace".to_string(), "child".to_string()])
+                .unwrap();
+        let namespace_upper =
+            NamespaceIdent::from_vec(vec!["MY_NAMESPACE".to_string(), "CHILD".to_string()])
+                .unwrap();
+        initialize_namespace(state.clone(), warehouse_id, &namespace_lower, None).await;
+
+        let table_ident_lower = TableIdent {
+            namespace: namespace_lower.clone(),
+            name: "my_table".to_string(),
+        };
+        let table_ident_upper = TableIdent {
+            namespace: namespace_upper.clone(),
+            name: "MY_TABLE".to_string(),
+        };
+
+        let _ = initialize_table(
+            warehouse_id,
+            state.clone(),
+            false,
+            Some(namespace_lower.clone()),
+            Some(table_ident_lower.name.clone()),
+        )
+        .await;
+        let _ = initialize_table(
+            warehouse_id,
+            state.clone(),
+            false,
+            Some(namespace_lower.clone()),
+            Some("a_table_not_to_be_included_in_results".to_string()),
+        )
+        .await;
+
+        // Lower idents are in db and we query upper.
+        let existing = table_idents_to_ids(
+            warehouse_id,
+            //tables.clone(),
+            HashSet::from([&table_ident_upper]),
+            ListFlags::default(),
+            &state.read_pool(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(existing.len(), 1);
+        // The queried ident must be the key in the map.
+        assert!(existing.get(&table_ident_upper).unwrap().is_some());
+
+        // Verify behavior of querying the same table twice with different cases.
+        let existing = table_idents_to_ids(
+            warehouse_id,
+            HashSet::from([&table_ident_lower, &table_ident_upper]),
+            ListFlags::default(),
+            &state.read_pool(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(existing.len(), 2);
+        let entry_lower = existing.get(&table_ident_lower).unwrap().unwrap();
+        let entry_upper = existing.get(&table_ident_upper).unwrap().unwrap();
+        assert_eq!(entry_lower, entry_upper);
+    }
+
+    #[sqlx::test]
     async fn test_rename_without_namespace(pool: sqlx::PgPool) {
         let state = CatalogState::from_pools(pool.clone(), pool.clone());
 


### PR DESCRIPTION
Closes #1319 

It seems like there are no other getters where collation could cause a similar issue, or did I miss something? In particular namespaces should not be affected as there is no corresponding `namespace_idents_to_ids` function. Besides tabulars and namespaces, I think collation is applied nowhere else.

Regarding the modification of the db query: indices generated on the Rust side would need to be plumbed into a new, non-static CTE at the beginning of the query. Going instead with the jsonb encoding of `Vec<Vec<String>>` appeared to be the simpler approach. As a positive side effect, the whole query is static now.