### PR TITLE
feat: Adds max_request_body_size and max_request_time configuration variables

### DIFF
--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -271,6 +271,16 @@ pub struct DynAppConfig {
     // ------------- Debug -------------
     #[serde(default)]
     pub debug: DebugConfig,
+
+    // ------------- Request Limits -------------
+    /// Maximum request body size in bytes. Defaults to 2 MB.
+    pub max_request_body_size: usize,
+    /// Maximum request time. Defaults to 30 seconds.
+    #[serde(
+        deserialize_with = "seconds_to_std_duration",
+        serialize_with = "serialize_std_duration_as_ms"
+    )]
+    pub max_request_time: Duration,
 }
 
 pub(crate) fn seconds_to_duration<'de, D>(deserializer: D) -> Result<chrono::Duration, D::Error>
@@ -593,6 +603,8 @@ impl Default for DynAppConfig {
             skip_storage_validation: false,
             debug: DebugConfig::default(),
             cache: Cache::default(),
+            max_request_body_size: 2 * 1024 * 1024, // 2 MB
+            max_request_time: Duration::from_secs(30),
         }
     }
 }

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -30,13 +30,13 @@ Lakekeeper has default values for `default` and `max` page sizes of paginated qu
 The REST catalog [spec](https://github.com/apache/iceberg/blob/404c8057275c9cfe204f2c7cc61114c128fbf759/open-api/rest-catalog-open-api.yaml#L2030-L2032) requires servers to return *all* results if `pageToken` is not set in the request. To obtain that behavior, set `LAKEKEEPER__PAGINATION_SIZE_MAX` to 4294967295, which corresponds to `u32::MAX`. Larger page sizes would lead to practical problems. Things to keep in mind:
 
 - Retrieving huge numbers of rows is expensive, which might be exploited by malicious requests.
-- Requests may time out or responses may exceed size limits for huge numbers of results. 
+- Requests may time out or responses may exceed size limits for huge numbers of results.
 
 | Variable                                          | Example            | Description |
 |---------------------------------------------------|--------------------|-----|
 | <nobr>`LAKEKEEPER__PAGINATION_SIZE_DEFAULT`<nobr> | <nobr>`1024`<nobr> | The default page size used for paginated queries. This value is used if the request's `pageToken` is set but empty. Default: `100` |
 | <nobr>`LAKEKEEPER__PAGINATION_SIZE_MAX`<nobr>     | <nobr>`2048`<nobr> | The max page size used for paginated queries. This value is used if the request's `pageToken` is not set. Default: `1000` |
- 
+
 ### Storage
 
 | Variable                                                    | Example            | Description |
@@ -51,7 +51,7 @@ The REST catalog [spec](https://github.com/apache/iceberg/blob/404c8057275c9cfe2
 
 Currently Lakekeeper supports only Postgres as a persistence store. You may either provide connection strings using `PG_DATABASE_URL_*` or use the `PG_*` environment variables. Connection strings take precedence. Postgres needs to be Version 15 or higher.
 
-Lakekeeper supports configuring separate database URLs for read and write operations, allowing you to utilize read replicas for better scalability. By directing read queries to dedicated replicas via `LAKEKEEPER__PG_DATABASE_URL_READ`, you can significantly reduce load on your database primary (specified by `LAKEKEEPER__PG_DATABASE_URL_WRITE`), improving overall system performance as your deployment scales. This separation is particularly beneficial for read-heavy workloads. When using read replicas, be aware that replication lag may occur between the primary and replica databases depending on your Database setup. This means that immediately after a write operation, the changes might not be instantly visible when querying a read-only Lakekeeper endpoint (which uses the read replica). Consider this potential lag when designing applications that require immediate read-after-write consistency. For deployments where read-after-write consistency is critical, you can simply omit the `LAKEKEEPER__PG_DATABASE_URL_READ` setting, which will cause all operations to use the primary database connection. 
+Lakekeeper supports configuring separate database URLs for read and write operations, allowing you to utilize read replicas for better scalability. By directing read queries to dedicated replicas via `LAKEKEEPER__PG_DATABASE_URL_READ`, you can significantly reduce load on your database primary (specified by `LAKEKEEPER__PG_DATABASE_URL_WRITE`), improving overall system performance as your deployment scales. This separation is particularly beneficial for read-heavy workloads. When using read replicas, be aware that replication lag may occur between the primary and replica databases depending on your Database setup. This means that immediately after a write operation, the changes might not be instantly visible when querying a read-only Lakekeeper endpoint (which uses the read replica). Consider this potential lag when designing applications that require immediate read-after-write consistency. For deployments where read-after-write consistency is critical, you can simply omit the `LAKEKEEPER__PG_DATABASE_URL_READ` setting, which will cause all operations to use the primary database connection.
 
 | Variable                                               | Example                                               | Description |
 |--------------------------------------------------------|-------------------------------------------------------|-----|
@@ -189,7 +189,7 @@ The following Authenticators are available. Enabled Authenticators are checked i
    **Accepts JWT if:**<br>
     - Tokens issuer is `kubernetes/serviceaccount` or `https://kubernetes.default.svc.cluster.local`
 
-If `LAKEKEEPER__OPENID_PROVIDER_URI` is specified, Lakekeeper will  verify access tokens against this provider. The provider must provide the `.well-known/openid-configuration` endpoint and the openid-configuration needs to have `jwks_uri` and `issuer` defined. 
+If `LAKEKEEPER__OPENID_PROVIDER_URI` is specified, Lakekeeper will  verify access tokens against this provider. The provider must provide the `.well-known/openid-configuration` endpoint and the openid-configuration needs to have `jwks_uri` and `issuer` defined.
 
 Typical values for `LAKEKEEPER__OPENID_PROVIDER_URI` are:
 
@@ -349,6 +349,15 @@ Lakekeeper collects statistics about the usage of its endpoints. Every Lakekeepe
 ### SSL Dependencies
 
 You may be running Lakekeeper in your own environment which uses self-signed certificates for e.g. Minio. Lakekeeper is built with reqwest's `rustls-tls-native-roots` feature activated, this means `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables are respected. If both are not set, the system's default CA store is used. If you want to use a custom CA store, set `SSL_CERT_FILE` to the path of the CA file or `SSL_CERT_DIR` to the path of the CA directory. The certificate used by the server cannot be a CA. It needs to be an end entity certificate, else you may run into `CaUsedAsEndEntity` errors.
+
+### Request Limits
+
+Lakekeeper allows you to configure limits on incoming requests to protect against resource exhaustion and denial-of-service attacks.
+
+| Variable                                            | Example | Description |
+|-----------------------------------------------------|---------|-------------|
+| <nobr>`LAKEKEEPER__MAX_REQUEST_BODY_SIZE`</nobr>    | `2097152` | Maximum request body size in bytes. Default: `2097152` (2 MB) |
+| <nobr>`LAKEKEEPER__MAX_REQUEST_TIME`</nobr>         | `30s`   | Maximum time allowed for a request to complete. Accepts format `{number}{ms|s}` (e.g., `30s` or `5000ms`). Default: `30s` |
 
 ### Debug
 


### PR DESCRIPTION
Resolves https://github.com/lakekeeper/lakekeeper/issues/1582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added configurable maximum request body size (defaults to 2 MB)
* Added configurable request timeout duration (defaults to 30 seconds)
* Both settings can be managed via environment variables

## Documentation
* Updated configuration documentation with new request limit settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->