### PR TITLE
feat: Make Warehouse Cache case-insensitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3954,6 +3954,7 @@ dependencies = [
  "tracing-test",
  "tryhard",
  "typed-builder 0.22.0",
+ "unicase",
  "url",
  "urlencoding",
  "utoipa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.87.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]
+unicase = "2.8.1"
 anyhow = "^1.0"
 assert-json-diff = "2.0.2"
 async-channel = { version = "2.3.1" }

--- a/crates/lakekeeper/Cargo.toml
+++ b/crates/lakekeeper/Cargo.toml
@@ -97,6 +97,7 @@ strum_macros = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
+unicase = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true, features = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Warehouse name lookups now support case-insensitive matching. Users can query warehouses using any combination of uppercase, lowercase, or mixed-case names and retrieve the correct warehouse.

* **Tests**
  * Added test coverage validating case-insensitive warehouse name lookups across different case variations.

* **Chores**
  * Added unicase dependency to support case-insensitive string operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->