### PR TITLE
fix(docs): Fix inconsistent URL format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd lakekeeper/examples/minimal
 docker compose up
 ```
 
-Then open your browser and head to [localhost:8888](localhost:8888) to load the example Jupyter notebooks or head to [localhost:8181](localhost:8181) for the Lakekeeper UI.
+Then open your browser and head to [localhost:8888](http://localhost:8888) to load the example Jupyter notebooks or head to [localhost:8181](http://localhost:8181) for the Lakekeeper UI.
 
 For more information on deployment, please check the [Getting Started Guide](https://docs.lakekeeper.io/getting-started/).
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated two Quickstart links in the README to use explicit http://localhost URLs (ports 8888 and 8181) instead of bare host:port.
  - Links are now consistently clickable across GitHub, IDEs, and other Markdown viewers that require scheme-prefixed URLs.
  - Improves clarity when launching local services from the guide.
  - No behavioral changes; all other README content remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->