### PR TITLE
feat(storage): drop opendal, validate vended creds via lakekeeper_io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,15 +1349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,15 +1452,6 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
-]
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -1745,15 +1727,6 @@ dependencies = [
  "digest",
  "rustversion",
  "spin 0.10.0",
-]
-
-[[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
 ]
 
 [[package]]
@@ -2124,15 +2097,6 @@ name = "dissimilar"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
-
-[[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
 
 [[package]]
 name = "dotenvy"
@@ -2797,12 +2761,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -3193,25 +3151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iceberg-storage-opendal"
-version = "0.9.0"
-source = "git+https://github.com/lakekeeper/iceberg-rust.git?rev=bb7017339f778de44830b4f970d9d5e1e84f5599#bb7017339f778de44830b4f970d9d5e1e84f5599"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "cfg-if",
- "futures",
- "iceberg",
- "opendal",
- "reqsign",
- "reqwest 0.12.28",
- "serde",
- "typetag",
- "url",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,7 +3299,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -3442,47 +3380,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jiff"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87d9b8105c23642f50cbbae03d1f75d8422c5cb98ce7ee9271f7ff7505be6b8"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b787bebb543f8969132630c51fd0afab173a86c6abae56ff3b9e5e3e3f9f6e58"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.112",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
 
 [[package]]
 name = "jni"
@@ -3718,6 +3615,7 @@ dependencies = [
  "azure_storage",
  "azure_storage_blobs",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "cloudevents-sdk",
  "derive_more",
@@ -3732,7 +3630,6 @@ dependencies = [
  "http-body-util",
  "iceberg",
  "iceberg-ext",
- "iceberg-storage-opendal",
  "iso8601",
  "itertools 0.14.0",
  "lakekeeper",
@@ -3877,6 +3774,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "thiserror 2.0.17",
+ "token-source",
  "tokio",
  "tracing",
  "tryhard",
@@ -4517,35 +4415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "opendal"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
-dependencies = [
- "anyhow",
- "backon",
- "base64 0.22.1",
- "bytes",
- "crc32c",
- "futures",
- "getrandom 0.2.16",
- "http 1.4.0",
- "http-body 1.0.1",
- "jiff",
- "log",
- "md-5",
- "percent-encoding",
- "quick-xml 0.38.4",
- "reqsign",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "tokio",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "openfga-client"
 version = "0.5.1"
 source = "git+https://github.com/vakamo-labs/openfga-client.git?rev=6121e38#6121e38ce39601c15b330dddcf8654a35c2d796c"
@@ -4624,16 +4493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4744,16 +4603,6 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
 
 [[package]]
 name = "pear"
@@ -4911,21 +4760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes",
- "cbc",
- "der 0.7.10",
- "pbkdf2",
- "scrypt",
- "sha2",
- "spki 0.7.3",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4942,8 +4776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
- "pkcs5",
- "rand_core 0.6.4",
  "spki 0.7.3",
 ]
 
@@ -4984,15 +4816,6 @@ name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -5229,16 +5052,6 @@ name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
  "serde",
@@ -5563,37 +5376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "reqsign"
-version = "0.16.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.22.1",
- "chrono",
- "form_urlencoded",
- "getrandom 0.2.16",
- "hex",
- "hmac",
- "home",
- "http 1.4.0",
- "jsonwebtoken 9.3.1",
- "log",
- "percent-encoding",
- "quick-xml 0.37.5",
- "rand 0.8.5",
- "reqwest 0.12.28",
- "rsa",
- "rust-ini",
- "serde",
- "serde_json",
- "sha1",
- "sha2",
- "tokio",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5767,7 +5549,6 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -5807,16 +5588,6 @@ checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
  "sha2",
  "walkdir",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
 ]
 
 [[package]]
@@ -5993,15 +5764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6061,17 +5823,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2",
- "salsa20",
- "sha2",
-]
 
 [[package]]
 name = "sec1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,11 +99,6 @@ hostname = "0.4.0"
 http = "1.3.1"
 http-body-util = "^0.1"
 iceberg = { git = "https://github.com/lakekeeper/iceberg-rust.git", rev = "bb7017339f778de44830b4f970d9d5e1e84f5599" }
-iceberg-storage-opendal = { git = "https://github.com/lakekeeper/iceberg-rust.git", rev = "bb7017339f778de44830b4f970d9d5e1e84f5599", default-features = false, features = [
-    "opendal-s3",
-    "opendal-gcs",
-    "opendal-azdls",
-] }
 iso8601 = "0.6.2"
 itertools = "0.14.0"
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }

--- a/crates/iceberg-ext/src/configs/table.rs
+++ b/crates/iceberg-ext/src/configs/table.rs
@@ -157,5 +157,6 @@ mod tests {
         assert_eq!(iceberg::io::S3_PATH_STYLE_ACCESS, s3::PathStyleAccess::KEY);
         assert_eq!(iceberg::io::S3_ACCESS_KEY_ID, s3::AccessKeyId::KEY);
         assert_eq!(iceberg::io::S3_SECRET_ACCESS_KEY, s3::SecretAccessKey::KEY);
+        assert_eq!(iceberg::io::S3_SESSION_TOKEN, s3::SessionToken::KEY);
     }
 }

--- a/crates/io/Cargo.toml
+++ b/crates/io/Cargo.toml
@@ -42,6 +42,7 @@ storage-gcs = [
     "dep:reqwest-middleware",
     "dep:reqwest-retry",
     "dep:google-cloud-auth",
+    "dep:google-cloud-token",
 ]
 storage-in-memory = []
 default = ["storage-s3", "storage-adls", "storage-gcs"]
@@ -70,6 +71,7 @@ derive_more = { workspace = true }
 futures = { workspace = true }
 google-cloud-auth = { workspace = true, optional = true }
 google-cloud-storage = { workspace = true, features = [], optional = true }
+google-cloud-token = { workspace = true, optional = true }
 md5 = { workspace = true }
 moka = { workspace = true, optional = true }
 reqwest = { workspace = true }

--- a/crates/io/src/adls.rs
+++ b/crates/io/src/adls.rs
@@ -58,12 +58,20 @@ pub enum AzureAuth {
     ClientCredentials(AzureClientCredentialsAuth),
     SharedAccessKey(AzureSharedAccessKeyAuth),
     AzureSystemIdentity,
+    /// SAS (Shared Access Signature) token. Used with downscoped credentials vended via SAS delegation.
+    Sas(AzureSasAuth),
 }
 
 #[derive(Redact, Clone, PartialEq, Eq, typed_builder::TypedBuilder)]
 pub struct AzureSharedAccessKeyAuth {
     #[redact(partial)]
     pub key: String,
+}
+
+#[derive(Redact, Clone, PartialEq, Eq, typed_builder::TypedBuilder)]
+pub struct AzureSasAuth {
+    #[redact(partial)]
+    pub sas_token: String,
 }
 
 #[derive(Redact, Clone, PartialEq, Eq, typed_builder::TypedBuilder)]
@@ -132,6 +140,11 @@ impl AzureSettings {
                 let identity: Arc<DefaultAzureCredential> = self.get_system_identity().await?;
                 StorageCredentials::token_credential(identity)
             }
+            AzureAuth::Sas(AzureSasAuth { sas_token }) => StorageCredentials::sas_token(sas_token)
+                .map_err(|e| InitializeClientError {
+                    reason: format!("Invalid Azure SAS token: {e}"),
+                    source: Some(Box::new(e)),
+                })?,
         })
     }
 

