### PR TITLE
feat: Extend Server Info with console information and commit SHAs

### DIFF
--- a/.github/workflows/authz.yml
+++ b/.github/workflows/authz.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Setup Regal
         uses: styrainc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776 # v1.0.0
+        with:
+          version: v0.39.0
 
       - name: OPA Check (strict)
         run: opa check --strict policies/

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = ["OpenFGA", "OAuth", "CloudEvents", "UUIDv7"]
+doc-valid-idents = ["OpenFGA", "OAuth", "CloudEvents", "UUIDv7", "SemVer"]

--- a/crates/lakekeeper/src/api/management/v1/server.rs
+++ b/crates/lakekeeper/src/api/management/v1/server.rs
@@ -60,6 +60,49 @@ pub static APACHE_LICENSE_STATUS: std::sync::LazyLock<LicenseStatus> =
         license_id: None,
     });
 
+/// Default `BuildInfo` used when a binary does not inject one.
+///
+/// Callers that want to surface commit SHAs, an enterprise edition version, or
+/// console information via the `/management/v1/info` endpoint must provide a
+/// custom `BuildInfo` via `ServeConfiguration::build_info`.
+pub static DEFAULT_BUILD_INFO: std::sync::LazyLock<BuildInfo> =
+    std::sync::LazyLock::new(BuildInfo::default);
+
+/// Information about the UI (console) shipped with this binary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[serde(rename_all = "kebab-case")]
+pub struct ConsoleInfo {
+    /// Edition / crate name of the bundled console.
+    /// e.g. `lakekeeper-console` for the OSS console or
+    /// `lakekeeper-console-plus` for the enterprise console.
+    pub edition: String,
+    /// SemVer of the console crate.
+    pub version: String,
+    /// Git commit SHA of the console source, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+}
+
+/// Build-time information injected by the binary.
+///
+/// All fields are optional: the OSS `lakekeeper` binary leaves them empty, while
+/// downstream distributions (e.g. `lakekeeper-plus`) populate them from their
+/// build scripts to expose upstream + enterprise versions, commit SHAs, and
+/// console details via the server-info endpoint.
+#[derive(Debug, Clone, Default)]
+pub struct BuildInfo {
+    /// Git commit SHA of the upstream `lakekeeper` dependency, if known.
+    pub lakekeeper_commit_sha: Option<String>,
+    /// SemVer of the enterprise binary (e.g. `lakekeeper-plus`), if this is an
+    /// enterprise build.
+    pub lakekeeper_enterprise_version: Option<String>,
+    /// Git commit SHA of the enterprise binary, if known.
+    pub lakekeeper_enterprise_commit_sha: Option<String>,
+    /// Bundled console, if any.
+    pub console: Option<ConsoleInfo>,
+}
+
 /// Status of license validation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
@@ -92,8 +135,27 @@ pub struct LicenseStatus {
 #[serde(rename_all = "kebab-case")]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ServerInfo {
-    /// Version of the server.
+    /// Deprecated alias of `lakekeeper-version`. Always equal to it; kept
+    /// for clients that read the plain `version` field. New clients should
+    /// read `lakekeeper-version` and/or `lakekeeper-enterprise-version`.
     pub version: String,
+    /// SemVer of the upstream `lakekeeper` crate the server was built
+    /// against.
+    pub lakekeeper_version: String,
+    /// Git commit SHA of the upstream `lakekeeper` crate, if the binary
+    /// reported it at build time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lakekeeper_commit_sha: Option<String>,
+    /// SemVer of the enterprise binary (e.g. `lakekeeper-plus`) when this
+    /// server is an enterprise build. `None` on OSS builds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lakekeeper_enterprise_version: Option<String>,
+    /// Git commit SHA of the enterprise binary, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lakekeeper_enterprise_commit_sha: Option<String>,
+    /// Information about the bundled console (UI), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub console: Option<ConsoleInfo>,
     /// Whether the catalog has been bootstrapped.
     pub bootstrapped: bool,
     /// ID of the server.
@@ -256,11 +318,17 @@ pub(crate) trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         }
 
         // ------------------- Business Logic -------------------
-        let version = env!("CARGO_PKG_VERSION").to_string();
+        let lakekeeper_version = env!("CARGO_PKG_VERSION").to_string();
         let server_data = C::get_server_info(state.v1_state.catalog).await?;
+        let build_info = state.v1_state.build_info;
 
         Ok(ServerInfo {
-            version,
+            version: lakekeeper_version.clone(),
+            lakekeeper_version,
+            lakekeeper_commit_sha: build_info.lakekeeper_commit_sha.clone(),
+            lakekeeper_enterprise_version: build_info.lakekeeper_enterprise_version.clone(),
+            lakekeeper_enterprise_commit_sha: build_info.lakekeeper_enterprise_commit_sha.clone(),
+            console: build_info.console.clone(),
             bootstrapped: !server_data.is_open_for_bootstrap(),
             server_id: *server_data.server_id(),
             default_project_id: DEFAULT_PROJECT_ID.clone(),

--- a/crates/lakekeeper/src/api/management/v1/server.rs
+++ b/crates/lakekeeper/src/api/management/v1/server.rs
@@ -138,6 +138,7 @@ pub struct ServerInfo {
     /// Deprecated alias of `lakekeeper-version`. Always equal to it; kept
     /// for clients that read the plain `version` field. New clients should
     /// read `lakekeeper-version` and/or `lakekeeper-enterprise-version`.
+    #[cfg_attr(feature = "open-api", schema(deprecated = true))]
     pub version: String,
     /// SemVer of the upstream `lakekeeper` crate the server was built
     /// against.

--- a/crates/lakekeeper/src/serve.rs
+++ b/crates/lakekeeper/src/serve.rs
@@ -9,7 +9,9 @@ use crate::{
     CONFIG, CancellationToken,
     api::{
         ApiContext,
-        management::v1::server::{APACHE_LICENSE_STATUS, LicenseStatus},
+        management::v1::server::{
+            APACHE_LICENSE_STATUS, BuildInfo, DEFAULT_BUILD_INFO, LicenseStatus,
+        },
         router::{RouterArgs, new_full_router, serve as service_serve},
         shutdown_signal,
     },
@@ -155,6 +157,10 @@ pub struct ServeConfiguration<
     /// License Status
     #[builder(default)]
     pub license_status: Option<&'static LicenseStatus>,
+    /// Build-time information (commit SHAs, enterprise version, bundled console).
+    /// Defaults to empty values; downstream binaries should inject their own.
+    #[builder(default)]
+    pub build_info: Option<&'static BuildInfo>,
 }
 
 /// Starts the service with the provided configuration.
@@ -328,9 +334,11 @@ async fn serve_inner<
         event_dispatcher: additional_event_dispatcher,
         register_additional_background_services_fn: additional_background_services,
         license_status,
+        build_info,
     } = config;
 
     let license_status = license_status.unwrap_or(&APACHE_LICENSE_STATUS);
+    let build_info = build_info.unwrap_or(&DEFAULT_BUILD_INFO);
 
     let listener = tokio::net::TcpListener::bind(bind_addr)
         .await
@@ -444,6 +452,7 @@ async fn serve_inner<
             registered_task_queues,
             events: dispatcher,
             license_status,
+            build_info,
         },
     };
 

--- a/crates/lakekeeper/src/service/mod.rs
+++ b/crates/lakekeeper/src/service/mod.rs
@@ -25,7 +25,10 @@ use tasks::RegisteredTaskQueues;
 use self::authz::Authorizer;
 pub use crate::api::{ErrorModel, IcebergErrorResponse};
 use crate::{
-    api::{ThreadSafe as ServiceState, management::v1::server::LicenseStatus},
+    api::{
+        ThreadSafe as ServiceState,
+        management::v1::server::{BuildInfo, LicenseStatus},
+    },
     service::{contract_verification::ContractVerifiers, events::EventDispatcher},
 };
 
@@ -44,6 +47,7 @@ pub struct State<A: Authorizer + Clone, C: CatalogStore, S: SecretStore> {
     pub events: EventDispatcher,
     pub registered_task_queues: RegisteredTaskQueues,
     pub license_status: &'static LicenseStatus,
+    pub build_info: &'static BuildInfo,
 }
 
 impl<A: Authorizer + Clone, C: CatalogStore, S: SecretStore> ServiceState for State<A, C, S> {}

--- a/crates/lakekeeper/src/tests/mod.rs
+++ b/crates/lakekeeper/src/tests/mod.rs
@@ -6,7 +6,7 @@ use crate::{
         RequestMetadata,
         management::v1::{
             ApiServer,
-            server::{APACHE_LICENSE_STATUS, BootstrapRequest, Service as _},
+            server::{APACHE_LICENSE_STATUS, BootstrapRequest, DEFAULT_BUILD_INFO, Service as _},
             warehouse::{CreateWarehouseRequest, Service as _, TabularDeleteProfile},
         },
     },
@@ -243,6 +243,7 @@ pub(crate) async fn get_api_context<T: Authorizer>(
             ]),
             registered_task_queues,
             license_status: &APACHE_LICENSE_STATUS,
