### PR TITLE
feat(authz): support switching to OpenFGA via reconcile + reopen-bootstrap

### DIFF
--- a/.sqlx/query-298c38a2042a2b7d19ec8b3ea880e71dfdc087eb0b298637578c141e738cf0d2.json
+++ b/.sqlx/query-298c38a2042a2b7d19ec8b3ea880e71dfdc087eb0b298637578c141e738cf0d2.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE server\n        SET open_for_bootstrap = true\n        WHERE server.open_for_bootstrap = false\n        RETURNING server_id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "server_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "298c38a2042a2b7d19ec8b3ea880e71dfdc087eb0b298637578c141e738cf0d2"
+}

--- a/crates/authz-openfga/src/authorizer.rs
+++ b/crates/authz-openfga/src/authorizer.rs
@@ -26,7 +26,7 @@ use lakekeeper::{
 use openfga_client::{
     client::{
         BasicOpenFgaClient, BatchCheckItem, CheckRequestTupleKey, ConsistencyPreference,
-        ReadRequestTupleKey, ReadResponse, Tuple, TupleKey, TupleKeyWithoutCondition,
+        ReadRequestTupleKey, ReadResponse, Tuple, TupleKey, TupleKeyWithoutCondition, WriteOptions,
         batch_check_single_result::CheckResult,
     },
     tonic,
@@ -69,6 +69,14 @@ impl OpenFGAAuthorizer {
             health: Arc::new(RwLock::new(vec![])),
             server_id,
         }
+    }
+
+    /// Reference to the underlying OpenFGA store client. Exposed for
+    /// maintenance entry points (e.g. reconcile) that need to issue
+    /// store-level reads/writes alongside the authorizer.
+    #[must_use]
+    pub fn client(&self) -> &BasicOpenFgaClient {
+        &self.client
     }
 }
 
@@ -157,17 +165,24 @@ impl Authorizer for OpenFGAAuthorizer {
             ServerRelation::Admin
         };
 
-        self.write(
-            Some(vec![TupleKey {
-                user: user.to_openfga(),
-                relation: relation.to_string(),
-                object: self.openfga_server().clone(),
-                condition: None,
-            }]),
-            None,
-        )
-        .await
-        .map_err(authz_to_error_no_audit)?;
+        // Idempotent: a re-bootstrap (after `lakekeeper reopen-bootstrap`)
+        // may run against an OpenFGA store that already holds the same
+        // admin/operator tuple — strict writes would fail in that case.
+        self.client
+            .write_with_options(
+                Some(vec![TupleKey {
+                    user: user.to_openfga(),
+                    relation: relation.to_string(),
+                    object: self.openfga_server().clone(),
+                    condition: None,
+                }]),
+                None,
+                WriteOptions::new_idempotent(),
+            )
+            .await
+            .inspect_err(|e| tracing::error!("Failed to write bootstrap tuple to OpenFGA: {e}"))
+            .map_err(crate::error::OpenFGAError::from)
+            .map_err(authz_to_error_no_audit)?;
 
         Ok(())
     }

--- a/crates/authz-openfga/src/reconcile.rs
+++ b/crates/authz-openfga/src/reconcile.rs
@@ -93,8 +93,6 @@ const READ_PAGE_SIZE: i32 = 100;
 /// Postgres advisory lock key. Stable arbitrary value; the lock is scoped
 /// to "reconcile-with-deletion".
 const RECONCILE_LOCK_KEY: i64 = 0x5f8e_2d63_a4b1_00ff;
-/// Cap on how many pages to scan when sanity-checking server-id consistency.
-const SERVER_ID_SANITY_MAX_PAGES: u32 = 50;
 
 // ============================================================================
 // Public types
