### PR TITLE
fix(storage): harden STS/CEL credential policies against path injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,6 +3767,7 @@ dependencies = [
  "md5",
  "moka",
  "pastey",
+ "percent-encoding",
  "reqwest 0.12.28",
  "reqwest-middleware",
  "reqwest-retry",

--- a/crates/io/Cargo.toml
+++ b/crates/io/Cargo.toml
@@ -74,6 +74,7 @@ google-cloud-storage = { workspace = true, features = [], optional = true }
 google-cloud-token = { workspace = true, optional = true }
 md5 = { workspace = true }
 moka = { workspace = true, optional = true }
+percent-encoding = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true, optional = true }
 reqwest-retry = { workspace = true, optional = true }

--- a/crates/io/src/adls/adls_location.rs
+++ b/crates/io/src/adls/adls_location.rs
@@ -83,16 +83,26 @@ impl AdlsLocation {
                     format!("ADLS path segment `{path_segment}` must not contain slashes."),
                 ));
             }
-            // Azure ADLS Gen2 rejects path segments that decode to whitespace
-            // only (e.g. `%20`) with `400 InvalidUri`. Reject up-front with a
-            // clear error rather than letting it surface as an opaque
-            // server-side failure.
+            // Reject segments whose decoded form would create silent
+            // path-divergence bugs. Our `Location` stores the raw URL input,
+            // but `url::Url::parse` (used by the SDK during request-URL
+            // construction) normalises encoded dot-segments and may decode
+            // `%2F`. The result is a Lakekeeper-side path that disagrees with
+            // what Azure actually receives. Reject up-front rather than let
+            // it surface as InvalidUri / silent 403 / wrong-path writes.
+            //   - `%20` (and other whitespace) → Azure rejects InvalidUri
+            //   - `%2E` / `%2E%2E` → `url::Url` strips, path silently shrinks
+            //   - `%2F` (or any encoded slash) → ambiguous nesting
             let decoded = percent_decode_str(path_segment).decode_utf8_lossy();
-            if !decoded.is_empty() && decoded.trim().is_empty() {
+            let invalid = decoded.contains('/')
+                || decoded == "."
+                || decoded == ".."
+                || (!decoded.is_empty() && decoded.trim().is_empty());
+            if invalid {
                 return Err(InvalidLocationError::new(
                     location_dbg.clone(),
                     format!(
-                        "ADLS path segment `{path_segment}` decodes to whitespace only, which Azure rejects."
+                        "ADLS path segment `{path_segment}` decodes to a value that is normalised or rejected by URL/Azure handling."
                     ),
                 ));
             }
@@ -525,22 +535,33 @@ mod test {
     }
 
     #[test]
-    fn test_rejects_whitespace_only_segment() {
-        // Azure ADLS Gen2 returns 400 InvalidUri for these; reject up-front.
+    fn test_rejects_problematic_decoded_segments() {
         for bad in [
+            // whitespace-only — Azure rejects InvalidUri
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/%20/bar",
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/%09/bar",
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/%20%20/bar",
+            // dot-segments — `url::Url` normalises these, path silently shrinks
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%2E/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%2e%2e/bar",
+            // encoded slash — ambiguous nesting once decoded
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%2F/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%2Fy/bar",
         ] {
             let loc = Location::from_str(bad).unwrap();
             let res = AdlsLocation::try_from_location(&loc, false);
             assert!(res.is_err(), "expected reject for `{bad}`");
         }
-        // Non-empty segments containing whitespace are fine.
-        let ok = "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%20y/bar";
-        let loc = Location::from_str(ok).unwrap();
-        AdlsLocation::try_from_location(&loc, false)
-            .unwrap_or_else(|e| panic!("expected accept for `{ok}`: {e}"));
+        // Non-empty segments that include but do not decode-to one of the
+        // forbidden values are fine.
+        for ok in [
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%20y/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%2Ey/bar",
+        ] {
+            let loc = Location::from_str(ok).unwrap();
+            AdlsLocation::try_from_location(&loc, false)
+                .unwrap_or_else(|e| panic!("expected accept for `{ok}`: {e}"));
+        }
     }
 
     #[test]

--- a/crates/io/src/adls/adls_location.rs
+++ b/crates/io/src/adls/adls_location.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr as _;
 
+use percent_encoding::percent_decode_str;
 use url::Host;
 
 use crate::{
@@ -82,19 +83,17 @@ impl AdlsLocation {
                     format!("ADLS path segment `{path_segment}` must not contain slashes."),
                 ));
             }
-            // Reject `..` and `.` segments. This is an Azure-specific
-            // correctness fix, not a security one. Azure normalises `..` in
-            // request URLs during SAS canonical-resource reconstruction —
-            // verified by integration test
-            // `azure_sas_canonical_resource_is_literal_not_normalised` —
-            // which means a SAS signed with a literal `..` canonical can
-            // never authenticate a request and the table would silently have
-            // unusable credentials. Refusing the location at the boundary
-            // gives a clear error instead of a perpetually-failing 403.
-            if *path_segment == ".." || *path_segment == "." {
+            // Azure ADLS Gen2 rejects path segments that decode to whitespace
+            // only (e.g. `%20`) with `400 InvalidUri`. Reject up-front with a
+            // clear error rather than letting it surface as an opaque
+            // server-side failure.
+            let decoded = percent_decode_str(path_segment).decode_utf8_lossy();
+            if !decoded.is_empty() && decoded.trim().is_empty() {
                 return Err(InvalidLocationError::new(
                     location_dbg.clone(),
-                    format!("ADLS path segment `{path_segment}` is not allowed."),
+                    format!(
+                        "ADLS path segment `{path_segment}` decodes to whitespace only, which Azure rejects."
+                    ),
                 ));
             }
         }
@@ -523,6 +522,25 @@ mod test {
             let parsed_location = AdlsLocation::try_from_location(&location, false);
             assert!(parsed_location.is_err(), "{parsed_location:?}");
         }
+    }
+
+    #[test]
+    fn test_rejects_whitespace_only_segment() {
+        // Azure ADLS Gen2 returns 400 InvalidUri for these; reject up-front.
+        for bad in [
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%20/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%09/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%20%20/bar",
+        ] {
+            let loc = Location::from_str(bad).unwrap();
+            let res = AdlsLocation::try_from_location(&loc, false);
+            assert!(res.is_err(), "expected reject for `{bad}`");
+        }
+        // Non-empty segments containing whitespace are fine.
+        let ok = "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%20y/bar";
+        let loc = Location::from_str(ok).unwrap();
+        AdlsLocation::try_from_location(&loc, false)
+            .unwrap_or_else(|e| panic!("expected accept for `{ok}`: {e}"));
     }
 
     #[test]

--- a/crates/io/src/adls/adls_location.rs
+++ b/crates/io/src/adls/adls_location.rs
@@ -82,6 +82,21 @@ impl AdlsLocation {
                     format!("ADLS path segment `{path_segment}` must not contain slashes."),
                 ));
             }
+            // Reject `..` and `.` segments. This is an Azure-specific
+            // correctness fix, not a security one. Azure normalises `..` in
+            // request URLs during SAS canonical-resource reconstruction —
+            // verified by integration test
+            // `azure_sas_canonical_resource_is_literal_not_normalised` —
+            // which means a SAS signed with a literal `..` canonical can
+            // never authenticate a request and the table would silently have
+            // unusable credentials. Refusing the location at the boundary
+            // gives a clear error instead of a perpetually-failing 403.
+            if *path_segment == ".." || *path_segment == "." {
+                return Err(InvalidLocationError::new(
+                    location_dbg.clone(),
+                    format!("ADLS path segment `{path_segment}` is not allowed."),
+                ));
+            }
         }
 
         let endpoint_suffix = normalize_host(host)

