### PR TITLE
fix: Develper Experience: Make the minimal example more durable on restarts.

### DIFF
--- a/examples/minimal/docker-compose.yaml
+++ b/examples/minimal/docker-compose.yaml
@@ -156,7 +156,7 @@ services:
       /bin/sh -c "
       sleep 5;
       /usr/bin/mc alias set dockerminio http://minio:9000 minio-root-user minio-root-password;
-      /usr/bin/mc mb dockerminio/examples;
+      /usr/bin/mc mb --ignore-existing dockerminio/examples;
       exit 0;
       "
     networks:


### PR DESCRIPTION
In the case where you already have a bucket created, like the "examples" bucket, I ran into an issue where the createbuckets service fails, and this can prevent `lakekeeper` from starting back up (after `docker compose down`)

This fix adds a simple minio flag to ignore buckets that already exist, making things even more user friendly.

> Note: This isn't always reproducible. But if the timing is perfect then the lakekeeper-minio-1 and lakekeeper-db-1 containers will be left running.


<img width="1342" height="168" alt="Screenshot 2025-09-26 at 2 58 12 PM" src="https://github.com/user-attachments/assets/083b83ca-3b0c-4ec9-8c4d-6fe9a5c46d46" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made bucket creation in the minimal Docker Compose example idempotent, preventing errors on repeated starts when the bucket already exists.

* **Style**
  * Minor formatting cleanup in the networks section of the Docker Compose example for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->