### PR TITLE
feat(io): expose object size on FileInfo

### DIFF
--- a/crates/io/src/adls/adls_storage.rs
+++ b/crates/io/src/adls/adls_storage.rs
@@ -466,10 +466,12 @@ fn try_parse_file_info(base_location: &Location) -> impl FnMut(&Path) -> Option<
         let location = Location::from_str(&full_path).ok()?;
         let last_modified = path.last_modified;
         let last_modified = DateTime::from_timestamp(last_modified.unix_timestamp(), 0);
-        Some(FileInfo {
-            last_modified,
-            location,
-        })
+        let size = if path.is_directory {
+            None
+        } else {
+            crate::list_size_to_u64(path.content_length, &full_path)
+        };
+        Some(FileInfo::new(last_modified, location, size))
     }
 }
 

--- a/crates/io/src/gcs/gcs_storage.rs
+++ b/crates/io/src/gcs/gcs_storage.rs
@@ -454,15 +454,13 @@ fn try_parse_file_info(bucket_name: &str) -> impl FnMut(Object) -> Result<FileIn
             IOError::new(
                 ErrorKind::Unexpected,
                 format!("Failed to parse GCS object path returned from list: {e}"),
-                gcs_path,
+                gcs_path.clone(),
             )
         })?;
         let last_modified = object
             .updated
             .and_then(|timestamp| DateTime::from_timestamp(timestamp.unix_timestamp(), 0));
-        Ok(FileInfo {
-            last_modified,
-            location,
-        })
+        let size = crate::list_size_to_u64(object.size, &gcs_path);
+        Ok(FileInfo::new(last_modified, location, size))
     }
 }

--- a/crates/io/src/lib.rs
+++ b/crates/io/src/lib.rs
@@ -84,6 +84,30 @@ pub(crate) fn validate_file_size(size: i64, location: impl Into<String>) -> Resu
     }
 }
 
+#[cfg(any(
+    feature = "storage-adls",
+    feature = "storage-gcs",
+    feature = "storage-s3"
+))]
+/// Converts a backend-reported file size from `i64` to `u64` for use in
+/// [`FileInfo::size`]. Negative sizes are unexpected — they indicate a
+/// protocol or parser bug in the backend SDK — so we emit a warning and
+/// return `None` rather than failing the whole list page over a single
+/// malformed entry.
+pub(crate) fn list_size_to_u64(raw: i64, location: &str) -> Option<u64> {
+    u64::try_from(raw)
+        .inspect_err(|e| {
+            tracing::warn!(
+                size = raw,
+                location,
+                error = %e,
+                "Storage backend reported invalid object size during list; \
+                 size will be omitted from FileInfo"
+            );
+        })
+        .ok()
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, strum_macros::Display)]
 pub enum OperationType {
     Delete,
@@ -156,14 +180,20 @@ where
 pub struct FileInfo {
     last_modified: Option<DateTime<Utc>>,
     location: Location,
+    size: Option<u64>,
 }
 
 impl FileInfo {
     #[must_use]
-    pub fn new(last_modified: Option<DateTime<Utc>>, location: Location) -> Self {
+    pub fn new(
+        last_modified: Option<DateTime<Utc>>,
+        location: Location,
+        size: Option<u64>,
+    ) -> Self {
         Self {
             last_modified,
             location,
+            size,
         }
     }
 
@@ -175,6 +205,14 @@ impl FileInfo {
     #[must_use]
     pub fn location(&self) -> &Location {
         &self.location
+    }
+
+    /// Object size in bytes. `None` if the storage backend did not surface
+    /// a size for this entry (e.g. backends that omit the field, or
+    /// directory-style entries without a content length).
+    #[must_use]
+    pub fn size(&self) -> Option<u64> {
+        self.size
     }
 }
 

--- a/crates/io/src/memory.rs
+++ b/crates/io/src/memory.rs
@@ -208,26 +208,23 @@ impl LakekeeperStorage for MemoryStorage {
         };
 
         let data = self.data.read().await;
-        let mut matching_files: Vec<(String, DateTime<Utc>)> = data
+        let mut matching_files: Vec<(String, DateTime<Utc>, u64)> = data
             .iter()
             .filter(|(key, _)| key.starts_with(&prefix))
-            .map(|(key, (_, last_modified))| (key.clone(), *last_modified))
+            .map(|(key, (bytes, last_modified))| (key.clone(), *last_modified, bytes.len() as u64))
             .collect();
 
         // Sort for consistent ordering
-        matching_files.sort();
+        matching_files.sort_by(|a, b| a.0.cmp(&b.0));
 
         let page_size = page_size.unwrap_or(1000);
 
         let mut all_file_infos = Vec::new();
-        for (key, last_modified) in matching_files {
+        for (key, last_modified, size) in matching_files {
             let location_str = format!("{MEMORY_PREFIX}{key}");
             match location_str.parse::<Location>() {
                 Ok(location) => {
-                    let file_info = FileInfo {
-                        last_modified: Some(last_modified),
-                        location,
-                    };
+                    let file_info = FileInfo::new(Some(last_modified), location, Some(size));
                     all_file_infos.push(file_info);
                 }
                 Err(e) => {

--- a/crates/io/src/s3/s3_storage.rs
+++ b/crates/io/src/s3/s3_storage.rs
@@ -440,10 +440,10 @@ fn try_parse_file_info(
         let scheme = base_location.scheme();
         let full_path = format!("{scheme}://{s3_bucket}/{key}");
         let location = Location::from_str(&full_path).ok()?;
-        Some(FileInfo {
-            last_modified,
-            location,
-        })
+        let size = object
+            .size()
+            .and_then(|s| crate::list_size_to_u64(s, &full_path));
+        Some(FileInfo::new(last_modified, location, size))
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File size information is now included in results from listing operations across all supported storage backends (ADLS, GCS, S3, and in-memory storage). Users can access object sizes when querying storage items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->