### PR TITLE
feat: Add `debug_migrate_before_serve` env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4008,10 +4008,12 @@ version = "0.10.1"
 dependencies = [
  "anyhow",
  "clap",
+ "figment",
  "lakekeeper",
  "lakekeeper-console",
  "limes",
  "reqwest",
+ "serde",
  "tracing-subscriber",
 ]
 

--- a/crates/lakekeeper-bin/Cargo.toml
+++ b/crates/lakekeeper-bin/Cargo.toml
@@ -23,8 +23,13 @@ ui = ["dep:lakekeeper-console"]
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "^4.5", features = ["derive"] }
+figment = { workspace = true }
 lakekeeper = { path = "../lakekeeper", features = ["all"] }
 lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.10.2", optional = true }
 limes = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+figment = { workspace = true, features = ["test"] }

--- a/crates/lakekeeper-bin/src/config.rs
+++ b/crates/lakekeeper-bin/src/config.rs
@@ -13,8 +13,8 @@ pub(crate) struct DynAppConfig {
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, Default)]
-pub struct DebugConfig {
-    pub migrate_before_serve: bool,
+pub(crate) struct DebugConfig {
+    pub(crate) migrate_before_serve: bool,
 }
 
 fn get_config() -> DynAppConfig {

--- a/crates/lakekeeper-bin/src/config.rs
+++ b/crates/lakekeeper-bin/src/config.rs
@@ -4,14 +4,17 @@ use serde::{Deserialize, Serialize};
 
 pub(crate) static CONFIG_BIN: LazyLock<DynAppConfig> = LazyLock::new(get_config);
 
-#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Deserialize, Serialize, Debug, Default)]
 pub(crate) struct DynAppConfig {
     /// Run migration before serving requests. This can simplify testing.
     /// We do not recommend enabling this in production, especially if
     /// multiple instances of Lakekeeper are running.
-    #[serde(alias = "debug__migrate_before_serve")]
-    pub(crate) debug_migrate_before_serve: bool,
+    pub(crate) debug: DebugConfig,
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, Default)]
+pub struct DebugConfig {
+    pub migrate_before_serve: bool,
 }
 
 fn get_config() -> DynAppConfig {
@@ -46,21 +49,21 @@ mod tests {
     fn test_migrate_before_serve_env_vars() {
         figment::Jail::expect_with(|_jail| {
             let config = get_config();
-            assert!(!config.debug_migrate_before_serve);
+            assert!(!config.debug.migrate_before_serve);
             Ok(())
         });
 
         figment::Jail::expect_with(|jail| {
             jail.set_env("LAKEKEEPER_TEST__DEBUG__MIGRATE_BEFORE_SERVE", "true");
             let config = get_config();
-            assert!(config.debug_migrate_before_serve);
+            assert!(config.debug.migrate_before_serve);
             Ok(())
         });
 
         figment::Jail::expect_with(|jail| {
             jail.set_env("LAKEKEEPER_TEST__DEBUG__MIGRATE_BEFORE_SERVE", "false");
             let config = get_config();
-            assert!(!config.debug_migrate_before_serve);
+            assert!(!config.debug.migrate_before_serve);
             Ok(())
         });
     }

--- a/crates/lakekeeper-bin/src/config.rs
+++ b/crates/lakekeeper-bin/src/config.rs
@@ -1,0 +1,67 @@
+use std::sync::LazyLock;
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) static CONFIG_BIN: LazyLock<DynAppConfig> = LazyLock::new(get_config);
+
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Deserialize, Serialize, Debug, Default)]
+pub(crate) struct DynAppConfig {
+    /// Run migration before serving requests. This can simplify testing.
+    /// We do not recommend enabling this in production, especially if
+    /// multiple instances of Lakekeeper are running.
+    #[serde(alias = "debug__migrate_before_serve")]
+    pub(crate) debug_migrate_before_serve: bool,
+}
+
+fn get_config() -> DynAppConfig {
+    let defaults = figment::providers::Serialized::defaults(DynAppConfig::default());
+
+    #[cfg(not(test))]
+    let prefixes = &["LAKEKEEPER__"];
+    #[cfg(test)]
+    let prefixes = &["LAKEKEEPER_TEST__"];
+
+    let mut config = figment::Figment::from(defaults);
+    for prefix in prefixes {
+        let env = figment::providers::Env::prefixed(prefix).split("__");
+        config = config.merge(env);
+    }
+
+    let config = match config.extract::<DynAppConfig>() {
+        Ok(c) => c,
+        Err(e) => {
+            panic!("Failed to extract Lakekeeper Binary config: {e}");
+        }
+    };
+
+    config
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_migrate_before_serve_env_vars() {
+        figment::Jail::expect_with(|_jail| {
+            let config = get_config();
+            assert!(!config.debug_migrate_before_serve);
+            Ok(())
+        });
+
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__DEBUG__MIGRATE_BEFORE_SERVE", "true");
+            let config = get_config();
+            assert!(config.debug_migrate_before_serve);
+            Ok(())
+        });
+
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__DEBUG__MIGRATE_BEFORE_SERVE", "false");
+            let config = get_config();
+            assert!(!config.debug_migrate_before_serve);
+            Ok(())
+        });
+    }
+}

