### PR TITLE
chore: remove dep on forked rdkafka and remove build dep on openssl-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2406,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -3865,7 +3865,6 @@ dependencies = [
  "middle",
  "mockall",
  "moka",
- "openssl-src",
  "paste",
  "percent-encoding",
  "pretty_assertions",
@@ -5658,8 +5657,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.37.0"
-source = "git+https://github.com/lakekeeper/rust-rdkafka.git?rev=1ccd38d#1ccd38dbdd4acc1cddd074ebb3807d752d982269"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f1856d72dbbbea0d2a5b2eaf6af7fb3847ef2746e883b11781446a51dbc85c0"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -5675,8 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.9.0+2.8.0"
-source = "git+https://github.com/lakekeeper/rust-rdkafka.git?rev=1ccd38d#1ccd38dbdd4acc1cddd074ebb3807d752d982269"
+version = "4.9.0+2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5230dca48bc354d718269f3e4353280e188b610f7af7e2fcf54b7a79d5802872"
 dependencies = [
  "cmake",
  "curl-sys",
@@ -6115,7 +6116,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -7180,7 +7181,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -8267,7 +8268,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ paste = "1.0.15"
 percent-encoding = "2.3.1"
 pretty_assertions = "~1.4"
 quick-xml = { version = "0.38.3", features = ["serialize"] }
-rdkafka = { git = "https://github.com/lakekeeper/rust-rdkafka.git", rev = "1ccd38d", default-features = false, features = [
+rdkafka = { version = "0.38.0", default-features = false, features = [
     "tokio",
     "zstd",
     "gssapi-vendored",

--- a/crates/lakekeeper/Cargo.toml
+++ b/crates/lakekeeper/Cargo.toml
@@ -27,7 +27,7 @@ s3-signer = ["dep:aws-sigv4"]
 router = ["dep:tower-http", "dep:tower"]
 nats = ["dep:async-nats"]
 default = ["sqlx-postgres", "s3-signer", "router", "vendored-protoc"]
-kafka = ["dep:rdkafka", "dep:openssl-src"]
+kafka = ["dep:rdkafka"]
 vendored-protoc = []
 test-utils = ["lakekeeper-io/storage-in-memory"]
 open-api = ["dep:utoipa", "dep:utoipa-swagger-ui", "dep:serde_norway"]
@@ -117,11 +117,6 @@ uuid = { workspace = true }
 vaultrs = "0.7.2"
 vaultrs-login = "0.2.1"
 veil = { workspace = true }
-
-[build-dependencies]
-openssl-src = { version = "300.4.2", features = [
-    "force-engine",
-], default-features = false, optional = true }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }


### PR DESCRIPTION
- forked rdkafka contained fixes that are now available in last rdkafka release
- build dep on openssl-sys was necessary for musl builds, which we don't do anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kafka client dependency to a stable published release version with expanded build features.
  * Improved build configuration for enhanced system compatibility and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->