### PR TITLE
fix: Parse empty ProjectID headers as None

### DIFF
--- a/crates/lakekeeper/src/request_metadata.rs
+++ b/crates/lakekeeper/src/request_metadata.rs
@@ -277,8 +277,9 @@ pub(crate) async fn create_request_metadata_with_trace_and_project_fn(
         .get(X_PROJECT_ID_HEADER)
         .or(headers.get(PROJECT_ID_HEADER_DEPRECATED))
         .and_then(|hv| hv.to_str().ok())
-        .map(ProjectId::from_str)
-        .transpose();
+        .and_then(|s| (!s.is_empty()).then(|| ProjectId::from_str(s)))
+        .transpose()
+        .map_err(|e| e.append_detail("Invalid project ID header value"));
     let project_id = match project_id {
         Ok(ident) => ident,
         Err(err) => return IcebergErrorResponse::from(err).into_response(),

--- a/crates/lakekeeper/src/request_metadata.rs
+++ b/crates/lakekeeper/src/request_metadata.rs
@@ -255,7 +255,9 @@ pub(crate) async fn create_request_metadata_with_trace_and_project_fn(
     let request_id: Uuid = headers
         .get(X_REQUEST_ID_HEADER)
         .and_then(|hv| hv.to_str().ok())
-        .and_then(|s| (!s.is_empty()).then(|| Uuid::from_str(s)))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(Uuid::from_str)
         .transpose()
         .ok()
         .flatten()
@@ -274,7 +276,9 @@ pub(crate) async fn create_request_metadata_with_trace_and_project_fn(
         .get(X_PROJECT_ID_HEADER)
         .or(headers.get(PROJECT_ID_HEADER_DEPRECATED))
         .and_then(|hv| hv.to_str().ok())
-        .and_then(|s| (!s.is_empty()).then(|| ProjectId::from_str(s)))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ProjectId::from_str)
         .transpose()
         .map_err(|e| e.append_detail(format!("Invalid {X_PROJECT_ID_HEADER} header value.")));
     let project_id = match project_id {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Empty X-Project header values are now safely ignored, preventing unnecessary parsing and reducing false error responses.
  - When a non-empty X-Project header is invalid, the API returns a clearer error with a specific detail indicating an invalid project ID value.
  - X-Request-Id header values are now trimmed, empty values ignored, and validated as UUIDs to improve request tracing and reduce parsing errors.
  - Overall reliability of request handling and troubleshooting improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->