### PR TITLE
feat: POC: Add labels field to LoadTableResult

### DIFF
--- a/crates/iceberg-ext/src/catalog/rest/table.rs
+++ b/crates/iceberg-ext/src/catalog/rest/table.rs
@@ -27,6 +27,14 @@ pub struct LoadCredentialsResponse {
     pub storage_credentials: Vec<StorageCredential>,
 }
 
+/// Catalog-scoped labels for API-level metadata enrichment.
+/// Not part of Iceberg table state — ephemeral annotations only.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Labels {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table: Option<HashMap<String, String>>,
+}
+
 /// Result used when a table is successfully loaded.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -38,6 +46,8 @@ pub struct LoadTableResult {
     pub config: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_credentials: Option<Vec<StorageCredential>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Labels>,
 }
 
 impl LoadTableResult {
@@ -238,6 +248,7 @@ mod tests {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
+            labels: None,
         };
 
         let response = load_table_result.into_response();
@@ -257,6 +268,7 @@ mod tests {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
+            labels: None,
         };
 
         let response = load_table_result.into_response();
@@ -275,6 +287,7 @@ mod tests {
             metadata: table_metadata.clone(),
             config: None,
             storage_credentials: None,
+            labels: None,
         };
 
         let response = load_table_result.clone().into_response();

--- a/crates/lakekeeper/src/api/iceberg/v1/tables.rs
+++ b/crates/lakekeeper/src/api/iceberg/v1/tables.rs
@@ -1158,6 +1158,7 @@ mod test {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
+            labels: None,
         };
         let load_table_result_response_expected = load_table_result.clone().into_response();
 

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -533,6 +533,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             metadata: table_metadata,
             config: Some(config.config.into()),
             storage_credentials: None,
+            labels: None,
         })
     }
 

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -342,6 +342,7 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
         metadata: table_metadata.clone(),
         config: Some(config.config.into()),
         storage_credentials,
+        labels: None,
     };
 
     // Create table in authorizer

--- a/crates/lakekeeper/src/server/tables/load_table.rs
+++ b/crates/lakekeeper/src/server/tables/load_table.rs
@@ -115,7 +115,7 @@ pub(super) async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: Secret
     let mut t = C::Transaction::begin_read(catalog_state.clone()).await?;
     let CatalogLoadTableResult {
         table_id: _,
-        namespace_id: _,
+        namespace_id,
         table_metadata,
         metadata_location,
         warehouse_version,
@@ -128,6 +128,22 @@ pub(super) async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: Secret
         &mut t,
     )
     .await?;
+
+    // Fetch namespace properties for label extraction (catalog-scoped, not Iceberg metadata).
+    // Namespace properties with "label." prefix are inherited by all tables in that namespace.
+    let namespace_labels = match C::get_namespace(warehouse_id, namespace_id, t.transaction()).await
+    {
+        Ok(Some(hierarchy)) => hierarchy.properties().and_then(|props| {
+            let label_map: std::collections::HashMap<String, String> = props
+                .iter()
+                .filter(|(k, _)| k.starts_with("label."))
+                .map(|(k, v)| (k.strip_prefix("label.").unwrap().to_string(), v.clone()))
+                .collect();
+            if label_map.is_empty() { None } else { Some(label_map) }
+        }),
+        _ => None,
+    };
+
     t.commit().await?;
 
     // Refetch warehouse if version is stale
@@ -179,6 +195,12 @@ pub(super) async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: Secret
         })
     });
 
+    // Labels from namespace properties (catalog-scoped, not Iceberg table state).
+    // Namespace properties with "label." prefix are inherited by all tables in that namespace.
+    let labels = namespace_labels.map(|lm| iceberg_ext::catalog::rest::table::Labels {
+        table: Some(lm),
+    });
+
     let metadata_ref = Arc::new(table_metadata);
     let metadata_location_ref = metadata_location.map(Arc::new);
 
@@ -189,6 +211,7 @@ pub(super) async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: Secret
         metadata: metadata_ref,
         config: storage_config.map(|c| c.config.into()),
         storage_credentials,
+        labels,
     };
 
     Ok(LoadTableResultOrNotModified::LoadTableResult(


### PR DESCRIPTION
Add optional labels field to the IRC LoadTableResult response for catalog-specific metadata enrichment. Labels are ephemeral API-level annotations — not part of Iceberg table state.

Same pattern as Polaris and Unity Catalog POCs: catalog-scoped metadata surfaced through the standard IRC protocol via a labels field.

New struct: Labels (table-level string key-value pairs)
Modified: LoadTableResult (optional labels field)

Proof-of-concept for the IRC Labels proposal: https://github.com/apache/iceberg/issues/15521.