### PR TITLE
feat(perf): add warehouse/namespace broad-access fast path to Trino OPA batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ spark-warehouse
 .idea/
 .vscode
 memory
+.claude
 
 settings.local.json
 

--- a/authz/opa-bridge/policies/lakekeeper/authentication.rego
+++ b/authz/opa-bridge/policies/lakekeeper/authentication.rego
@@ -34,3 +34,28 @@ authenticated_http_send(lakekeeper_id, method, path, body) := response if {
 		"body": body,
 	})
 }
+
+# Send an authenticated HTTP request with OPA force_cache enabled.
+#
+# `request_id` is forwarded to Lakekeeper as `X-Request-ID` — Lakekeeper's
+# tracing middleware preserves the client-provided value, so Trino's queryId
+# flows into Lakekeeper's audit/trace logs. It also varies OPA's http.send
+# cache key (which includes headers), giving per-query consistency: each
+# Trino query re-probes once, then all its fan-out waves hit the cache.
+authenticated_http_send_cached(lakekeeper_id, method, path, body, request_id, cache_secs) := response if {
+	this := config_by_id[lakekeeper_id]
+	url := concat("/", [this.url, trim_left(path, "/")])
+	response := http.send({
+		"method": method,
+		"url": url,
+		"headers": {
+			"Authorization": sprintf("Bearer %v", [access_token[lakekeeper_id]]),
+			"Content-Type": "application/json",
+			"X-Request-ID": request_id,
+		},
+		"body": body,
+		"force_cache": true,
+		"force_cache_duration_seconds": cache_secs,
+		"caching_mode": "deserialized",
+	})
+}

--- a/authz/opa-bridge/policies/lakekeeper/check.rego
+++ b/authz/opa-bridge/policies/lakekeeper/check.rego
@@ -188,6 +188,26 @@ batch_check_results(lakekeeper_id, checks) := all_results if {
 	]
 }
 
+# Like `batch_check_results` but uses OPA force_cache, keyed via the
+# `X-Request-ID` header set to `request_id`. Prefer this for probes that
+# repeat many times within one query's fan-out (e.g. warehouse/namespace
+# list_everything checks) — pass queryId so each new query re-probes once,
+# then all its waves hit the cache, and Lakekeeper's audit logs carry the
+# originating Trino queryId.
+batch_check_results_cached(lakekeeper_id, checks, request_id, cache_secs) := all_results if {
+	count(checks) > 0
+	_raw_max := object.get(config_by_id[lakekeeper_id], "max_batch_check_size", 1000)
+	max_size := max([_raw_max, 1])
+	num_batches := ceil(count(checks) / max_size)
+	all_results := [result |
+		some batch_idx in numbers.range(0, num_batches - 1)
+		start := batch_idx * max_size
+		batch := array.slice(checks, start, start + max_size)
+		chunk_results := _batch_check_http_cached(lakekeeper_id, batch, request_id, cache_secs)
+		some result in chunk_results
+	]
+}
+
 # Send a single batch-check HTTP request.
 _batch_check_http(lakekeeper_id, checks) := value.results if {
 	value := authenticated_http_send(
@@ -198,6 +218,29 @@ _batch_check_http(lakekeeper_id, checks) := value.results if {
 			"checks": checks,
 		},
 	).body
+}
+
+# Cached variant of `_batch_check_http`.
+_batch_check_http_cached(lakekeeper_id, checks, request_id, cache_secs) := value.results if {
+	value := authenticated_http_send_cached(
+		lakekeeper_id,
+		"POST", "/management/v1/action/batch-check",
+		{
+			"error-on-not-found": false,
+			"checks": checks,
+		},
+		request_id,
+		cache_secs,
+	).body
+}
+
+# Build a single check object for a warehouse action
+build_warehouse_check(warehouse_id, user, action) := {
+	"operation": {"warehouse": {
+		"action": {"action": action},
+		"warehouse-id": warehouse_id,
+	}},
+	"identity": {"user": user},
 }
 
 # Build a single check object for a table action

