### PR TITLE
chore: Set Get Task Permission to "CanGetMetadata"

### DIFF
--- a/crates/lakekeeper/src/api/management/v1/tasks.rs
+++ b/crates/lakekeeper/src/api/management/v1/tasks.rs
@@ -18,7 +18,7 @@ use crate::{
     WarehouseId,
 };
 
-const GET_TASK_PERMISSION: CatalogTableAction = CatalogTableAction::CanCommit;
+const GET_TASK_PERMISSION: CatalogTableAction = CatalogTableAction::CanGetMetadata;
 const CONTROL_TASK_PERMISSION: CatalogTableAction = CatalogTableAction::CanDrop;
 const CONTROL_TASK_WAREHOUSE_PERMISSION: CatalogWarehouseAction = CatalogWarehouseAction::CanDelete;
 const CAN_GET_ALL_TASKS_DETAILS_WAREHOUSE_PERMISSION: CatalogWarehouseAction =


### PR DESCRIPTION
Tasks are Metadata about a Table that is useful to know for everyone working with this table.
Control actions are not affected by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected authorization for listing and viewing task details. These actions now require metadata-read access instead of commit-level permissions, reducing overly strict access checks and preventing unnecessary denials for read-only users. No functional changes to task behavior; only the permission level for viewing task information was adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->