### PR TITLE
chore(db): remove `join namespace` from `active_tabulars` view

### DIFF
--- a/crates/lakekeeper/migrations/20250930101627_active_tabulars_remove_namespace_join.sql
+++ b/crates/lakekeeper/migrations/20250930101627_active_tabulars_remove_namespace_join.sql
@@ -1,0 +1,13 @@
+-- namespace_name was added as FK to tabular, so no need to join namespace anymore
+CREATE OR REPLACE VIEW active_tabulars AS
+SELECT t.tabular_id,
+    t.namespace_id,
+    t.name,
+    t.typ,
+    t.metadata_location,
+    t.fs_protocol,
+    t.fs_location,
+    t.warehouse_id,
+    t.tabular_namespace_name as namespace_name
+   FROM tabular t
+     JOIN warehouse w ON t.warehouse_id = w.warehouse_id AND w.status = 'active'::warehouse_status;


### PR DESCRIPTION
As a result of recent changes, a `JOIN` can be removed to make queries more efficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The active_tabulars view now includes a Namespace Name column alongside existing fields, enabling direct visibility of namespace for each tabular entry.
* **Chores**
  * Database view updated via migration to reflect the new schema for active tabulars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->