--- a/authz/opa-bridge/policies/trino/check_batch.rego
+++ b/authz/opa-bridge/policies/trino/check_batch.rego
@@ -70,9 +70,7 @@ _namespace_broad[catalog_name] := allowed_names if {
 	# `schema_names[i]` when mapping results back to allowed names.
 	schema_names := sort(schema_set)
 	checks := [
-	lakekeeper.build_namespace_check(
-		warehouse_id, namespace_for_schema(name), lakekeeper_user_id, "list_everything",
-	) |
+	lakekeeper.build_namespace_check(warehouse_id, namespace_for_schema(name), lakekeeper_user_id, "list_everything") |
 		some name in schema_names
 	]
 	results := lakekeeper.batch_check_results_cached(

--- a/authz/opa-bridge/policies/trino/check_batch.rego
+++ b/authz/opa-bridge/policies/trino/check_batch.rego
@@ -1,6 +1,13 @@
 # Optimized batch filtering for Lakekeeper-managed catalogs.
 # Instead of calling `allow` per resource (which makes 1+ HTTP calls each),
 # this collects all checks into a single Lakekeeper batch-check HTTP request.
+#
+# Fast path: when the principal has `list_everything` on the warehouse or on
+# individual namespaces, the per-table batch-check is skipped entirely for the
+# covered resources. The coarse check is cached per-query (via the queryId
+# salt on the cached batch-check helper), so queries that fan out across many
+# tables (information_schema, SHOW TABLES, etc.) only pay the cost once per
+# query.
 package trino
 
 import data.lakekeeper
@@ -12,17 +19,129 @@ _batch_lakekeeper_actions := {
 	"SelectFromColumns": "read_data",
 }
 
+# Cache TTL for broad-access (list_everything) checks. Short enough to respect
+# permission revocations quickly; the cache is also keyed per queryId so the
+# practical staleness window is bounded by the duration of one query.
+_BROAD_ACCESS_CACHE_SECS := 30
+
+# Request ID forwarded to Lakekeeper as X-Request-ID on broad-access probes.
+# Uses the Trino queryId so each new query re-probes once (all waves share
+# the result), and Lakekeeper's audit/trace logs correlate to the query.
+# Falls back to empty string if queryId is absent — broad-access probes
+# then share a cache key across queries (acceptable fallback, not expected
+# from Trino).
+_broad_access_request_id := object.get(input.context, "queryId", "")
+
+# --- Fast path: warehouse-level `list_everything` ---
+#
+# `can_list_everything` on a warehouse is defined as `describe` in the FGA
+# model, which propagates `describe from parent` to every namespace/table and
+# implies `can_get_metadata` on each. So it's semantically safe to short-circuit
+# FilterTables/FilterColumns/FilterSchemas. SelectFromColumns needs `read_data`
+# (= `select`, NOT implied by `describe`) and must stay on the slow path.
+_warehouse_broad contains catalog_name if {
+	some catalog_name in _managed_catalog_names
+	trino_catalog := catalog_config_by_name[catalog_name]
+	warehouse_id := lakekeeper.warehouse_id_for_name(trino_catalog.lakekeeper_id, trino_catalog.lakekeeper_warehouse)
+	check := lakekeeper.build_warehouse_check(warehouse_id, lakekeeper_user_id, "list_everything")
+	results := lakekeeper.batch_check_results_cached(
+		trino_catalog.lakekeeper_id,
+		[check],
+		_broad_access_request_id,
+		_BROAD_ACCESS_CACHE_SECS,
+	)
+	results[0].allowed == true
+}
+
+# --- Fast path: namespace-level `list_everything` ---
+#
+# Only evaluated when the warehouse-level path doesn't apply. One cached
+# batch-check per catalog containing all distinct namespaces in the batch.
+# regal ignore:rule-length
+_namespace_broad[catalog_name] := allowed_names if {
+	some catalog_name in _managed_catalog_names
+	not catalog_name in _warehouse_broad
+	trino_catalog := catalog_config_by_name[catalog_name]
+	warehouse_id := lakekeeper.warehouse_id_for_name(trino_catalog.lakekeeper_id, trino_catalog.lakekeeper_warehouse)
+	schema_names := _distinct_schemas_for(catalog_name)
+	count(schema_names) > 0
+	checks := [lakekeeper.build_namespace_check(warehouse_id, namespace_for_schema(name), lakekeeper_user_id, "list_everything") |
+		some name in schema_names
+	]
+	results := lakekeeper.batch_check_results_cached(
+		trino_catalog.lakekeeper_id,
+		checks,
+		_broad_access_request_id,
+		_BROAD_ACCESS_CACHE_SECS,
+	)
+	allowed_names := {schema_names[i] |
+		some i, result in results
+		result.allowed == true
+	}
+}
+
+# Helper: distinct schema names appearing in the batch for one catalog.
+# Returns an array (order matters for alignment with the `checks` array
+# built from it in `_namespace_broad`).
+_distinct_schemas_for(catalog_name) := names if {
+	input.action.operation in ["FilterTables", "FilterColumns", "SelectFromColumns"]
+	names := [n |
+		some r in input.action.filterResources
+		r.table.catalogName == catalog_name
+		not r.table.schemaName in lakekeeper_system_schemas
+		n := r.table.schemaName
+	]
+} else := names if {
+	input.action.operation == "FilterSchemas"
+	names := [n |
+		some r in input.action.filterResources
+		r.schema.catalogName == catalog_name
+		not r.schema.schemaName in lakekeeper_system_schemas
+		n := r.schema.schemaName
+	]
+} else := []
+
+# Helper: does the fast path cover this table resource? Used to exclude
+# such resources from the per-table slow path. Applies only to the describe-
+# level operations — SelectFromColumns intentionally never hits this.
+_fast_path_covers_table(raw_resource) if {
+	input.action.operation in ["FilterTables", "FilterColumns"]
+	raw_resource.table.catalogName in _warehouse_broad
+}
+
+_fast_path_covers_table(raw_resource) if {
+	input.action.operation in ["FilterTables", "FilterColumns"]
+	catalog := raw_resource.table.catalogName
+	not catalog in _warehouse_broad
+	raw_resource.table.schemaName in object.get(_namespace_broad, catalog, set())
+}
+
+# Helper: does the fast path cover this schema resource?
+_fast_path_covers_schema(raw_resource) if {
+	input.action.operation == "FilterSchemas"
+	raw_resource.schema.catalogName in _warehouse_broad
+}
+
+_fast_path_covers_schema(raw_resource) if {
+	input.action.operation == "FilterSchemas"
+	catalog := raw_resource.schema.catalogName
+	not catalog in _warehouse_broad
+	raw_resource.schema.schemaName in object.get(_namespace_broad, catalog, set())
+}
+
 # _managed_catalog_names is defined in main.rego
 
-# --- Table/View batch ---
+# --- Table/View batch (slow path) ---
 
-# Collect non-system-schema table resource indices for managed catalogs.
+# Collect non-system-schema table resource indices for managed catalogs,
+# excluding anything already covered by the fast path.
 _lakekeeper_batch_table_indices contains i if {
 	input.action.operation in ["FilterTables", "FilterColumns", "SelectFromColumns"]
 	some i, raw_resource in input.action.filterResources
 	raw_resource.table.catalogName in _managed_catalog_names
 	not raw_resource.table.schemaName in lakekeeper_system_schemas
 	not is_metadata_table(raw_resource.table.tableName)
+	not _fast_path_covers_table(raw_resource)
 }
 
 # Build checks, execute batch-check, and return allowed indices per catalog.
@@ -73,13 +192,14 @@ _lakekeeper_batch_allowed[catalog_name] := allowed_indices if {
 	}
 }
 
-# --- Schema batch ---
+# --- Schema batch (slow path) ---
 
 _lakekeeper_batch_schema_indices contains i if {
 	input.action.operation == "FilterSchemas"
 	some i, raw_resource in input.action.filterResources
 	raw_resource.schema.catalogName in _managed_catalog_names
 	not raw_resource.schema.schemaName in lakekeeper_system_schemas
+	not _fast_path_covers_schema(raw_resource)
 }
 
 # regal ignore:rule-length
@@ -115,8 +235,9 @@ _lakekeeper_batch_schema_allowed[catalog_name] := allowed_indices if {
 	}
 }
 
