### PR TITLE
chore: Pin examples duckdb version to 1.3

### DIFF
--- a/examples/minimal/notebooks/DuckDB.ipynb
+++ b/examples/minimal/notebooks/DuckDB.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install pyiceberg duckdb --upgrade"
+    "!pip install pyiceberg \"duckdb==1.3.*\" --upgrade"
    ]
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the DuckDB example notebook to pin duckdb to version 1.3.* for improved compatibility and consistent environments during setup.

- **Documentation**
  - Clarified the installation cell in the DuckDB example by quoting the duckdb version constraint so it’s treated as a single argument, reducing installation parsing issues and improving reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->