--- a/crates/io/src/location.rs
+++ b/crates/io/src/location.rs
@@ -287,7 +287,14 @@ impl FromStr for Location {
         if location.fragment().is_some() {
             return Err(LocationParseError {
                 value: value.to_string(),
-                reason: "URL has a fragment (#)".to_string(),
+                reason: "URL has a fragment (#) — encode `#` in object names as %23".to_string(),
+            });
+        }
+
+        if location.query().is_some() {
+            return Err(LocationParseError {
+                value: value.to_string(),
+                reason: "URL has a query (?) — encode `?` in object names as %3F".to_string(),
             });
         }
 
@@ -328,6 +335,20 @@ mod tests {
         assert_eq!(location.as_str(), "s3://bucket/foo /bar");
         let location = Location::from_str("s3://bucket/foo%20/bar").unwrap();
         assert_eq!(location.as_str(), "s3://bucket/foo%20/bar");
+    }
+
+    #[test]
+    fn test_rejects_query_and_fragment() {
+        // Literal `?` and `#` in URL paths get parsed as query/fragment by
+        // `url::Url`, which would diverge from our raw `authority_and_path`
+        // view. Reject up-front and require percent-encoded `%3F`/`%23`.
+        let frag = Location::from_str("s3://bucket/foo#bar").unwrap_err();
+        assert!(frag.reason.contains("fragment"), "{}", frag.reason);
+        let query = Location::from_str("s3://bucket/foo?bar").unwrap_err();
+        assert!(query.reason.contains("query"), "{}", query.reason);
+        // Encoded forms must still work.
+        Location::from_str("s3://bucket/foo%23bar").unwrap();
+        Location::from_str("s3://bucket/foo%3Fbar").unwrap();
     }
 
     #[test]

--- a/crates/io/src/s3/s3_location.rs
+++ b/crates/io/src/s3/s3_location.rs
@@ -319,7 +319,7 @@ mod tests {
 
         for case in cases {
             let result = S3Location::try_from_str(case, false);
-            assert!(result.is_err());
+            assert!(result.is_err(), "expected error for `{case}`");
         }
     }
 

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -1133,9 +1133,15 @@ async fn test_special_characters_in_url_segments_impl(
         "üñîçødé",
         "日本語",
     ];
-    // Negative: segments that must be rejected up-front (Azure rejects
-    // whitespace-only segments with `InvalidUri`).
-    let negative_segments = vec!["%20", "%09", "%20%20"];
+    // Negative: segments that must be rejected up-front. The reasons differ
+    // (Azure InvalidUri for whitespace-only; `url::Url` normalises encoded
+    // dot-segments and encoded `/`) but the outcome is the same: silent
+    // path divergence that we surface as a clean parse-time error.
+    let negative_segments = vec![
+        "%20", "%09", "%20%20", // whitespace-only
+        "%2E", "%2e", "%2E%2E", "%2e%2e", // dot-segments
+        "%2F",    // encoded slash
+    ];
 
     let base_dir = config.test_dir_path("special-chars-url-segments");
     let mut written_paths = Vec::new();
@@ -1167,14 +1173,19 @@ async fn test_special_characters_in_url_segments_impl(
         let _ = storage.delete(path).await;
     }
 
-    for seg in &negative_segments {
-        let path = format!("{base_dir}{seg}/data/metadata/00000-test.metadata.json");
-        match storage.write(&path, Bytes::from("x")).await {
-            Ok(()) => {
-                failures.push(format!("write({seg}): expected reject, got Ok"));
-                let _ = storage.delete(&path).await;
+    // The decoded-segment rejections live in `AdlsLocation` only — S3 keys
+    // and GCS object names accept these chars literally, so the test is
+    // ADLS-specific.
+    if matches!(storage, StorageBackend::Adls(_)) {
+        for seg in &negative_segments {
+            let path = format!("{base_dir}{seg}/data/metadata/00000-test.metadata.json");
+            match storage.write(&path, Bytes::from("x")).await {
+                Ok(()) => {
+                    failures.push(format!("write({seg}): expected reject, got Ok"));
+                    let _ = storage.delete(&path).await;
+                }
+                Err(_) => { /* expected */ }
             }
-            Err(_) => { /* expected */ }
         }
     }
 

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -1034,11 +1034,14 @@ async fn test_special_characters_impl(
     storage: &StorageBackend,
     config: &TestConfig,
 ) -> anyhow::Result<()> {
-    // Names are path of URL string, which may contain urlencoded chars
+    // Sub-delims (`!`, `=`, `-`, `_`, `.`, `+`, `*`, `'`, `$`, `,`, `;`) and
+    // multibyte UTF-8 are accepted literally. Reserved chars `?` and `#`
+    // are rejected by `Location::from_str` and must be percent-encoded;
+    // their round-trip is covered by `test_special_characters_in_url_segments`.
     let special_files = vec![
         "file with spaces.txt",
         "file-with-dashes.txt",
-        "y fl !? -_ä oats=1.2.txt",
+        "y fl ! -_ä oats=1.2.txt",
         "file_with_underscores.txt",
         "file.with.dots.txt",
         "file-with-ue-ü.txt",

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -240,6 +240,10 @@ test_all_storages!(
 test_all_storages!(test_empty_files, test_empty_files_impl);
 test_all_storages!(test_large_files, test_large_files_impl);
 test_all_storages!(test_special_characters, test_special_characters_impl);
+test_all_storages!(
+    test_special_characters_in_url_segments,
+    test_special_characters_in_url_segments_impl
+);
 test_all_storages!(test_error_handling, test_error_handling_impl);
 test_all_storages!(
     test_delete_non_existent_files,
@@ -1102,6 +1106,85 @@ async fn test_special_characters_impl(
         );
     }
 
+    Ok(())
+}
+
+/// Like `test_special_characters_impl` but the special chars appear as
+/// pre-percent-encoded URL segments (e.g. `%3F`, `%20`) — what
+/// Lakekeeper REST receives when a client provides a URL-style location.
+async fn test_special_characters_in_url_segments_impl(
+    storage: &StorageBackend,
+    config: &TestConfig,
+) -> anyhow::Result<()> {
+    // Each entry: a URL-encoded path segment that should round-trip through
+    // write → read → list when used as a directory name in a URL location.
+    // Positive: segments that must round-trip end-to-end.
+    let positive_segments = vec![
+        "%3F",     // ?
+        "%22",     // "
+        "x%20y",   // space in the middle
+        "%20x",    // leading space
+        "x%20",    // trailing space
+        "x%20%20", // trailing double space
+        "%2A",     // *
+        "%24",     // $
+        "%27",     // '
+        "%2B",     // +
+        "üñîçødé",
+        "日本語",
+    ];
+    // Negative: segments that must be rejected up-front (Azure rejects
+    // whitespace-only segments with `InvalidUri`).
+    let negative_segments = vec!["%20", "%09", "%20%20"];
+
+    let base_dir = config.test_dir_path("special-chars-url-segments");
+    let mut written_paths = Vec::new();
+    let mut failures = Vec::new();
+
+    for seg in &positive_segments {
+        let path = format!("{base_dir}{seg}/data/metadata/00000-test.metadata.json");
+        match storage
+            .write(&path, Bytes::from(format!("Content for {seg}")))
+            .await
+        {
+            Ok(()) => written_paths.push((seg.to_string(), path)),
+            Err(e) => failures.push(format!("write({seg}): {e}")),
+        }
+    }
+
+    for (seg, path) in &written_paths {
+        match storage.read(path).await {
+            Ok(read) => {
+                let s = String::from_utf8(read.to_vec())?;
+                if s != format!("Content for {seg}") {
+                    failures.push(format!("read({seg}): mismatch (got {s:?})"));
+                }
+            }
+            Err(e) => failures.push(format!("read({seg}): {e}")),
+        }
+    }
+    for (_, path) in &written_paths {
+        let _ = storage.delete(path).await;
+    }
+
+    for seg in &negative_segments {
+        let path = format!("{base_dir}{seg}/data/metadata/00000-test.metadata.json");
+        match storage.write(&path, Bytes::from("x")).await {
+            Ok(()) => {
+                failures.push(format!("write({seg}): expected reject, got Ok"));
+                let _ = storage.delete(&path).await;
+            }
+            Err(_) => { /* expected */ }
+        }
+    }
+
+    if !failures.is_empty() {
+        anyhow::bail!(
+            "{} segment(s) failed:\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
     Ok(())
 }
 

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -488,6 +488,7 @@ impl AdlsProfile {
     ) -> Result<String, CredentialsError> {
         let path = reduce_scheme_string(stc_request.table_location.as_ref());
         let rootless_path = path.trim_start_matches('/').trim_end_matches('/');
+
         let depth = rootless_path.split('/').count();
 
         let canonical_resource = format!(

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -486,7 +486,12 @@ impl AdlsProfile {
         signed_expiry: OffsetDateTime,
         key: impl Into<SasKey>,
     ) -> Result<String, CredentialsError> {
-        let path = reduce_scheme_string(stc_request.table_location.as_ref());
+        let path = reduce_scheme_string(stc_request.table_location.as_ref()).map_err(|e| {
+            CredentialsError::ShortTermCredential {
+                reason: format!("Invalid ADLS location for SAS signing: {e}"),
+                source: Some(Box::new(e)),
+            }
+        })?;
         let rootless_path = path.trim_start_matches('/').trim_end_matches('/');
         let depth = rootless_path.split('/').count();
 
@@ -597,11 +602,10 @@ impl AdlsProfile {
 
 /// Removes the hostname and user from the path.
 /// Keeps only the path and optionally the scheme.
-#[must_use]
-pub(crate) fn reduce_scheme_string(path: &str) -> String {
-    AdlsLocation::try_from_str(path, true)
-        .map(|l| format!("/{}", l.blob_name().clone().trim_start_matches('/')))
-        .unwrap_or(path.to_string())
+/// Reduce an ADLS URL to its rooted blob path (`/<blob_name>`).
+pub(crate) fn reduce_scheme_string(path: &str) -> Result<String, InvalidLocationError> {
+    let l = AdlsLocation::try_from_str(path, true)?;
+    Ok(format!("/{}", l.blob_name().trim_start_matches('/')))
 }
 
 #[derive(Redact, Hash, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -740,19 +744,15 @@ pub(crate) mod test {
 
     #[test]
     fn test_reduce_scheme_string() {
-        // Test abfss protocol
         let path = "abfss://filesystem@dfs.windows.net/path/_test";
-        let reduced_path = reduce_scheme_string(path);
-        assert_eq!(reduced_path, "/path/_test");
+        assert_eq!(reduce_scheme_string(path).unwrap(), "/path/_test");
 
-        // Test wasbs protocol
         let wasbs_path = "wasbs://filesystem@account.windows.net/path/to/data";
-        let reduced_wasbs_path = reduce_scheme_string(wasbs_path);
-        assert_eq!(reduced_wasbs_path, "/path/to/data");
+        assert_eq!(reduce_scheme_string(wasbs_path).unwrap(), "/path/to/data");
 
-        // Test a non-matching path
+        // Non-ADLS scheme must error rather than silently pass through.
         let non_matching = "http://example.com/path";
-        assert_eq!(reduce_scheme_string(non_matching), non_matching);
+        assert!(reduce_scheme_string(non_matching).is_err());
     }
 
     pub(crate) mod azure_integration_tests {

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -488,14 +488,17 @@ impl AdlsProfile {
     ) -> Result<String, CredentialsError> {
         let path = reduce_scheme_string(stc_request.table_location.as_ref());
         let rootless_path = path.trim_start_matches('/').trim_end_matches('/');
-
         let depth = rootless_path.split('/').count();
 
+        // Azure recomputes the canonical-resource by URL-decoding the request
+        // URL path. Hand-rolling the canonical with the encoded form (e.g.
+        // literal `%3F` or `%20`) produces a signature mismatch.
+        let decoded_path = percent_encoding::percent_decode_str(rootless_path).decode_utf8_lossy();
         let canonical_resource = format!(
             "/blob/{}/{}/{}",
             self.account_name.as_str(),
             self.filesystem.as_str(),
-            rootless_path
+            decoded_path
         );
 
         tracing::debug!(

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -23,7 +23,7 @@ pub(crate) async fn downscope(
             bucket,
             &stc_request.table_location,
             stc_request.storage_permissions,
-        ),
+        )?,
     )?;
 
     let response = HTTP_CLIENT
@@ -117,13 +117,19 @@ impl Options {
         bucket: &str,
         table_location: &Location,
         storage_permissions: StoragePermissions,
-    ) -> Self {
+    ) -> Result<Self, TableConfigError> {
         let mut table_location = table_location.clone();
         table_location.with_trailing_slash();
         let prefixless_location = table_location
             .as_str()
             .replace(&format!("gs://{bucket}/"), "");
-        Options {
+
+        // The bucket is admin-set and validated to `[a-z0-9.\-_]`, but wrap
+        // it as a raw literal anyway as defense in depth.
+        let bucket_cel = cel_raw_single_quoted(bucket)?;
+        let path_cel = cel_raw_single_quoted(&prefixless_location)?;
+
+        Ok(Options {
             access_boundary: AccessBoundary {
                 access_boundary_rules: vec![AccessBoundaryRule {
                     available_resource: format!(
@@ -143,15 +149,60 @@ impl Options {
                     },
                     availability_condition: AvailabilityCondition {
                         title: "obj-prefixes".to_string(),
-                        // need the getAttribute to allow Listing operations
+                        // need the getAttribute to allow Listing operations.
+                        // `bucket_cel` and `path_cel` are complete raw string
+                        // literals (`r'...'`) so they're embedded without
+                        // surrounding quotes. CEL string-concat (`+`) builds
+                        // the prefix; this avoids re-quoting and makes the
+                        // injection-resistance obvious from the format string.
                         expression: format!(
-                            "resource.name.startsWith('projects/_/buckets/{bucket}/objects/{prefixless_location}') || resource.name.startsWith('projects/_/buckets/{bucket}/folders/{prefixless_location}') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('{prefixless_location}')",
+                            "resource.name.startsWith('projects/_/buckets/' + {bucket_cel} + '/objects/' + {path_cel}) || resource.name.startsWith('projects/_/buckets/' + {bucket_cel} + '/folders/' + {path_cel}) || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith({path_cel})",
                         ),
                     }.into(),
                 }],
             },
+        })
+    }
+}
+
+/// Wrap `value` as a CEL raw single-quoted string literal: `r'...'`.
+///
+/// Returns the complete literal *including* the `r'` prefix and `'` suffix, so
+/// the caller embeds it without adding their own quotes.
+///
+/// CEL raw strings do not interpret escape sequences ([CEL spec §
+/// String literals](https://github.com/google/cel-spec/blob/master/doc/langdef.md)),
+/// which collapses the escaping problem to "what character can close the
+/// literal." For raw single-quoted strings the answer is exactly:
+///
+/// - `'`  — the closing delimiter
+/// - `\n` / `\r` — single-quoted strings (raw or not) cannot contain unescaped
+///   newlines per the grammar
+///
+/// All three are rejected here. `\`, `"`, control bytes, and multibyte UTF-8
+/// pass through verbatim and are matched as literals by the CEL evaluator.
+fn cel_raw_single_quoted(value: &str) -> Result<String, TableConfigError> {
+    for c in value.chars() {
+        let reject = c == '\''
+            || c == '\n'
+            || c == '\r'
+            // Defense in depth: reject all other ASCII / Unicode control
+            // characters too. Some are technically allowed in CEL string
+            // literals but a NUL byte (or other unusual control) reaching
+            // GCP's evaluator could cause string truncation / non-canonical
+            // matching that's worth refusing outright.
+            || c.is_control();
+        if reject {
+            return Err(TableConfigError::Internal(
+                format!(
+                    "Refusing to build GCS access boundary: input contains a character that cannot appear in a CEL raw single-quoted string (U+{:04X})",
+                    c as u32
+                ),
+                None,
+            ));
         }
     }
+    Ok(format!("r'{value}'"))
 }
 
 #[derive(Serialize, Deserialize)]
@@ -214,5 +265,92 @@ impl From<&GcsServiceKey> for CredentialsFile {
             quota_project_id: None,
             workforce_pool_user_project: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cel_raw_single_quoted_wraps_plain_value() {
+        assert_eq!(cel_raw_single_quoted("foo/bar").unwrap(), "r'foo/bar'");
+    }
+
+    #[test]
+    fn cel_raw_single_quoted_passes_through_backslash_and_double_quote() {
+        // These are the chars a hand-rolled escape function is most likely to
+        // get wrong. Raw strings just pass them through.
+        assert_eq!(
+            cel_raw_single_quoted(r#"a\b"c"#).unwrap(),
+            r#"r'a\b"c'"#
+        );
+    }
+
+    #[test]
+    fn cel_raw_single_quoted_rejects_single_quote() {
+        // Injection payload: `') || true || resource.name.startsWith('`. Must
+        // be rejected before the literal is constructed, otherwise the closing
+        // `'` would let the rest be parsed as CEL syntax.
+        let err = cel_raw_single_quoted("') || true || resource.name.startsWith('")
+            .expect_err("single quote must be rejected");
+        assert!(matches!(err, TableConfigError::Internal(_, _)));
+    }
+
+    #[test]
+    fn cel_raw_single_quoted_rejects_newline_and_carriage_return() {
+        cel_raw_single_quoted("foo\nbar").expect_err("newline must be rejected");
+        cel_raw_single_quoted("foo\rbar").expect_err("CR must be rejected");
+    }
+
+    #[test]
+    fn options_neutralizes_cel_injection_in_path() {
+        // End-to-end: the constructed CEL expression must not be twistable
+        // into evaluating to `true` by an injection attempt in the path.
+        let bucket = "my-bucket";
+        let location: Location = "gs://my-bucket/wh/safe-prefix/"
+            .parse()
+            .unwrap();
+        let opts = Options::from_location_and_permissions(
+            bucket,
+            &location,
+            StoragePermissions::Read,
+        )
+        .unwrap();
+        let expr = &opts.access_boundary.access_boundary_rules[0]
+            .availability_condition
+            .as_ref()
+            .unwrap()
+            .expression;
+        // Must contain raw-string literals, not bare format!-interpolated
+        // strings — that's what closes the injection class.
+        assert!(
+            expr.contains("r'wh/safe-prefix/'"),
+            "expected raw-string path literal in expression, got: {expr}"
+        );
+        assert!(
+            expr.contains("r'my-bucket'"),
+            "expected raw-string bucket literal in expression, got: {expr}"
+        );
+    }
+
+    #[test]
+    fn options_rejects_cel_injection_payload_in_path() {
+        // A table location whose path contains `'` must cause credential
+        // construction to fail outright rather than producing a smuggled CEL
+        // expression.
+        let bucket = "my-bucket";
+        let location: Location = "gs://my-bucket/x'/data/"
+            .parse()
+            .expect("URL parse should accept ' (sub-delim)");
+        let result = Options::from_location_and_permissions(
+            bucket,
+            &location,
+            StoragePermissions::Read,
+        );
+        let Err(err) = result else {
+            panic!("input with ' must be rejected");
+        };
+        assert!(matches!(err, TableConfigError::Internal(_, _)));
     }
 }

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -124,10 +124,8 @@ impl Options {
             .as_str()
             .replace(&format!("gs://{bucket}/"), "");
 
-        // The bucket is admin-set and validated to `[a-z0-9.\-_]`, but wrap
-        // it as a raw literal anyway as defense in depth.
-        let bucket_cel = cel_raw_single_quoted(bucket)?;
-        let path_cel = cel_raw_single_quoted(&prefixless_location)?;
+        validate_safe_for_cel_single_quoted(bucket)?;
+        validate_safe_for_cel_single_quoted(&prefixless_location)?;
 
         Ok(Options {
             access_boundary: AccessBoundary {
@@ -149,14 +147,9 @@ impl Options {
                     },
                     availability_condition: AvailabilityCondition {
                         title: "obj-prefixes".to_string(),
-                        // need the getAttribute to allow Listing operations.
-                        // `bucket_cel` and `path_cel` are complete raw string
-                        // literals (`r'...'`) so they're embedded without
-                        // surrounding quotes. CEL string-concat (`+`) builds
-                        // the prefix; this avoids re-quoting and makes the
-                        // injection-resistance obvious from the format string.
+                        // getAttribute is needed for Listing operations.
                         expression: format!(
-                            "resource.name.startsWith('projects/_/buckets/' + {bucket_cel} + '/objects/' + {path_cel}) || resource.name.startsWith('projects/_/buckets/' + {bucket_cel} + '/folders/' + {path_cel}) || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith({path_cel})",
+                            "resource.name.startsWith('projects/_/buckets/{bucket}/objects/{prefixless_location}') || resource.name.startsWith('projects/_/buckets/{bucket}/folders/{prefixless_location}') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('{prefixless_location}')",
                         ),
                     }.into(),
                 }],
@@ -165,44 +158,23 @@ impl Options {
     }
 }
 
-/// Wrap `value` as a CEL raw single-quoted string literal: `r'...'`.
-///
-/// Returns the complete literal *including* the `r'` prefix and `'` suffix, so
-/// the caller embeds it without adding their own quotes.
-///
-/// CEL raw strings do not interpret escape sequences ([CEL spec §
-/// String literals](https://github.com/google/cel-spec/blob/master/doc/langdef.md)),
-/// which collapses the escaping problem to "what character can close the
-/// literal." For raw single-quoted strings the answer is exactly:
-///
-/// - `'`  — the closing delimiter
-/// - `\n` / `\r` — single-quoted strings (raw or not) cannot contain unescaped
-///   newlines per the grammar
-///
-/// All three are rejected here. `\`, `"`, control bytes, and multibyte UTF-8
-/// pass through verbatim and are matched as literals by the CEL evaluator.
-fn cel_raw_single_quoted(value: &str) -> Result<String, TableConfigError> {
+/// Reject characters that can escape a CEL single-quoted string literal.
+/// GCP's access-boundary CEL doesn't accept `r'...'` raw strings or `+`
+/// concat, so values are interpolated directly into `'...'`.
+fn validate_safe_for_cel_single_quoted(value: &str) -> Result<(), TableConfigError> {
     for c in value.chars() {
-        let reject = c == '\''
-            || c == '\n'
-            || c == '\r'
-            // Defense in depth: reject all other ASCII / Unicode control
-            // characters too. Some are technically allowed in CEL string
-            // literals but a NUL byte (or other unusual control) reaching
-            // GCP's evaluator could cause string truncation / non-canonical
-            // matching that's worth refusing outright.
-            || c.is_control();
+        let reject = c == '\'' || c == '\\' || c == '\n' || c == '\r' || c.is_control();
         if reject {
             return Err(TableConfigError::Internal(
                 format!(
-                    "Refusing to build GCS access boundary: input contains a character that cannot appear in a CEL raw single-quoted string (U+{:04X})",
+                    "Refusing to build GCS access boundary: input contains a character that cannot appear in a CEL single-quoted string (U+{:04X})",
                     c as u32
                 ),
                 None,
             ));
         }
     }
-    Ok(format!("r'{value}'"))
+    Ok(())
 }
 
 #[derive(Serialize, Deserialize)]
@@ -273,34 +245,38 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cel_raw_single_quoted_wraps_plain_value() {
-        assert_eq!(cel_raw_single_quoted("foo/bar").unwrap(), "r'foo/bar'");
+    fn validate_safe_for_cel_single_quoted_accepts_plain_value() {
+        validate_safe_for_cel_single_quoted("foo/bar").unwrap();
+        // Multibyte UTF-8 and double quotes are fine inside a single-quoted
+        // CEL literal — they have no special meaning.
+        validate_safe_for_cel_single_quoted("foo/bar/üñîçødé").unwrap();
+        validate_safe_for_cel_single_quoted(r#"foo"bar"#).unwrap();
     }
 
     #[test]
-    fn cel_raw_single_quoted_passes_through_backslash_and_double_quote() {
-        // These are the chars a hand-rolled escape function is most likely to
-        // get wrong. Raw strings just pass them through.
-        assert_eq!(
-            cel_raw_single_quoted(r#"a\b"c"#).unwrap(),
-            r#"r'a\b"c'"#
-        );
-    }
-
-    #[test]
-    fn cel_raw_single_quoted_rejects_single_quote() {
+    fn validate_safe_for_cel_single_quoted_rejects_single_quote() {
         // Injection payload: `') || true || resource.name.startsWith('`. Must
-        // be rejected before the literal is constructed, otherwise the closing
-        // `'` would let the rest be parsed as CEL syntax.
-        let err = cel_raw_single_quoted("') || true || resource.name.startsWith('")
+        // be rejected, otherwise the closing `'` would terminate the literal
+        // and let the rest be parsed as CEL syntax.
+        let err = validate_safe_for_cel_single_quoted("') || true || resource.name.startsWith('")
             .expect_err("single quote must be rejected");
         assert!(matches!(err, TableConfigError::Internal(_, _)));
     }
 
     #[test]
-    fn cel_raw_single_quoted_rejects_newline_and_carriage_return() {
-        cel_raw_single_quoted("foo\nbar").expect_err("newline must be rejected");
-        cel_raw_single_quoted("foo\rbar").expect_err("CR must be rejected");
+    fn validate_safe_for_cel_single_quoted_rejects_backslash() {
+        // Backslash starts an escape sequence in non-raw CEL strings (e.g.
+        // `\'` would be a literal `'`, defeating the closing-delimiter
+        // check). Must be rejected.
+        let err = validate_safe_for_cel_single_quoted(r"foo\bar")
+            .expect_err("backslash must be rejected");
+        assert!(matches!(err, TableConfigError::Internal(_, _)));
+    }
+
+    #[test]
+    fn validate_safe_for_cel_single_quoted_rejects_newline_and_carriage_return() {
+        validate_safe_for_cel_single_quoted("foo\nbar").expect_err("newline must be rejected");
+        validate_safe_for_cel_single_quoted("foo\rbar").expect_err("CR must be rejected");
     }
 
     #[test]
@@ -308,29 +284,32 @@ mod tests {
         // End-to-end: the constructed CEL expression must not be twistable
         // into evaluating to `true` by an injection attempt in the path.
         let bucket = "my-bucket";
-        let location: Location = "gs://my-bucket/wh/safe-prefix/"
-            .parse()
-            .unwrap();
-        let opts = Options::from_location_and_permissions(
-            bucket,
-            &location,
-            StoragePermissions::Read,
-        )
-        .unwrap();
+        let location: Location = "gs://my-bucket/wh/safe-prefix/".parse().unwrap();
+        let opts =
+            Options::from_location_and_permissions(bucket, &location, StoragePermissions::Read)
+                .unwrap();
         let expr = &opts.access_boundary.access_boundary_rules[0]
             .availability_condition
             .as_ref()
             .unwrap()
             .expression;
-        // Must contain raw-string literals, not bare format!-interpolated
-        // strings — that's what closes the injection class.
+        // GCP's CEL subset doesn't accept raw-string literals or string
+        // concat; safety comes from `validate_safe_for_cel_single_quoted`
+        // having rejected anything that could escape the surrounding `'...'`.
+        // The expression should embed bucket/path inline as plain literals.
         assert!(
-            expr.contains("r'wh/safe-prefix/'"),
-            "expected raw-string path literal in expression, got: {expr}"
+            expr.contains("/buckets/my-bucket/objects/wh/safe-prefix/"),
+            "expected inline path literal in expression, got: {expr}"
+        );
+        // And it must not regress to using the rejected raw-string / concat
+        // forms.
+        assert!(
+            !expr.contains("r'"),
+            "expression must not use raw-string literals (rejected by GCP), got: {expr}"
         );
         assert!(
-            expr.contains("r'my-bucket'"),
-            "expected raw-string bucket literal in expression, got: {expr}"
+            !expr.contains(" + "),
+            "expression must not use string concat (rejected by GCP), got: {expr}"
         );
     }
 
@@ -343,11 +322,8 @@ mod tests {
         let location: Location = "gs://my-bucket/x'/data/"
             .parse()
             .expect("URL parse should accept ' (sub-delim)");
-        let result = Options::from_location_and_permissions(
-            bucket,
-            &location,
-            StoragePermissions::Read,
-        );
+        let result =
+            Options::from_location_and_permissions(bucket, &location, StoragePermissions::Read);
         let Err(err) = result else {
             panic!("input with ' must be rejected");
         };

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -320,8 +320,11 @@ mod tests {
     #[test]
     fn options_rejects_cross_bucket_table_location() {
         let location: Location = "gs://other-bucket/data/".parse().unwrap();
-        let result =
-            Options::from_location_and_permissions("my-bucket", &location, StoragePermissions::Read);
+        let result = Options::from_location_and_permissions(
+            "my-bucket",
+            &location,
+            StoragePermissions::Read,
+        );
         let Err(err) = result else {
             panic!("cross-bucket location must be rejected");
         };

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -135,8 +135,8 @@ impl Options {
             })?
             .to_owned();
 
-        validate_safe_for_cel_single_quoted(bucket)?;
-        validate_safe_for_cel_single_quoted(&prefixless_location)?;
+        let bucket_cel = escape_for_cel_single_quoted(bucket)?;
+        let path_cel = escape_for_cel_single_quoted(&prefixless_location)?;
 
         Ok(Options {
             access_boundary: AccessBoundary {
@@ -160,7 +160,7 @@ impl Options {
                         title: "obj-prefixes".to_string(),
                         // getAttribute is needed for Listing operations.
                         expression: format!(
-                            "resource.name.startsWith('projects/_/buckets/{bucket}/objects/{prefixless_location}') || resource.name.startsWith('projects/_/buckets/{bucket}/folders/{prefixless_location}') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('{prefixless_location}')",
+                            "resource.name.startsWith('projects/_/buckets/{bucket_cel}/objects/{path_cel}') || resource.name.startsWith('projects/_/buckets/{bucket_cel}/folders/{path_cel}') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('{path_cel}')",
                         ),
                     }.into(),
                 }],
@@ -169,23 +169,34 @@ impl Options {
     }
 }
 
-/// Reject characters that can escape a CEL single-quoted string literal.
+/// Escape `value` for interpolation inside a CEL single-quoted literal.
 /// GCP's access-boundary CEL doesn't accept `r'...'` raw strings or `+`
-/// concat, so values are interpolated directly into `'...'`.
-fn validate_safe_for_cel_single_quoted(value: &str) -> Result<(), TableConfigError> {
+/// concat. Control chars without a CEL escape are rejected.
+fn escape_for_cel_single_quoted(value: &str) -> Result<String, TableConfigError> {
+    let mut out = String::with_capacity(value.len());
     for c in value.chars() {
-        let reject = c == '\'' || c == '\\' || c == '\n' || c == '\r' || c.is_control();
-        if reject {
-            return Err(TableConfigError::Internal(
-                format!(
-                    "Refusing to build GCS access boundary: input contains a character that cannot appear in a CEL single-quoted string (U+{:04X})",
-                    c as u32
-                ),
-                None,
-            ));
+        match c {
+            '\'' => out.push_str("\\'"),
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0C}' => out.push_str("\\f"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => {
+                return Err(TableConfigError::Internal(
+                    format!(
+                        "Refusing to build GCS access boundary: input contains an unsupported control character (U+{:04X})",
+                        c as u32
+                    ),
+                    None,
+                ));
+            }
+            c => out.push(c),
         }
     }
-    Ok(())
+    Ok(out)
 }
 
 #[derive(Serialize, Deserialize)]
@@ -256,30 +267,50 @@ mod tests {
     use super::*;
 
     #[test]
-    fn validate_safe_for_cel_single_quoted_accepts_plain_value() {
-        validate_safe_for_cel_single_quoted("foo/bar").unwrap();
-        validate_safe_for_cel_single_quoted("foo/bar/üñîçødé").unwrap();
-        validate_safe_for_cel_single_quoted(r#"foo"bar"#).unwrap();
+    fn escape_for_cel_single_quoted_passes_plain_value() {
+        assert_eq!(escape_for_cel_single_quoted("foo/bar").unwrap(), "foo/bar");
+        assert_eq!(
+            escape_for_cel_single_quoted("foo/bar/üñîçødé").unwrap(),
+            "foo/bar/üñîçødé",
+        );
     }
 
     #[test]
-    fn validate_safe_for_cel_single_quoted_rejects_single_quote() {
-        let err = validate_safe_for_cel_single_quoted("') || true || resource.name.startsWith('")
-            .expect_err("single quote must be rejected");
-        assert!(matches!(err, TableConfigError::Internal(_, _)));
+    fn escape_for_cel_single_quoted_escapes_quote_backslash_and_double_quote() {
+        // Injection payload: closing the literal early. The `'` must be
+        // escaped to `\'` so the CEL parser keeps reading inside the literal.
+        assert_eq!(
+            escape_for_cel_single_quoted("') || true || x.startsWith('").unwrap(),
+            "\\') || true || x.startsWith(\\'",
+        );
+        assert_eq!(
+            escape_for_cel_single_quoted(r"foo\bar").unwrap(),
+            r"foo\\bar"
+        );
+        assert_eq!(
+            escape_for_cel_single_quoted(r#"foo"bar"#).unwrap(),
+            r#"foo\"bar"#
+        );
     }
 
     #[test]
-    fn validate_safe_for_cel_single_quoted_rejects_backslash() {
-        let err = validate_safe_for_cel_single_quoted(r"foo\bar")
-            .expect_err("backslash must be rejected");
-        assert!(matches!(err, TableConfigError::Internal(_, _)));
+    fn escape_for_cel_single_quoted_escapes_handled_control_chars() {
+        assert_eq!(escape_for_cel_single_quoted("a\nb").unwrap(), "a\\nb");
+        assert_eq!(escape_for_cel_single_quoted("a\rb").unwrap(), "a\\rb");
+        assert_eq!(escape_for_cel_single_quoted("a\tb").unwrap(), "a\\tb");
+        assert_eq!(escape_for_cel_single_quoted("a\u{08}b").unwrap(), "a\\bb");
+        assert_eq!(escape_for_cel_single_quoted("a\u{0C}b").unwrap(), "a\\fb");
     }
 
     #[test]
-    fn validate_safe_for_cel_single_quoted_rejects_newline_and_carriage_return() {
-        validate_safe_for_cel_single_quoted("foo\nbar").expect_err("newline must be rejected");
-        validate_safe_for_cel_single_quoted("foo\rbar").expect_err("CR must be rejected");
+    fn escape_for_cel_single_quoted_rejects_unsupported_control_chars() {
+        // NUL and other unhandled control chars have no CEL escape.
+        for cp in [0x00u32, 0x01, 0x07, 0x0B, 0x1F, 0x7F] {
+            let input = format!("a{}b", char::from_u32(cp).unwrap());
+            let err = escape_for_cel_single_quoted(&input)
+                .expect_err(&format!("U+{cp:04X} must be rejected"));
+            assert!(matches!(err, TableConfigError::Internal(_, _)));
+        }
     }
 
     #[test]
@@ -304,17 +335,26 @@ mod tests {
     }
 
     #[test]
-    fn options_rejects_cel_injection_payload_in_path() {
+    fn options_escapes_quote_in_path_instead_of_rejecting() {
+        // A path containing `'` must produce a CEL expression where the quote
+        // is escaped (`\'`), not closed early. The location is accepted, not
+        // rejected.
         let bucket = "my-bucket";
         let location: Location = "gs://my-bucket/x'/data/"
             .parse()
             .expect("URL parse should accept ' (sub-delim)");
-        let result =
-            Options::from_location_and_permissions(bucket, &location, StoragePermissions::Read);
-        let Err(err) = result else {
-            panic!("input with ' must be rejected");
-        };
-        assert!(matches!(err, TableConfigError::Internal(_, _)));
+        let opts =
+            Options::from_location_and_permissions(bucket, &location, StoragePermissions::Read)
+                .unwrap();
+        let expr = &opts.access_boundary.access_boundary_rules[0]
+            .availability_condition
+            .as_ref()
+            .unwrap()
+            .expression;
+        assert!(
+            expr.contains("/objects/x\\'/data/"),
+            "expected escaped `'` in expression, got: {expr}"
+        );
     }
 
     #[test]

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -120,9 +120,20 @@ impl Options {
     ) -> Result<Self, TableConfigError> {
         let mut table_location = table_location.clone();
         table_location.with_trailing_slash();
+        let bucket_prefix = format!("gs://{bucket}/");
         let prefixless_location = table_location
             .as_str()
-            .replace(&format!("gs://{bucket}/"), "");
+            .strip_prefix(&bucket_prefix)
+            .ok_or_else(|| {
+                TableConfigError::Internal(
+                    format!(
+                        "Refusing to build GCS access boundary: table location `{}` is not under bucket `{bucket}`",
+                        table_location.as_str()
+                    ),
+                    None,
+                )
+            })?
+            .to_owned();
 
         validate_safe_for_cel_single_quoted(bucket)?;
         validate_safe_for_cel_single_quoted(&prefixless_location)?;
@@ -302,6 +313,17 @@ mod tests {
             Options::from_location_and_permissions(bucket, &location, StoragePermissions::Read);
         let Err(err) = result else {
             panic!("input with ' must be rejected");
+        };
+        assert!(matches!(err, TableConfigError::Internal(_, _)));
+    }
+
+    #[test]
+    fn options_rejects_cross_bucket_table_location() {
+        let location: Location = "gs://other-bucket/data/".parse().unwrap();
+        let result =
+            Options::from_location_and_permissions("my-bucket", &location, StoragePermissions::Read);
+        let Err(err) = result else {
+            panic!("cross-bucket location must be rejected");
         };
         assert!(matches!(err, TableConfigError::Internal(_, _)));
     }

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -247,17 +247,12 @@ mod tests {
     #[test]
     fn validate_safe_for_cel_single_quoted_accepts_plain_value() {
         validate_safe_for_cel_single_quoted("foo/bar").unwrap();
-        // Multibyte UTF-8 and double quotes are fine inside a single-quoted
-        // CEL literal — they have no special meaning.
         validate_safe_for_cel_single_quoted("foo/bar/üñîçødé").unwrap();
         validate_safe_for_cel_single_quoted(r#"foo"bar"#).unwrap();
     }
 
     #[test]
     fn validate_safe_for_cel_single_quoted_rejects_single_quote() {
-        // Injection payload: `') || true || resource.name.startsWith('`. Must
-        // be rejected, otherwise the closing `'` would terminate the literal
-        // and let the rest be parsed as CEL syntax.
         let err = validate_safe_for_cel_single_quoted("') || true || resource.name.startsWith('")
             .expect_err("single quote must be rejected");
         assert!(matches!(err, TableConfigError::Internal(_, _)));
@@ -265,9 +260,6 @@ mod tests {
 
     #[test]
     fn validate_safe_for_cel_single_quoted_rejects_backslash() {
-        // Backslash starts an escape sequence in non-raw CEL strings (e.g.
-        // `\'` would be a literal `'`, defeating the closing-delimiter
-        // check). Must be rejected.
         let err = validate_safe_for_cel_single_quoted(r"foo\bar")
             .expect_err("backslash must be rejected");
         assert!(matches!(err, TableConfigError::Internal(_, _)));
@@ -281,8 +273,6 @@ mod tests {
 
     #[test]
     fn options_neutralizes_cel_injection_in_path() {
-        // End-to-end: the constructed CEL expression must not be twistable
-        // into evaluating to `true` by an injection attempt in the path.
         let bucket = "my-bucket";
         let location: Location = "gs://my-bucket/wh/safe-prefix/".parse().unwrap();
         let opts =
@@ -293,31 +283,17 @@ mod tests {
             .as_ref()
             .unwrap()
             .expression;
-        // GCP's CEL subset doesn't accept raw-string literals or string
-        // concat; safety comes from `validate_safe_for_cel_single_quoted`
-        // having rejected anything that could escape the surrounding `'...'`.
-        // The expression should embed bucket/path inline as plain literals.
         assert!(
             expr.contains("/buckets/my-bucket/objects/wh/safe-prefix/"),
             "expected inline path literal in expression, got: {expr}"
         );
-        // And it must not regress to using the rejected raw-string / concat
-        // forms.
-        assert!(
-            !expr.contains("r'"),
-            "expression must not use raw-string literals (rejected by GCP), got: {expr}"
-        );
-        assert!(
-            !expr.contains(" + "),
-            "expression must not use string concat (rejected by GCP), got: {expr}"
-        );
+        // Guard against regressing to forms GCP rejects.
+        assert!(!expr.contains("r'"), "raw-string literal in: {expr}");
+        assert!(!expr.contains(" + "), "string concat in: {expr}");
     }
 
     #[test]
     fn options_rejects_cel_injection_payload_in_path() {
-        // A table location whose path contains `'` must cause credential
-        // construction to fail outright rather than producing a smuggled CEL
-        // expression.
         let bucket = "my-bucket";
         let location: Location = "gs://my-bucket/x'/data/"
             .parse()

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -928,15 +928,17 @@ impl S3Profile {
 
     fn permission_to_actions(storage_permissions: StoragePermissions) -> &'static [&'static str] {
         match storage_permissions {
-            StoragePermissions::Read => &["s3:GetObject"],
+            StoragePermissions::Read => &["s3:GetObject", "s3:GetObjectVersion"],
             StoragePermissions::ReadWrite => &[
                 "s3:GetObject",
+                "s3:GetObjectVersion",
                 "s3:PutObject",
                 "s3:AbortMultipartUpload",
                 "s3:ListMultipartUploadParts",
             ],
             StoragePermissions::ReadWriteDelete => &[
                 "s3:GetObject",
+                "s3:GetObjectVersion",
                 "s3:PutObject",
                 "s3:DeleteObject",
                 "s3:AbortMultipartUpload",
@@ -984,6 +986,15 @@ impl S3Profile {
                         "s3:prefix": key_wildcard,
                     },
                 },
+            }),
+            // Some AWS clients call GetBucketLocation to discover the bucket's
+            // region before issuing data-plane requests. Without it, requests
+            // can fail with `IllegalLocationConstraintException`.
+            json!({
+                "Sid": "GetBucketLocation",
+                "Effect": "Allow",
+                "Action": "s3:GetBucketLocation",
+                "Resource": bucket_arn,
             }),
         ];
 

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -2144,7 +2144,13 @@ pub(crate) mod test {
 
     #[test]
     fn policy_string_neutralizes_question_mark_in_table_path() {
-        let table_location = "s3://bucket-name/wh/ev?l/table";
+        // `Location::from_str` now rejects raw `?` at parse time, so this
+        // state can't be reached via REST anymore. Build via `extend()`
+        // (which doesn't re-parse) to defense-in-depth check that the
+        // escape is wired up in the policy path even if some future code
+        // bypasses the parser.
+        let mut table_location: Location = "s3://bucket-name/wh".parse().unwrap();
+        table_location.extend(["ev?l", "table"]);
         let profile = S3Profile::builder()
             .bucket("bucket-name".to_string())
             .key_prefix("wh".to_string())
@@ -2153,10 +2159,7 @@ pub(crate) mod test {
             .sts_enabled(true)
             .build();
         let policy = profile
-            .get_sts_policy_string(
-                &table_location.parse().unwrap(),
-                StoragePermissions::ReadWriteDelete,
-            )
+            .get_sts_policy_string(&table_location, StoragePermissions::ReadWriteDelete)
             .unwrap();
         assert!(
             policy.contains("wh/ev${?}l/table"),
@@ -2164,7 +2167,7 @@ pub(crate) mod test {
         );
         assert!(
             !policy.contains("wh/ev?l/table"),
-            "raw user-supplied `?` leaked into policy: {policy}"
+            "raw `?` leaked into policy: {policy}"
         );
         let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
     }

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -22,6 +22,7 @@ use lakekeeper_io::{
     },
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use veil::Redact;
 
 use super::ShortTermCredentialsRequest;
@@ -925,17 +926,22 @@ impl S3Profile {
         Ok(identity)
     }
 
-    fn permission_to_actions(storage_permissions: StoragePermissions) -> &'static str {
+    fn permission_to_actions(storage_permissions: StoragePermissions) -> &'static [&'static str] {
         match storage_permissions {
-            StoragePermissions::Read => "\"s3:GetObject\"",
-            StoragePermissions::ReadWrite => concat!(
-                "\"s3:GetObject\", \"s3:PutObject\", ",
-                "\"s3:AbortMultipartUpload\", \"s3:ListMultipartUploadParts\""
-            ),
-            StoragePermissions::ReadWriteDelete => concat!(
-                "\"s3:GetObject\", \"s3:PutObject\", \"s3:DeleteObject\", ",
-                "\"s3:AbortMultipartUpload\", \"s3:ListMultipartUploadParts\""
-            ),
+            StoragePermissions::Read => &["s3:GetObject"],
+            StoragePermissions::ReadWrite => &[
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts",
+            ],
+            StoragePermissions::ReadWriteDelete => &[
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts",
+            ],
         }
     }
 
@@ -954,62 +960,51 @@ impl S3Profile {
             "arn:aws:s3:::{}",
             table_location.bucket_name().trim_end_matches('/')
         );
-        let key = format!("{}/", table_location.key().join("/"));
+        let key = escape_iam_glob_literal(&format!("{}/", table_location.key().join("/")));
+        let key_wildcard = format!("{key}*");
 
-        let mut statements = format!(
-            r#"
-            {{
+        let actions = Self::permission_to_actions(storage_permissions);
+        let mut statements = vec![
+            json!({
                 "Sid": "TableAccess",
                 "Effect": "Allow",
-                "Action": [
-                    {}
-                ],
+                "Action": actions,
                 "Resource": [
-                    "{bucket_arn}/{key}",
-                    "{bucket_arn}/{key}*"
-                ]
-            }},
-            {{
+                    format!("{bucket_arn}/{key}"),
+                    format!("{bucket_arn}/{key_wildcard}"),
+                ],
+            }),
+            json!({
                 "Sid": "ListBucketForFolder",
                 "Effect": "Allow",
                 "Action": "s3:ListBucket",
-                "Resource": "{bucket_arn}",
-                "Condition": {{
-                    "StringLike": {{
-                        "s3:prefix": "{key}*"
-                    }}
-                }}
-            }}
-        "#,
-            Self::permission_to_actions(storage_permissions),
-        )
-        .replace('\n', "");
+                "Resource": bucket_arn,
+                "Condition": {
+                    "StringLike": {
+                        "s3:prefix": key_wildcard,
+                    },
+                },
+            }),
+        ];
 
         if let Some(kms_key_arn) = self.aws_kms_key_arn.as_ref() {
-            statements = format!(
-                r#"
-                {statements},
-                {{
-                    "Sid": "KmsAccess",
-                    "Effect": "Allow",
-                    "Action": [
-                        "kms:Decrypt",
-                        "kms:GenerateDataKey"
-                    ],
-                    "Resource": "{kms_key_arn}"
-                }}"#
-            );
+            statements.push(json!({
+                "Sid": "KmsAccess",
+                "Effect": "Allow",
+                "Action": ["kms:Decrypt", "kms:GenerateDataKey"],
+                "Resource": kms_key_arn,
+            }));
         }
 
-        Ok(format!(
-            r#"{{
-        "Version": "2012-10-17",
-        "Statement": [
-            {statements}
-        ]
-        }}"#
-        )
-        .replace('\n', ""))
+        let policy = json!({
+            "Version": "2012-10-17",
+            "Statement": statements,
+        });
+
+        serde_json::to_string(&policy).map_err(|e| CredentialsError::ShortTermCredential {
+            source: Some(Box::new(e)),
+            reason: "Failed to serialize STS downscoped policy".to_string(),
+        })
     }
 
     fn validate_session_tags(&self) -> Result<(), ValidationError> {
@@ -1170,6 +1165,22 @@ impl S3Profile {
 
         Ok(())
     }
+}
+
+/// Escape characters that IAM policy strings treat as pattern metacharacters
+/// so the input is matched literally inside `Resource` ARNs and `StringLike`
+/// condition values.
+fn escape_iam_glob_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '*' => out.push_str("${*}"),
+            '?' => out.push_str("${?}"),
+            '$' => out.push_str("${$}"),
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 fn storage_profile_to_s3_settings(profile: &S3Profile) -> S3Settings {
@@ -2030,6 +2041,120 @@ pub(crate) mod test {
                 StoragePermissions::ReadWriteDelete,
             )
             .unwrap();
+        let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
+    }
+
+    #[test]
+    fn escape_iam_glob_literal_escapes_pattern_chars() {
+        assert_eq!(escape_iam_glob_literal("plain/key"), "plain/key");
+        assert_eq!(escape_iam_glob_literal("with*star"), "with${*}star");
+        assert_eq!(escape_iam_glob_literal("with?q"), "with${?}q");
+        assert_eq!(escape_iam_glob_literal("with$dollar"), "with${$}dollar");
+        // Adversarial: literal ${aws:username} must not become a live variable.
+        // After escape the `${` opener is broken into `${$}{`, so IAM sees the
+        // valid `${$}` escape (resolves to `$`) followed by literal `{aws:username}`.
+        assert_eq!(
+            escape_iam_glob_literal("${aws:username}"),
+            "${$}{aws:username}"
+        );
+        // Adversarial: combining all metacharacters.
+        assert_eq!(escape_iam_glob_literal("a*b?c$d"), "a${*}b${?}c${$}d");
+    }
+
+    #[test]
+    fn policy_string_neutralizes_wildcard_in_table_path() {
+        // A table location containing `*` must not turn into an IAM wildcard
+        // in the issued credentials — that would broaden the scope to every
+        // key matching the pattern, not just the one table.
+        let table_location = "s3://bucket-name/wh/evil*/table";
+        let profile = S3Profile::builder()
+            .bucket("bucket-name".to_string())
+            .key_prefix("wh".to_string())
+            .region("us-east-1".to_string())
+            .flavor(S3Flavor::S3Compat)
+            .sts_enabled(true)
+            .build();
+        let policy = profile
+            .get_sts_policy_string(
+                &table_location.parse().unwrap(),
+                StoragePermissions::ReadWriteDelete,
+            )
+            .unwrap();
+        // The user-supplied `*` must be escaped; only the trailing `*` we
+        // append ourselves may remain as a live wildcard.
+        assert!(
+            policy.contains("wh/evil${*}/table"),
+            "expected escaped key in policy, got: {policy}"
+        );
+        assert!(
+            !policy.contains("wh/evil*/table"),
+            "raw user-supplied `*` leaked into policy: {policy}"
+        );
+        // Policy must still be valid JSON.
+        let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
+    }
+
+    #[test]
+    fn policy_string_handles_json_special_chars_in_path() {
+        // url::Url::parse percent-encodes `"` and most JSON-breaking chars in
+        // the path, but `\` survives unchanged. With raw format!() this would
+        // produce invalid JSON or worse. With serde_json the value gets
+        // escaped automatically. This test pins that behavior.
+        let table_location = r"s3://bucket-name/wh/back\slash/table";
+        let profile = S3Profile::builder()
+            .bucket("bucket-name".to_string())
+            .key_prefix("wh".to_string())
+            .region("us-east-1".to_string())
+            .flavor(S3Flavor::S3Compat)
+            .sts_enabled(true)
+            .build();
+        let policy = profile
+            .get_sts_policy_string(
+                &table_location.parse().unwrap(),
+                StoragePermissions::ReadWriteDelete,
+            )
+            .unwrap();
+        // Must round-trip as valid JSON.
+        let parsed: serde_json::Value = serde_json::from_str(&policy).unwrap();
+        // The backslash must appear escaped in the serialized form.
+        assert!(
+            policy.contains(r"back\\slash"),
+            "expected `\\\\` in serialized policy, got: {policy}"
+        );
+        // And the parsed JSON must contain a single literal backslash.
+        let resources = parsed["Statement"][0]["Resource"].as_array().unwrap();
+        assert!(
+            resources
+                .iter()
+                .any(|r| r.as_str().unwrap().contains(r"back\slash")),
+            "expected literal backslash in parsed Resource, got: {resources:?}"
+        );
+    }
+
+    #[test]
+    fn policy_string_neutralizes_question_mark_in_table_path() {
+        let table_location = "s3://bucket-name/wh/ev?l/table";
+        let profile = S3Profile::builder()
+            .bucket("bucket-name".to_string())
+            .key_prefix("wh".to_string())
+            .region("us-east-1".to_string())
+            .flavor(S3Flavor::S3Compat)
+            .sts_enabled(true)
+            .build();
+        let policy = profile
+            .get_sts_policy_string(
+                &table_location.parse().unwrap(),
+                StoragePermissions::ReadWriteDelete,
+            )
+            .unwrap();
+        assert!(
+            policy.contains("wh/ev${?}l/table"),
+            "expected escaped `?` in policy, got: {policy}"
+        );
+        assert!(
+            !policy.contains("wh/ev?l/table"),
+            "raw user-supplied `?` leaked into policy: {policy}"
+        );
         let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
     }
 

--- a/tests/python/tests/test_special_char_locations.py
+++ b/tests/python/tests/test_special_char_locations.py
@@ -1,0 +1,275 @@
+"""End-to-end tests for special characters in table locations.
+
+For each char, create a table at a location containing it (via REST, no
+Spark), then use vended creds via the per-cloud SDK to:
+  - write at the table prefix → must succeed (proves encoding consistency)
+  - write at a sibling path → must 403 (proves scope tightness)
+
+`expect_deny` flips the positive write to "must 403" for cloud-side
+limitations (e.g. MinIO doesn't resolve IAM `${*}` → safe over-restrict).
+This pins the safe failure mode and catches a regression to over-permit.
+"""
+
+import dataclasses
+import uuid
+from typing import Optional
+from urllib.parse import quote, urlparse
+
+import conftest
+import pytest
+import requests
+
+
+@dataclasses.dataclass(frozen=True)
+class SpecialChar:
+    """`url_segment` is the form that goes into the URL path — literal for
+    sub-delims (`*`, `+`, `'`, `$`), percent-encoded otherwise."""
+
+    id: str
+    url_segment: str
+    # (provider, flavor) → reason. Flavor `"*"` matches any.
+    # `expect_deny`: cloud-side limitation, asserts positive deny (safe).
+    expect_deny: dict = dataclasses.field(default_factory=dict)
+    # `expect_create_reject`: Lakekeeper rejects createTable up-front
+    # (e.g. ADLS rejects whitespace-only segments since Azure does).
+    expect_create_reject: dict = dataclasses.field(default_factory=dict)
+
+
+# MinIO does not resolve AWS IAM policy variables, so our `${*}`/`${$}`/`${?}`
+# glob-escape is treated as a literal 4-char string. Deny is the safe outcome.
+_MINIO_NO_IAM_VARS = "MinIO does not resolve IAM policy variables (${*}/${?}/${$})"
+
+# Note: `..` and `.` are removed by RFC 3986 path normalisation in
+# `url::Url`, so they can never round-trip in a URL-based location and are
+# not testable here.
+SPECIAL_CHARS = [
+    SpecialChar("star", "*", expect_deny={("s3", "minio"): _MINIO_NO_IAM_VARS}),
+    SpecialChar("question", "%3F"),
+    SpecialChar("dollar", "$", expect_deny={("s3", "minio"): _MINIO_NO_IAM_VARS}),
+    SpecialChar("squote", "'"),
+    SpecialChar("plus", "+"),
+    SpecialChar("dquote", "%22"),
+    SpecialChar(
+        "space",
+        "%20",
+        expect_create_reject={
+            ("adls", "*"): "Azure ADLS rejects whitespace-only path segments"
+        },
+    ),
+]
+
+
+def _lookup(table: dict, provider: str, flavor: Optional[str]) -> Optional[str]:
+    return table.get((provider, flavor or "")) or table.get((provider, "*"))
+
+# Minimal Iceberg schema used for every funky-location table.
+SCHEMA = {
+    "type": "struct",
+    "schema-id": 0,
+    "fields": [{"id": 1, "name": "v", "type": "int", "required": False}],
+}
+
+
+def _provider(storage_config: dict) -> str:
+    t = storage_config["storage-profile"]["type"]
+    return "s3" if t in ("s3", "aws") else t
+
+
+def _vending_enabled(storage_config: dict) -> bool:
+    profile = storage_config["storage-profile"]
+    if profile["type"] in ("s3", "aws"):
+        return bool(profile.get("sts-enabled"))
+    return True  # ADLS and GCS always vend
+
+
+def _wh_url(warehouse: conftest.Warehouse) -> str:
+    return (
+        warehouse.server.catalog_url.rstrip("/") + f"/v1/{warehouse.warehouse_id}"
+    )
+
+
+def _auth(warehouse: conftest.Warehouse) -> dict:
+    return {"Authorization": f"Bearer {warehouse.access_token}"}
+
+
+def _create_namespace(warehouse: conftest.Warehouse, namespace: str) -> None:
+    r = requests.post(
+        f"{_wh_url(warehouse)}/namespaces",
+        headers=_auth(warehouse),
+        json={"namespace": [namespace], "properties": {}},
+    )
+    r.raise_for_status()
+
+
+def _load_namespace_location(
+    warehouse: conftest.Warehouse, namespace: str
+) -> str:
+    r = requests.get(
+        f"{_wh_url(warehouse)}/namespaces/{quote(namespace, safe='')}",
+        headers=_auth(warehouse),
+    )
+    r.raise_for_status()
+    return r.json()["properties"]["location"].rstrip("/")
+
+
+def _create_table(
+    warehouse: conftest.Warehouse,
+    namespace: str,
+    table: str,
+    location: str,
+) -> dict:
+    r = requests.post(
+        f"{_wh_url(warehouse)}/namespaces/{quote(namespace, safe='')}/tables",
+        headers=_auth(warehouse),
+        json={"name": table, "location": location, "schema": SCHEMA},
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _load_table_with_creds(
+    warehouse: conftest.Warehouse, namespace: str, table: str
+) -> dict:
+    """REST `loadTable` with vended-credentials header. Returns the parsed
+    response (`metadata`, `config`, …)."""
+    r = requests.get(
+        f"{_wh_url(warehouse)}/namespaces/{quote(namespace, safe='')}/tables/{quote(table, safe='')}",
+        headers={
+            **_auth(warehouse),
+            "X-Iceberg-Access-Delegation": "vended-credentials",
+        },
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _try_write(provider: str, config: dict, target_url: str) -> Optional[str]:
+    """Attempt a small object PUT at `target_url` using vended creds.
+    Returns None on SUCCESS, or a short description of the failure."""
+    if provider == "s3":
+        import boto3
+        import botocore.exceptions
+
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=config.get("s3.access-key-id"),
+            aws_secret_access_key=config.get("s3.secret-access-key"),
+            aws_session_token=config.get("s3.session-token"),
+            endpoint_url=config.get("s3.endpoint") or None,
+            region_name=config.get("s3.region") or None,
+        )
+        try:
+            s3.put_object(Bucket=bucket, Key=key, Body=b"canary")
+        except botocore.exceptions.ClientError as e:
+            return f"s3 ClientError: {e.response.get('Error', {}).get('Code', '?')}"
+        return None
+    if provider == "adls":
+        sas_key = next((k for k in config if k.startswith("adls.sas-token.")), None)
+        assert sas_key, f"no adls.sas-token.* in config: {list(config)}"
+        sas = config[sas_key].lstrip("?")
+        parsed = urlparse(target_url)
+        fs = parsed.username
+        # Vended SAS is a Blob Service SAS — use the blob endpoint (single
+        # PUT) rather than DFS (which would need 3-step create/append/flush).
+        host = (parsed.hostname or "").replace(".dfs.", ".blob.")
+        path = parsed.path
+        https_url = f"https://{host}/{fs}{path}?{sas}"
+        r = requests.put(
+            https_url, headers={"x-ms-blob-type": "BlockBlob"}, data=b"canary"
+        )
+        if 200 <= r.status_code < 300:
+            return None
+        return f"adls HTTP {r.status_code}: {r.text[:200]}"
+    if provider == "gcs":
+        token = config.get("gcs.oauth2.token")
+        assert token, f"no gcs.oauth2.token in config: {list(config)}"
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        https_url = f"https://storage.googleapis.com/{bucket}/{quote(key, safe='/')}"
+        r = requests.put(
+            https_url,
+            headers={"Authorization": f"Bearer {token}"},
+            data=b"canary",
+        )
+        if 200 <= r.status_code < 300:
+            return None
+        return f"gcs HTTP {r.status_code}: {r.text[:200]}"
+    raise AssertionError(f"unknown provider: {provider}")
+
+
+@pytest.mark.parametrize("char", SPECIAL_CHARS, ids=lambda c: c.id)
+def test_special_char_in_location(
+    warehouse: conftest.Warehouse, storage_config, char: SpecialChar
+):
+    if not _vending_enabled(storage_config):
+        pytest.skip("requires vended credentials")
+    provider = _provider(storage_config)
+    flavor: Optional[str] = storage_config["storage-profile"].get("flavor")
+    expect_deny = _lookup(char.expect_deny, provider, flavor)
+    expect_create_reject = _lookup(char.expect_create_reject, provider, flavor)
+
+    ns_name = f"sc_{char.id}_{uuid.uuid4().hex[:8]}"
+    table_name = "data"
+    table_dir = f"sc_{char.id}"
+
+    _create_namespace(warehouse, ns_name)
+    ns_location = _load_namespace_location(warehouse, ns_name)
+
+    table_location = f"{ns_location}/{table_dir}/{char.url_segment}/data/"
+    sibling_location = f"{ns_location}/{table_dir}_evil/canary"
+
+    if expect_create_reject:
+        with pytest.raises(requests.HTTPError) as excinfo:
+            _create_table(warehouse, ns_name, table_name, table_location)
+        assert excinfo.value.response.status_code == 400, (
+            f"expected 400 from createTable for {char.id} on {provider}/{flavor} "
+            f"({expect_create_reject}); got {excinfo.value.response.status_code}"
+        )
+        return
+
+    _create_table(warehouse, ns_name, table_name, table_location)
+
+    loaded = _load_table_with_creds(warehouse, ns_name, table_name)
+    config = loaded.get("config", {})
+    stored_location = loaded["metadata"]["location"].rstrip("/")
+    if char.url_segment not in stored_location:
+        pytest.skip(
+            f"Lakekeeper normalised `{char.url_segment}` out of the location "
+            f"(requested {table_location.rstrip('/')}, stored {stored_location})"
+        )
+
+    # Positive: write at the table prefix.
+    target = f"{stored_location}/canary.txt"
+    err = _try_write(provider, config, target)
+    if expect_deny:
+        # Cloud-side limitation (not a Lakekeeper bug). Pin the *safe*
+        # outcome: must deny, not allow. A regression to over-permit would
+        # be a security issue.
+        assert err is not None, (
+            f"expected deny (cloud-side limitation: {expect_deny}) but write "
+            f"to {target} SUCCEEDED — credential scope is over-permissive on "
+            f"{provider}/{flavor} for char {char.id}"
+        )
+        return  # No point testing the negative — creds are already too tight.
+
+    assert err is None, (
+        f"vended credentials failed to write at the table prefix\n"
+        f"  char         = {char.id}\n"
+        f"  table_loc    = {table_location}\n"
+        f"  stored_loc   = {stored_location}\n"
+        f"  target       = {target}\n"
+        f"  config_keys  = {sorted(config)}\n"
+        f"  error        = {err}"
+    )
+
+    # Negative: vended creds for the table must NOT allow a sibling write.
+    err = _try_write(provider, config, sibling_location)
+    assert err is not None, (
+        f"vended credentials for {table_location} unexpectedly allowed write "
+        f"to {sibling_location} (provider={provider}, char={char.id}). "
+        f"Credential scope is too broad."
+    )

--- a/tests/python/tests/test_special_char_locations.py
+++ b/tests/python/tests/test_special_char_locations.py
@@ -62,6 +62,10 @@ SPECIAL_CHARS = [
 def _lookup(table: dict, provider: str, flavor: Optional[str]) -> Optional[str]:
     return table.get((provider, flavor or "")) or table.get((provider, "*"))
 
+# Per-request timeout (seconds). Prevents CI hangs on a stalled cloud
+# endpoint or slow Lakekeeper. Generous enough for cold cloud calls.
+HTTP_TIMEOUT = 30
+
 # Minimal Iceberg schema used for every funky-location table.
 SCHEMA = {
     "type": "struct",
@@ -97,6 +101,7 @@ def _create_namespace(warehouse: conftest.Warehouse, namespace: str) -> None:
         f"{_wh_url(warehouse)}/namespaces",
         headers=_auth(warehouse),
         json={"namespace": [namespace], "properties": {}},
+        timeout=HTTP_TIMEOUT,
     )
     r.raise_for_status()
 
@@ -107,6 +112,7 @@ def _load_namespace_location(
     r = requests.get(
         f"{_wh_url(warehouse)}/namespaces/{quote(namespace, safe='')}",
         headers=_auth(warehouse),
+        timeout=HTTP_TIMEOUT,
     )
     r.raise_for_status()
     return r.json()["properties"]["location"].rstrip("/")
@@ -122,6 +128,7 @@ def _create_table(
         f"{_wh_url(warehouse)}/namespaces/{quote(namespace, safe='')}/tables",
         headers=_auth(warehouse),
         json={"name": table, "location": location, "schema": SCHEMA},
+        timeout=HTTP_TIMEOUT,
     )
     r.raise_for_status()
     return r.json()
@@ -138,6 +145,7 @@ def _load_table_with_creds(
             **_auth(warehouse),
             "X-Iceberg-Access-Delegation": "vended-credentials",
         },
+        timeout=HTTP_TIMEOUT,
     )
     r.raise_for_status()
     return r.json()
@@ -178,7 +186,10 @@ def _try_write(provider: str, config: dict, target_url: str) -> Optional[str]:
         path = parsed.path
         https_url = f"https://{host}/{fs}{path}?{sas}"
         r = requests.put(
-            https_url, headers={"x-ms-blob-type": "BlockBlob"}, data=b"canary"
+            https_url,
+            headers={"x-ms-blob-type": "BlockBlob"},
+            data=b"canary",
+            timeout=HTTP_TIMEOUT,
         )
         if 200 <= r.status_code < 300:
             return None
@@ -194,6 +205,7 @@ def _try_write(provider: str, config: dict, target_url: str) -> Optional[str]:
             https_url,
             headers={"Authorization": f"Bearer {token}"},
             data=b"canary",
+            timeout=HTTP_TIMEOUT,
         )
         if 200 <= r.status_code < 300:
             return None

--- a/tests/python/tox.ini
+++ b/tests/python/tox.ini
@@ -51,7 +51,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_minio_s3a]
 description = spark_minio_s3a
@@ -91,7 +91,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_minio_sts_separate_endpoint]
 description = spark_minio_sts with separate sts-endpoint via nginx proxy (S3 and STS on different ports)
@@ -105,7 +105,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_adls]
 description = spark_adls
@@ -116,7 +116,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_openfga]
 description = spark_openfga
@@ -129,7 +129,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_kv2]
 description = spark_kv2
@@ -142,7 +142,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_gcs]
 description = spark_gcs
@@ -153,7 +153,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_aws_remote_signing]
 description = spark_aws_remote_signing
@@ -166,7 +166,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_aws_sts]
 description = spark_aws_sts
@@ -179,7 +179,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_aws_system_identity_remote_signing]
 description = spark_aws_system_identity_remote_signing
@@ -192,7 +192,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_aws_system_identity_sts]
 description = spark_aws_system_identity_sts
@@ -205,7 +205,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 
 [testenv:trino]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,6 +19,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 
 SUITE="$1"
+if [ -z "$SUITE" ]; then
+    echo "usage: bash run.sh <tox-env>[-<iceberg-version>] [extra pytest args...]" >&2
+    echo "  e.g.  bash run.sh spark_minio_sts-1.10.1" >&2
+    exit 2
+fi
 TOX_NAME="${SUITE%%-*}"
 SPARK_VERSION="${SUITE#*-}"
 # No version suffix → SPARK_VERSION equals TOX_NAME; normalise to empty.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -8,19 +8,23 @@
 # CONTAINER mode (LAKEKEEPER_IN_CONTAINER=1): runs tox directly.
 #
 # Usage (host):
-#   cd tests && bash run.sh <tox-env>[-<iceberg-version>]
+#   cd tests && bash run.sh <tox-env>[-<iceberg-version>] [extra pytest args...]
 #   e.g.  bash run.sh spark_minio_sts-1.10.1
 #         bash run.sh pyiceberg
 #         bash run.sh trino_opa
+#         bash run.sh spark_minio_sts-1.10.1 -k test_special_char_in_location
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 
-TOX_NAME="${1%%-*}"
-SPARK_VERSION="${1#*-}"
+SUITE="$1"
+TOX_NAME="${SUITE%%-*}"
+SPARK_VERSION="${SUITE#*-}"
 # No version suffix → SPARK_VERSION equals TOX_NAME; normalise to empty.
 [ "$SPARK_VERSION" = "$TOX_NAME" ] && SPARK_VERSION=""
+shift
+PYTEST_ARGS=("$@")
 
 # ── Container-side execution ──────────────────────────────────────────────────
 if [ "${LAKEKEEPER_IN_CONTAINER:-0}" = "1" ]; then
@@ -30,7 +34,7 @@ if [ "${LAKEKEEPER_IN_CONTAINER:-0}" = "1" ]; then
     fi
     echo "Running tests: $TOX_NAME  iceberg version: ${LAKEKEEPER_TEST__SPARK_ICEBERG_VERSION:-default}"
     cd "${SCRIPT_DIR}/python"
-    exec tox -qe "${TOX_NAME}"
+    exec tox -qe "${TOX_NAME}" -- "${PYTEST_ARGS[@]}"
 fi
 
 # ── Host-side execution ───────────────────────────────────────────────────────
@@ -43,23 +47,23 @@ echo "Iceberg version   : ${SPARK_VERSION:-default}" >&2
 # Build the docker compose -f arguments, mirroring overlay rules from CI.
 # The order of the elif chain matters: 'openfga' must be checked before 'opa'.
 COMPOSE_ARGS=("-f" "${SCRIPT_DIR}/docker-compose.yaml")
-if [[ "$1" == *"openfga"* ]]; then
+if [[ "$SUITE" == *"openfga"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-openfga-overlay.yaml")
-    elif [[ "$1" == *"kv2"* ]]; then
+    elif [[ "$SUITE" == *"kv2"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-vault-overlay.yaml")
-    elif [[ "$1" == *"opa"* ]]; then
+    elif [[ "$SUITE" == *"opa"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-openfga-overlay.yaml")
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-trino-opa-overlay.yaml")
-    elif [[ "$1" == *"starrocks"* ]]; then
+    elif [[ "$SUITE" == *"starrocks"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-starrocks-overlay.yaml")
-    elif [[ "$1" == *"aws_system_identity"* ]]; then
+    elif [[ "$SUITE" == *"aws_system_identity"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-s3-system-identity-overlay.yaml")
-    elif [[ "$1" == *"legacy_md5"* ]]; then
+    elif [[ "$SUITE" == *"legacy_md5"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-legacy-md5-overlay.yaml")
-    elif [[ "$1" == *"separate_endpoint"* ]]; then
+    elif [[ "$SUITE" == *"separate_endpoint"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-sts-endpoint-overlay.yaml")
 fi
 
 exec docker compose "${COMPOSE_ARGS[@]}" run --quiet-pull spark \
 /opt/entrypoint.sh bash -c \
-'cd /opt/tests && LAKEKEEPER_IN_CONTAINER=1 bash run.sh "$1"' -- "$1"
+'cd /opt/tests && LAKEKEEPER_IN_CONTAINER=1 bash run.sh "$@"' -- "$SUITE" "${PYTEST_ARGS[@]}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter ADLS path validation: rejects problematic decoded segments (e.g., "."/"..", whitespace-only), rejects URLs with fragments/queries with clearer guidance, and ensures correct decoding for SAS generation.

* **Refactor**
  * Safer GCS credential scoping with escaped policy boundaries.
  * S3 policy generation rebuilt to JSON with improved escaping.

* **Tests**
  * New unit, integration, and end-to-end tests for special/URL-encoded path handling across providers; minor test message update.

* **Chores**
  * Test runner updated to include new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->