### PR TITLE
chore(docs): Add spark streaming example notebook

### DIFF
--- a/examples/minimal/notebooks/Spark-Streaming.ipynb
+++ b/examples/minimal/notebooks/Spark-Streaming.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyspark\n",
+    "from pyspark.conf import SparkConf\n",
+    "from pyspark.sql import SparkSession\n",
+    "import pandas as pd\n",
+    "\n",
+    "# This CATALOG_URL works for the \"docker compose\" testing and development environment\n",
+    "# Change 'lakekeeper' if you are not running on \"docker compose\" (f. ex. 'localhost' if Lakekeeper is running locally).\n",
+    "CATALOG_URL = \"http://lakekeeper:8181/catalog\"\n",
+    "WAREHOUSE = \"demo\"\n",
+    "\n",
+    "SPARK_VERSION = pyspark.__version__\n",
+    "SPARK_MINOR_VERSION = '.'.join(SPARK_VERSION.split('.')[:2])\n",
+    "ICEBERG_VERSION = \"1.9.1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Connect with Spark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    f\"spark.sql.catalog.lakekeeper\": \"org.apache.iceberg.spark.SparkCatalog\",\n",
+    "    f\"spark.sql.catalog.lakekeeper.type\": \"rest\",\n",
+    "    f\"spark.sql.catalog.lakekeeper.uri\": CATALOG_URL,\n",
+    "    f\"spark.sql.catalog.lakekeeper.warehouse\": WAREHOUSE,\n",
+    "    f\"spark.sql.catalog.lakekeeper.io-impl\": \"org.apache.iceberg.aws.s3.S3FileIO\",\n",
+    "    \"spark.sql.extensions\": \"org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions\",\n",
+    "    \"spark.sql.defaultCatalog\": \"lakekeeper\",\n",
+    "    \"spark.jars.packages\": f\"com.amazonaws:aws-java-sdk-bundle:1.12.262,org.apache.hadoop:hadoop-aws:3.3.4,org.apache.iceberg:iceberg-spark-runtime-{SPARK_MINOR_VERSION}_2.12:{ICEBERG_VERSION},org.apache.iceberg:iceberg-aws-bundle:{ICEBERG_VERSION}\",\n",
+    "    # These credentials are used to store the Checkpoint. Table IO is still done via vended-credentials from Lakekeeper\n",
+    "    \"spark.hadoop.fs.s3a.access.key\": \"minio-root-user\",\n",
+    "    \"spark.hadoop.fs.s3a.secret.key\": \"minio-root-password\",\n",
+    "    \"spark.hadoop.fs.s3a.endpoint\": \"http://minio:9000\",\n",
+    "    \"spark.hadoop.fs.s3a.path.style.access\": \"true\"\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark_config = SparkConf().setMaster('local').setAppName(\"Iceberg-REST\")\n",
+    "for k, v in config.items():\n",
+    "    spark_config = spark_config.set(k, v)\n",
+    "\n",
+    "spark = SparkSession.builder.config(conf=spark_config).getOrCreate()\n",
+    "\n",
+    "spark.sql(\"USE lakekeeper\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read and Write Tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.sql(f\"CREATE NAMESPACE IF NOT EXISTS streaming_namespace\")\n",
+    "spark.sql(\"SHOW NAMESPACES\").toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyspark.sql.functions as F\n",
+    "stream = (spark\n",
+    "  .readStream\n",
+    "  .format(\"rate\")\n",
+    "  .option(\"rowsPerSecond\", 1)\n",
+    "  .load()\n",
+    ")\n",
+    "stream = stream.withColumn(\"result\", F.col(\"value\") + F.lit(1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(stream.writeStream\n",
+    "    .format(\"iceberg\")\n",
+    "    .outputMode(\"append\")\n",
+    "    .option(\"checkpointLocation\", \"s3a://examples/my-checkpoint/location/\")\n",
+    "    .toTable(\"streaming_namespace.streaming_table\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.sql(\"SELECT * FROM my_namespace.streaming_table\").toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
```bash
cd examples/minimal
docker compose up -d
```
-> Open localhost:8888
-> Execute Spark Streaming Notebook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Jupyter notebook example demonstrating Spark Streaming with Iceberg REST catalog integration, including SparkSession configuration, namespace management, real-time data streaming, and table queries with S3-compatible storage support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->