+            build_info: &DEFAULT_BUILD_INFO,
         },
     }
 }

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -3934,6 +3934,27 @@ components:
         allowed:
           type: boolean
           description: Whether the action is allowed.
+    ConsoleInfo:
+      type: object
+      description: Information about the UI (console) shipped with this binary.
+      required:
+        - edition
+        - version
+      properties:
+        commit-sha:
+          type:
+            - string
+            - 'null'
+          description: Git commit SHA of the console source, if known.
+        edition:
+          type: string
+          description: |-
+            Edition / crate name of the bundled console.
+            e.g. `lakekeeper-console` for the OSS console or
+            `lakekeeper-console-plus` for the enterprise console.
+        version:
+          type: string
+          description: SemVer of the console crate.
     ControlTaskAction:
       oneOf:
         - type: object
@@ -6827,6 +6848,7 @@ components:
       type: object
       required:
         - version
+        - lakekeeper-version
         - bootstrapped
         - server-id
         - authz-backend
@@ -6848,6 +6870,11 @@ components:
         bootstrapped:
           type: boolean
           description: Whether the catalog has been bootstrapped.
+        console:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/ConsoleInfo'
+              description: Information about the bundled console (UI), if any.
         default-project-id:
           type:
             - string
@@ -6856,6 +6883,30 @@ components:
         gcp-system-identities-enabled:
           type: boolean
           description: If using GCP system identities for GCS storage profiles are enabled.