--- a/crates/io/src/gcs.rs
+++ b/crates/io/src/gcs.rs
@@ -2,14 +2,17 @@ mod gcs_error;
 mod gcs_location;
 mod gcs_storage;
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
+use async_trait::async_trait;
 pub use gcs_location::{GcsLocation, InvalidGCSBucketName, validate_bucket_name};
 pub use gcs_storage::GcsStorage;
 pub use google_cloud_storage::client::google_cloud_auth::credentials::CredentialsFile;
 use google_cloud_storage::client::{Client, ClientConfig};
+use google_cloud_token::{TokenSource, TokenSourceProvider};
 use reqwest_middleware::ClientBuilder;
 use reqwest_retry::{Jitter, RetryTransientMiddleware, policies::ExponentialBackoff};
+use veil::Redact;
 
 use crate::InitializeClientError;
 
@@ -49,6 +52,52 @@ pub enum GcsAuth {
     /// Use the service account that the application is running as.
     /// This can be a Compute Engine default service account or a user-assigned service account.
     GcpSystemIdentity {},
+
+    /// Static `OAuth2` bearer token. Used with downscoped tokens vended via STS.
+    BearerToken(GcsBearerTokenAuth),
+}
+
+#[derive(Redact, Clone, PartialEq, Eq)]
+pub struct GcsBearerTokenAuth {
+    #[redact(partial)]
+    pub access_token: String,
+}
+
+struct StaticTokenSource {
+    bearer: String,
+}
+
+impl std::fmt::Debug for StaticTokenSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StaticTokenSource")
+            .field("bearer", &"<redacted>")
+            .finish()
+    }
+}
+
+#[async_trait]
+impl TokenSource for StaticTokenSource {
+    async fn token(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(self.bearer.clone())
+    }
+}
+
+struct StaticTokenSourceProvider {
+    source: Arc<StaticTokenSource>,
+}
+
+impl std::fmt::Debug for StaticTokenSourceProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StaticTokenSourceProvider")
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+impl TokenSourceProvider for StaticTokenSourceProvider {
+    fn token_source(&self) -> Arc<dyn TokenSource> {
+        self.source.clone()
+    }
 }
 
 impl GCSSettings {
@@ -100,6 +149,16 @@ impl GCSSettings {
                     reason: format!("Failed to initialize GCS client with credentials file: {e}"),
                     source: Some(e.into()),
                 })?,
+            GcsAuth::BearerToken(GcsBearerTokenAuth { access_token }) => {
+                let mut config = config;
+                let provider = StaticTokenSourceProvider {
+                    source: Arc::new(StaticTokenSource {
+                        bearer: format!("Bearer {access_token}"),
+                    }),
+                };
+                config.token_source_provider = Some(Box::new(provider));
+                config
+            }
         };
 
         Ok(Client::new(config))