@@ -118,8 +116,12 @@ pub enum ReconcileMode {
 /// `tuples_submitted` is an **upper bound** on tuples actually persisted
 /// because writes are idempotent and OpenFGA does not return a count of
 /// duplicates. `tuples_deleted` is exact.
+///
+/// In `dry_run` mode the same fields describe what *would* have been
+/// written or deleted; no OpenFGA mutation occurs.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ReconcileReport {
+    pub dry_run: bool,
     pub tuples_submitted: u64,
     pub write_requests: u64,
     pub tuples_deleted: u64,
@@ -152,6 +154,9 @@ pub type RebuildReport = ReconcileReport;
 /// Add any structural hierarchy tuples the catalog implies but OpenFGA is
 /// missing. Never deletes. Generic over the catalog backend.
 ///
+/// When `dry_run` is true, the OpenFGA writes are skipped but the report
+/// reflects what *would* have been written.
+///
 /// See module docs.
 ///
 /// # Errors
@@ -160,15 +165,19 @@ pub async fn rebuild_hierarchy_tuples_from_catalog<C>(
     catalog_state: C::State,
     sink: &BasicOpenFgaClient,
     server_id: ServerId,
+    dry_run: bool,
 ) -> anyhow::Result<ReconcileReport>
 where
     C: CatalogStore,
 {
-    tracing::info!("rebuild (additive): starting for server {server_id}");
-    let mut report = ReconcileReport::default();
+    tracing::info!("rebuild (additive): starting for server {server_id} (dry_run={dry_run})");
+    let mut report = ReconcileReport {
+        dry_run,
+        ..ReconcileReport::default()
+    };
     let idx = CatalogIndex::build::<C>(&catalog_state, server_id).await?;
     log_index(&idx);
-    write_missing_from_index(&idx, sink, &mut report).await?;
+    write_missing_from_index(&idx, sink, &mut report, dry_run).await?;
     log_done(&report, "rebuild");
     Ok(report)
 }
@@ -181,18 +190,26 @@ where
 /// deletion. Postgres-only because of the advisory lock and per-delete
 /// revalidation.
 ///
+/// When `dry_run` is true, no OpenFGA writes or deletes occur — the report
+/// counts what *would* have been changed. The advisory lock is still
+/// acquired so a dry-run reads a stable snapshot relative to other
+/// reconciles.
+///
 /// # Errors
 /// * Catalog or OpenFGA call fails.
 /// * Advisory lock is already held by another reconcile.
-/// * Server-id sanity check finds tuples for a different server.
 pub async fn reconcile_hierarchy_tuples_from_catalog(
     catalog_state: CatalogState,
     sink: &BasicOpenFgaClient,
     server_id: ServerId,
     mode: ReconcileMode,
+    dry_run: bool,
 ) -> anyhow::Result<ReconcileReport> {
-    tracing::info!("reconcile: starting (mode={mode:?}, server_id={server_id})");
-    let mut report = ReconcileReport::default();
+    tracing::info!("reconcile: starting (mode={mode:?}, server_id={server_id}, dry_run={dry_run})");
+    let mut report = ReconcileReport {
+        dry_run,
+        ..ReconcileReport::default()
+    };
 
     let _lock = AdvisoryLock::acquire(&catalog_state).await?;
 
@@ -204,13 +221,12 @@ pub async fn reconcile_hierarchy_tuples_from_catalog(
     log_index(&idx);
 
     if matches!(mode, ReconcileMode::AddMissingAndDeleteDrift) {
-        verify_server_id_consistency(sink, server_id).await?;
-        diff_walk_and_delete(&idx, sink, &mut report).await?;
+        diff_walk_and_delete(&idx, sink, &mut report, dry_run).await?;
     }
 
     // Always run the additive pass last so that anything missing (or freshly
     // unknown after a delete) gets added back.
-    write_missing_from_index(&idx, sink, &mut report).await?;
+    write_missing_from_index(&idx, sink, &mut report, dry_run).await?;
 
     log_done(&report, "reconcile");
     Ok(report)
@@ -526,9 +542,10 @@ async fn write_missing_from_index(
     idx: &CatalogIndex,
     sink: &BasicOpenFgaClient,
     report: &mut ReconcileReport,
+    dry_run: bool,
 ) -> anyhow::Result<()> {
     let server = idx.server_id.to_openfga();
-    let mut writer = BatchWriter::new(sink, report);
+    let mut writer = BatchWriter::new(sink, report, dry_run);
 
     for project in &idx.projects {
         writer
@@ -574,6 +591,7 @@ async fn diff_walk_and_delete(
     idx: &CatalogIndex,
     sink: &BasicOpenFgaClient,
     report: &mut ReconcileReport,
+    dry_run: bool,
 ) -> anyhow::Result<()> {
     let consistent_sink = sink
         .clone()
@@ -624,7 +642,7 @@ async fn diff_walk_and_delete(
 
             if delete_buffer.len() >= WRITE_BATCH_SIZE {
                 let chunk = std::mem::take(&mut delete_buffer);
-                flush_deletes(&consistent_sink, chunk, report).await?;
+                flush_deletes(&consistent_sink, chunk, report, dry_run).await?;
             }
         }
 
@@ -634,7 +652,7 @@ async fn diff_walk_and_delete(
         continuation = Some(resp.continuation_token);
     }
     if !delete_buffer.is_empty() {
-        flush_deletes(&consistent_sink, delete_buffer, report).await?;
+        flush_deletes(&consistent_sink, delete_buffer, report, dry_run).await?;
     }
     Ok(())
 }
@@ -682,56 +700,16 @@ async fn flush_deletes(
     sink: &BasicOpenFgaClient,
     chunk: Vec<TupleKeyWithoutCondition>,
     report: &mut ReconcileReport,
+    dry_run: bool,
 ) -> anyhow::Result<()> {
     let n = chunk.len();
-    sink.write_with_options(None, Some(chunk), WriteOptions::new_idempotent())
-        .await
-        .map_err(|e| anyhow::anyhow!("reconcile: openfga delete failed: {e}"))?;
+    if !dry_run {
+        sink.write_with_options(None, Some(chunk), WriteOptions::new_idempotent())
+            .await
+            .map_err(|e| anyhow::anyhow!("reconcile: openfga delete failed: {e}"))?;
+    }
     report.tuples_deleted += n as u64;
     report.delete_requests += 1;
-    Ok(())
-}
-
-// ============================================================================
-// Server-id sanity
-// ============================================================================
-
-async fn verify_server_id_consistency(
-    sink: &BasicOpenFgaClient,
-    server_id: ServerId,
-) -> anyhow::Result<()> {
-    let consistent_sink = sink
-        .clone()
-        .set_consistency(ConsistencyPreference::HigherConsistency);
-    let configured = server_id.to_openfga();
-    let mut continuation: Option<String> = None;
-    let mut pages_scanned = 0u32;
-
-    loop {
-        let resp = consistent_sink
-            .read(READ_PAGE_SIZE, None, continuation.clone())
-            .await
-            .map_err(|e| anyhow::anyhow!("reconcile: server-id sanity Read failed: {e}"))?;
-        let resp = resp.into_inner();
-        for tuple in resp.tuples.iter().filter_map(|t| t.key.as_ref()) {
-            if tuple.relation == "server"
-                && tuple.object.starts_with("project:")
-                && tuple.user.starts_with("server:")
-                && tuple.user != configured
-            {
-                anyhow::bail!(
-                    "reconcile: refusing to run; OpenFGA store contains hierarchy tuples for {} but configured server is {}",
-                    tuple.user,
-                    configured
-                );
-            }
-        }
-        pages_scanned += 1;
-        if resp.continuation_token.is_empty() || pages_scanned >= SERVER_ID_SANITY_MAX_PAGES {
-            break;
-        }
-        continuation = Some(resp.continuation_token);
-    }
     Ok(())
 }
 
@@ -775,15 +753,17 @@ struct BatchWriter<'a> {
     buffer: Vec<TupleKey>,
     options: WriteOptions,
     report: &'a mut ReconcileReport,
+    dry_run: bool,
 }
 
 impl<'a> BatchWriter<'a> {
-    fn new(sink: &'a BasicOpenFgaClient, report: &'a mut ReconcileReport) -> Self {
+    fn new(sink: &'a BasicOpenFgaClient, report: &'a mut ReconcileReport, dry_run: bool) -> Self {
         Self {
             sink,
             buffer: Vec::with_capacity(WRITE_BATCH_SIZE),
             options: WriteOptions::new_idempotent(),
             report,
+            dry_run,
         }
     }
 
@@ -806,10 +786,14 @@ impl<'a> BatchWriter<'a> {
     }
 
     async fn write_chunk(&mut self, chunk: Vec<TupleKey>) -> anyhow::Result<()> {
-        self.sink
-            .write_with_options(Some(chunk), None, self.options)
-            .await
-            .map_err(|e| anyhow::anyhow!("reconcile: openfga write_with_options failed: {e}"))?;
+        if !self.dry_run {
+            self.sink
+                .write_with_options(Some(chunk), None, self.options)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("reconcile: openfga write_with_options failed: {e}")
+                })?;
+        }
         self.report.write_requests += 1;
         Ok(())
     }
@@ -832,8 +816,9 @@ fn log_index(idx: &CatalogIndex) {
 }
 
 fn log_done(report: &ReconcileReport, fn_label: &str) {
+    let label = if report.dry_run { "dry-run" } else { "applied" };
     tracing::info!(
-        "{fn_label}: done; submitted={}, deleted={}, ignored_unmanaged={}, ignored_orphan={}",
+        "{fn_label} ({label}): submitted={}, deleted={}, ignored_unmanaged={}, ignored_orphan={}",
         report.tuples_submitted,
         report.tuples_deleted,
         report.tuples_ignored_unmanaged,
@@ -1003,6 +988,7 @@ mod openfga_integration_tests {
             pg_state(&pool),
             &authorizer.client,
             server_id,
+            false,
         )
         .await
         .unwrap();
@@ -1012,6 +998,7 @@ mod openfga_integration_tests {
             pg_state(&pool),
             &authorizer.client,
             server_id,
+            false,
         )
         .await
         .unwrap();
@@ -1056,6 +1043,7 @@ mod openfga_integration_tests {
             pg_state(&pool),
             &authorizer.client,
             server_id,
+            false,
         )
         .await
         .unwrap();
@@ -1105,6 +1093,7 @@ mod openfga_integration_tests {
             pg_state(&pool),
             &authorizer.client,
             server_id,
+            false,
         )
         .await
         .unwrap();
@@ -1126,6 +1115,7 @@ mod openfga_integration_tests {
             pg_state(&pool),
             &sink,
             server_id,
+            false,
         )
         .await
         .unwrap();
@@ -1221,6 +1211,7 @@ mod openfga_integration_tests {
             &authorizer.client,
             server_id,
             ReconcileMode::AddMissingAndDeleteDrift,
+            false,
         )
         .await
         .unwrap();
@@ -1282,6 +1273,7 @@ mod openfga_integration_tests {
             &authorizer.client,
             server_id,
             ReconcileMode::AddMissingAndDeleteDrift,
+            false,
         )
         .await
         .unwrap();
@@ -1319,6 +1311,7 @@ mod openfga_integration_tests {
             &authorizer.client,
             server_id,
             ReconcileMode::AddMissingAndDeleteDrift,
+            false,
         )
         .await;
 
@@ -1334,5 +1327,53 @@ mod openfga_integration_tests {
 
         // Release: drop conn (advisory_lock is session-scoped so it's released on close).
         drop(conn);
+    }
+
+    #[sqlx::test]
+    async fn test_reconcile_dry_run_reports_without_mutating(pool: sqlx::PgPool) {
+        let operator_id = UserId::new_unchecked("oidc", &Uuid::now_v7().to_string());
+        let (_svc_client, authorizer) = authorizer_for_empty_store().await;
+        let server_id = authorizer.server_id();
+        let (warehouse, root_ns_id, _child, _role) =
+            populate(&authorizer, &pool, &operator_id).await;
+
+        // Plant drift the same way the deletion test does — a stale parent
+        // edge that catalog state contradicts.
+        let bogus_table = Uuid::now_v7();
+        let stale_forward = TupleKey {
+            user: format!("namespace:{root_ns_id}"),
+            relation: "parent".to_string(),
+            object: format!("lakekeeper_table:{}/{bogus_table}", warehouse.warehouse_id),
+            condition: None,
+        };
+        authorizer
+            .client
+            .write(Some(vec![stale_forward.clone()]), None)
+            .await
+            .unwrap();
+
+        let state_before = read_all_tuples(&authorizer.client).await;
+
+        let report = reconcile_hierarchy_tuples_from_catalog(
+            pg_state(&pool),
+            &authorizer.client,
+            server_id,
+            ReconcileMode::AddMissingAndDeleteDrift,
+            true, // dry_run
+        )
+        .await
+        .unwrap();
+
+        assert!(report.dry_run, "report must mark itself as a dry run");
+        assert!(
+            report.tuples_deleted >= 1,
+            "dry run should still account for what it would delete; report={report:?}"
+        );
+
+        let state_after = read_all_tuples(&authorizer.client).await;
+        assert_eq!(
+            state_before, state_after,
+            "dry run must not mutate the OpenFGA store"
+        );
     }
 }

--- a/crates/lakekeeper-bin/src/main.rs
+++ b/crates/lakekeeper-bin/src/main.rs
@@ -13,7 +13,7 @@
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use lakekeeper::{
     CONFIG,
     implementations::{CatalogState, postgres::PostgresBackend},
@@ -110,6 +110,71 @@ enum Commands {
     #[cfg(feature = "open-api")]
     /// Get the `OpenAPI` specification of the Management API as yaml
     ManagementOpenapi {},
+    /// OpenFGA authorizer maintenance operations.
+    Openfga {
+        #[command(subcommand)]
+        command: OpenfgaCommands,
+    },
+    /// Re-open the catalog so `/management/v1/bootstrap` can be called again.
+    ///
+    /// Operator-only recovery path used when switching authorizer backends
+    /// (for example `AllowAll` → `OpenFGA` on an already-bootstrapped
+    /// catalog) or when fixing a misconfigured first bootstrap. Flips the
+    /// `open_for_bootstrap` flag in Postgres back to `true`. Does not
+    /// touch the server-id, catalog data, or any existing OpenFGA tuples.
+    /// After running this, an authenticated principal must call
+    /// `/management/v1/bootstrap` to seed the initial admin/operator.
+    ReopenBootstrap {
+        #[clap(
+            long,
+            short = 'y',
+            default_value_t = false,
+            help = "Required confirmation. Without --yes the command refuses to run."
+        )]
+        yes: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum OpenfgaCommands {
+    /// Reconcile structural OpenFGA hierarchy tuples against the Postgres
+    /// catalog. Catalog is the source of truth: missing edges are added,
+    /// and (in `add-and-delete-drift` mode) drift is removed.
+    ///
+    /// Run during a low-traffic window — concurrent API writes can produce
+    /// transient inconsistencies that self-heal on the next run.
+    Reconcile {
+        #[clap(
+            long,
+            value_enum,
+            default_value_t = ReconcileModeArg::AddMissing,
+            help = "Reconcile semantics. `add-missing` is purely additive; `add-and-delete-drift` also removes structural tuples the catalog contradicts."
+        )]
+        mode: ReconcileModeArg,
+        #[clap(
+            long,
+            default_value_t = false,
+            help = "Compute and report the diff without writing to OpenFGA."
+        )]
+        dry_run: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ReconcileModeArg {
+    /// Add missing hierarchy edges, never delete.
+    AddMissing,
+    /// Add missing edges and delete drift (structural tuples the catalog contradicts).
+    AddAndDeleteDrift,
+}
+
+impl From<ReconcileModeArg> for lakekeeper_authz_openfga::ReconcileMode {
+    fn from(m: ReconcileModeArg) -> Self {
+        match m {
+            ReconcileModeArg::AddMissing => Self::AddMissingOnly,
+            ReconcileModeArg::AddAndDeleteDrift => Self::AddMissingAndDeleteDrift,
+        }
+    }
 }
 
 #[tokio::main]
@@ -161,6 +226,16 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Version {}) => {
             println!("{}", env!("CARGO_PKG_VERSION"));
         }
+        Some(Commands::Openfga { command }) => match command {
+            OpenfgaCommands::Reconcile { mode, dry_run } => {
+                print_info();
+                openfga_reconcile(mode.into(), dry_run).await?;
+            }
+        },
+        Some(Commands::ReopenBootstrap { yes }) => {
+            print_info();
+            reopen_bootstrap(yes).await?;
+        }
         #[cfg(feature = "open-api")]
         Some(Commands::ManagementOpenapi {}) => {
             use lakekeeper::{
@@ -205,6 +280,115 @@ async fn serve_and_maybe_migrate(force_start: bool) -> anyhow::Result<()> {
         migrate().await?;
     }
     serve(force_start).await
+}
+
+async fn reopen_bootstrap(yes: bool) -> anyhow::Result<()> {
+    if !yes {
+        anyhow::bail!(
+            "reopen-bootstrap re-allows /management/v1/bootstrap to be called. \
+             Re-run with --yes to confirm."
+        );
+    }
+
+    let write_pool = lakekeeper::implementations::postgres::get_writer_pool(
+        CONFIG
+            .to_pool_opts()
+            .acquire_timeout(std::time::Duration::from_secs(CONFIG.pg_acquire_timeout)),
+    )
+    .await?;
+    let catalog_state = CatalogState::from_pools(write_pool.clone(), write_pool);
+
+    let server_id =
+        <PostgresBackend as lakekeeper::service::CatalogStore>::reopen_for_bootstrap(catalog_state)
+            .await
+            .map_err(|e| anyhow::anyhow!("reopen-bootstrap failed: {e}"))?;
+    tracing::info!(
+        "Catalog re-opened for bootstrap (server_id={server_id}). \
+         Call POST /management/v1/bootstrap to seed admin/operator."
+    );
+    println!();
+    println!("Catalog re-opened for bootstrap.");
+    println!("  server_id: {server_id}");
+    println!("  next:      POST /management/v1/bootstrap (with an authenticated principal)");
+
+    Ok(())
+}
+
+async fn openfga_reconcile(
+    mode: lakekeeper_authz_openfga::ReconcileMode,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    if !lakekeeper_authz_openfga::CONFIG.is_openfga_enabled() {
+        anyhow::bail!(
+            "openfga reconcile requires LAKEKEEPER__AUTHZ_BACKEND=openfga; current backend is {:?}",
+            CONFIG.authz_backend
+        );
+    }
+
+    let read_pool = lakekeeper::implementations::postgres::get_reader_pool(
+        CONFIG
+            .to_pool_opts()
+            .max_connections(CONFIG.pg_read_pool_connections),
+    )
+    .await?;
+    let write_pool = lakekeeper::implementations::postgres::get_writer_pool(
+        CONFIG
+            .to_pool_opts()
+            .max_connections(CONFIG.pg_write_pool_connections),
+    )
+    .await?;
+    let catalog_state = CatalogState::from_pools(read_pool, write_pool);
+
+    let server_id = <PostgresBackend as lakekeeper::service::CatalogStore>::get_server_info(
+        catalog_state.clone(),
+    )
+    .await?
+    .server_id();
+
+    let authorizer =
+        lakekeeper_authz_openfga::new_authorizer_from_default_config(server_id).await?;
+
+    tracing::info!("openfga reconcile: starting (mode={mode:?}, dry_run={dry_run})");
+    let report = lakekeeper_authz_openfga::reconcile_hierarchy_tuples_from_catalog(
+        catalog_state,
+        authorizer.client(),
+        server_id,
+        mode,
+        dry_run,
+    )
+    .await?;
+
+    let action = if report.dry_run { "would" } else { "did" };
+    println!();
+    println!(
+        "OpenFGA reconcile report ({})",
+        if report.dry_run { "dry run" } else { "applied" }
+    );
+    println!("  mode: {mode:?}");
+    println!(
+        "  {action} submit {} tuple(s) in {} request(s)",
+        report.tuples_submitted, report.write_requests
+    );
+    println!(
+        "  {action} delete {} tuple(s) in {} request(s)",
+        report.tuples_deleted, report.delete_requests
+    );
+    println!(
+        "  ignored (unmanaged relation/type): {}",
+        report.tuples_ignored_unmanaged
+    );
+    println!(
+        "  ignored (both endpoints unknown):  {}",
+        report.tuples_ignored_orphan
+    );
+    if !report.per_type.is_empty() {
+        println!("  per-type submitted:");
+        for (ty, n) in &report.per_type {
+            println!("    {ty:<10} {n}");
+        }
+    }
+
+    Ok(())
 }
 
 async fn migrate() -> anyhow::Result<()> {

--- a/crates/lakekeeper/src/implementations/postgres/bootstrap.rs
+++ b/crates/lakekeeper/src/implementations/postgres/bootstrap.rs
@@ -78,6 +78,45 @@ pub(super) async fn get_validation_data<
     }
 }
 
+/// Re-open the catalog for bootstrap. Operator-only recovery path (see
+/// the `lakekeeper reopen-bootstrap` CLI subcommand) used when switching
+/// authorizer backends or recovering from a misconfigured first
+/// bootstrap. Flips `open_for_bootstrap` back to `true`; leaves
+/// `server_id`, `terms_accepted`, and all catalog data untouched.
+///
+/// Returns the existing `server_id`, or an error if no server row exists
+/// (run `migrate` first) or the catalog is already open for bootstrap
+/// (no-op refused so the operator notices).
+pub(super) async fn reopen_for_bootstrap<
+    'e,
+    'c: 'e,
+    E: sqlx::Executor<'c, Database = sqlx::Postgres>,
+>(
+    connection: E,
+) -> Result<ServerId> {
+    let row = sqlx::query!(
+        r#"
+        UPDATE server
+        SET open_for_bootstrap = true
+        WHERE server.open_for_bootstrap = false
+        RETURNING server_id
+        "#
+    )
+    .fetch_optional(connection)
+    .await
+    .map_err(|e| e.into_error_model("Error while re-opening catalog for bootstrap.".to_string()))?;
+
+    match row {
+        Some(r) => Ok(ServerId::from(r.server_id)),
+        None => Err(ErrorModel::bad_request(
+            "Catalog is already open for bootstrap, or no server row exists (did you run `lakekeeper migrate`?).".to_string(),
+            "CatalogAlreadyOpenForBootstrap",
+            None,
+        )
+        .into()),
+    }
+}
+
 pub(super) async fn bootstrap<'e, 'c: 'e, E: sqlx::Executor<'c, Database = sqlx::Postgres>>(
     terms_accepted: bool,
     connection: E,
@@ -134,6 +173,48 @@ mod test {
 
         let success = bootstrap(true, &state.read_write.write_pool).await.unwrap();
         assert!(!success);
+    }
+
+    #[sqlx::test]
+    async fn test_reopen_for_bootstrap_round_trip(pool: PgPool) {
+        migrate(&pool).await.unwrap();
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
+
+        // Fresh server: already open. reopen must refuse so the operator
+        // notices they're calling it in the wrong state.
+        let err = reopen_for_bootstrap(&state.read_write.write_pool)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("already open"),
+            "expected 'already open' refusal; got: {err}"
+        );
+
+        // Bootstrap, then reopen, then verify state is set up for /bootstrap again.
+        let initial = get_validation_data(&state.read_pool()).await.unwrap();
+        let server_id_before = initial.server_id();
+        bootstrap(true, &state.read_write.write_pool).await.unwrap();
+        let after_bootstrap = get_validation_data(&state.read_pool()).await.unwrap();
+        assert!(!after_bootstrap.is_open_for_bootstrap());
+        assert!(after_bootstrap.terms_accepted());
+
+        let returned_id = reopen_for_bootstrap(&state.read_write.write_pool)
+            .await
+            .unwrap();
+        assert_eq!(returned_id, server_id_before);
+
+        let after_reopen = get_validation_data(&state.read_pool()).await.unwrap();
+        assert!(after_reopen.is_open_for_bootstrap());
+        // server_id and terms_accepted are intentionally preserved.
+        assert_eq!(after_reopen.server_id(), server_id_before);
+        assert!(
+            after_reopen.terms_accepted(),
+            "terms_accepted must not be reset by reopen — only the next bootstrap call rewrites it"
+        );
+
+        // After reopen, bootstrap is callable again.
+        let success = bootstrap(true, &state.read_write.write_pool).await.unwrap();
+        assert!(success, "bootstrap should succeed after reopen");
     }
 
     #[sqlx::test]

--- a/crates/lakekeeper/src/implementations/postgres/catalog.rs
+++ b/crates/lakekeeper/src/implementations/postgres/catalog.rs
@@ -7,7 +7,7 @@ use lakekeeper_io::Location;
 
 use super::{
     CatalogState, PostgresTransaction,
-    bootstrap::{bootstrap, get_validation_data},
+    bootstrap::{bootstrap, get_validation_data, reopen_for_bootstrap},
     namespace::{create_namespace, drop_namespace, list_namespaces, update_namespace_properties},
     role::{create_roles, delete_roles, list_roles, list_roles_by_idents, update_role},
     tabular::table::load_tables,
@@ -71,14 +71,14 @@ use crate::{
         LoadTableError, LoadTableResponse, LoadViewError, MarkTabularAsDeletedError,
         NamespaceDropInfo, NamespaceId, NamespaceWithParent, ProjectId, RenameTabularError,
         ResolveTasksError, ResolvedTask, ResolvedWarehouse, Result, Role, RoleId, RoleIdent,
-        RoleProviderId, SearchRoleResponse, SearchRolesError, SearchTabularError, ServerInfo,
-        SetTabularProtectionError, SetWarehouseDeletionProfileError, SetWarehouseProtectedError,
-        SetWarehouseStatusError, StagedTableId, SyncRoleMembersError, SyncRoleMembersResult,
-        SyncUserRoleAssignmentsError, SyncUserRoleAssignmentsResult, TableCommit, TableCreation,
-        TableId, TableIdent, TableInfo, TabularId, TabularIdentBorrowed, TabularListFlags,
-        TaskDetails, TaskList, Transaction, UniqueMembers, UniqueRoles, UpdateRoleError,
-        UpdateWarehouseStorageProfileError, ViewCommit, ViewId, ViewInfo, ViewOrTableDeletionInfo,
-        ViewOrTableInfo, WarehouseId, WarehouseStatus,
+        RoleProviderId, SearchRoleResponse, SearchRolesError, SearchTabularError, ServerId,
+        ServerInfo, SetTabularProtectionError, SetWarehouseDeletionProfileError,
+        SetWarehouseProtectedError, SetWarehouseStatusError, StagedTableId, SyncRoleMembersError,
+        SyncRoleMembersResult, SyncUserRoleAssignmentsError, SyncUserRoleAssignmentsResult,
+        TableCommit, TableCreation, TableId, TableIdent, TableInfo, TabularId,
+        TabularIdentBorrowed, TabularListFlags, TaskDetails, TaskList, Transaction, UniqueMembers,
+        UniqueRoles, UpdateRoleError, UpdateWarehouseStorageProfileError, ViewCommit, ViewId,
+        ViewInfo, ViewOrTableDeletionInfo, ViewOrTableInfo, WarehouseId, WarehouseStatus,
         authn::UserId,
         idempotency::{IdempotencyCheck, IdempotencyInfo, IdempotencyKey},
         storage::StorageProfile,
@@ -107,6 +107,10 @@ impl CatalogStore for super::PostgresBackend {
         transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'a>,
     ) -> Result<bool> {
         bootstrap(terms_accepted, &mut **transaction).await
+    }
+
+    async fn reopen_for_bootstrap(catalog_state: Self::State) -> Result<ServerId> {
+        reopen_for_bootstrap(&catalog_state.write_pool()).await
     }
 
     async fn get_warehouse_by_name_impl(

--- a/crates/lakekeeper/src/service/catalog_store.rs
+++ b/crates/lakekeeper/src/service/catalog_store.rs
@@ -32,7 +32,7 @@ use crate::{
         },
     },
     service::{
-        ArcProjectId, RoleProviderId, RoleSourceId, TabularId, TabularIdentBorrowed,
+        ArcProjectId, RoleProviderId, RoleSourceId, ServerId, TabularId, TabularIdentBorrowed,
         authn::UserId,
         health::HealthExt,
         task_configs::TaskQueueConfigFilter,
@@ -187,6 +187,17 @@ where
         terms_accepted: bool,
         transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'a>,
     ) -> Result<bool>;
+
+    /// Operator-only recovery: re-open the catalog so the bootstrap flow
+    /// can be run again. Used when switching authorizer backends or
+    /// recovering from a misconfigured first bootstrap. Must preserve
+    /// `server_id`, `terms_accepted`, and all catalog data; the next
+    /// `bootstrap` call will overwrite `terms_accepted`.
+    ///
+    /// Implementations must error if the catalog is already open for
+    /// bootstrap or no server row exists, so the operator notices when
+    /// the call is a no-op.
+    async fn reopen_for_bootstrap(catalog_state: Self::State) -> Result<ServerId>;
 
     // ---------------- Project Management ----------------
     /// Create a project

--- a/docs/docs/authorization-openfga.md
+++ b/docs/docs/authorization-openfga.md
@@ -4,6 +4,9 @@ Lakekeeper can use [OpenFGA](https://openfga.dev) to store and evaluate permissi
 
 Check the [Authorization Configuration](./configuration.md#authorization) for setup details.
 
+!!! note "Minimum OpenFGA version"
+    **OpenFGA v1.11 or later is required.** The bootstrap and `lakekeeper openfga reconcile` paths use OpenFGA's idempotent-write semantics (`on_duplicate: ignore` / `on_missing: ignore`), introduced in v1.11. Earlier versions will fail with `cannot write a tuple which already exists` during a re-bootstrap or reconcile run. We test against v1.14.
+
 ## Grants
 The default permission model is focused on collaborating on data. Permissions are additive. The underlying OpenFGA model is defined in [`schema.fga` on GitHub](https://github.com/lakekeeper/lakekeeper/blob/main/authz/openfga/). The following grants are available:
 
@@ -81,7 +84,7 @@ When deploying OpenFGA in production environments, ensure you follow the [OpenFG
 
 Lakekeeper includes [Query Consistency](https://openfga.dev/docs/interacting/consistency) specifications with each authorization request to OpenFGA. For most operations, `MINIMIZE_LATENCY` consistency provides optimal performance while maintaining sufficient data consistency guarantees.
 
-For medium to large-scale deployments, we strongly recommend enabling caching in OpenFGA and increasing the database connection pool limits. These optimizations significantly reduce database load and improve authorization latency. Configure the following environment variables in OpenFGA (written for version 1.10). You may increase the number of connections further if your database deployment can handle additional connections:
+For medium to large-scale deployments, we strongly recommend enabling caching in OpenFGA and increasing the database connection pool limits. These optimizations significantly reduce database load and improve authorization latency. Configure the following environment variables in OpenFGA (written for version 1.14). You may increase the number of connections further if your database deployment can handle additional connections:
 
 ```sh
 OPENFGA_DATASTORE_MAX_OPEN_CONNS=200
@@ -90,3 +93,57 @@ OPENFGA_CACHE_CONTROLLER_ENABLED=true
 OPENFGA_CHECK_QUERY_CACHE_ENABLED=true
 OPENFGA_CHECK_ITERATOR_CACHE_ENABLED=true
 ```
+
+## Reconciling OpenFGA against the catalog
+
+The Postgres catalog is the source of truth for *which objects exist* (projects, warehouses, namespaces, tables, views, roles). OpenFGA stores the **structural hierarchy** between those objects plus all permissions (grants, ownership, role assignments). Under normal operation Lakekeeper keeps the two in sync on every API call.
+
+Drift can still happen — for example after a backup/restore where Postgres and OpenFGA were snapshotted at different times, after pointing Lakekeeper at a fresh OpenFGA store, or after a rare bug. The `lakekeeper openfga reconcile` subcommand rebuilds the structural hierarchy in OpenFGA from the Postgres catalog.
+
+```sh
+# Add any hierarchy edges the catalog implies but OpenFGA is missing.
+# Purely additive; never deletes. Safe default.
+lakekeeper openfga reconcile --mode add-missing
+
+# Same plus delete structural tuples the catalog contradicts.
+lakekeeper openfga reconcile --mode add-and-delete-drift
+
+# Show the diff without writing anything.
+lakekeeper openfga reconcile --mode add-and-delete-drift --dry-run
+```
+
+### What reconcile touches
+
+Reconcile only operates on the **structural** parts of the OpenFGA store: the parent/child edges between server, projects, warehouses, namespaces, tables, views, and roles. Ownership tuples, grants, role assignments, bootstrap admin tuples, and authorization-model bookkeeping are left alone. Tuples whose endpoints both refer to objects that *don't* exist in the catalog are also untouched — there is no anchor by which to interpret them.
+
+### Operational notes
+
+- Run during a low-traffic window. Reconcile does **not** stop API writes; concurrent renames/creates/deletes can produce transient inconsistencies that self-heal on the next run.
+- A Postgres advisory lock prevents two reconciles from running at once. A held lock causes the second invocation to fail fast.
+- Use `--dry-run` first when you intend to delete drift.
+
+## Switching to OpenFGA or replacing the store
+
+OpenFGA can be enabled, or its store replaced, on an already-bootstrapped Lakekeeper. Reconcile rebuilds the **structural hierarchy** from the catalog — but the initial server `admin` / `operator` tuple, ownership records, grants, and role assignments are **not** stored in the catalog and cannot be reconstructed from it. Lakekeeper's `/management/v1/bootstrap` endpoint runs only once per catalog by design; the `lakekeeper reopen-bootstrap` CLI re-opens it for cases like this without touching `server_id`, catalog data, or existing OpenFGA tuples.
+
+### Procedure
+
+1. Stand up an OpenFGA deployment.
+2. Configure Lakekeeper for OpenFGA (`LAKEKEEPER__AUTHZ_BACKEND=openfga` plus the `LAKEKEEPER__OPENFGA__*` settings).
+3. Run `lakekeeper migrate` once. This installs the OpenFGA authorization model in the configured store.
+4. Run `lakekeeper openfga reconcile --mode add-missing` to seed the structural hierarchy from the catalog into OpenFGA.
+5. Re-open bootstrap and seed the initial admin/operator via the API:
+
+    ```sh
+    lakekeeper reopen-bootstrap --yes
+    ```
+
+    This flips `server.open_for_bootstrap` back to `true`. The `server_id` is preserved, so the hierarchy tuples written in step 4 remain valid.
+
+6. Open the Lakekeeper UI and complete the bootstrap flow as the intended initial admin (or operator) — same path as a fresh deploy.
+7. From that admin/operator account, recreate the role assignments and grants you need through the management API. If you exported tuples from the previous OpenFGA store, you can also selectively reimport them with the [fga CLI](https://github.com/openfga/cli) — reconcile leaves non-structural tuples alone.
+
+Switching *away* from OpenFGA (for example to Cedar) is not covered by reconcile and generally requires a new Lakekeeper instance.
+
+> Instance admins are useful as a parallel safety net while the OpenFGA store has no admin tuples: they can still manage projects, warehouses, namespaces, and tables. They do **not** confer data-plane access (`ReadData`, `WriteData`, view `Select`) and they **cannot** write to the OpenFGA permission-management endpoints — see [Instance Admins](./authorization.md#instance-admins).
+

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -237,7 +237,9 @@ Please check the [Authentication Guide](./authentication.md) for more details.
 
 
 ### Authorization
-Authorization is only effective if [Authentication](#authentication) is enabled. Authorization must not be enabled after Lakekeeper has been bootstrapped! Please create a new Lakekeeper instance, bootstrap it with authorization enabled, and migrate your tables.
+Authorization is only effective if [Authentication](#authentication) is enabled.
+
+We strongly recommend bootstrapping new deployments with authorization already enabled. Switching the configured `AUTHZ_BACKEND` after bootstrap is supported when moving to (or replacing the OpenFGA store behind) the OpenFGA backend — see [Switching to OpenFGA](./authorization-openfga.md#switching-to-openfga-or-replacing-the-store) for the procedure and its limitations (structural hierarchy is rebuilt from the catalog; ownership, grants, and role assignments are not). For other backends, create a new Lakekeeper instance and migrate your tables.
 
 | Variable                                 | Example                                                              | Description          |
 |------------------------------------------|----------------------------------------------------------------------|----------------------|

--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -221,7 +221,7 @@ Some authorization unit tests need to be run against an OpenFGA server. They are
 
 ```bash
 # Start an OpenFGA server in a docker container
-docker rm --force openfga-client && docker run -d --name openfga-client -p 36080:8080 -p 36081:8081 -p 36300:3000 openfga/openfga:v1.8 run
+docker rm --force openfga-client && docker run -d --name openfga-client -p 36080:8080 -p 36081:8081 -p 36300:3000 openfga/openfga:v1.14 run
 
 # Set Lakekeeper's OpenFGA endpoint
 export LAKEKEEPER_TEST__OPENFGA__ENDPOINT="http://localhost:36081"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `openfga reconcile` CLI command with configurable modes (add-missing or add-and-delete-drift) to sync authorization hierarchy with catalog
  * New `reopen-bootstrap` CLI command to re-enable bootstrap mode for catalog recovery
  * Dry-run support for reconciliation to preview changes without applying

* **Bug Fixes**
  * Bootstrap tuple writes now handle repeated runs gracefully without failures

* **Documentation**
  * Added OpenFGA reconciliation workflow and command examples
  * Updated minimum OpenFGA version requirement and setup guidance
  * Added procedure for enabling or replacing OpenFGA on existing instances

* **Tests**
  * Added integration test verifying dry-run prevents mutations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->