--- a/crates/lakekeeper-bin/src/main.rs
+++ b/crates/lakekeeper-bin/src/main.rs
@@ -141,7 +141,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Commands::Serve { force_start }) => {
             print_info();
-            if CONFIG_BIN.debug_migrate_before_serve {
+            if CONFIG_BIN.debug.migrate_before_serve {
                 wait_for_db::wait_for_db(false, 15, 2, true).await?;
                 migrate().await?;
             }

--- a/crates/lakekeeper-bin/src/main.rs
+++ b/crates/lakekeeper-bin/src/main.rs
@@ -18,12 +18,14 @@ use lakekeeper::{
 };
 use tracing_subscriber::{filter::LevelFilter, EnvFilter};
 
+mod config;
 mod healthcheck;
 mod serve;
 #[cfg(feature = "ui")]
 mod ui;
 mod wait_for_db;
 
+pub(crate) use config::CONFIG_BIN;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Parser)]
@@ -135,37 +137,15 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Commands::Migrate {}) => {
             print_info();
-            println!("Migrating database...");
-            let write_pool = lakekeeper::implementations::postgres::get_writer_pool(
-                CONFIG
-                    .to_pool_opts()
-                    .acquire_timeout(std::time::Duration::from_secs(CONFIG.pg_acquire_timeout)),
-            )
-            .await?;
-
-            // This embeds database migrations in the application binary so we can ensure the database
-            // is migrated correctly on startup
-            let server_id =
-                lakekeeper::implementations::postgres::migrations::migrate(&write_pool).await?;
-            println!("Database migration complete.");
-
-            println!("Migrating authorizer...");
-            lakekeeper::service::authz::implementations::migrate_default_authorizer(server_id)
-                .await?;
-            println!("Authorizer migration complete.");
+            migrate().await?;
         }
         Some(Commands::Serve { force_start }) => {
             print_info();
-            tracing::info!(
-                "Starting server on {}:{}...",
-                CONFIG.bind_ip,
-                CONFIG.listen_port
-            );
-            let bind_addr = std::net::SocketAddr::from((CONFIG.bind_ip, CONFIG.listen_port));
-            if !force_start {
-                wait_for_db::wait_for_db(true, 0, 0, true).await?;
+            if CONFIG_BIN.debug_migrate_before_serve {
+                wait_for_db::wait_for_db(false, 15, 2, true).await?;
+                migrate().await?;
             }
-            serve::serve_default(bind_addr).await?;
+            serve(force_start).await?;
         }
         Some(Commands::Healthcheck {
             check_all,
@@ -195,6 +175,42 @@ async fn main() -> anyhow::Result<()> {
             eprintln!("No subcommand provided. Use --help for more information.");
         }
     }
+
+    Ok(())
+}
+
+async fn migrate() -> anyhow::Result<()> {
+    println!("Migrating database...");
+    let write_pool = lakekeeper::implementations::postgres::get_writer_pool(
+        CONFIG
+            .to_pool_opts()
+            .acquire_timeout(std::time::Duration::from_secs(CONFIG.pg_acquire_timeout)),
+    )
+    .await?;
+
+    // This embeds database migrations in the application binary so we can ensure the database
+    // is migrated correctly on startup
+    let server_id = lakekeeper::implementations::postgres::migrations::migrate(&write_pool).await?;
+    println!("Database migration complete.");
+
+    println!("Migrating authorizer...");
+    lakekeeper::service::authz::implementations::migrate_default_authorizer(server_id).await?;
+    println!("Authorizer migration complete.");
+
+    Ok(())
+}
+
+async fn serve(force_start: bool) -> anyhow::Result<()> {
+    tracing::info!(
+        "Starting server on {}:{}...",
+        CONFIG.bind_ip,
+        CONFIG.listen_port
+    );
+    let bind_addr = std::net::SocketAddr::from((CONFIG.bind_ip, CONFIG.listen_port));
+    if !force_start {
+        wait_for_db::wait_for_db(true, 0, 0, true).await?;
+    }
+    serve::serve_default(bind_addr).await?;
 
     Ok(())
 }

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -90,11 +90,11 @@ Configuration parameters if a Vault KV version 2 (i.e. Hashicorp Vault) compatib
 
 Lakekeeper uses task queues internally to remove soft-deleted tabulars and purge tabular files. The following global configuration options are available:
 
-| Variable                                                                                                                                 | Example    | Description |
-|------------------------------------------------------------------------------------------------------------------------------------------|------------|-----|
-| <nobr>`LAKEKEEPER__TASK_POLL_INTERVAL`</nobr>                                                                                            | 3600ms/30s | Interval between polling for new tasks. Default: 10s. Supported units: ms (milliseconds) and s (seconds), leaving the unit out is deprecated, it'll default to seconds but is due to be removed in a future release. |
-| `LAKEKEEPER__TASK_TABULAR_EXPIRATION_WORKERS`                                                                                            | 2          | Number of workers spawned to expire soft-deleted tables and views. |
-| `LAKEKEEPER__TASK_TABULAR_PURGE_WORKERS`                                                                                                 | 2          | Number of workers spawned to purge table files after dropping a table with the purge option. |
+| Variable                                                                          | Example    | Description |
+|-----------------------------------------------------------------------------------|------------|-----|
+| <nobr>`LAKEKEEPER__TASK_POLL_INTERVAL`</nobr>                                     | 3600ms/30s | Interval between polling for new tasks. Default: 10s. Supported units: ms (milliseconds) and s (seconds), leaving the unit out is deprecated, it'll default to seconds but is due to be removed in a future release. |
+| `LAKEKEEPER__TASK_TABULAR_EXPIRATION_WORKERS`                                     | 2          | Number of workers spawned to expire soft-deleted tables and views. |
+| `LAKEKEEPER__TASK_TABULAR_PURGE_WORKERS`                                          | 2          | Number of workers spawned to purge table files after dropping a table with the purge option. |
 | <nobr>`LAKEKEEPER__TASK_EXPIRE_SNAPSHOTS_WORKERS`</nobr><span class="lkp"></span> | 2          | Number of workers spawned that work on expire Snapshots tasks. See [Expire Snapshots Docs](./table-maintenance.md#expire-snapshots) for more information. |
 
 ### NATS
@@ -258,9 +258,10 @@ You may be running Lakekeeper in your own environment which uses self-signed cer
 
 Lakekeeper provides debugging options to help troubleshoot issues during development. These options should **not** be enabled in production environments as they can expose sensitive data and impact performance.
 
-| Variable                                             | Example | Description |
-|------------------------------------------------------|---------|-------------|
-| <nobr>`LAKEKEEPER__DEBUG__LOG_REQUEST_BODIES`</nobr> | `true`  | If set to `true`, Lakekeeper will log all incoming request bodies at debug level. This is useful for debugging API interactions but should **never** be enabled in production as it can expose sensitive data (credentials, tokens, etc.) and significantly impact performance. Default: `false` |
+| Variable                                               | Example | Description |
+|--------------------------------------------------------|---------|-----------|
+| <nobr>`LAKEKEEPER__DEBUG__LOG_REQUEST_BODIES`</nobr>   | `true`  | If set to `true`, Lakekeeper will log all incoming request bodies at debug level. This is useful for debugging API interactions but should **never** be enabled in production as it can expose sensitive data (credentials, tokens, etc.) and significantly impact performance. Default: `false` |
+| <nobr>`LAKEKEEPER__DEBUG__MIGRATE_BEFORE_SERVE`</nobr> | `true`  | If set to `true`, Lakekeeper waits for the DB (30s) and runs migrations when `serve` is called. Default: `false` |
 
 **Warning**: Debug options can expose sensitive information in logs and should only be used in secure development environments.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional pre-serve database migration, controllable via environment variable (LAKEKEEPER__DEBUG__MIGRATE_BEFORE_SERVE).
  - Introduced configuration for task worker count handling snapshot expiration (LAKEKEEPER__TASK_EXPIRE_SNAPSHOTS_WORKERS).

- Documentation
  - Updated configuration guide with the new environment variables and improved table formatting.
  - Clarified the Debug section and included a warning note for better guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->