### PR TITLE
fix: support view creation without "properties" (fix trino security invoker)

### DIFF
--- a/crates/iceberg-ext/src/catalog/rest/view.rs
+++ b/crates/iceberg-ext/src/catalog/rest/view.rs
@@ -17,7 +17,7 @@ pub struct CreateViewRequest {
     pub schema: Schema,
     #[serde(rename = "view-version")]
     pub view_version: ViewVersion,
-    #[serde(rename = "properties")]
+    #[serde(default, rename = "properties")]
     pub properties: std::collections::HashMap<String, String>,
 }
 

--- a/tests/python/tests/test_trino.py
+++ b/tests/python/tests/test_trino.py
@@ -750,3 +750,17 @@ def test_table_extra_properties(trino, warehouse: conftest.Warehouse):
         "SELECT key, value FROM test_table_extra_properties.\"my_table$properties\" WHERE key = 'extra.property.one'"
     ).fetchall()
     assert r == [["extra.property.one", "foo"]]
+
+
+def test_create_view_security_invoker(trino, warehouse: conftest.Warehouse):
+    cur = trino.cursor()
+    cur.execute("CREATE SCHEMA test_create_view_security_invoker_trino")
+    cur.execute(
+        "CREATE TABLE test_create_view_security_invoker_trino.my_table (my_ints INT, my_floats DOUBLE, strings VARCHAR) WITH (format='PARQUET')"
+    )
+    cur.execute(
+        "CREATE OR REPLACE VIEW test_create_view_security_invoker_trino.my_view SECURITY INVOKER AS SELECT strings FROM test_create_view_security_invoker_trino.my_table"
+    )
+    assert ["my_view"] in cur.execute(
+        f"SHOW TABLES IN test_create_view_security_invoker_trino"
+    ).fetchall()


### PR DESCRIPTION
Closes https://github.com/lakekeeper/lakekeeper/issues/1540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * View creation API requests now treat the properties field as optional, automatically providing a default empty configuration when not supplied.

* **Tests**
  * Expanded test coverage for creating views with SECURITY INVOKER settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->