### PR TITLE
docs: support deploying into a custom Postgres schema

### DIFF
--- a/crates/lakekeeper/src/implementations/postgres/migrations/mod.rs
+++ b/crates/lakekeeper/src/implementations/postgres/migrations/mod.rs
@@ -257,7 +257,13 @@ mod tests {
         // role intentionally has no CREATE-on-database privilege, so the
         // `CREATE EXTENSION IF NOT EXISTS` calls in the migrations must hit the
         // no-op path.
-        for ext in ["uuid-ossp", "pgcrypto", "pg_trgm", "btree_gin", "btree_gist"] {
+        for ext in [
+            "uuid-ossp",
+            "pgcrypto",
+            "pg_trgm",
+            "btree_gin",
+            "btree_gist",
+        ] {
             sqlx::query(&format!(r#"CREATE EXTENSION IF NOT EXISTS "{ext}""#))
                 .execute(&admin_pool)
                 .await

--- a/crates/lakekeeper/src/implementations/postgres/migrations/mod.rs
+++ b/crates/lakekeeper/src/implementations/postgres/migrations/mod.rs
@@ -231,3 +231,127 @@ fn validate_applied_migrations(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use sqlx::{
+        PgPool,
+        postgres::{PgConnectOptions, PgPoolOptions},
+    };
+    use uuid::Uuid;
+
+    use super::migrate;
+
+    /// Regression test for #1519 / #1707: migrations must succeed when run by a
+    /// low-privilege role into a non-`public` schema, with the schema selected
+    /// via the role's default `search_path`.
+    #[sqlx::test(migrations = false)]
+    async fn test_migrate_into_custom_schema_as_low_privilege_user(admin_pool: PgPool) {
+        // Unique names so parallel tests don't collide on cluster-global roles.
+        let suffix = Uuid::new_v4().simple().to_string();
+        let schema = format!("lk_app_{suffix}");
+        let role = format!("lk_app_user_{suffix}");
+        let password = "lk_app_password";
+
+        // Pre-install required extensions in `public` as admin. The application
+        // role intentionally has no CREATE-on-database privilege, so the
+        // `CREATE EXTENSION IF NOT EXISTS` calls in the migrations must hit the
+        // no-op path.
+        for ext in ["uuid-ossp", "pgcrypto", "pg_trgm", "btree_gin", "btree_gist"] {
+            sqlx::query(&format!(r#"CREATE EXTENSION IF NOT EXISTS "{ext}""#))
+                .execute(&admin_pool)
+                .await
+                .unwrap();
+        }
+
+        sqlx::query(&format!(
+            r#"CREATE ROLE "{role}" LOGIN PASSWORD '{password}'"#
+        ))
+        .execute(&admin_pool)
+        .await
+        .unwrap();
+        sqlx::query(&format!(
+            r#"CREATE SCHEMA "{schema}" AUTHORIZATION "{role}""#
+        ))
+        .execute(&admin_pool)
+        .await
+        .unwrap();
+
+        let db = admin_pool
+            .connect_options()
+            .get_database()
+            .unwrap()
+            .to_string();
+        sqlx::query(&format!(r#"GRANT CONNECT ON DATABASE "{db}" TO "{role}""#))
+            .execute(&admin_pool)
+            .await
+            .unwrap();
+        sqlx::query(&format!(r#"GRANT USAGE ON SCHEMA public TO "{role}""#))
+            .execute(&admin_pool)
+            .await
+            .unwrap();
+        sqlx::query(&format!(r#"REVOKE CREATE ON SCHEMA public FROM "{role}""#))
+            .execute(&admin_pool)
+            .await
+            .unwrap();
+
+        // The mechanism we document for #1707: server-side default search_path on
+        // the role itself, so every new connection lands in the custom schema.
+        // `public` is included so functions/operators from extensions installed
+        // there (e.g. uuid_generate_v1mc from uuid-ossp) resolve.
+        sqlx::query(&format!(
+            r#"ALTER ROLE "{role}" SET search_path = "{schema}", public"#
+        ))
+        .execute(&admin_pool)
+        .await
+        .unwrap();
+
+        let admin_opts = admin_pool.connect_options();
+        let app_opts = PgConnectOptions::new()
+            .host(admin_opts.get_host())
+            .port(admin_opts.get_port())
+            .database(&db)
+            .username(&role)
+            .password(password);
+        let app_pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect_with(app_opts)
+            .await
+            .unwrap();
+
+        migrate(&app_pool)
+            .await
+            .expect("migrations should succeed for low-privilege user in custom schema");
+
+        let in_schema: bool = sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+             WHERE table_schema = $1 AND table_name = 'warehouse')",
+        )
+        .bind(&schema)
+        .fetch_one(&admin_pool)
+        .await
+        .unwrap();
+        assert!(in_schema, "`warehouse` should be created in {schema}");
+
+        let in_public: bool = sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+             WHERE table_schema = 'public' AND table_name = 'warehouse')",
+        )
+        .fetch_one(&admin_pool)
+        .await
+        .unwrap();
+        assert!(!in_public, "`warehouse` must not leak into public");
+
+        // Drain the app pool before dropping the role it authenticated as.
+        app_pool.close().await;
+        let _ = sqlx::query(&format!(r#"DROP SCHEMA "{schema}" CASCADE"#))
+            .execute(&admin_pool)
+            .await;
+        let _ = sqlx::query(&format!(r#"DROP OWNED BY "{role}""#))
+            .execute(&admin_pool)
+            .await;
+        let _ = sqlx::query(&format!(r#"DROP ROLE "{role}""#))
+            .execute(&admin_pool)
+            .await;
+    }
+}

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -73,6 +73,31 @@ Lakekeeper supports configuring separate database URLs for read and write operat
 | `LAKEKEEPER__PG_CONNECTION_MAX_LIFETIME`               | `1800`                                                | Maximum lifetime of connections in seconds |
 | `LAKEKEEPER__PG_ACQUIRE_TIMEOUT`                       | `10`                                                  | Timeout to acquire a new postgres connection in seconds. Default: `5` |
 
+#### Required Postgres extensions
+
+Lakekeeper migrations require the following extensions: `uuid-ossp`, `pgcrypto`, `pg_trgm`, `btree_gin`, `btree_gist`. They are part of the standard `postgresql-contrib` package and are pre-installed on most managed Postgres offerings (AWS RDS, Cloud SQL, Azure Database, etc.).
+
+If the role Lakekeeper connects as has `CREATE` privilege on the database, the migrations will create the extensions automatically. Otherwise — for example, when running Lakekeeper as a low-privilege role (see below) — an administrator must pre-create them once per database:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+CREATE EXTENSION IF NOT EXISTS "btree_gin";
+CREATE EXTENSION IF NOT EXISTS "btree_gist";
+```
+
+#### Using a non-`public` Postgres schema
+
+By default Lakekeeper creates its tables in whichever schema Postgres resolves via `search_path` — typically `public`. To install it into a dedicated schema (e.g. for tenant isolation or policies that disallow DDL in `public`), set the default `search_path` on the role Lakekeeper connects as, server-side:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS lakekeeper AUTHORIZATION lakekeeper;
+ALTER ROLE lakekeeper SET search_path = lakekeeper, public;
+```
+
+Postgres applies this before any query runs on a new session, so both migrations and runtime queries land in `lakekeeper`. Keep `public` in `search_path` so functions installed by extensions there (e.g. `uuid_generate_v1mc` from `uuid-ossp`) still resolve. If you use separate roles for `LAKEKEEPER__PG_DATABASE_URL_READ` and `LAKEKEEPER__PG_DATABASE_URL_WRITE`, run `ALTER ROLE` for both. Setting `search_path` via the URL `options` parameter is fragile — encoding pitfalls and connection poolers (e.g. PgBouncer in transaction pooling mode) often drop it — so the role-level default is the recommended approach.
+
 ### Vault KV Version 2
 
 Configuration parameters if a Vault KV version 2 (i.e. Hashicorp Vault) compatible storage is used as a backend. Currently, we only support the `userpass` authentication method. Configuration may be passed as single values like `LAKEKEEPER__KV2__URL=http://vault.local` or as a compound value:

--- a/site/docs/assets/css/extra.css
+++ b/site/docs/assets/css/extra.css
@@ -26,6 +26,24 @@
   user-select: all;
 }
 
+/* Material's default h4/h5 are very thin and easily missed inside dense pages
+   like configuration.md. Bump weight and size so nested subsections are
+   visually distinct from body text without competing with h2/h3. */
+.md-typeset h4 {
+  font-size: 1.05em;
+  font-weight: 600;
+  margin-top: 1.6em;
+  color: var(--md-default-fg-color);
+}
+.md-typeset h5 {
+  font-size: 0.95em;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: normal;
+  margin-top: 1.4em;
+  color: var(--md-default-fg-color);
+}
+
 /* Short Lakekeeper Plus Badge with auto-generated content */
 .lkp::after {
   content: "★ lakekeeper ＋";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration/regression test validating migrations run correctly when using a low-privilege database role and a non-public (custom) schema.

* **Documentation**
  * Added required PostgreSQL extensions list with conditional installation SQL.
  * Added guidance for installing into a dedicated custom schema using server-side search_path and role configuration, plus notes on read/write role separation.

* **Style**
  * Improved documentation heading styles for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->