### PR TITLE
feat(opa-bridge): allow CreateViewWithSelectFromColumns on views so view-on-view queries pass the run-as-owner check

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -189,6 +189,8 @@ jobs:
         env:
           VAULT_DEV_ROOT_TOKEN_ID: myroot
           VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+          # GHA runners drop CAP_SETFCAP; skip the entrypoint setcap call.
+          SKIP_SETCAP: "true"
         options: >-
           --health-cmd "vault status -address http://localhost:8200"
           --health-interval 10s

--- a/authz/opa-bridge/policies/trino/allow_view.rego
+++ b/authz/opa-bridge/policies/trino/allow_view.rego
@@ -70,7 +70,7 @@ allow_view_metadata if {
 }
 
 allow_view_read if {
-	input.action.operation == "SelectFromColumns"
+	input.action.operation in ["SelectFromColumns", "CreateViewWithSelectFromColumns"]
 	catalog := input.action.resource.table.catalogName
 	schema := input.action.resource.table.schemaName
 	table := input.action.resource.table.tableName

--- a/tests/docker-compose-vault-overlay.yaml
+++ b/tests/docker-compose-vault-overlay.yaml
@@ -15,6 +15,8 @@ services:
     environment:
       - VAULT_DEV_ROOT_TOKEN_ID=myroot
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+      # GHA runners drop CAP_SETFCAP; skip the entrypoint setcap call.
+      - SKIP_SETCAP=true
     cap_add:
       - IPC_LOCK
     healthcheck:

--- a/tests/python/tests/test_trino.py
+++ b/tests/python/tests/test_trino.py
@@ -794,7 +794,7 @@ def test_select_from_view_on_view(trino, warehouse: conftest.Warehouse):
         f"CREATE OR REPLACE VIEW {ns}.outer_view AS SELECT strings FROM {ns}.inner_view"
     )
 
-    r = cur.execute(f"SELECT * FROM {ns}.outer_view").fetchall()
+    r = cur.execute(f"SELECT * FROM {ns}.outer_view ORDER BY strings").fetchall()
     assert r == [["a"], ["b"]]
 
 

--- a/tests/python/tests/test_trino.py
+++ b/tests/python/tests/test_trino.py
@@ -774,6 +774,30 @@ def test_table_extra_properties(trino, warehouse: conftest.Warehouse):
     assert r == [["extra.property.one", "foo"]]
 
 
+def test_select_from_view_on_view(trino, warehouse: conftest.Warehouse):
+    # View-on-view: the outer view's DEFINER-run-as-owner check on the inner
+    # view reaches Trino as CreateViewWithSelectFromColumns on the inner
+    # view's name. The OPA bridge must permit that via the view path;
+    # table-lookup at Lakekeeper returns not-found for a view and would
+    # otherwise deny.
+    ns = "test_select_from_view_on_view"
+    cur = trino.cursor()
+    cur.execute(f"CREATE SCHEMA {ns}")
+    cur.execute(
+        f"CREATE TABLE {ns}.my_table (my_ints INT, my_floats DOUBLE, strings VARCHAR) WITH (format='PARQUET')"
+    )
+    cur.execute(f"INSERT INTO {ns}.my_table VALUES (1, 1.0, 'a'), (2, 2.0, 'b')")
+    cur.execute(
+        f"CREATE OR REPLACE VIEW {ns}.inner_view AS SELECT strings FROM {ns}.my_table"
+    )
+    cur.execute(
+        f"CREATE OR REPLACE VIEW {ns}.outer_view AS SELECT strings FROM {ns}.inner_view"
+    )
+
+    r = cur.execute(f"SELECT * FROM {ns}.outer_view").fetchall()
+    assert r == [["a"], ["b"]]
+
+
 def test_create_view_security_invoker(trino, warehouse: conftest.Warehouse):
     cur = trino.cursor()
     cur.execute("CREATE SCHEMA test_create_view_security_invoker_trino")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can create views that select from other views in Trino, enabling nested view composition.

* **Bug Fixes**
  * Access checks adjusted so view creation that selects from columns (including CREATE VIEW ... SELECT ...) is allowed.

* **Tests**
  * Added an end-to-end test validating view-on-view creation and correct query results across multiple view layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->