### PR TITLE
fix: CORS allow access delegation & etag headers

### DIFF
--- a/crates/lakekeeper/src/api/iceberg/v1/tables.rs
+++ b/crates/lakekeeper/src/api/iceberg/v1/tables.rs
@@ -381,7 +381,7 @@ pub struct TableParameters {
 }
 
 pub const DATA_ACCESS_HEADER: &str = "X-Iceberg-Access-Delegation";
-pub const IF_NON_MATCH_HEADER: &str = "If-None-Match";
+pub const IF_NONE_MATCH_HEADER: &str = "If-None-Match";
 pub const ETAG_HEADER: &str = "ETag";
 
 #[derive(Debug, Clone, PartialEq, Copy)]

--- a/crates/lakekeeper/src/api/router.rs
+++ b/crates/lakekeeper/src/api/router.rs
@@ -20,7 +20,7 @@ use crate::{
     api::{
         iceberg::v1::{
             new_v1_full_router,
-            tables::{DATA_ACCESS_HEADER, ETAG_HEADER, IF_NON_MATCH_HEADER},
+            tables::{DATA_ACCESS_HEADER, ETAG_HEADER, IF_NONE_MATCH_HEADER},
         },
         management::v1::{api_doc as v1_api_doc, ApiServer},
         ApiContext,
@@ -239,9 +239,9 @@ fn get_cors_layer(
                 HeaderName::from_static(X_PROJECT_ID_HEADER),
                 HeaderName::from_static("x-user-agent"),
                 HeaderName::from_static(DATA_ACCESS_HEADER),
-                HeaderName::from_static(IF_NON_MATCH_HEADER),
-                HeaderName::from_static(ETAG_HEADER),
+                HeaderName::from_static(IF_NONE_MATCH_HEADER),
             ])
+            .expose_headers(vec![HeaderName::from_static(ETAG_HEADER)])
             .allow_methods(vec![
                 Method::GET,
                 Method::HEAD,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for ETag and If-None-Match headers in the API.
  * Updated CORS to allow and expose these headers (alongside existing data-access header).
  * Improves conditional request handling and response efficiency for clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->