+        lakekeeper-commit-sha:
+          type:
+            - string
+            - 'null'
+          description: |-
+            Git commit SHA of the upstream `lakekeeper` crate, if the binary
+            reported it at build time.
+        lakekeeper-enterprise-commit-sha:
+          type:
+            - string
+            - 'null'
+          description: Git commit SHA of the enterprise binary, if known.
+        lakekeeper-enterprise-version:
+          type:
+            - string
+            - 'null'
+          description: |-
+            SemVer of the enterprise binary (e.g. `lakekeeper-plus`) when this
+            server is an enterprise build. `None` on OSS builds.
+        lakekeeper-version:
+          type: string
+          description: |-
+            SemVer of the upstream `lakekeeper` crate the server was built
+            against.
         license-status:
           $ref: '#/components/schemas/LicenseStatus'
           description: License status information
@@ -6872,7 +6923,10 @@ components:
             Returns null if the catalog has not been bootstrapped.
         version:
           type: string
-          description: Version of the server.
+          description: |-
+            Deprecated alias of `lakekeeper-version`. Always equal to it; kept
+            for clients that read the plain `version` field. New clients should
+            read `lakekeeper-version` and/or `lakekeeper-enterprise-version`.
     ServerRelation:
       type: string
       enum:

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -6927,6 +6927,7 @@ components:
             Deprecated alias of `lakekeeper-version`. Always equal to it; kept
             for clients that read the plain `version` field. New clients should
             read `lakekeeper-version` and/or `lakekeeper-enterprise-version`.
+          deprecated: true
     ServerRelation:
       type: string
       enum:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server info endpoint now returns detailed build and console metadata (lakekeeper version, commit SHAs, enterprise version, console edition/version); legacy `version` field marked deprecated in favor of `lakekeeper-version`.
* **Documentation**
  * OpenAPI schema updated to expose new server and console metadata fields.
* **Tests**
  * Test context updated to include default build info.
* **Chores**
  * CI workflow now pins a tool version in setup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->