### PR TITLE
fix: Use FnOnce for queue & service registration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,8 @@ time = "0.3.36"
 tokio = { version = "1.41", default-features = false, features = [
     "signal",
     "rt-multi-thread",
+    "macros",
+    "time",
 ] }
 tokio-util = { version = "^0.7" }
 tower = { version = "^0.5" }

--- a/crates/iceberg-ext/src/catalog/rest/table.rs
+++ b/crates/iceberg-ext/src/catalog/rest/table.rs
@@ -1,3 +1,4 @@
+use iceberg::spec::TableMetadataRef;
 use typed_builder::TypedBuilder;
 
 #[cfg(feature = "axum")]
@@ -88,7 +89,7 @@ pub struct CommitTableRequest {
 #[serde(rename_all = "kebab-case")]
 pub struct CommitTableResponse {
     pub metadata_location: String,
-    pub metadata: TableMetadata,
+    pub metadata: TableMetadataRef,
     pub config: Option<std::collections::HashMap<String, String>>,
 }
 

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -1042,11 +1042,13 @@ pub trait Service<C: Catalog, A: Authorizer, S: SecretStore> {
         // ------------------- Business Logic -------------------
         let config = C::get_task_queue_config(warehouse_id, queue_name, context.v1_state.catalog)
             .await?
-            .ok_or(ErrorModel::not_found(
-                "Task queue config not found",
-                "TaskQueueConfigNotFound",
-                None,
-            ))?;
+            .unwrap_or_else(|| GetTaskQueueConfigResponse {
+                queue_config: QueueConfigResponse {
+                    config: serde_json::json!({}),
+                    queue_name: queue_name.clone(),
+                },
+                max_seconds_since_last_heartbeat: None,
+            });
         Ok(config)
     }
 }

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -261,6 +261,10 @@ pub struct DynAppConfig {
 
     // ------------- Testing -------------
     pub skip_storage_validation: bool,
+
+    // ------------- Debug -------------
+    #[serde(default)]
+    pub debug: DebugConfig,
 }
 
 pub(crate) fn seconds_to_duration<'de, D>(deserializer: D) -> Result<chrono::Duration, D::Error>
@@ -443,6 +447,21 @@ pub enum SecretBackend {
     Postgres,
 }
 
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+pub struct DebugConfig {
+    /// If true, log all request bodies to the debug log for debugging purposes.
+    /// This is expensive and should only be used for debugging.
+    pub log_request_bodies: bool,
+}
+
+impl Default for DebugConfig {
+    fn default() -> Self {
+        Self {
+            log_request_bodies: false,
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, PartialEq, Redact)]
 pub struct KV2Config {
     pub url: Url,
@@ -521,6 +540,7 @@ impl Default for DynAppConfig {
             endpoint_stat_flush_interval: Duration::from_secs(30),
             serve_swagger_ui: true,
             skip_storage_validation: false,
+            debug: DebugConfig::default(),
         }
     }
 }
@@ -1238,6 +1258,32 @@ mod test {
             jail.set_env("LAKEKEEPER_TEST__SKIP_STORAGE_VALIDATION", "false");
             let config = get_config();
             assert!(!config.skip_storage_validation);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_debug_log_request_bodies() {
+        // Test default value (should be false)
+        figment::Jail::expect_with(|_jail| {
+            let config = get_config();
+            assert!(!config.debug.log_request_bodies);
+            Ok(())
+        });
+
+        // Test setting to true
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__DEBUG__LOG_REQUEST_BODIES", "true");
+            let config = get_config();
+            assert!(config.debug.log_request_bodies);
+            Ok(())
+        });
+
+        // Test setting to false explicitly
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__DEBUG__LOG_REQUEST_BODIES", "false");
+            let config = get_config();
+            assert!(!config.debug.log_request_bodies);
             Ok(())
         });
     }

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -447,19 +447,11 @@ pub enum SecretBackend {
     Postgres,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Default)]
 pub struct DebugConfig {
     /// If true, log all request bodies to the debug log for debugging purposes.
     /// This is expensive and should only be used for debugging.
     pub log_request_bodies: bool,
-}
-
-impl Default for DebugConfig {
-    fn default() -> Self {
-        Self {
-            log_request_bodies: false,
-        }
-    }
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Redact)]

--- a/crates/lakekeeper/src/implementations/postgres/tabular/table/commit.rs
+++ b/crates/lakekeeper/src/implementations/postgres/tabular/table/commit.rs
@@ -1,6 +1,9 @@
 use std::collections::HashSet;
 
-use iceberg::{spec::TableMetadata, ErrorKind};
+use iceberg::{
+    spec::{TableMetadata, TableMetadataRef},
+    ErrorKind,
+};
 use iceberg_ext::catalog::rest::ErrorModel;
 use itertools::Itertools;
 use lakekeeper_io::Location;
