### PR TITLE
fix(linter): fix linter errors for implicit cloning

### DIFF
--- a/crates/authz-openfga/Cargo.toml
+++ b/crates/authz-openfga/Cargo.toml
@@ -10,10 +10,10 @@ license = { workspace = true }
 description = "OpenFGA Authorizer for Lakekeeper"
 keywords = ["iceberg", "rest", "lakekeeper", "openfga"]
 
+[lib]
+
 [features]
 open-api = ["dep:utoipa", "lakekeeper/open-api"]
-
-[lib]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/authz-openfga/src/api.rs
+++ b/crates/authz-openfga/src/api.rs
@@ -402,7 +402,7 @@ async fn get_server_access<C: CatalogStore, S: SecretStore>(
 ) -> Result<(StatusCode, Json<GetServerAccessResponse>)> {
     let authorizer = api_context.v1_state.authz;
     let query = ParsedAccessQuery::try_from(query)?;
-    let openfga_server = authorizer.openfga_server().to_string();
+    let openfga_server = authorizer.openfga_server().clone();
     let relations = get_allowed_actions(
         authorizer,
         metadata.actor(),
@@ -836,7 +836,7 @@ async fn get_server_assignments<C: CatalogStore, S: SecretStore>(
     Query(query): Query<GetServerAssignmentsQuery>,
 ) -> Result<(StatusCode, Json<GetServerAssignmentsResponse>)> {
     let authorizer = api_context.v1_state.authz;
-    let server_id = authorizer.openfga_server().to_string();
+    let server_id = authorizer.openfga_server().clone();
     authorizer
         .require_action(&metadata, AllServerAction::CanReadAssignments, &server_id)
         .await?;
@@ -1073,7 +1073,7 @@ async fn update_server_assignments<C: CatalogStore, S: SecretStore>(
     Json(request): Json<UpdateServerAssignmentsRequest>,
 ) -> Result<StatusCode> {
     let authorizer = api_context.v1_state.authz;
-    let server_id = authorizer.openfga_server().to_string();
+    let server_id = authorizer.openfga_server().clone();
     checked_write(
         authorizer,
         metadata.actor(),
@@ -1522,7 +1522,7 @@ async fn get_allowed_actions<A: ReducedRelation + IntoEnumIterator>(
     let actions = A::iter().collect::<Vec<_>>();
     let for_principal = for_principal
         .map(super::entities::OpenFgaEntity::to_openfga)
-        .unwrap_or(openfga_actor.to_string());
+        .unwrap_or(openfga_actor.clone());
 
     let actions = actions.iter().map(|action| async {
         let key = CheckRequestTupleKey {
@@ -1764,7 +1764,7 @@ mod tests {
                     Some(vec![TupleKey {
                         user: user_id.to_openfga(),
                         relation: ServerRelation::Admin.to_openfga().to_string(),
-                        object: openfga_server.to_string(),
+                        object: openfga_server.clone(),
                         condition: None,
                     }]),
                     None,
@@ -1900,7 +1900,7 @@ mod tests {
                     Some(vec![TupleKey {
                         user: user_id.to_openfga(),
                         relation: ServerRelation::Admin.to_openfga().to_string(),
-                        object: openfga_server.to_string(),
+                        object: openfga_server.clone(),
                         condition: None,
                     }]),
                     None,
@@ -1938,7 +1938,7 @@ mod tests {
                     Some(vec![TupleKey {
                         user: role_id.into_assignees().to_openfga(),
                         relation: ServerRelation::Admin.to_openfga().to_string(),
-                        object: openfga_server.to_string(),
+                        object: openfga_server.clone(),
                         condition: None,
                     }]),
                     None,
@@ -1968,7 +1968,7 @@ mod tests {
                     Some(vec![TupleKey {
                         user: user_id.to_openfga(),
                         relation: ServerRelation::Admin.to_openfga().to_string(),
-                        object: openfga_server.to_string(),
+                        object: openfga_server.clone(),
                         condition: None,
                     }]),
                     None,
@@ -1991,7 +1991,7 @@ mod tests {
                     Some(vec![TupleKey {
                         user: role_id.into_assignees().to_openfga(),
                         relation: ServerRelation::Admin.to_openfga().to_string(),
-                        object: openfga_server.to_string(),
+                        object: openfga_server.clone(),
                         condition: None,
                     }]),
                     None,
@@ -2026,7 +2026,7 @@ mod tests {
                     Some(vec![TupleKey {
                         user: user1_id.to_openfga(),
                         relation: ServerRelation::Admin.to_openfga().to_string(),
-                        object: openfga_server.to_string(),
+                        object: openfga_server.clone(),
                         condition: None,
                     }]),
                     None,

--- a/crates/authz-openfga/src/authorizer.rs
+++ b/crates/authz-openfga/src/authorizer.rs
@@ -172,7 +172,7 @@ impl Authorizer for OpenFGAAuthorizer {
             Some(vec![TupleKey {
                 user: user.to_openfga(),
                 relation: relation.to_string(),
-                object: self.openfga_server().to_string(),
+                object: self.openfga_server().clone(),
                 condition: None,
             }]),
             None,
@@ -235,7 +235,7 @@ impl Authorizer for OpenFGAAuthorizer {
             };
         }
 
-        let server_id = self.openfga_server().to_string();
+        let server_id = self.openfga_server().clone();
         match action {
             // Currently, given a user-id, all information about a user can be retrieved.
             // For multi-tenant setups, we need to restrict this to a tenant.
@@ -268,7 +268,7 @@ impl Authorizer for OpenFGAAuthorizer {
         self.check(CheckRequestTupleKey {
             user: metadata.actor().to_openfga(),
             relation: action.to_string(),
-            object: self.openfga_server().to_string(),
+            object: self.openfga_server().clone(),
         })
         .await
         .map_err(Into::into)
@@ -471,7 +471,7 @@ impl Authorizer for OpenFGAAuthorizer {
         let actor = metadata.actor();
 
         self.require_no_relations(project_id).await?;
-        let server = self.openfga_server().to_string();
+        let server = self.openfga_server().clone();
         let this_id = project_id.to_openfga();
         self.write(
             Some(vec![
@@ -725,7 +725,7 @@ impl OpenFGAAuthorizer {
             .check(CheckRequestTupleKey {
                 user: actor.to_openfga(),
                 relation: ServerRelation::CanListAllProjects.to_string(),
-                object: self.openfga_server().to_string(),
+                object: self.openfga_server().clone(),
             })
             .await?;
 

--- a/crates/authz-openfga/src/check.rs
+++ b/crates/authz-openfga/src/check.rs
@@ -146,7 +146,7 @@ async fn check_warehouse(
         .await?;
     Ok((
         action.to_openfga().to_string(),
-        warehouse_id.to_openfga().to_string(),
+        warehouse_id.to_openfga().clone(),
     ))
 }
 
@@ -181,7 +181,7 @@ async fn check_server(
     for_principal: &mut Option<UserOrRole>,
     action: &APIServerAction,
 ) -> Result<(String, String)> {
-    let openfga_server = authorizer.openfga_server().to_string();
+    let openfga_server = authorizer.openfga_server().clone();
     if for_principal.is_some() {
         authorizer
             .require_action(

--- a/crates/authz-openfga/src/health.rs
+++ b/crates/authz-openfga/src/health.rs
@@ -17,7 +17,7 @@ impl HealthExt for OpenFGAAuthorizer {
             .check(CheckRequestTupleKey {
                 user: ProjectId::new_random().to_openfga(),
                 relation: ServerRelation::Project.to_string(),
-                object: self.openfga_server().to_string(),
+                object: self.openfga_server().clone(),
             })
             .await;
 

--- a/crates/authz-openfga/src/migration/migration_fns_v4.rs
+++ b/crates/authz-openfga/src/migration/migration_fns_v4.rs
@@ -238,7 +238,7 @@ async fn get_all_warehouses(
             let tuples = client
                 .read_all_pages(
                     Some(ReadRequestTupleKey {
-                        user: p.to_string(),
+                        user: p.clone(),
                         relation: WarehouseRelation::Project.to_string(),
                         object: "warehouse:".to_string(),
                     }),
@@ -597,13 +597,13 @@ mod openfga_integration_tests {
             .write(
                 Some(vec![
                     TupleKey {
-                        user: authorizer.openfga_server().to_string(),
+                        user: authorizer.openfga_server().clone(),
                         relation: ProjectRelation::Server.to_string(),
                         object: "project:p1".to_string(),
                         condition: None,
                     },
                     TupleKey {
-                        user: authorizer.openfga_server().to_string(),
+                        user: authorizer.openfga_server().clone(),
                         relation: ProjectRelation::Server.to_string(),
                         object: "project:p2".to_string(),
                         condition: None,
@@ -1733,7 +1733,7 @@ mod openfga_integration_tests {
                 Some(vec![
                     // Project structure
                     TupleKey {
-                        user: authorizer.openfga_server().to_string(),
+                        user: authorizer.openfga_server().clone(),
                         relation: ProjectRelation::Server.to_string(),
                         object: project_openfga.clone(),
                         condition: None,

--- a/crates/io/src/gcs/gcs_storage.rs
+++ b/crates/io/src/gcs/gcs_storage.rs
@@ -158,7 +158,7 @@ impl LakekeeperStorage for GcsStorage {
         };
 
         if bytes.len() < MAX_BYTES_PER_REQUEST {
-            let mut media = Media::new(location.object_name().to_string());
+            let mut media = Media::new(location.object_name().clone());
             media.content_length = Some(bytes.len() as u64);
             let upload_type = UploadType::Simple(media);
 

--- a/crates/lakekeeper/src/api/endpoints.rs
+++ b/crates/lakekeeper/src/api/endpoints.rs
@@ -440,7 +440,7 @@ mod test {
             // Remove leading "/" to match normalized paths from YAML
             assert!(path.starts_with('/'), "Path should start with '/'");
             let normalized_path = path.trim_start_matches('/');
-            actual_endpoints.insert((method.to_string(), normalized_path.to_string()));
+            actual_endpoints.insert((method.clone(), normalized_path.to_string()));
         }
 
         // Find missing endpoints

--- a/crates/lakekeeper/src/implementations/postgres/endpoint_statistics/sink.rs
+++ b/crates/lakekeeper/src/implementations/postgres/endpoint_statistics/sink.rs
@@ -230,7 +230,7 @@ async fn resolve_warehouses(
             e.keys().filter_map(|epi| {
                 epi.warehouse_name
                     .as_ref()
-                    .map(|warehouse| (p.to_string(), warehouse.to_string()))
+                    .map(|warehouse| (p.to_string(), warehouse.clone()))
             })
         })
         .unique()

--- a/crates/lakekeeper/src/implementations/postgres/role.rs
+++ b/crates/lakekeeper/src/implementations/postgres/role.rs
@@ -203,7 +203,7 @@ pub(crate) async fn list_roles<'e, 'c: 'e, E: sqlx::Executor<'c, Database = sqlx
             .map(|id| Uuid::from(id))
             .collect::<Vec<uuid::Uuid>>() as Vec<Uuid>,
         filter_name.is_empty(),
-        filter_name.to_string(),
+        filter_name.clone(),
         token_ts,
         token_id,
         page_size,

--- a/crates/lakekeeper/src/implementations/postgres/tabular/table/common.rs
+++ b/crates/lakekeeper/src/implementations/postgres/tabular/table/common.rs
@@ -610,7 +610,7 @@ pub(crate) async fn set_table_properties(
     }
     let (keys, vals): (Vec<String>, Vec<String>) = properties
         .iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .map(|(k, v)| (k.clone(), v.clone()))
         .unzip();
     sqlx::query!(
         r#"WITH drop as (DELETE FROM table_properties WHERE warehouse_id = $1 AND table_id = $2)

--- a/crates/lakekeeper/src/implementations/postgres/tabular/view/mod.rs
+++ b/crates/lakekeeper/src/implementations/postgres/tabular/view/mod.rs
@@ -175,7 +175,7 @@ pub(crate) async fn set_view_properties(
 ) -> Result<(), CatalogBackendError> {
     let (keys, vals): (Vec<String>, Vec<String>) = properties
         .iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .map(|(k, v)| (k.clone(), v.clone()))
         .unzip();
     sqlx::query!(
         r#"INSERT INTO view_properties (warehouse_id, view_id, key, value)

--- a/crates/lakekeeper/src/implementations/postgres/user.rs
+++ b/crates/lakekeeper/src/implementations/postgres/user.rs
@@ -130,7 +130,7 @@ pub(crate) async fn list_users<'e, 'c: 'e, E: sqlx::Executor<'c, Database = sqlx
         LIMIT $7
         "#,
         filter_name.is_empty(),
-        filter_name.to_string(),
+        filter_name.clone(),
         filter_user_id.is_none(),
         filter_user_id
             .unwrap_or_default()

--- a/crates/lakekeeper/src/server/namespace.rs
+++ b/crates/lakekeeper/src/server/namespace.rs
@@ -878,7 +878,7 @@ mod tests {
         CatalogServer,
         ListNamespacesQuery,
         namespaces,
-        |ns| ns.inner()[0].to_string()
+        |ns| ns.inner()[0].clone()
     );
 
     #[sqlx::test]

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -4049,7 +4049,7 @@ pub(crate) mod test {
         // Test without overwrite flag - should fail
         let register_request = iceberg_ext::catalog::rest::RegisterTableRequest::builder()
             .name("test_overwrite".to_string())
-            .metadata_location(second_table.metadata_location.as_ref().unwrap().to_string())
+            .metadata_location(second_table.metadata_location.as_ref().unwrap().clone())
             .build();
 
         CatalogServer::register_table(
@@ -4065,7 +4065,7 @@ pub(crate) mod test {
         let register_request_with_overwrite =
             iceberg_ext::catalog::rest::RegisterTableRequest::builder()
                 .name("test_overwrite".to_string())
-                .metadata_location(second_table.metadata_location.as_ref().unwrap().to_string())
+                .metadata_location(second_table.metadata_location.as_ref().unwrap().clone())
                 .overwrite(true)
                 .build();
 

--- a/crates/lakekeeper/src/server/views/drop.rs
+++ b/crates/lakekeeper/src/server/views/drop.rs
@@ -207,7 +207,7 @@ mod test {
         let loaded_view = load_view(
             api_context.clone(),
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(&table_ident).unwrap(),
             },
         )
@@ -216,7 +216,7 @@ mod test {
         assert_eq!(loaded_view.metadata, created_view.metadata);
         drop_view(
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(&table_ident).unwrap(),
             },
             DropParams {
@@ -232,7 +232,7 @@ mod test {
         let error = load_view(
             api_context.clone(),
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(table_ident).unwrap(),
             },
         )
@@ -284,7 +284,7 @@ mod test {
         let loaded_view = load_view(
             api_context.clone(),
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(&table_ident).unwrap(),
             },
         )
@@ -304,7 +304,7 @@ mod test {
 
         let e = drop_view(
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(&table_ident).unwrap(),
             },
             DropParams {
@@ -331,7 +331,7 @@ mod test {
 
         drop_view(
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(&table_ident).unwrap(),
             },
             DropParams {
@@ -347,7 +347,7 @@ mod test {
         let error = load_view(
             api_context,
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(table_ident).unwrap(),
             },
         )
@@ -379,7 +379,7 @@ mod test {
         let loaded_view = load_view(
             api_context.clone(),
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(&table_ident).unwrap(),
             },
         )
@@ -399,7 +399,7 @@ mod test {
 
         drop_view(
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(&table_ident).unwrap(),
             },
             DropParams {
@@ -415,7 +415,7 @@ mod test {
         let error = load_view(
             api_context,
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(table_ident).unwrap(),
             },
         )

--- a/crates/lakekeeper/src/server/views/load.rs
+++ b/crates/lakekeeper/src/server/views/load.rs
@@ -189,7 +189,7 @@ pub(crate) mod test {
         let loaded_view = load_view(
             api_context,
             ViewParameters {
-                prefix: Some(Prefix(prefix.to_string())),
+                prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(table_ident).unwrap(),
             },
         )

--- a/crates/lakekeeper/src/service/event_publisher/mod.rs
+++ b/crates/lakekeeper/src/service/event_publisher/mod.rs
@@ -550,9 +550,9 @@ impl CloudEventsPublisherBackgroundTask {
                 .extension("tabular-type", tabular_id.typ_str())
                 .extension("tabular-id", tabular_id.to_string())
                 .extension("warehouse-id", warehouse_id.to_string())
-                .extension("name", name.to_string())
-                .extension("namespace", namespace.to_string())
-                .extension("prefix", prefix.to_string())
+                .extension("name", name.clone())
+                .extension("namespace", namespace.clone())
+                .extension("prefix", prefix.clone())
                 .extension("num-events", i64::try_from(num_events).unwrap_or(i64::MAX))
                 .extension(
                     "sequence-number",

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -272,7 +272,7 @@ impl AdlsProfile {
                     OffsetDateTime::now_utc()
                         .saturating_sub(time::Duration::minutes(5))
                         .saturating_add(time::Duration::days(7)),
-                    azure_core::auth::Secret::new(key.to_string()),
+                    azure_core::auth::Secret::new(key.clone()),
                 )?,
                 AzCredential::AzureSystemIdentity {} => {
                     let client = self.blob_service_client(credential).await?;
@@ -483,7 +483,7 @@ impl AdlsProfile {
 #[must_use]
 pub(crate) fn reduce_scheme_string(path: &str) -> String {
     AdlsLocation::try_from_str(path, true)
-        .map(|l| format!("/{}", l.blob_name().to_string().trim_start_matches('/')))
+        .map(|l| format!("/{}", l.blob_name().clone().trim_start_matches('/')))
         .unwrap_or(path.to_string())
 }
 
@@ -557,7 +557,7 @@ pub(super) fn get_file_io_from_table_config(
     let mut sas_token = None;
     for (key, value) in &config {
         if key.starts_with(sas_token_prefix) {
-            sas_token = Some(value.to_string());
+            sas_token = Some(value.clone());
             break;
         }
     }
@@ -647,7 +647,7 @@ pub(crate) mod test {
             let key_prefix = format!("test-{}", uuid::Uuid::now_v7());
             AdlsProfile {
                 filesystem,
-                key_prefix: Some(key_prefix.to_string()),
+                key_prefix: Some(key_prefix.clone()),
                 account_name,
                 authority_host: None,
                 host: None,

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -193,7 +193,7 @@ impl From<&GcsServiceKey> for CredentialsFile {
         }: &GcsServiceKey,
     ) -> Self {
         Self {
-            tp: tp.to_string(),
+            tp: tp.clone(),
             client_email: Some(client_email.clone()),
             private_key_id: Some(private_key_id.clone()),
             private_key: Some(private_key.clone()),

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -429,12 +429,12 @@ impl S3Profile {
             config.insert(&s3::PathStyleAccess(true));
         }
 
-        config.insert(&s3::Region(self.region.to_string()));
+        config.insert(&s3::Region(self.region.clone()));
         config.insert(&custom::CustomConfig {
             key: "region".to_string(),
-            value: self.region.to_string(),
+            value: self.region.clone(),
         });
-        config.insert(&client::Region(self.region.to_string()));
+        config.insert(&client::Region(self.region.clone()));
 
         if let Some(endpoint) = &self.endpoint {
             config.insert(&s3::Endpoint(endpoint.clone()));

--- a/crates/lakekeeper/src/tests/drop_recursive.rs
+++ b/crates/lakekeeper/src/tests/drop_recursive.rs
@@ -613,7 +613,7 @@ async fn setup_drop_test(
         let _ = crate::tests::create_ns(
             ctx.clone(),
             warehouse.warehouse_id.to_string(),
-            ns_name.to_string(),
+            ns_name.clone(),
         )
         .await;
         for i in 0..n_tabs {


### PR DESCRIPTION
`clippy 0.1.91 (f8297e351a 2025-10-28)`

an example of the fixed errors
```
error: implicitly cloning a `String` by calling `to_string` on its dereferenced type
   --> crates/lakekeeper/src/service/storage/az.rs:275:51
    |
275 |                     azure_core::auth::Secret::new(key.to_string()),
    |                                                   ^^^^^^^^^^^^^^^ help: consider using: `key.clone()`
    |
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized string ownership handling across authorization, storage, and API modules by using more efficient cloning patterns.

* **Tests**
  * Updated test implementations to use optimized string handling patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->