-# --- Batch rules (grouped together to avoid messy-rule) ---
+# --- Batch rules ---
 
+# Slow-path results.
 batch contains i if {
 	some catalog_name in _managed_catalog_names
 	some i in _lakekeeper_batch_allowed[catalog_name]
@@ -125,6 +246,44 @@ batch contains i if {
 batch contains i if {
 	some catalog_name in _managed_catalog_names
 	some i in _lakekeeper_batch_schema_allowed[catalog_name]
+}
+
+# Fast-path: warehouse-level broad access → allow all qualifying table indices.
+batch contains i if {
+	input.action.operation in ["FilterTables", "FilterColumns"]
+	some i, raw_resource in input.action.filterResources
+	raw_resource.table.catalogName in _warehouse_broad
+	not raw_resource.table.schemaName in lakekeeper_system_schemas
+	not is_metadata_table(raw_resource.table.tableName)
+}
+
+# Fast-path: namespace-level broad access → allow table indices in those namespaces.
+batch contains i if {
+	input.action.operation in ["FilterTables", "FilterColumns"]
+	some i, raw_resource in input.action.filterResources
+	catalog := raw_resource.table.catalogName
+	not catalog in _warehouse_broad
+	not raw_resource.table.schemaName in lakekeeper_system_schemas
+	not is_metadata_table(raw_resource.table.tableName)
+	raw_resource.table.schemaName in object.get(_namespace_broad, catalog, set())
+}
+
+# Fast-path for FilterSchemas: warehouse broad → all schema indices.
+batch contains i if {
+	input.action.operation == "FilterSchemas"
+	some i, raw_resource in input.action.filterResources
+	raw_resource.schema.catalogName in _warehouse_broad
+	not raw_resource.schema.schemaName in lakekeeper_system_schemas
+}
+
+# Fast-path for FilterSchemas: namespace broad → matching schema indices.
+batch contains i if {
+	input.action.operation == "FilterSchemas"
+	some i, raw_resource in input.action.filterResources
+	catalog := raw_resource.schema.catalogName
+	not catalog in _warehouse_broad
+	not raw_resource.schema.schemaName in lakekeeper_system_schemas
+	raw_resource.schema.schemaName in object.get(_namespace_broad, catalog, set())
 }
 
 # FilterColumns with a single table + columns array on a managed catalog:
@@ -138,6 +297,20 @@ batch contains i if {
 	raw_resource.table.catalogName in _managed_catalog_names
 	not raw_resource.table.schemaName in lakekeeper_system_schemas
 	not is_metadata_table(raw_resource.table.tableName)
-	0 in _lakekeeper_batch_allowed[raw_resource.table.catalogName]
+	_single_table_filter_columns_allowed(raw_resource)
 	some i in numbers.range(0, count(raw_resource.table.columns) - 1)
+}
+
+# Single-resource FilterColumns is allowed if any of the paths say so.
+_single_table_filter_columns_allowed(raw_resource) if {
+	raw_resource.table.catalogName in _warehouse_broad
+}
+
+_single_table_filter_columns_allowed(raw_resource) if {
+	catalog := raw_resource.table.catalogName
+	raw_resource.table.schemaName in object.get(_namespace_broad, catalog, set())
+}
+
+_single_table_filter_columns_allowed(raw_resource) if {
+	0 in _lakekeeper_batch_allowed[raw_resource.table.catalogName]
 }

--- a/authz/opa-bridge/policies/trino/check_batch.rego
+++ b/authz/opa-bridge/policies/trino/check_batch.rego
@@ -22,7 +22,7 @@ _batch_lakekeeper_actions := {
 # Cache TTL for broad-access (list_everything) checks. Short enough to respect
 # permission revocations quickly; the cache is also keyed per queryId so the
 # practical staleness window is bounded by the duration of one query.
-_BROAD_ACCESS_CACHE_SECS := 30
+_broad_access_cache_secs := 30
 
 # Request ID forwarded to Lakekeeper as X-Request-ID on broad-access probes.
 # Uses the Trino queryId so each new query re-probes once (all waves share
@@ -48,7 +48,7 @@ _warehouse_broad contains catalog_name if {
 		trino_catalog.lakekeeper_id,
 		[check],
 		_broad_access_request_id,
-		_BROAD_ACCESS_CACHE_SECS,
+		_broad_access_cache_secs,
 	)
 	results[0].allowed == true
 }
@@ -69,18 +69,21 @@ _namespace_broad[catalog_name] := allowed_names if {
 	# Sort the set into a deterministic list so `checks[i]` aligns with
 	# `schema_names[i]` when mapping results back to allowed names.
 	schema_names := sort(schema_set)
-	checks := [lakekeeper.build_namespace_check(warehouse_id, namespace_for_schema(name), lakekeeper_user_id, "list_everything") |
+	checks := [
+	lakekeeper.build_namespace_check(
+		warehouse_id, namespace_for_schema(name), lakekeeper_user_id, "list_everything",
+	) |
 		some name in schema_names
 	]
 	results := lakekeeper.batch_check_results_cached(
 		trino_catalog.lakekeeper_id,
 		checks,
 		_broad_access_request_id,
-		_BROAD_ACCESS_CACHE_SECS,
+		_broad_access_cache_secs,
 	)
-	allowed_names := {schema_names[i] |
-		some i, result in results
-		result.allowed == true
+	allowed_names := {name |
+		some i, name in schema_names
+		results[i].allowed == true
 	}
 }
 
@@ -89,19 +92,17 @@ _namespace_broad[catalog_name] := allowed_names if {
 # of rows sharing the same schema, and we want one namespace check per schema.
 _distinct_schemas_for(catalog_name) := names if {
 	input.action.operation in ["FilterTables", "FilterColumns", "SelectFromColumns"]
-	names := {n |
+	names := {r.table.schemaName |
 		some r in input.action.filterResources
 		r.table.catalogName == catalog_name
 		not r.table.schemaName in lakekeeper_system_schemas
-		n := r.table.schemaName
 	}
 } else := names if {
 	input.action.operation == "FilterSchemas"
-	names := {n |
+	names := {r.schema.schemaName |
 		some r in input.action.filterResources
 		r.schema.catalogName == catalog_name
 		not r.schema.schemaName in lakekeeper_system_schemas
-		n := r.schema.schemaName
 	}
 } else := set()
 

--- a/authz/opa-bridge/policies/trino/check_batch.rego
+++ b/authz/opa-bridge/policies/trino/check_batch.rego
@@ -63,8 +63,12 @@ _namespace_broad[catalog_name] := allowed_names if {
 	not catalog_name in _warehouse_broad
 	trino_catalog := catalog_config_by_name[catalog_name]
 	warehouse_id := lakekeeper.warehouse_id_for_name(trino_catalog.lakekeeper_id, trino_catalog.lakekeeper_warehouse)
-	schema_names := _distinct_schemas_for(catalog_name)
-	count(schema_names) > 0
+	schema_set := _distinct_schemas_for(catalog_name)
+	count(schema_set) > 0
+
+	# Sort the set into a deterministic list so `checks[i]` aligns with
+	# `schema_names[i]` when mapping results back to allowed names.
+	schema_names := sort(schema_set)
 	checks := [lakekeeper.build_namespace_check(warehouse_id, namespace_for_schema(name), lakekeeper_user_id, "list_everything") |
 		some name in schema_names
 	]
@@ -81,25 +85,25 @@ _namespace_broad[catalog_name] := allowed_names if {
 }
 
 # Helper: distinct schema names appearing in the batch for one catalog.
-# Returns an array (order matters for alignment with the `checks` array
-# built from it in `_namespace_broad`).
+# Set comprehension dedups — a single FilterTables batch can contain thousands
+# of rows sharing the same schema, and we want one namespace check per schema.
 _distinct_schemas_for(catalog_name) := names if {
 	input.action.operation in ["FilterTables", "FilterColumns", "SelectFromColumns"]
-	names := [n |
+	names := {n |
 		some r in input.action.filterResources
 		r.table.catalogName == catalog_name
 		not r.table.schemaName in lakekeeper_system_schemas
 		n := r.table.schemaName
-	]
+	}
 } else := names if {
 	input.action.operation == "FilterSchemas"
-	names := [n |
+	names := {n |
 		some r in input.action.filterResources
 		r.schema.catalogName == catalog_name
 		not r.schema.schemaName in lakekeeper_system_schemas
 		n := r.schema.schemaName
-	]
-} else := []
+	}
+} else := set()
 
 # Helper: does the fast path cover this table resource? Used to exclude
 # such resources from the per-table slow path. Applies only to the describe-

--- a/authz/opa-bridge/policies/trino/main.rego
+++ b/authz/opa-bridge/policies/trino/main.rego
@@ -139,6 +139,12 @@ batch contains i if {
 	count(input.action.filterResources) == 1
 	raw_resource := input.action.filterResources[0]
 	count(raw_resource.table.columns) > 0
+
+	# Skip when check_batch.rego already handles this case (managed catalog,
+	# non-system schema, non-metadata table). That rule short-circuits via
+	# warehouse/namespace broad access or a single per-table batch-check —
+	# running per-column `allow` here would duplicate Lakekeeper calls.
+	not _single_filter_columns_handled_by_batch
 	new_resources := [
 	object.union(raw_resource, {"table": object.union(raw_resource.table, {"column": column_name})}) |
 		some column_name in raw_resource.table.columns
@@ -147,4 +153,14 @@ batch contains i if {
 
 	# regal ignore:with-outside-test-context
 	allow with input.action.resource as resource
+}
+
+# True when single-resource FilterColumns is fully handled by check_batch.rego,
+# i.e. catalog is managed, schema is not a Lakekeeper system schema, and the
+# table is not an iceberg metadata-table ($history, $snapshots, ...).
+_single_filter_columns_handled_by_batch if {
+	raw_resource := input.action.filterResources[0]
+	raw_resource.table.catalogName in _managed_catalog_names
+	not raw_resource.table.schemaName in lakekeeper_system_schemas
+	not is_metadata_table(raw_resource.table.tableName)
 }

--- a/authz/opa-bridge/policies/trino/main.rego
+++ b/authz/opa-bridge/policies/trino/main.rego
@@ -82,19 +82,47 @@ _batch_resource_catalog(raw_resource) := raw_resource.catalog.name
 _batch_resource_schema(raw_resource) := raw_resource.table.schemaName
 _batch_resource_schema(raw_resource) := raw_resource.schema.schemaName
 
-# Fast path for unmanaged catalogs: only default_access + allow_unmanaged
-_allow_unmanaged if allow_default_access
+# Unique unmanaged catalog names in this batch request.
+_batch_unmanaged_catalogs contains name if {
+	some raw_resource in input.action.filterResources
+	name := _batch_resource_catalog(raw_resource)
+	not name in _managed_catalog_names
+}
 
-_allow_unmanaged if allow_unmanaged
+# Catalogs blanket-allowed via allow_unmanaged, evaluated once per unique
+# catalog (not per resource). allow_unmanaged's decision is catalog-level
+# (depends on configuration.trino_allow_unmanaged_catalogs + catalog name),
+# so one evaluation per catalog suffices — avoids re-running the rule for
+# every filterResource in a large batch.
+_allowed_unmanaged_batch_catalogs contains catalog_name if {
+	some catalog_name in _batch_unmanaged_catalogs
+	representative := [r |
+		some r in input.action.filterResources
+		_batch_resource_catalog(r) == catalog_name
+	][0]
 
-# Unmanaged catalogs in batch operations: fast path (no Lakekeeper evaluation)
+	# regal ignore:with-outside-test-context
+	allow_unmanaged with input.action.resource as representative
+}
+
+# Unmanaged catalogs allowed by allow_unmanaged: one membership check per resource.
+batch contains i if {
+	input.action.operation in _batch_operations
+	some i, raw_resource in input.action.filterResources
+	_batch_resource_catalog(raw_resource) in _allowed_unmanaged_batch_catalogs
+}
+
+# Unmanaged catalogs not blanket-allowed: fall back to per-resource
+# allow_default_access (depends on operation/schema specifics like
+# ExecuteQuery or information_schema, so can't be collapsed per-catalog).
 batch contains i if {
 	input.action.operation in _batch_operations
 	some i, raw_resource in input.action.filterResources
 	not _batch_resource_catalog(raw_resource) in _managed_catalog_names
+	not _batch_resource_catalog(raw_resource) in _allowed_unmanaged_batch_catalogs
 
 	# regal ignore:with-outside-test-context
-	_allow_unmanaged with input.action.resource as raw_resource
+	allow_default_access with input.action.resource as raw_resource
 }
 
 # System schema resources in managed catalogs still need per-resource evaluation

--- a/authz/opa-bridge/tests/trino/fast_path_test.rego
+++ b/authz/opa-bridge/tests/trino/fast_path_test.rego
@@ -1,0 +1,139 @@
+# Tests for the broad-access fast path in check_batch.rego.
+# Verifies that `list_everything` on warehouse or namespace short-circuits the
+# per-resource batch-check and that the slow path is correctly bypassed.
+package trino_test
+
+import data.trino
+
+# ===================================================================
+# Warehouse-level list_everything: all qualifying resources allowed
+# without per-resource Lakekeeper calls.
+# ===================================================================
+
+test_fast_path_warehouse_broad_allows_all_tables if {
+	result := trino.batch with input as {
+		"context": mock_context,
+		"action": {
+			"operation": "FilterTables",
+			"filterResources": [
+				{"table": {"catalogName": "managed", "schemaName": "schema_a", "tableName": "table_a"}},
+				{"table": {"catalogName": "managed", "schemaName": "schema_b", "tableName": "table_b"}},
+				{"table": {"catalogName": "managed", "schemaName": "schema_c", "tableName": "table_c"}},
+			],
+		},
+	}
+		with data.configuration.lakekeeper as mock_lakekeeper
+		with data.configuration.trino_catalog as mock_trino_catalog
+		with http.send as mock_http_warehouse_list_everything
+
+	# All three allowed via fast path (mock denies per-resource checks, so if
+	# the slow path ran they'd fail).
+	0 in result
+	1 in result
+	2 in result
+}
+
+test_fast_path_warehouse_broad_allows_all_schemas if {
+	result := trino.batch with input as {
+		"context": mock_context,
+		"action": {
+			"operation": "FilterSchemas",
+			"filterResources": [
+				{"schema": {"catalogName": "managed", "schemaName": "schema_a"}},
+				{"schema": {"catalogName": "managed", "schemaName": "schema_b"}},
+			],
+		},
+	}
+		with data.configuration.lakekeeper as mock_lakekeeper
+		with data.configuration.trino_catalog as mock_trino_catalog
+		with http.send as mock_http_warehouse_list_everything
+
+	0 in result
+	1 in result
+}
+
+test_fast_path_warehouse_broad_single_table_filter_columns if {
+	result := trino.batch with input as {
+		"context": mock_context,
+		"action": {
+			"operation": "FilterColumns",
+			"filterResources": [{"table": {
+				"catalogName": "managed",
+				"schemaName": "schema_a",
+				"tableName": "table_a",
+				"columns": ["c1", "c2", "c3"],
+			}}],
+		},
+	}
+		with data.configuration.lakekeeper as mock_lakekeeper
+		with data.configuration.trino_catalog as mock_trino_catalog
+		with http.send as mock_http_warehouse_list_everything
+
+	# All column indices allowed.
+	0 in result
+	1 in result
+	2 in result
+}
+
+# Fast-path must NOT cover SelectFromColumns, because `list_everything` only
+# implies describe-level access, not read_data. Slow path runs and denies.
+test_fast_path_does_not_cover_select_from_columns if {
+	result := trino.batch with input as {
+		"context": mock_context,
+		"action": {
+			"operation": "SelectFromColumns",
+			"filterResources": [{"table": {"catalogName": "managed", "schemaName": "schema_a", "tableName": "table_a"}}],
+		},
+	}
+		with data.configuration.lakekeeper as mock_lakekeeper
+		with data.configuration.trino_catalog as mock_trino_catalog
+		with http.send as mock_http_warehouse_list_everything
+
+	# Mock denies per-resource checks — slow path kicks in, table denied.
+	not 0 in result
+}
+
+# ===================================================================
+# Namespace-level list_everything: only resources in allowed namespaces
+# short-circuit; others fall through to slow path.
+# ===================================================================
+
+test_fast_path_namespace_broad_allows_matching_namespace if {
+	result := trino.batch with input as {
+		"context": mock_context,
+		"action": {
+			"operation": "FilterTables",
+			"filterResources": [
+				{"table": {"catalogName": "managed", "schemaName": "schema_a", "tableName": "table_a"}},
+				{"table": {"catalogName": "managed", "schemaName": "schema_b", "tableName": "table_b"}},
+			],
+		},
+	}
+		with data.configuration.lakekeeper as mock_lakekeeper
+		with data.configuration.trino_catalog as mock_trino_catalog
+		with http.send as mock_http_namespace_list_everything_schema_a
+
+	# schema_a allowed via namespace fast path; schema_b denied (slow path
+	# runs, mock returns false for per-resource checks).
+	0 in result
+	not 1 in result
+}
+
+test_fast_path_namespace_broad_allows_matching_schema if {
+	result := trino.batch with input as {
+		"context": mock_context,
+		"action": {
+			"operation": "FilterSchemas",
+			"filterResources": [
+				{"schema": {"catalogName": "managed", "schemaName": "schema_a"}},
+				{"schema": {"catalogName": "managed", "schemaName": "schema_b"}},
+			],
+		},
+	}
+		with data.configuration.lakekeeper as mock_lakekeeper
+		with data.configuration.trino_catalog as mock_trino_catalog
+		with http.send as mock_http_namespace_list_everything_schema_a
+
+	0 in result
+	not 1 in result
+}

--- a/authz/opa-bridge/tests/trino/helpers_test.rego
+++ b/authz/opa-bridge/tests/trino/helpers_test.rego
@@ -75,11 +75,15 @@ mock_http_allow_views_only(request) := {"status_code": 200, "body": {"access_tok
 	results := [_mock_view_only_result(check) | some check in request.body.checks]
 }
 
-# Allow only namespace ["schema_a"] + warehouse checks (needed for system schema fallback)
+# Allow only namespace ["schema_a"] + warehouse checks (needed for system schema fallback).
+# `list_everything` is denied so check_batch.rego's broad-access fast path stays
+# disabled; these tests exercise the per-resource slow path only.
 _mock_schema_a_result(check) := {"allowed": true} if {
 	check.operation.namespace.namespace == ["schema_a"]
+	check.operation.namespace.action.action != "list_everything"
 } else := {"allowed": true} if {
 	check.operation.warehouse
+	check.operation.warehouse.action.action != "list_everything"
 } else := {"allowed": false}
 
 mock_http_allow_schema_a(request) := {"status_code": 200, "body": {"access_token": "mock-token"}} if {
@@ -93,8 +97,10 @@ mock_http_allow_schema_a(request) := {"status_code": 200, "body": {"access_token
 
 # Allow only warehouse-level checks (get_config), deny table/view-level checks.
 # Simulates: user has catalog access but Lakekeeper doesn't know about system schema tables.
+# `list_everything` is denied so the broad-access fast path stays disabled.
 _mock_warehouse_only_result(check) := {"allowed": true} if {
 	check.operation.warehouse
+	check.operation.warehouse.action.action != "list_everything"
 } else := {"allowed": false}
 
 mock_http_allow_warehouse_only(request) := {"status_code": 200, "body": {"access_token": "mock-token"}} if {
@@ -106,11 +112,14 @@ mock_http_allow_warehouse_only(request) := {"status_code": 200, "body": {"access
 	results := [_mock_warehouse_only_result(check) | some check in request.body.checks]
 }
 
-# Allow only "products" table/view checks
+# Allow only "products" table/view checks.
+# `list_everything` on warehouse is denied so the broad-access fast path stays
+# disabled — this mock exercises the selective per-resource slow path.
 _mock_products_only_result(check) := {"allowed": true} if {
 	_mock_check_name(check) == "products"
 } else := {"allowed": true} if {
 	check.operation.warehouse
+	check.operation.warehouse.action.action != "list_everything"
 } else := {"allowed": false}
 
 mock_http_allow_products_only(request) := {"status_code": 200, "body": {"access_token": "mock-token"}} if {
@@ -120,4 +129,37 @@ mock_http_allow_products_only(request) := {"status_code": 200, "body": {"access_
 } else := {"status_code": 200, "body": {"results": results}} if {
 	contains(request.url, "batch-check")
 	results := [_mock_products_only_result(check) | some check in request.body.checks]
+}
+
+# Allow ONLY warehouse-level list_everything — deny everything else.
+# Used to test the fast-path short-circuit: if per-resource checks are still
+# being made (i.e. slow path ran), they'd return false and the test would fail.
+_mock_warehouse_list_everything_result(check) := {"allowed": true} if {
+	check.operation.warehouse.action.action == "list_everything"
+} else := {"allowed": false}
+
+mock_http_warehouse_list_everything(request) := {"status_code": 200, "body": {"access_token": "mock-token"}} if {
+	endswith(request.url, "/token")
+} else := {"status_code": 200, "body": {"defaults": {"prefix": "mock-wh-id"}}} if {
+	contains(request.url, "catalog/v1/config")
+} else := {"status_code": 200, "body": {"results": results}} if {
+	contains(request.url, "batch-check")
+	results := [_mock_warehouse_list_everything_result(check) | some check in request.body.checks]
+}
+
+# Allow ONLY namespace-level list_everything on namespace ["schema_a"] — deny
+# warehouse-level list_everything and all per-resource checks. Used to test the
+# namespace-level fast path in isolation.
+_mock_namespace_list_everything_schema_a_result(check) := {"allowed": true} if {
+	check.operation.namespace.action.action == "list_everything"
+	check.operation.namespace.namespace == ["schema_a"]
+} else := {"allowed": false}
+
+mock_http_namespace_list_everything_schema_a(request) := {"status_code": 200, "body": {"access_token": "mock-token"}} if {
+	endswith(request.url, "/token")
+} else := {"status_code": 200, "body": {"defaults": {"prefix": "mock-wh-id"}}} if {
+	contains(request.url, "catalog/v1/config")
+} else := {"status_code": 200, "body": {"results": results}} if {
+	contains(request.url, "batch-check")
+	results := [_mock_namespace_list_everything_schema_a_result(check) | some check in request.body.checks]
 }

--- a/authz/opa-bridge/tests/trino/main_test.rego
+++ b/authz/opa-bridge/tests/trino/main_test.rego
@@ -156,3 +156,68 @@ test_batch_unmanaged_no_lakekeeper_calls if {
 	0 in result
 	1 in result
 }
+
+# Large batch on a single unmanaged catalog: verifies the per-catalog optimization
+# (allow_unmanaged evaluated once per unique catalog, not once per resource) still
+# returns every allowed index. Regression test for _allowed_unmanaged_batch_catalogs
+# membership check — if the collapse dropped indices, result would be a strict subset.
+test_batch_unmanaged_many_rows_same_catalog if {
+	rows := [{"table": {"catalogName": "external_db", "schemaName": "public", "tableName": sprintf("t%d", [i])}} |
+		some i in numbers.range(0, 199)
+	]
+	result := trino.batch with input as {
+		"context": mock_context,
+		"action": {
+			"operation": "FilterTables",
+			"filterResources": rows,
+		},
+	}
+		with data.configuration.trino_allow_unmanaged_catalogs as true
+
+	# All 200 indices must be present.
+	count(result) == 200
+	count({i | some i in numbers.range(0, 199); i in result}) == 200
+}
+
+# Multiple distinct unmanaged catalogs in one batch: each catalog must be
+# evaluated independently. Regression test for _batch_unmanaged_catalogs
+# dedup — if dedup collapsed catalogs incorrectly, some would be missed.
+test_batch_unmanaged_mixed_catalogs if {
+	result := trino.batch with input as {
+		"context": mock_context,
+		"action": {
+			"operation": "FilterTables",
+			"filterResources": [
+				{"table": {"catalogName": "external_a", "schemaName": "public", "tableName": "t1"}},
+				{"table": {"catalogName": "external_b", "schemaName": "public", "tableName": "t2"}},
+				{"table": {"catalogName": "external_a", "schemaName": "public", "tableName": "t3"}},
+				{"table": {"catalogName": "external_c", "schemaName": "public", "tableName": "t4"}},
+			],
+		},
+	}
+		with data.configuration.trino_allow_unmanaged_catalogs as true
+
+	result == {0, 1, 2, 3}
+}
+
+# Without blanket-allow, unmanaged catalogs fall back to per-resource
+# allow_default_access. Verifies the fallback rule still admits resources
+# that default_access would pass (system catalog / jdbc.types).
+test_batch_unmanaged_fallback_via_default_access if {
+	result := trino.batch with input as {
+		"context": mock_context,
+		"action": {
+			"operation": "FilterTables",
+			"filterResources": [
+				{"table": {"catalogName": "external_db", "schemaName": "public", "tableName": "users"}},
+				{"table": {"catalogName": "system", "schemaName": "jdbc", "tableName": "types"}},
+			],
+		},
+	}
+
+	# external_db is unmanaged and the flag is off → denied.
+	not 0 in result
+
+	# system.jdbc.types is admitted by allow_default_access.
+	1 in result
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request‑ID propagation and OPA force‑cache support for authenticated API calls and cached batch checks.
  * Implemented fast‑path broad‑access caching (warehouse/namespace and per‑catalog) to skip many per‑resource checks.
  * Per‑catalog unmanaged batch evaluation now deduplicates and evaluates once per catalog.

* **Bug Fixes**
  * Avoided duplicate external authorization evaluations for certain column‑filter requests.

* **Tests**
  * Added tests and mocks validating fast‑path short‑circuiting, cached batch behavior, and unmanaged‑catalog handling.

* **Chores**
  * Updated .gitignore to exclude local tooling file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->