### PR TITLE
fix: table rename authz and error handling

### DIFF
--- a/crates/lakekeeper/src/catalog/tables.rs
+++ b/crates/lakekeeper/src/catalog/tables.rs
@@ -879,6 +879,9 @@ impl<C: Catalog, A: Authorizer + Clone, S: SecretStore>
         validate_table_or_view_ident(destination)?;
 
         // ------------------- AUTHZ -------------------
+        // Authorization is required for:
+        // * renaming the old table
+        // * creating a table in the destination namespace
         let authorizer = state.v1_state.authz;
         let mut t = C::Transaction::begin_write(state.v1_state.catalog).await?;
         let list_flags = ListFlags {
@@ -897,14 +900,21 @@ impl<C: Catalog, A: Authorizer + Clone, S: SecretStore>
         )
         .await?;
 
-        let namespace_id =
-            C::namespace_to_id(warehouse_id, &source.namespace, t.transaction()).await; // We can't fail before AuthZ
+        let destination_namespace_id =
+            C::namespace_to_id(warehouse_id, &destination.namespace, t.transaction())
+                .await?
+                .ok_or_else(|| {
+                    ErrorModel::not_found(
+                        "Destination namespace not found",
+                        "NoSuchNamespaceException",
+                        None,
+                    )
+                })?;
 
-        // We need to be allowed to delete the old table and create the new one
         authorizer
             .require_namespace_action(
                 &request_metadata,
-                namespace_id,
+                Ok(Some(destination_namespace_id)),
                 CatalogNamespaceAction::CanCreateTable,
             )
             .await?;
@@ -2003,10 +2013,11 @@ pub(crate) mod test {
             SnapshotRetention, Summary, TableMetadata, Transform, Type, UnboundPartitionField,
             UnboundPartitionSpec, MAIN_BRANCH, PROPERTY_METADATA_PREVIOUS_VERSIONS_MAX,
         },
-        TableIdent,
+        NamespaceIdent, TableIdent,
     };
     use iceberg_ext::catalog::rest::{
         CommitTableRequest, CreateNamespaceResponse, CreateTableRequest, LoadTableResult,
+        RenameTableRequest,
     };
     use itertools::Itertools;
     use lakekeeper_io::Location;
@@ -2032,7 +2043,7 @@ pub(crate) mod test {
         implementations::postgres::{PostgresCatalog, SecretsState},
         request_metadata::RequestMetadata,
         service::{
-            authz::{tests::HidingAuthorizer, AllowAllAuthorizer},
+            authz::{tests::HidingAuthorizer, AllowAllAuthorizer, CatalogTableAction},
             State, UserId,
         },
         tests::random_request_metadata,
@@ -3555,6 +3566,75 @@ pub(crate) mod test {
         )
         .await
         .expect("Table couldn't be force dropped which should be possible");
+    }
+
+    #[sqlx::test]
+    async fn test_rename_table_without_can_rename(pool: sqlx::PgPool) {
+        let prof = crate::catalog::test::memory_io_profile();
+        let authz = HidingAuthorizer::new();
+        let (ctx, warehouse) = crate::catalog::test::setup(
+            pool.clone(),
+            prof,
+            None,
+            authz.clone(),
+            TabularDeleteProfile::Hard {},
+            Some(UserId::new_unchecked("oidc", "test-user-id")),
+        )
+        .await;
+
+        let from_ns = crate::catalog::test::create_ns(
+            ctx.clone(),
+            warehouse.warehouse_id.to_string(),
+            "from_ns".to_string(),
+        )
+        .await;
+        let ns_params = NamespaceParameters {
+            prefix: Some(Prefix(warehouse.warehouse_id.to_string())),
+            namespace: from_ns.namespace.clone(),
+        };
+        let prefix = Some(Prefix(warehouse.warehouse_id.to_string()));
+        let table_name = "from_table".to_string();
+        CatalogServer::create_table(
+            ns_params.clone(),
+            create_request(Some(table_name.clone()), Some(false)),
+            DataAccess {
+                vended_credentials: true,
+                remote_signing: false,
+            },
+            ctx.clone(),
+            RequestMetadata::new_unauthenticated(),
+        )
+        .await
+        .unwrap();
+
+        // Cannot rename source table
+        authz.block_action(format!("table:{}", CatalogTableAction::CanRename).as_str());
+        let cannot_rename_table_response = CatalogServer::rename_table(
+            prefix,
+            RenameTableRequest {
+                source: TableIdent {
+                    namespace: ns_params.namespace.clone(),
+                    name: table_name.clone(),
+                },
+                destination: TableIdent {
+                    namespace: NamespaceIdent::new("to_ns".to_string()),
+                    name: table_name,
+                },
+            },
+            ctx.clone(),
+            RequestMetadata::new_unauthenticated(),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            cannot_rename_table_response.error.code,
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            cannot_rename_table_response.error.r#type,
+            "TableActionForbidden"
+        );
     }
 
     #[sqlx::test]


### PR DESCRIPTION
This PR revives #1278 as this fix is needed for the upcoming release. Credits / co-authorship to @ndrluis.

Opening a new PR inside lakekeeper to run the full test suite.