### PR TITLE
feat: Improve Kubernetes Auth docs

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -460,4 +460,23 @@ subjects:
   name: <lakekeeper-serviceaccount>
   namespace: <lakekeeper-namespace>
 ```
+
 The [Lakekeeper Helm Chart](https://github.com/lakekeeper/lakekeeper-charts/tree/main/charts/lakekeeper) creates the required binding by default.
+
+Applications running in Kubernetes pods can now authenticate using the service account token, which is typically mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`. Simply read this token and include it in the `Authorization` header.
+
+**Example with CURL:**
+```bash
+curl -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+     http://my-lakekeeper:8181/catalog/v1/config
+```
+
+**Example with Spark:**
+```bash
+spark-submit \
+  --conf spark.sql.catalog.lakekeeper.token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  --conf spark.sql.catalog.lakekeeper.uri="http://my-lakekeeper:8181/catalog" \
+  my-spark-job.py
+```
+
+User identities appear in Lakekeeper as `k8s~<namespace>~<service-account-name>`.


### PR DESCRIPTION
Closes https://github.com/lakekeeper/lakekeeper/issues/1339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for authenticating with Kubernetes service account tokens via the Authorization header.
  * Included step-by-step cURL and Apache Spark examples for token-based authentication.
  * Documented how identities are mapped as k8s~<namespace>~<service-account-name>.
  * Clarified that the Helm chart provisions the required binding by default.
  * Improves clarity for cluster-based deployments and simplifies setup for users integrating with Kubernetes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->