@@ -99,7 +102,7 @@ pub(crate) async fn commit_table_transaction(
 struct TableMetadataTransition {
     warehouse_id: WarehouseId,
     previous_metadata_location: Option<Location>,
-    new_metadata: TableMetadata,
+    new_metadata: TableMetadataRef,
     new_metadata_location: Location,
 }
 

--- a/crates/lakekeeper/src/serve.rs
+++ b/crates/lakekeeper/src/serve.rs
@@ -36,16 +36,19 @@ use crate::{
 ///
 /// # Returns
 /// - `Vec<(String, tokio::task::AbortHandle)>`: A vector of tuples containing the name of the service and its associated abort handle.
-pub type RegisterBackgroundServiceFn<A, C, S> = std::sync::Arc<
-    dyn Fn(
+pub type RegisterBackgroundServiceFn<A, C, S> = Box<
+    dyn FnOnce(
         &mut JoinSet<Result<(), anyhow::Error>>,
         CancellationToken,
         ApiContext<State<A, C, S>>,
     ) -> BoxFuture<'_, anyhow::Result<Vec<(String, AbortHandle)>>>,
 >;
 
-pub type RegisterTaskQueueFn<A, C, S> = std::sync::Arc<
-    dyn Fn(TaskQueueRegistry, ApiContext<State<A, C, S>>) -> BoxFuture<'static, anyhow::Result<()>>,
+pub type RegisterTaskQueueFn<A, C, S> = Box<
+    dyn FnOnce(
+        TaskQueueRegistry,
+        ApiContext<State<A, C, S>>,
+    ) -> BoxFuture<'static, anyhow::Result<()>>,
 >;
 
 /// Helper function to process the result of a service task completion

--- a/crates/lakekeeper/src/service/catalog.rs
+++ b/crates/lakekeeper/src/service/catalog.rs
@@ -1,11 +1,11 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::LazyLock,
+    sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
 
 use iceberg::{
-    spec::{TableMetadata, ViewMetadata},
+    spec::{TableMetadata, TableMetadataRef, ViewMetadata},
     TableUpdate,
 };
 use iceberg_ext::catalog::rest::{CatalogConfig, ErrorModel};
@@ -175,10 +175,10 @@ pub struct GetProjectResponse {
 
 #[derive(Debug, Clone)]
 pub struct TableCommit {
-    pub new_metadata: TableMetadata,
+    pub new_metadata: TableMetadataRef,
     pub new_metadata_location: Location,
     pub previous_metadata_location: Option<Location>,
-    pub updates: Vec<TableUpdate>,
+    pub updates: Arc<Vec<TableUpdate>>,
     pub diffs: TableMetadataDiffs,
 }
 

--- a/crates/lakekeeper/src/service/endpoint_hooks.rs
+++ b/crates/lakekeeper/src/service/endpoint_hooks.rs
@@ -6,7 +6,7 @@ use std::{
 
 use futures::TryFutureExt;
 use iceberg::{
-    spec::{TableMetadata, ViewMetadata},
+    spec::{TableMetadata, TableMetadataRef, ViewMetadata},
     TableIdent,
 };
 use iceberg_ext::catalog::rest::{
@@ -393,7 +393,7 @@ pub trait EndpointHook: Send + Sync + Debug + Display {
         _warehouse_id: WarehouseId,
         _parameters: NamespaceParameters,
         _request: Arc<RegisterTableRequest>,
-        _metadata: Arc<TableMetadata>,
+        _metadata: TableMetadataRef,
         _metadata_location: Arc<Location>,
         _request_metadata: Arc<RequestMetadata>,
     ) -> anyhow::Result<()> {
@@ -406,7 +406,7 @@ pub trait EndpointHook: Send + Sync + Debug + Display {
         _warehouse_id: WarehouseId,
         _parameters: NamespaceParameters,
         _request: Arc<CreateTableRequest>,
-        _metadata: Arc<TableMetadata>,
+        _metadata: TableMetadataRef,
         _metadata_location: Option<Arc<Location>>,
         _data_access: DataAccessMode,
         _request_metadata: Arc<RequestMetadata>,

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -2250,7 +2250,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TabularExpirationQueueConfig'
+                $ref: '#/components/schemas/GetTabularExpirationQueueConfig'
         4XX:
           description: ''
           content:
@@ -2274,7 +2274,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TabularExpirationQueueConfig'
+              $ref: '#/components/schemas/SetTabularExpirationQueueConfig'
         required: true
       responses:
         '204':
@@ -2311,7 +2311,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PurgeQueueConfig'
+                $ref: '#/components/schemas/GetPurgeQueueConfig'
         4XX:
           description: ''
           content:
@@ -2335,7 +2335,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PurgeQueueConfig'
+              $ref: '#/components/schemas/SetPurgeQueueConfig'
         required: true
       responses:
         '204':
@@ -3324,6 +3324,18 @@ components:
         project-name:
           type: string
           description: Name of the project
+    GetPurgeQueueConfig:
+      type: object
+      required:
+        - queue-config
+      properties:
+        max-seconds-since-last-heartbeat:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        queue-config:
+          $ref: '#/components/schemas/PurgeQueueConfig'
     GetRoleAccessResponse:
       type: object
       required:
@@ -3378,6 +3390,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TableAssignment'
+    GetTabularExpirationQueueConfig:
+      type: object
+      required:
+        - queue-config
+      properties:
+        max-seconds-since-last-heartbeat:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        queue-config:
+          $ref: '#/components/schemas/TabularExpirationQueueConfig'
     GetTaskDetailsResponse:
       allOf:
         - $ref: '#/components/schemas/Task'
@@ -3400,18 +3424,6 @@ components:
             task-data:
               type: object
               description: Task-specific data
-    GetTaskQueueConfigResponse:
-      type: object
-      required:
-        - queue-config
-      properties:
-        max-seconds-since-last-heartbeat:
-          type:
-            - integer
-            - 'null'
-          format: int64
-        queue-config:
-          $ref: '#/components/schemas/QueueConfigResponse'
     GetViewAccessResponse:
       type: object
       required:
@@ -4417,7 +4429,7 @@ components:
         protected:
           type: boolean
           description: Setting this to `true` will prevent the entity from being deleted unless `force` is used.
-    SetTaskQueueConfigRequest:
+    SetPurgeQueueConfig:
       type: object
       required:
         - queue-config
@@ -4428,7 +4440,19 @@ components:
             - 'null'
           format: int64
         queue-config:
-          $ref: '#/components/schemas/QueueConfig'
+          $ref: '#/components/schemas/PurgeQueueConfig'
+    SetTabularExpirationQueueConfig:
+      type: object
+      required:
+        - queue-config
+      properties:
+        max-seconds-since-last-heartbeat:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        queue-config:
+          $ref: '#/components/schemas/TabularExpirationQueueConfig'
     StorageCredential:
       oneOf:
         - allOf:

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -253,6 +253,15 @@ Lakekeeper collects statistics about the usage of its endpoints. Every Lakekeepe
 
 You may be running Lakekeeper in your own environment which uses self-signed certificates for e.g. Minio. Lakekeeper is built with reqwest's `rustls-tls-native-roots` feature activated, this means `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables are respected. If both are not set, the system's default CA store is used. If you want to use a custom CA store, set `SSL_CERT_FILE` to the path of the CA file or `SSL_CERT_DIR` to the path of the CA directory. The certificate used by the server cannot be a CA. It needs to be an end entity certificate, else you may run into `CaUsedAsEndEntity` errors.
 
+### Debug
+
+Lakekeeper provides debugging options to help troubleshoot issues during development. These options should **not** be enabled in production environments as they can expose sensitive data and impact performance.
+
+| Variable                                             | Example | Description |
+|------------------------------------------------------|---------|-------------|
+| <nobr>`LAKEKEEPER__DEBUG__LOG_REQUEST_BODIES`</nobr> | `true`  | If set to `true`, Lakekeeper will log all incoming request bodies at debug level. This is useful for debugging API interactions but should **never** be enabled in production as it can expose sensitive data (credentials, tokens, etc.) and significantly impact performance. Default: `false` |
+
+**Warning**: Debug options can expose sensitive information in logs and should only be used in secure development environments.
 
 ### Test Configurations
 | Variable                                          | Example | Description    |

--- a/examples/minimal/notebooks/Spark.ipynb
+++ b/examples/minimal/notebooks/Spark.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,20 +48,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DataFrame[]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "spark_config = SparkConf().setMaster('local').setAppName(\"Iceberg-REST\")\n",
     "for k, v in config.items():\n",
@@ -81,57 +70,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>namespace</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>pyiceberg_namespace</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>my_namespace</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "             namespace\n",
-       "0  pyiceberg_namespace\n",
-       "1         my_namespace"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "spark.sql(f\"CREATE NAMESPACE IF NOT EXISTS my_namespace\")\n",
     "spark.sql(\"SHOW NAMESPACES\").toPandas()"
@@ -139,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,56 +99,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>strings</th>\n",
-       "      <th>floats</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>a-string</td>\n",
-       "      <td>2.2</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   id   strings  floats\n",
-       "0   1  a-string     2.2"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "spark.sql(f\"SELECT * FROM my_namespace.my_table\").toPandas()"
    ]


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Use FnOnce for queue & service registration

fix: Return default initial Task Queue Config
fix: Dynamic OpenAPI generation for registered Task Queues
END_COMMIT_OVERRIDE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Fetch warehouse-specific task queue configuration.
  - Task scheduling accepts any iterator for flexible batch enqueuing.

- Improvements
  - Optional request-body logging via a new debug config flag (off by default).
  - get_task_queue_config now returns a default empty config instead of an error when missing.
  - OpenAPI now exposes per-queue config schemas for task queue endpoints.

- Documentation
  - Added Debug configuration docs and warnings; updated config reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->