### PR TITLE
feat!: Require warehouse_id when checking permissions on views or tables via ID

### DIFF
--- a/crates/lakekeeper/src/service/authz/implementations/openfga/check.rs
+++ b/crates/lakekeeper/src/service/authz/implementations/openfga/check.rs
@@ -249,7 +249,10 @@ async fn check_table<C: Catalog, S: SecretStore>(
         AllTableRelations::CanReadAssignments
     });
     Ok(match table {
-        TabularIdentOrUuid::Id { table_id } => {
+        TabularIdentOrUuid::Id {
+            table_id,
+            warehouse_id: _,
+        } => {
             let table_id = TableId::from(*table_id);
             authorizer
                 .require_table_action(metadata, Ok(Some(table_id)), action)
@@ -297,7 +300,10 @@ async fn check_view<C: Catalog, S: SecretStore>(
         AllViewRelations::CanReadAssignments
     });
     Ok(match view {
-        TabularIdentOrUuid::Id { table_id } => {
+        TabularIdentOrUuid::Id {
+            table_id,
+            warehouse_id: _,
+        } => {
             let view_id = ViewId::from(*table_id);
             authorizer
                 .require_view_action(metadata, Ok(Some(view_id)), action)
@@ -391,6 +397,8 @@ pub(super) enum TabularIdentOrUuid {
     Id {
         #[serde(alias = "view_id")]
         table_id: uuid::Uuid,
+        #[schema(value_type = uuid::Uuid)]
+        warehouse_id: WarehouseId,
     },
     #[serde(rename_all = "kebab-case")]
     Name {

--- a/crates/lakekeeper/src/service/authz/implementations/openfga/check.rs
+++ b/crates/lakekeeper/src/service/authz/implementations/openfga/check.rs
@@ -437,7 +437,7 @@ mod tests {
     use crate::service::UserId;
 
     #[test]
-    fn test_serde_check_action_table_id() {
+    fn test_serde_check_action_namespace_id() {
         let action = CheckOperation::Namespace {
             action: NamespaceAction::CreateTable,
             namespace: NamespaceIdentOrUuid::Id {
@@ -452,6 +452,53 @@ mod tests {
                 "namespace": {
                     "action": "create_table",
                     "namespace-id": "00000000-0000-0000-0000-000000000000"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_serde_check_action_table_id_variant() {
+        let action = CheckOperation::Table {
+            action: TableAction::GetMetadata,
+            table: TabularIdentOrUuid::Id {
+                table_id: uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
+                warehouse_id: WarehouseId::from_str("490cbf7a-cbfe-11ef-84c5-178606d4cab3")
+                    .unwrap(),
+            },
+        };
+        let json = serde_json::to_value(&action).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "table": {
+                    "action": "get_metadata",
+                    "table-id": "00000000-0000-0000-0000-000000000001",
+                    "warehouse-id": "490cbf7a-cbfe-11ef-84c5-178606d4cab3"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_serde_check_action_view_id_alias() {
+        let action = CheckOperation::View {
+            action: ViewAction::GetMetadata,
+            view: TabularIdentOrUuid::Id {
+                table_id: uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap(),
+                warehouse_id: WarehouseId::from_str("490cbf7a-cbfe-11ef-84c5-178606d4cab3")
+                    .unwrap(),
+            },
+        };
+        let json = serde_json::to_value(&action).unwrap();
+        // Accepts "view_id" as alias on input; on output it should be "table-id".
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "view": {
+                    "action": "get_metadata",
+                    "table-id": "00000000-0000-0000-0000-000000000002",
+                    "warehouse-id": "490cbf7a-cbfe-11ef-84c5-178606d4cab3"
                 }
             })
         );

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -4845,8 +4845,12 @@ components:
         - type: object
           required:
             - table-id
+            - warehouse-id
           properties:
             table-id:
+              type: string
+              format: uuid
+            warehouse-id:
               type: string
               format: uuid
         - type: object


### PR DESCRIPTION
`warehouse_id` is added as preparation for v0.11, which will then use it.

## Breaking change

Adds a field to `TabularIdentOrUuid` which is used on the `/check` endpoint of the management API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warehouse scoping to table/view identification. When using the table-id path, warehouse-id is now required alongside table-id.
  * For the namespace-based path, only namespace is required; table and warehouse-id are now optional.

* **Documentation**
  * Updated OpenAPI schema to reflect the new warehouse-id requirement for table-id paths and relaxed requirements for the namespace-based path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->