### PR TITLE
fix(linter): derive Default for AuthZBackend and OpenFGAAuth

### DIFF
--- a/crates/authz-openfga/src/config.rs
+++ b/crates/authz-openfga/src/config.rs
@@ -82,9 +82,10 @@ pub struct OpenFGAConfig {
     pub max_batch_check_size: usize,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, veil::Redact)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, veil::Redact)]
 #[serde(rename_all = "snake_case")]
 pub enum OpenFGAAuth {
+    #[default]
     Anonymous,
     ClientCredentials {
         client_id: String,
@@ -95,12 +96,6 @@ pub enum OpenFGAAuth {
     },
     #[redact(all)]
     ApiKey(String),
-}
-
-impl Default for OpenFGAAuth {
-    fn default() -> Self {
-        Self::Anonymous
-    }
 }
 
 fn deserialize_openfga_config<'de, D>(deserializer: D) -> Result<Option<OpenFGAConfig>, D::Error>

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -369,8 +369,9 @@ where
         .serialize(serializer)
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub enum AuthZBackend {
+    #[default]
     AllowAll,
     External(String),
 }
@@ -400,12 +401,6 @@ impl Serialize for AuthZBackend {
             AuthZBackend::AllowAll => "allowall".serialize(serializer),
             AuthZBackend::External(s) => s.to_lowercase().serialize(serializer),
         }
-    }
-}
-
-impl Default for AuthZBackend {
-    fn default() -> Self {
-        Self::AllowAll
     }
 }
 


### PR DESCRIPTION
`clippy 0.1.91 (f8297e351a 2025-10-28)`

```
error: this `impl` can be derived
   --> crates/lakekeeper/src/config.rs:406:1
    |
406 | / impl Default for AuthZBackend {
407 | |     fn default() -> Self {
408 | |         Self::AllowAll
409 | |     }
410 | | }
    | |_^
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Authorization backend configuration now supports flexible, case-insensitive string formats for more forgiving configuration management.
  * Default authorization backend behavior is now explicitly defined for clearer defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->