### PR TITLE
chore: OPA Use catalog config Endpoint to get warehouse id

### DIFF
--- a/authz/opa-bridge/policies/lakekeeper/identifiers.rego
+++ b/authz/opa-bridge/policies/lakekeeper/identifiers.rego
@@ -7,8 +7,8 @@ import data.lakekeeper
 # Cache the result for 1 hour to avoid repeated calls to the Lakekeeper API.
 warehouse_id_for_name(lakekeeper_id, warehouse_name) := warehouse_id if {
     this := lakekeeper.lakekeeper_by_id[lakekeeper_id]
-    url := concat("/", [this.url, "management/v1/warehouse"])
-    warehouses := http.send({
+    url := concat("/", [this.url, sprintf("catalog/v1/config?warehouse=%s", [urlquery.encode(warehouse_name)])])
+    warehouse_id := http.send({
         "method": "GET",  
         "url": url,
         "headers": {
@@ -17,8 +17,5 @@ warehouse_id_for_name(lakekeeper_id, warehouse_name) := warehouse_id if {
         "force_cache": true,
         "force_cache_duration_seconds": 3600,
         "caching_mode": "deserialized",
-    }).body.warehouses
-    lakekeeper_warehouse := warehouses[_]
-    warehouse_name == lakekeeper_warehouse.name
-    warehouse_id := lakekeeper_warehouse.id
+    }).body.defaults.prefix
 }


### PR DESCRIPTION
The /config endpoint registers users, which is convenient to grant permissions to OPA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized warehouse identification in authorization policies by updating the configuration lookup mechanism. Changes consolidate sequential operations into a streamlined approach while maintaining all authorization security controls, caching behavior, and system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->