@@ -162,6 +221,10 @@ impl std::fmt::Debug for GcsAuth {
             GcsAuth::GcpSystemIdentity {} => {
                 f.debug_struct("GcsCredential::GcpSystemIdentity").finish()
             }
+            GcsAuth::BearerToken(auth) => f
+                .debug_struct("GcsCredential::BearerToken")
+                .field("access_token", &auth)
+                .finish(),
         }
     }
 }

--- a/crates/io/src/s3.rs
+++ b/crates/io/src/s3.rs
@@ -133,6 +133,10 @@ pub struct S3AccessKeyAuth {
     pub aws_access_key_id: String,
     #[redact(partial)]
     pub aws_secret_access_key: String,
+    /// Session token for temporary credentials (vended via STS).
+    #[builder(default)]
+    #[redact(partial)]
+    pub aws_session_token: Option<String>,
     #[builder(default)]
     #[redact(partial)]
     pub external_id: Option<String>,
@@ -201,12 +205,13 @@ impl S3Settings {
             Some(S3Auth::AccessKey(S3AccessKeyAuth {
                 aws_access_key_id,
                 aws_secret_access_key,
+                aws_session_token,
                 external_id: _, // External ID handled below in assume role path
             })) => {
                 let aws_credentials = aws_credential_types::Credentials::new(
                     aws_access_key_id,
                     aws_secret_access_key,
-                    None,
+                    aws_session_token.clone(),
                     None,
                     "lakekeeper-secret-storage",
                 );

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -60,6 +60,7 @@ async fn create_s3_storage() -> anyhow::Result<(StorageBackend, TestConfig)> {
     let s3_auth = lakekeeper_io::s3::S3Auth::AccessKey(lakekeeper_io::s3::S3AccessKeyAuth {
         aws_access_key_id: access_key,
         aws_secret_access_key: secret_key,
+        aws_session_token: None,
         external_id: None,
     });
 

--- a/crates/lakekeeper/Cargo.toml
+++ b/crates/lakekeeper/Cargo.toml
@@ -67,7 +67,6 @@ hostname = { workspace = true }
 http = { workspace = true }
 http-body-util = { version = "~0.1" }
 iceberg = { workspace = true }
-iceberg-storage-opendal = { workspace = true }
 iceberg-ext = { path = "../iceberg-ext", features = ["axum"] }
 iso8601 = { workspace = true }
 itertools = { workspace = true }
@@ -122,6 +121,7 @@ xxhash-rust = { workspace = true, features = ["xxh3"] }
 [dev-dependencies]
 assert-json-diff = { workspace = true }
 aws-sdk-s3 = { workspace = true }
+bytes = { workspace = true }
 figment = { workspace = true, features = ["test"] }
 http-body-util = { workspace = true }
 lakekeeper = { path = ".", features = ["test-utils"] }

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -1,7 +1,8 @@
+#[cfg(test)]
+use std::sync::LazyLock;
 use std::{
     collections::HashMap,
     str::FromStr,
-    sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
 
@@ -14,7 +15,6 @@ use azure_storage::{
     },
 };
 use azure_storage_blobs::prelude::BlobServiceClient;
-use iceberg::io::ADLS_AUTHORITY_HOST;
 use iceberg_ext::configs::table::{TableProperties, adls, creds, custom};
 use lakekeeper_io::{
     InvalidLocationError, Location,
@@ -88,6 +88,7 @@ fn default_true() -> bool {
 }
 
 const DEFAULT_HOST: &str = "dfs.core.windows.net";
+#[cfg(test)]
 static DEFAULT_AUTHORITY_HOST: LazyLock<Url> = LazyLock::new(|| {
     Url::parse("https://login.microsoftonline.com").expect("Default authority host is a valid URL")
 });
@@ -661,36 +662,37 @@ fn iceberg_expiration_property_key(account_name: &str, endpoint_suffix: &str) ->
     format!("adls.sas-token-expires-at-ms.{account_name}.{endpoint_suffix}")
 }
 
-pub(super) fn get_file_io_from_table_config(config: &TableProperties) -> iceberg::io::FileIO {
-    // Add Authority host if not present
-    let mut config = config.inner().clone();
-
-    let sas_token_prefix = "adls.sas-token.";
-    // Iceberg Rust cannot parse tokens of form "<sas_token_prefix><storage_account_name>.<endpoint_suffix>=<sas_token>"
-    // https://github.com/apache/iceberg-rust/issues/1442
-    let mut matched = None;
-    for (key, value) in &config {
-        if key.starts_with(sas_token_prefix) {
-            matched = Some((key.clone(), value.clone()));
-            break;
-        }
-    }
-    if let Some((matched_key, sas_token)) = matched {
-        config.remove(&matched_key);
-        config.insert("adls.sas-token".to_string(), sas_token);
-    }
-
-    if !config.contains_key(ADLS_AUTHORITY_HOST) {
-        config.insert(
-            ADLS_AUTHORITY_HOST.to_string(),
-            DEFAULT_AUTHORITY_HOST.to_string(),
-        );
-    }
-    iceberg::io::FileIOBuilder::new(Arc::new(
-        iceberg_storage_opendal::OpenDalStorageFactory::Azdls,
-    ))
-    .with_props(config)
-    .build()
+/// Build an `AdlsStorage` client from vended-credentials properties.
+///
+/// Reads the SAS token (under the profile's account/endpoint-specific key)
+/// from the iceberg-format `TableProperties` previously produced by
+/// `generate_table_config`.
+///
+/// `profile` is required because the SAS-token property key embeds the storage
+/// account name and endpoint host (`adls.sas-token.<account>.<endpoint>`); it
+/// cannot be derived from `TableProperties` alone. Do not "normalize" this
+/// signature with the S3/GCS counterparts — removing `profile` will break the
+/// key lookup.
+pub(super) async fn lakekeeper_io_from_vended_table_config(
+    profile: &AdlsProfile,
+    config: &TableProperties,
+) -> Result<AdlsStorage, CredentialsError> {
+    let sas_key = profile.iceberg_sas_property_key();
+    let sas_token =
+        config
+            .get_custom_prop(&sas_key)
+            .ok_or_else(|| CredentialsError::ShortTermCredential {
+                reason: format!(
+                    "ADLS vended credentials are missing SAS token at key '{sas_key}'."
+                ),
+                source: None,
+            })?;
+    let auth = AzureAuth::Sas(lakekeeper_io::adls::AzureSasAuth { sas_token });
+    profile
+        .azure_settings()
+        .get_storage_client(&auth)
+        .await
+        .map_err(Into::into)
 }
 
 impl TryFrom<AzCredential> for AzureAuth {

--- a/crates/lakekeeper/src/service/storage/error.rs
+++ b/crates/lakekeeper/src/service/storage/error.rs
@@ -12,8 +12,6 @@ use crate::server::{compression_codec::UnsupportedCompressionCodec, io::IOErrorE
 pub enum ValidationError {
     #[error("{0}")]
     IoOperationFailed(#[from] Box<IOError>),
-    #[error("Validation of STS credentials with Iceberg FileIO failed: {0}")]
-    IcebergFileIoError(#[from] Box<IcebergFileIoError>),
     #[error(transparent)]
     Credentials(#[from] Box<CredentialsError>),
     #[error(transparent)]
@@ -81,12 +79,6 @@ impl From<InvalidGCSBucketName> for ValidationError {
 impl From<InvalidLocationError> for ValidationError {
     fn from(value: InvalidLocationError) -> Self {
         ValidationError::InvalidLocation(Box::new(value))
-    }
-}
-
-impl From<IcebergFileIoError> for ValidationError {
-    fn from(value: IcebergFileIoError) -> Self {
-        ValidationError::IcebergFileIoError(Box::new(value))
     }
 }
 
@@ -205,8 +197,6 @@ impl From<ValidationError> for ErrorModel {
                 "FileDecompressionError",
                 Some(e),
             ),
-            ValidationError::IcebergFileIoError(e) => ErrorModel::from(*e)
-                .append_detail("Validating Vended Credentials Access with Iceberg FileIO failed."),
         }
     }
 }
@@ -216,54 +206,6 @@ impl From<ValidationError> for IcebergErrorResponse {
         ErrorModel::from(value).into()
     }
 }
-
-#[derive(thiserror::Error, Debug)]
-pub enum IcebergFileIoError {
-    #[error("Action not supported: {0}")]
-    UnsupportedAction(String),
-    #[error(transparent)]
-    IcebergError(#[from] iceberg::Error),
-    #[error(transparent)]
-    Credentials(#[from] CredentialsError),
-}
-
-impl From<IcebergFileIoError> for ErrorModel {
-    fn from(err: IcebergFileIoError) -> Self {
-        match err {
-            IcebergFileIoError::UnsupportedAction(ref action) => ErrorModel::not_implemented(
-                err.to_string(),
-                format!("{action}NotSupported"),
-                Some(Box::new(err)),
-            ),
-            IcebergFileIoError::IcebergError(e) => ErrorModel::precondition_failed(
-                format!("Iceberg FileIO returned an error: {e}"),
-                "IcebergFileIOError",
-                Some(Box::new(e)),
-            ),
-            IcebergFileIoError::Credentials(cred_e) => cred_e.into(),
-        }
-    }
-}
-
-// #[derive(thiserror::Error, Debug)]
-// pub enum IOCreationError {
-//     #[error(transparent)]
-//     Credentials(#[from] CredentialsError),
-// }
-
-// impl From<IOCreationError> for ErrorModel {
-//     fn from(value: IOCreationError) -> Self {
-//         match value {
-//             IOCreationError::Credentials(e) => e.into(),
-//         }
-//     }
-// }
-
-// impl From<IOCreationError> for IcebergErrorResponse {
-//     fn from(value: IOCreationError) -> Self {
-//         ErrorModel::from(value).into()
-//     }
-// }
 
 #[derive(thiserror::Error, Debug)]
 pub enum TableConfigError {

--- a/crates/lakekeeper/src/service/storage/gcs/mod.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/mod.rs
@@ -537,12 +537,24 @@ impl GcsProfile {
     }
 }
 
-pub(super) fn get_file_io_from_table_config(config: &TableProperties) -> iceberg::io::FileIO {
-    iceberg::io::FileIOBuilder::new(Arc::new(
-        iceberg_storage_opendal::OpenDalStorageFactory::Gcs,
-    ))
-    .with_props(config.inner())
-    .build()
+/// Build a `GcsStorage` client from vended-credentials properties.
+///
+/// Reads the downscoped `OAuth2` access token from the iceberg-format
+/// `TableProperties` previously produced by `generate_table_config`.
+pub(super) async fn lakekeeper_io_from_vended_table_config(
+    config: &TableProperties,
+) -> Result<GcsStorage, CredentialsError> {
+    let access_token = config.get_prop_opt::<gcs::Token>().ok_or_else(|| {
+        CredentialsError::ShortTermCredential {
+            reason: "GCS vended credentials are missing the OAuth2 access token.".to_string(),
+            source: None,
+        }
+    })?;
+    let auth = GcsAuth::BearerToken(lakekeeper_io::gcs::GcsBearerTokenAuth { access_token });
+    GCSSettings {}
+        .get_storage_client(&auth)
+        .await
+        .map_err(Into::into)
 }
 
 impl TryFrom<GcsCredential> for GcsAuth {

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use error::ValidationError;
 use error::{CredentialsError, TableConfigError, UpdateError};
 use futures::StreamExt;
 pub use gcs::{GcsCredential, GcsProfile, GcsServiceKey};
-use iceberg::{NamespaceIdent, TableIdent, io::FileIO};
+use iceberg::{NamespaceIdent, TableIdent};
 use iceberg_ext::{catalog::rest::ErrorModel, configs::table::TableProperties};
 use lakekeeper_io::{
     InvalidLocationError, LakekeeperStorage, Location, LocationParseError, StorageBackend,
@@ -37,7 +37,7 @@ use crate::{
     service::{
         BasicTabularInfo, NamespaceVersion, TabularId, TabularInfo, WarehouseVersion,
         storage::{
-            error::{IcebergFileIoError, UnexpectedStorageType},
+            error::UnexpectedStorageType,
             storage_layout::{
                 DEFAULT_LAYOUT, NamespaceNameContext, NamespacePath, StorageLayout,
                 TabularNameContext,
@@ -524,65 +524,54 @@ impl StorageProfile {
             )
             .await?;
 
-        match &self {
+        let sts_storage: StorageBackend = match &self {
             StorageProfile::S3(_) => {
-                tracing::debug!("Getting s3 file io from table config for vended credentials.");
-                let sts_file_io = s3::get_file_io_from_table_config(&tbl_config.config);
-                tracing::debug!(
-                    "Validating read/write access to sub-location: {sub_location} and forbidden access to parent location: {test_location} using vended credentials"
-                );
-
-                // Run both validations in parallel
-                let read_write_validation =
-                    self.validate_read_write_iceberg(&sts_file_io, &sub_location, true);
-                let no_write_validation =
-                    self.validate_no_write_access_iceberg(&sts_file_io, test_location);
-
-                let (read_write_result, no_write_result) =
-                    tokio::join!(read_write_validation, no_write_validation);
-                read_write_result?;
-                no_write_result?;
+                tracing::debug!("Building S3 storage from vended credentials.");
+                s3::lakekeeper_io_from_vended_table_config(&tbl_config.config)
+                    .await?
+                    .into()
             }
-            StorageProfile::Adls(_) => {
-                tracing::debug!(
-                    "Validating adls vended credentials access to sub-location: {sub_location} and forbidden access to parent location: {test_location}"
-                );
-                let sts_file_io = az::get_file_io_from_table_config(&tbl_config.config);
-
-                // Run both validations in parallel
-                let read_write_validation =
-                    self.validate_read_write_iceberg(&sts_file_io, &sub_location, true);
-                let no_write_validation =
-                    self.validate_no_write_access_iceberg(&sts_file_io, test_location);
-
-                let (read_write_result, no_write_result) =
-                    tokio::join!(read_write_validation, no_write_validation);
-                read_write_result?;
-                no_write_result?;
+            StorageProfile::Adls(profile) => {
+                tracing::debug!("Building ADLS storage from vended credentials.");
+                az::lakekeeper_io_from_vended_table_config(profile, &tbl_config.config)
+                    .await?
+                    .into()
             }
             StorageProfile::Gcs(_) => {
-                tracing::debug!("Getting gcs file io from table config for vended credentials.");
-                let sts_file_io = gcs::get_file_io_from_table_config(&tbl_config.config);
-                tracing::debug!(
-                    "Validating gcs vended credentials access to sub-location: {sub_location} and forbidden access to parent location: {test_location}"
-                );
-
-                // Run both validations in parallel
-                let read_write_validation =
-                    self.validate_read_write_iceberg(&sts_file_io, &sub_location, true);
-                let no_write_validation =
-                    self.validate_no_write_access_iceberg(&sts_file_io, test_location);
-
-                let (read_write_result, no_write_result) =
-                    tokio::join!(read_write_validation, no_write_validation);
-                read_write_result?;
-                no_write_result?;
+                tracing::debug!("Building GCS storage from vended credentials.");
+                gcs::lakekeeper_io_from_vended_table_config(&tbl_config.config)
+                    .await?
+                    .into()
             }
             #[cfg(feature = "test-utils")]
             StorageProfile::Memory(_) => {
                 unreachable!("Local profile does not support vended credentials access validation")
             }
+        };
+
+        tracing::debug!(
+            "Validating read/write access to sub-location: {sub_location} and forbidden access to parent location: {test_location} using vended credentials"
+        );
+
+        // Run both validations in parallel
+        let read_write_validation =
+            self.validate_read_write_lakekeeper(&sts_storage, &sub_location);
+        let no_write_validation =
+            self.validate_no_write_access_lakekeeper(&sts_storage, test_location);
+
+        let (read_write_result, no_write_result) =
+            tokio::join!(read_write_validation, no_write_validation);
+
+        // If both validations failed, surface both — the no-write failure means
+        // downscoped credentials were over-permissive, which is a security signal
+        // that should not be hidden by an unrelated read/write failure.
+        if let (Err(rw), Err(nw)) = (&read_write_result, &no_write_result) {
+            tracing::warn!(
+                "Both vended-credentials validations failed. Read/write: {rw:?}. No-write: {nw:?}"
+            );
         }
+        read_write_result?;
+        no_write_result?;
 
         Ok(())
     }
@@ -638,72 +627,13 @@ impl StorageProfile {
         Ok(())
     }
 
-    async fn validate_read_write_iceberg(
-        &self,
-        file_io: &FileIO,
-        test_location: &Location,
-        is_vended_credentials: bool,
-    ) -> Result<(), ValidationError> {
-        let compression_codec = CompressionCodec::Gzip;
-
-        let mut test_file_write = self.default_metadata_location(
-            test_location,
-            &compression_codec,
-            uuid::Uuid::now_v7(),
-            0,
-        );
-        if is_vended_credentials {
-            let f = test_file_write
-                .path()
-                .and_then(|s| s.split('/').next_back())
-                .unwrap_or("missing")
-                .to_string();
-            test_file_write.pop().push("vended").push(&f);
-            tracing::debug!(
-                "Validating vended credential access to: {}",
-                test_file_write
-            );
-        } else {
-            test_file_write.pop().push("test");
-            tracing::debug!("Validating access to: {}", test_file_write);
-        }
-
-        // Test write
-        file_io
-            .new_output(&test_file_write)
-            .map_err(IcebergFileIoError::IcebergError)?
-            .write("test".into())
-            .await
-            .map_err(IcebergFileIoError::IcebergError)?;
-
-        // Test read
-        file_io
-            .new_input(&test_file_write)
-            .map_err(IcebergFileIoError::IcebergError)?
-            .read()
-            .await
-            .map_err(IcebergFileIoError::IcebergError)?;
-
-        // Test delete
-        file_io
-            .delete(&test_file_write)
-            .await
-            .map_err(IcebergFileIoError::IcebergError)?;
-
-        tracing::debug!(
-            "Successfully wrote, read and deleted file at `{test_file_write}` with Iceberg FileIO and vended credentials."
-        );
-
-        Ok(())
-    }
-
-    /// Validate that we cannot write to a location with vended credentials
+    /// Validate that we cannot write to a location with the given credentials.
     ///
     /// # Errors
     /// Fails if we can write to the location (which should not be allowed).
-    async fn validate_no_write_access_iceberg(
+    async fn validate_no_write_access_lakekeeper(
         &self,
-        file_io: &FileIO,
+        io: &impl LakekeeperStorage,
         test_location: &Location,
     ) -> Result<(), ValidationError> {
         let compression_codec = CompressionCodec::Gzip;
@@ -721,45 +651,34 @@ impl StorageProfile {
             test_file_write
         );
 
-        // Test that write should fail
-        match file_io
-            .new_output(&test_file_write)
-            .map_err(IcebergFileIoError::IcebergError)
+        match crate::server::io::write_file(
+            io,
+            &test_file_write,
+            "forbidden-content",
+            compression_codec,
+        )
+        .await
         {
-            Ok(output) => {
-                // If we got an output, try to write - this should fail
-                match output.write("forbidden-content".into()).await {
-                    Ok(()) => {
-                        // If write succeeded, this is an error - we should not be able to write here
-                        // Try to clean up the file we shouldn't have been able to create
-                        let _ = file_io.delete(&test_file_write).await;
-                        return Err(CredentialsError::ShortTermCredential {
-                            reason: "Downscoped credentials allow write access to parent location."
-                                .to_string(),
-                            source: None,
-                        }
-                        .into());
-                    }
-                    Err(_) => {
-                        // Expected - write should fail
-                        tracing::debug!(
-                            "Write correctly failed for forbidden location: {test_file_write}"
-                        );
-                    }
+            Ok(()) => {
+                // Should not have been able to write — try to clean up the rogue file.
+                if let Err(e) = crate::server::io::delete_file(io, &test_file_write).await {
+                    tracing::warn!(
+                        "Failed to delete rogue validation file at {test_file_write} (creds were over-permissive on write but cleanup failed): {e:?}"
+                    );
                 }
+                return Err(CredentialsError::ShortTermCredential {
+                    reason: "Downscoped credentials allow write access to parent location."
+                        .to_string(),
+                    source: None,
+                }
+                .into());
             }
-            Err(_) => {
-                // Expected - creating output should fail
+            Err(e) => {
                 tracing::debug!(
-                    "Output creation correctly failed for forbidden location: {test_file_write}"
+                    "Write correctly failed for forbidden location: {test_file_write} ({e:?})"
                 );
             }
         }
-
-        tracing::debug!(
-            "Successfully validated that write access is denied to: {}",
-            test_file_write
-        );
 
         Ok(())
     }
@@ -1631,22 +1550,37 @@ mod tests {
             )
             .await
             .unwrap();
-        let (downscoped1, downscoped2) = match profile {
-            StorageProfile::Adls(_) => {
-                let downscoped1 = az::get_file_io_from_table_config(&config1.config);
-                let downscoped2 = az::get_file_io_from_table_config(&config2.config);
-                (downscoped1, downscoped2)
-            }
-            StorageProfile::S3(_) => {
-                let downscoped1 = s3::get_file_io_from_table_config(&config1.config);
-                let downscoped2 = s3::get_file_io_from_table_config(&config2.config);
-                (downscoped1, downscoped2)
-            }
-            StorageProfile::Gcs(_) => {
-                let downscoped1 = gcs::get_file_io_from_table_config(&config1.config);
-                let downscoped2 = gcs::get_file_io_from_table_config(&config2.config);
-                (downscoped1, downscoped2)
-            }
+        let (downscoped1, downscoped2): (StorageBackend, StorageBackend) = match profile {
+            StorageProfile::Adls(p) => (
+                az::lakekeeper_io_from_vended_table_config(p, &config1.config)
+                    .await
+                    .unwrap()
+                    .into(),
+                az::lakekeeper_io_from_vended_table_config(p, &config2.config)
+                    .await
+                    .unwrap()
+                    .into(),
+            ),
+            StorageProfile::S3(_) => (
+                s3::lakekeeper_io_from_vended_table_config(&config1.config)
+                    .await
+                    .unwrap()
+                    .into(),
+                s3::lakekeeper_io_from_vended_table_config(&config2.config)
+                    .await
+                    .unwrap()
+                    .into(),
+            ),
+            StorageProfile::Gcs(_) => (
+                gcs::lakekeeper_io_from_vended_table_config(&config1.config)
+                    .await
+                    .unwrap()
+                    .into(),
+                gcs::lakekeeper_io_from_vended_table_config(&config2.config)
+                    .await
+                    .unwrap()
+                    .into(),
+            ),
             StorageProfile::Memory(_) => {
                 unreachable!("Local storage does not support vended credentials")
             }
@@ -1656,71 +1590,53 @@ mod tests {
         let test_file2 = table_location2.cloning_push("test.txt");
 
         downscoped1
-            .new_output(&test_file1)
-            .unwrap()
-            .write("test content 1".into())
+            .write(
+                test_file1.as_str(),
+                bytes::Bytes::from_static(b"test content 1"),
+            )
             .await
             .unwrap();
-
         downscoped2
-            .new_output(&test_file2)
-            .unwrap()
-            .write("test content 2".into())
+            .write(
+                test_file2.as_str(),
+                bytes::Bytes::from_static(b"test content 2"),
+            )
             .await
             .unwrap();
 
-        let input1 = downscoped1
-            .new_input(&test_file1)
-            .unwrap()
-            .read()
-            .await
-            .unwrap();
-        assert_eq!(input1, "test content 1");
+        let input1 = downscoped1.read(test_file1.as_str()).await.unwrap();
+        assert_eq!(input1.as_ref(), b"test content 1");
 
-        let input2 = downscoped2
-            .new_input(&test_file2)
-            .unwrap()
-            .read()
-            .await
-            .unwrap();
-        assert_eq!(input2, "test content 2");
+        let input2 = downscoped2.read(test_file2.as_str()).await.unwrap();
+        assert_eq!(input2.as_ref(), b"test content 2");
 
         // cannot read across locations
-        let _ = downscoped1
-            .new_input(&test_file2)
-            .unwrap()
-            .read()
-            .await
-            .unwrap_err();
-        let _ = downscoped2
-            .new_input(&test_file1)
-            .unwrap()
-            .read()
-            .await
-            .unwrap_err();
+        let _ = downscoped1.read(test_file2.as_str()).await.unwrap_err();
+        let _ = downscoped2.read(test_file1.as_str()).await.unwrap_err();
 
         // cannot write across locations
         let _ = downscoped1
-            .new_output(&test_file2)
-            .unwrap()
-            .write("this-should-fail".into())
+            .write(
+                test_file2.as_str(),
+                bytes::Bytes::from_static(b"this-should-fail"),
+            )
             .await
             .unwrap_err();
-
         let _ = downscoped2
-            .new_output(&test_file1)
-            .unwrap()
-            .write("this-should-fail".into())
+            .write(
+                test_file1.as_str(),
+                bytes::Bytes::from_static(b"this-should-fail"),
+            )
             .await
             .unwrap_err();
 
         // cannot delete across locations
-        downscoped1.delete(&test_file2).await.unwrap_err();
-        downscoped2.delete(&test_file1).await.unwrap_err();
+        downscoped1.delete(test_file2.as_str()).await.unwrap_err();
+        downscoped2.delete(test_file1.as_str()).await.unwrap_err();
 
         // can delete in own locations
-        downscoped1.delete(&test_file1).await.unwrap();
-        downscoped2.delete(&test_file2).await.unwrap();
+        downscoped1.delete(test_file1.as_str()).await.unwrap();
+        downscoped2.delete(test_file2.as_str()).await.unwrap();
 
         // cleanup
         profile

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -1223,7 +1223,17 @@ pub(super) async fn lakekeeper_io_from_vended_table_config(
                 external_id: None,
             }))
         }
-        _ => None,
+        (None, None) => None,
+        (Some(_), None) => {
+            return Err(CredentialsError::MissingCredential(
+                "Vended S3 credentials missing s3.secret-access-key".to_string(),
+            ));
+        }
+        (None, Some(_)) => {
+            return Err(CredentialsError::MissingCredential(
+                "Vended S3 credentials missing s3.access-key-id".to_string(),
+            ));
+        }
     };
 
     let settings = S3Settings::builder()

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     hash::Hash,
-    sync::{Arc, LazyLock},
+    sync::LazyLock,
     time::{Duration, Instant},
 };
 
@@ -12,10 +12,7 @@ use aws_sdk_sts::{config::ProvideCredentials as _, types::Tag};
 use aws_smithy_runtime_api::client::identity::Identity;
 use iceberg_ext::{
     catalog::rest::ErrorModel,
-    configs::{
-        ConfigProperty,
-        table::{TableProperties, client, creds, custom, s3},
-    },
+    configs::table::{TableProperties, client, creds, custom, s3},
 };
 use lakekeeper_io::{
     InvalidLocationError, Location,
@@ -1202,27 +1199,39 @@ struct R2TemporaryCredentialsResult {
     session_token: String,
 }
 
-pub(super) fn get_file_io_from_table_config(config: &TableProperties) -> iceberg::io::FileIO {
-    let mut builder = iceberg::io::FileIOBuilder::new(Arc::new(
-        iceberg_storage_opendal::OpenDalStorageFactory::S3 {
-            customized_credential_load: None,
-        },
-    ));
+/// Build an `S3Storage` client from vended-credentials properties.
+///
+/// Reads region, endpoint, path-style-access, and the temporary credentials
+/// (access key id, secret access key, session token) from the iceberg-format
+/// `TableProperties` previously produced by `generate_table_config`.
+pub(super) async fn lakekeeper_io_from_vended_table_config(
+    config: &TableProperties,
+) -> Result<S3Storage, CredentialsError> {
+    let region = config.get_prop_opt::<s3::Region>().unwrap_or_default();
+    let endpoint = config.get_prop_opt::<s3::Endpoint>();
+    let path_style_access = config.get_prop_opt::<s3::PathStyleAccess>();
 
-    for key in [
-        s3::Region::KEY,
-        s3::Endpoint::KEY,
-        s3::AccessKeyId::KEY,
-        s3::SecretAccessKey::KEY,
-        s3::SessionToken::KEY,
-        s3::PathStyleAccess::KEY,
-    ] {
-        if let Some(value) = config.get_custom_prop(key) {
-            builder = builder.with_prop(key, value);
+    let auth = match (
+        config.get_prop_opt::<s3::AccessKeyId>(),
+        config.get_prop_opt::<s3::SecretAccessKey>(),
+    ) {
+        (Some(aws_access_key_id), Some(aws_secret_access_key)) => {
+            Some(S3Auth::AccessKey(S3AccessKeyAuth {
+                aws_access_key_id,
+                aws_secret_access_key,
+                aws_session_token: config.get_prop_opt::<s3::SessionToken>(),
+                external_id: None,
+            }))
         }
-    }
+        _ => None,
+    };
 
-    builder.build()
+    let settings = S3Settings::builder()
+        .region(region)
+        .endpoint(endpoint)
+        .path_style_access(path_style_access)
+        .build();
+    Ok(settings.get_storage_client(auth.as_ref()).await)
 }
 
 fn validate_region(region: &str) -> Result<(), InvalidProfileError> {
@@ -1260,6 +1269,7 @@ impl From<S3AccessKeyCredential> for S3AccessKeyAuth {
         S3AccessKeyAuth {
             aws_access_key_id: access_key_credential.access_key_id,
             aws_secret_access_key: access_key_credential.secret_access_key,
+            aws_session_token: None,
             external_id: access_key_credential.external_id,
         }
     }
@@ -1297,6 +1307,7 @@ impl TryFrom<S3Credential> for S3Auth {
             }) => S3Auth::AccessKey(S3AccessKeyAuth {
                 aws_access_key_id: access_key_id,
                 aws_secret_access_key: secret_access_key,
+                aws_session_token: None,
                 external_id: None, // Cloudflare R2 does not use external ID
             }),
         })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure SAS token authentication for ADLS.
  * GCS bearer-token authentication for GCS.
  * Optional AWS session token support for S3 credentials.

* **Refactor**
  * Validation and vended-credentials flows now use unified storage backend operations instead of prior file-IO paths.

* **Chores**
  * Removed an unused storage dependency; updated GCS feature to include token support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->