### PR TITLE
feat(io): canonicalise Location at parse time to avoid aliases

### DIFF
--- a/crates/io/src/adls/adls_location.rs
+++ b/crates/io/src/adls/adls_location.rs
@@ -144,6 +144,15 @@ impl AdlsLocation {
         self.location.scheme()
     }
 
+    /// Egress encoder: the path string fed to the Azure SDK when
+    /// constructing request URLs.
+    ///
+    /// Returns the canonical path component, with literal `?` re-encoded
+    /// to `%3F`. The Azure SDK's URL construction uses `Url::join` which
+    /// truncates at the first `?` (treats it as the query separator);
+    /// our canonical Location keeps `%3F` encoded already, but defensive
+    /// re-encoding here ensures any future change that allows literal
+    /// `?` in the path still produces a safe SDK request URL.
     #[must_use]
     pub fn blob_name(&self) -> String {
         self.location

--- a/crates/io/src/adls/adls_location.rs
+++ b/crates/io/src/adls/adls_location.rs
@@ -46,16 +46,27 @@ pub struct AdlsLocation {
 }
 
 impl AdlsLocation {
-    /// Create a new [`AdlsLocation`] from the given parameters.
+    /// Create a new [`AdlsLocation`] from already-canonical parts.
+    ///
+    /// `key` segments are URL-encoded canonical form (as produced by
+    /// [`Location::path_segments`]); they are passed straight through
+    /// [`Location::extend`] which re-canonicalises but does not change
+    /// the structural meaning.
+    ///
+    /// This constructor is `pub(crate)` because callers should go
+    /// through [`Self::try_from_location`] / [`Self::try_from_str`],
+    /// which run the ADLS-specific structural and Azure-aliasing checks
+    /// against the parsed `Location`.
     ///
     /// # Errors
-    /// Fails if validation of account name, filesystem name or key fails.
-    pub fn new(
+    /// Fails if account name, filesystem name, host, scheme, or any
+    /// segment violates URL canonicalisation.
+    pub(crate) fn new(
         account_name: String,
         filesystem: String,
         host: String,
-        key: &[&str], // Not URL Encoded
-        // Optional custom prefix for the scheme, e.g., "abfss"
+        key: &[&str],
+        // Optional custom prefix for the scheme, e.g., "wasbs"
         scheme: Option<String>,
     ) -> Result<Self, InvalidLocationError> {
         let scheme = scheme.unwrap_or("abfss".to_string());
@@ -76,38 +87,6 @@ impl AdlsLocation {
         validate_account_name(&account_name)
             .map_err(|e| InvalidLocationError::new(location_dbg.clone(), e.to_string()))?;
 
-        for path_segment in key {
-            if path_segment.contains('/') {
-                return Err(InvalidLocationError::new(
-                    location_dbg.clone(),
-                    format!("ADLS path segment `{path_segment}` must not contain slashes."),
-                ));
-            }
-            // Reject segments whose decoded form would create silent
-            // path-divergence bugs. Our `Location` stores the raw URL input,
-            // but `url::Url::parse` (used by the SDK during request-URL
-            // construction) normalises encoded dot-segments and may decode
-            // `%2F`. The result is a Lakekeeper-side path that disagrees with
-            // what Azure actually receives. Reject up-front rather than let
-            // it surface as InvalidUri / silent 403 / wrong-path writes.
-            //   - `%20` (and other whitespace) → Azure rejects InvalidUri
-            //   - `%2E` / `%2E%2E` → `url::Url` strips, path silently shrinks
-            //   - `%2F` (or any encoded slash) → ambiguous nesting
-            let decoded = percent_decode_str(path_segment).decode_utf8_lossy();
-            let invalid = decoded.contains('/')
-                || decoded == "."
-                || decoded == ".."
-                || (!decoded.is_empty() && decoded.trim().is_empty());
-            if invalid {
-                return Err(InvalidLocationError::new(
-                    location_dbg.clone(),
-                    format!(
-                        "ADLS path segment `{path_segment}` decodes to a value that is normalised or rejected by URL/Azure handling."
-                    ),
-                ));
-            }
-        }
-
         let endpoint_suffix = normalize_host(host)
             .map_err(|e| InvalidLocationError::new(location_dbg.clone(), e.to_string()))?
             .unwrap_or(DEFAULT_HOST.to_string());
@@ -121,7 +100,15 @@ impl AdlsLocation {
         })?;
 
         if !key.is_empty() {
-            location.without_trailing_slash().extend(key.iter());
+            location
+                .without_trailing_slash()
+                .extend(key.iter())
+                .map_err(|e| {
+                    InvalidLocationError::new(
+                        e.value,
+                        format!("Failed to extend location with key segments - {}", e.reason),
+                    )
+                })?;
         }
 
         Ok(Self {
@@ -197,15 +184,7 @@ impl AdlsLocation {
         }
 
         let filesystem = location.username().unwrap_or_default().to_string();
-        let host = location
-            .host_str()
-            .ok_or_else(|| {
-                InvalidLocationError::new(
-                    location.to_string(),
-                    "ADLS location has no host specified".to_string(),
-                )
-            })?
-            .to_string();
+        let host = location.host_str().to_string();
         // Host: account_name.endpoint_suffix
         let (account_name, endpoint_suffix) =
             host.split_once('.')
@@ -213,6 +192,20 @@ impl AdlsLocation {
                     location.to_string(),
                     "ADLS location host must be in the format <account_name>.<endpoint_suffix>. Specified location has no point (.)".to_string(),
                 ))?;
+
+        // Azure-specific: reject path segments that decode to whitespace-only.
+        // Azure Blob/DFS endpoints reject `InvalidUri` for these. The other
+        // path-traversal classes (decoded `/`, `.`, `..`, segment ending in
+        // `.`) are already rejected at `Location::from_str`.
+        for segment in location.path_segments() {
+            let decoded = percent_decode_str(segment).decode_utf8_lossy();
+            if !decoded.is_empty() && decoded.trim().is_empty() {
+                return Err(InvalidLocationError::new(
+                    location.to_string(),
+                    format!("ADLS path segment `{segment}` decodes to whitespace only"),
+                ));
+            }
+        }
 
         let custom_prefix = if is_custom_variant {
             Some(schema.to_string())
@@ -372,19 +365,6 @@ impl std::fmt::Display for AdlsLocation {
     }
 }
 
-// fn urldecode(s: &str) -> String {
-//     url::form_urlencoded::parse(s.as_bytes())
-//         .map(|(k, v)| {
-//             if v.is_empty() {
-//                 k.to_string()
-//             } else {
-//                 format!("{k}={v}")
-//             }
-//         })
-//         .collect::<Vec<_>>()
-//         .join("&")
-// }
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -467,8 +447,12 @@ mod test {
 
     #[test]
     fn test_parse_adls_location() {
+        // (input, expected_canonical_form, account_name, filesystem, endpoint)
+        // Non-ASCII chars and literal spaces canonicalise to percent-encoded
+        // form (RFC 3986 — the only reserved alphabet for URL paths).
         let cases = vec![
             (
+                "abfss://filesystem@account0name.foo.com",
                 "abfss://filesystem@account0name.foo.com",
                 "account0name",
                 "filesystem",
@@ -476,11 +460,13 @@ mod test {
             ),
             (
                 "abfss://filesystem@account0name.dfs.core.windows.net/one",
+                "abfss://filesystem@account0name.dfs.core.windows.net/one",
                 "account0name",
                 "filesystem",
                 "dfs.core.windows.net",
             ),
             (
+                "abfss://filesystem@account0name.foo.com/one",
                 "abfss://filesystem@account0name.foo.com/one",
                 "account0name",
                 "filesystem",
@@ -488,38 +474,45 @@ mod test {
             ),
             (
                 "abfss://filesystem@account0name.foo.com/one/",
+                "abfss://filesystem@account0name.foo.com/one/",
                 "account0name",
                 "filesystem",
                 "foo.com",
             ),
             (
                 "abfss://filesystem@account0name.foo.com/one/ã.txt",
+                "abfss://filesystem@account0name.foo.com/one/%C3%A3.txt",
                 "account0name",
                 "filesystem",
                 "foo.com",
             ),
             (
                 "abfss://filesystem@account0name.foo.com/one/other-file with spaces.txt",
+                "abfss://filesystem@account0name.foo.com/one/other-file%20with%20spaces.txt",
                 "account0name",
                 "filesystem",
                 "foo.com",
             ),
         ];
 
-        for (location_str, account_name, filesystem, endpoint_suffix) in cases {
+        for (input, canonical, account_name, filesystem, endpoint_suffix) in cases {
             let adls_location =
-                AdlsLocation::try_from_location(&Location::from_str(location_str).unwrap(), false)
+                AdlsLocation::try_from_location(&Location::from_str(input).unwrap(), false)
                     .unwrap();
             assert_eq!(adls_location.account_name(), account_name);
             assert_eq!(adls_location.filesystem(), filesystem);
             assert_eq!(adls_location.endpoint_suffix(), endpoint_suffix);
-            // Roundtrip
-            assert_eq!(adls_location.to_string(), location_str);
+            // Roundtrip to canonical form (not necessarily byte-identical to input).
+            assert_eq!(adls_location.to_string(), canonical);
         }
     }
 
     #[test]
     fn test_invalid_adls_location() {
+        // Some inputs are now rejected up-front by `Location::from_str`'s
+        // canonicalisation (e.g. host trailing dot, decoded path-traversal
+        // segments). Others still pass parsing and are rejected by
+        // ADLS-specific validation. Accept either rejection point.
         let cases = vec![
             "abfss://filesystem@account_name",
             "abfss://filesystem@account_name.example.com./foo",
@@ -528,31 +521,45 @@ mod test {
         ];
 
         for location in cases {
-            let location = Location::from_str(location).unwrap();
-            let parsed_location = AdlsLocation::try_from_location(&location, false);
-            assert!(parsed_location.is_err(), "{parsed_location:?}");
+            let parse_then_adls = Location::from_str(location)
+                .map_err(|_| ())
+                .and_then(|l| AdlsLocation::try_from_location(&l, false).map_err(|_| ()));
+            assert!(
+                parse_then_adls.is_err(),
+                "expected reject (parse or ADLS) for `{location}`"
+            );
         }
     }
 
     #[test]
     fn test_rejects_problematic_decoded_segments() {
+        // Most of these are now rejected up-front at `Location::from_str`
+        // by the global canonicalisation rule (Phase 1 of the location
+        // refactor). A few that decode to non-ASCII whitespace still pass
+        // parsing on certain backends; either rejection point is acceptable
+        // — what matters is that they don't reach the cloud SDK.
         for bad in [
-            // whitespace-only — Azure rejects InvalidUri
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/%20/bar",
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/%09/bar",
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/%20%20/bar",
-            // dot-segments — `url::Url` normalises these, path silently shrinks
+            // Non-ASCII whitespace (NBSP, U+00A0) — `str::trim()` covers it,
+            // so the ADLS check correctly rejects despite our segment-level
+            // canonicalisation accepting it.
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%C2%A0/bar",
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/%2E/bar",
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/%2e%2e/bar",
-            // encoded slash — ambiguous nesting once decoded
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/%2F/bar",
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%2Fy/bar",
         ] {
-            let loc = Location::from_str(bad).unwrap();
-            let res = AdlsLocation::try_from_location(&loc, false);
-            assert!(res.is_err(), "expected reject for `{bad}`");
+            let parse_then_adls = Location::from_str(bad)
+                .map_err(|_| ())
+                .and_then(|l| AdlsLocation::try_from_location(&l, false).map_err(|_| ()));
+            assert!(
+                parse_then_adls.is_err(),
+                "expected reject (parse or ADLS) for `{bad}`"
+            );
         }
-        // Non-empty segments that include but do not decode-to one of the
+        // Segments that include — but do not decode-to — one of the
         // forbidden values are fine.
         for ok in [
             "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%20y/bar",
@@ -586,20 +593,4 @@ mod test {
         let result = AdlsLocation::try_from_location(&Location::from_str(location).unwrap(), false);
         assert!(result.is_err(), "Should fail with allow_variants = false");
     }
-
-    // #[test]
-    // fn test_url_decode() {
-    //     let cases = vec![
-    //         ("key=value", "key=value"),
-    //         ("%20with%20spaces", " with spaces"),
-    //         ("key%2Fwith%2Fslashes=value", "key/with/slashes=value"),
-    //         ("foo%3Dbar", "foo=bar"),
-    //         ("/key/%C3%BCbersetzen/comp l3x", "/key/übersetzen/comp l3x"),
-    //     ];
-
-    //     for (input, expected) in cases {
-    //         let decoded = urldecode(input);
-    //         assert_eq!(decoded, expected, "Failed for input: {input}");
-    //     }
-    // }
 }

--- a/crates/io/src/gcs/gcs_location.rs
+++ b/crates/io/src/gcs/gcs_location.rs
@@ -39,7 +39,15 @@ impl GcsLocation {
             )
         })?;
         if !key.is_empty() {
-            location.without_trailing_slash().extend(key.iter());
+            location
+                .without_trailing_slash()
+                .extend(key.iter())
+                .map_err(|e| {
+                    InvalidLocationError::new(
+                        e.value,
+                        format!("Failed to extend location with key segments - {}", e.reason),
+                    )
+                })?;
         }
 
         Ok(GcsLocation { location })
@@ -48,7 +56,7 @@ impl GcsLocation {
     /// Get the bucket name.
     #[must_use]
     pub fn bucket_name(&self) -> &str {
-        (self.location.host_str()).unwrap_or_default()
+        self.location.host_str()
     }
 
     #[must_use]
@@ -80,14 +88,7 @@ impl GcsLocation {
             return Err(InvalidLocationError::new(location.to_string(), reason));
         }
 
-        let bucket_name = location.host_str().ok_or_else(|| {
-            InvalidLocationError::new(
-                location.to_string(),
-                "GCS location does not have a bucket name.".to_string(),
-            )
-        })?;
-
-        GcsLocation::new(bucket_name, &location.path_segments())
+        GcsLocation::new(location.host_str(), &location.path_segments())
     }
 
     /// Create a new GCS location from a string.

--- a/crates/io/src/location.rs
+++ b/crates/io/src/location.rs
@@ -1,5 +1,23 @@
 use std::str::{FromStr, RMatchIndices};
 
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, percent_decode_str, utf8_percent_encode};
+
+/// A canonical URL-string location.
+///
+/// Two `Location`s are equal iff their canonical strings are byte-equal.
+/// `Location::from_str` is the only constructor that produces a canonical
+/// form; `extend`/`push` re-canonicalise after appending.
+///
+/// Canonicalisation rules (RFC 3986-grounded; see
+/// `docs/location-design.md` and `docs/location-refactor-plan.md`):
+/// - Reject NUL, tab, CR, LF, other C0 controls, DEL, bidi/format chars
+///   anywhere in the input.
+/// - Lowercase scheme and host. Reject host trailing dot.
+/// - Per path segment: decode `%XX` for unreserved and sub-delim bytes;
+///   keep `%XX` (uppercase hex) for reserved bytes (`?`, `#`, `[`, `]`,
+///   `%`); percent-encode literal non-ASCII / reserved / space; reject
+///   decoded `/`, `.`, `..`, empty segments, segments ending with `.`,
+///   and decoded controls.
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[allow(clippy::struct_field_names)]
 pub struct Location {
@@ -32,21 +50,18 @@ impl Location {
         &self.scheme
     }
 
+    /// The host (and optional `:port`), with userinfo and path stripped.
+    /// Always non-empty for a canonical Location.
     #[must_use]
-    pub fn host_str(&self) -> Option<&str> {
-        // Everything between @ and the first slash
-        let host_part = if let Some(at_pos) = self.authority_and_path.find('@') {
-            // If there's an @ symbol, take everything after it
-            &self.authority_and_path[at_pos + 1..]
-        } else {
-            // If there's no @ symbol, use the whole location
-            &self.authority_and_path
+    pub fn host_str(&self) -> &str {
+        // Everything after `@` (if present), up to the first `/`.
+        let after_userinfo = match self.authority_and_path.find('@') {
+            Some(at_pos) => &self.authority_and_path[at_pos + 1..],
+            None => &self.authority_and_path,
         };
-
-        // Now find the first slash and return everything before it
-        match host_part.find('/') {
-            Some(slash_pos) => Some(&host_part[..slash_pos]),
-            None => Some(host_part), // No slash found, return the whole host part
+        match after_userinfo.find('/') {
+            Some(slash_pos) => &after_userinfo[..slash_pos],
+            None => after_userinfo,
         }
     }
 
@@ -86,130 +101,179 @@ impl Location {
             .and_then(|(auth, _)| auth.split_once(':').map(|(user, _)| user).or(Some(auth)))
     }
 
+    /// Rebuild `full_location` from `scheme` + `authority_and_path`.
+    /// Every mutator that touches either field must call this to keep the
+    /// canonical invariant intact.
+    fn rebuild_full_location(&mut self) {
+        self.full_location.clear();
+        self.full_location.push_str(&self.scheme);
+        self.full_location.push_str("://");
+        self.full_location.push_str(&self.authority_and_path);
+    }
+
     pub fn with_trailing_slash(&mut self) -> &mut Self {
         if !self.authority_and_path.ends_with('/') {
             self.authority_and_path.push('/');
         }
-        self.full_location = format!("{}://{}", self.scheme, self.authority_and_path);
+        self.rebuild_full_location();
         self
     }
 
     pub fn without_trailing_slash(&mut self) -> &mut Self {
-        self.authority_and_path = self.authority_and_path.trim_end_matches('/').to_string();
-        self.full_location = format!("{}://{}", self.scheme, self.authority_and_path);
+        // Strip exactly one trailing `/` (canonical form has at most one).
+        if let Some(stripped) = self.authority_and_path.strip_suffix('/') {
+            self.authority_and_path.truncate(stripped.len());
+        }
+        self.rebuild_full_location();
         self
     }
 
+    /// Replace the scheme without re-validating. The caller MUST pass a
+    /// canonical scheme (lowercase ASCII, starts with letter). Otherwise
+    /// the resulting `Location` violates the canonical invariant and
+    /// `Location::from_str(self.as_str())` will fail or produce a
+    /// different value.
+    ///
+    /// Intended only for scheme-family normalisation against a known
+    /// allow-list (e.g. `s3a` → `s3`, `wasbs` → `abfss`). Do not use with
+    /// caller-supplied scheme strings.
     pub fn set_scheme_unchecked_mut(&mut self, scheme: &str) -> &mut Self {
+        debug_assert!(
+            !scheme.is_empty()
+                && scheme.bytes().all(|b| b.is_ascii_lowercase()
+                    || b.is_ascii_digit()
+                    || matches!(b, b'+' | b'-' | b'.'))
+                && scheme.as_bytes()[0].is_ascii_lowercase(),
+            "set_scheme_unchecked_mut called with non-canonical scheme `{scheme}` — see doc",
+        );
         self.scheme = scheme.to_string();
-        self.full_location = format!("{}://{}", self.scheme, self.authority_and_path);
+        self.rebuild_full_location();
         self
     }
 
-    pub fn extend<I>(&mut self, segments: I) -> &mut Self
+    /// Append path segments. Each non-empty segment is canonicalised
+    /// (decoded unreserved/sub-delim, percent-encoded reserved/space/
+    /// non-ASCII).
+    ///
+    /// Empty-segment handling:
+    /// - **trailing** empty preserves a trailing `/` on the result —
+    ///   `extend(["foo", ""])` ends in `/foo/`. `extend([""])` alone is
+    ///   equivalent to `with_trailing_slash`.
+    /// - **leading** empty(ies) is/are a no-op — `extend(["", "foo"])`
+    ///   and `extend(["", "", "foo"])` are both the same as
+    ///   `extend(["foo"])`. `extend` always inserts a separator before
+    ///   the first canonical segment, so leading `""`s add nothing.
+    /// - **middle** empty (between two non-empty segments) is rejected
+    ///   — it would create consecutive `/` in the canonical path, which
+    ///   `Location::from_str` also rejects.
+    ///
+    /// # Errors
+    /// Fails if any segment violates canonicalisation rules: contains
+    /// `/`, decodes to `.`/`..`, ends with `.`, contains a control byte
+    /// / smuggling char, or is an empty middle segment.
+    pub fn extend<I>(&mut self, segments: I) -> Result<&mut Self, LocationParseError>
     where
         I: IntoIterator,
         I::Item: AsRef<str>,
     {
-        let extension = segments
-            .into_iter()
-            .map(|s| {
-                if s.as_ref().is_empty() {
-                    "/"
-                } else {
-                    s.as_ref()
-                }
-                .to_string()
-            })
-            .collect::<Vec<_>>()
-            .join("/");
-        // Remove duplicate slashes if any
-        let extension = {
-            let mut result = String::with_capacity(extension.len());
-            let mut prev_slash = false;
-            for ch in extension.chars() {
-                if ch == '/' {
-                    if !prev_slash {
-                        result.push(ch);
-                    }
-                    prev_slash = true;
-                } else {
-                    result.push(ch);
-                    prev_slash = false;
-                }
-            }
-            result
-        };
+        // Materialise so we can index for the trailing-slash sentinel and
+        // for distinguishing leading / middle / trailing empties.
+        // `Vec<I::Item>` doesn't copy string contents — it's just
+        // `Vec<&str>` for `extend(["foo", "bar"])`.
+        let segments: Vec<I::Item> = segments.into_iter().collect();
+        let last_idx = segments.len().saturating_sub(1);
+        let extension_has_trailing_slash = segments.last().is_some_and(|s| s.as_ref().is_empty());
 
-        if !self.authority_and_path.ends_with('/')
-            && !extension.starts_with('/')
-            && !extension.is_empty()
-        {
+        let mut canon_segs: Vec<String> = Vec::with_capacity(segments.len());
+        for (i, item) in segments.iter().enumerate() {
+            let s = item.as_ref();
+            if s.is_empty() {
+                if i == last_idx {
+                    continue; // trailing-slash sentinel
+                }
+                if canon_segs.is_empty() {
+                    continue; // leading empty (no-op)
+                }
+                return Err(LocationParseError {
+                    value: self.full_location.clone(),
+                    reason: format!(
+                        "empty path segment at position {i} would create consecutive `/`"
+                    ),
+                });
+            }
+            check_smuggling_chars(s).map_err(|reason| LocationParseError {
+                value: self.full_location.clone(),
+                reason: format!("invalid extension segment: {reason}"),
+            })?;
+            let canon = canonicalize_segment(s).map_err(|reason| LocationParseError {
+                value: self.full_location.clone(),
+                reason: format!("invalid extension segment: {reason}"),
+            })?;
+            canon_segs.push(canon);
+        }
+
+        if canon_segs.is_empty() {
+            if extension_has_trailing_slash && !self.authority_and_path.ends_with('/') {
+                self.authority_and_path.push('/');
+                self.rebuild_full_location();
+            }
+            return Ok(self);
+        }
+        let extension = canon_segs.join("/");
+        if !self.authority_and_path.ends_with('/') {
             self.authority_and_path.push('/');
         }
         self.authority_and_path.push_str(&extension);
-        self.full_location = format!("{}://{}", self.scheme, self.authority_and_path);
-        self
+        if extension_has_trailing_slash {
+            self.authority_and_path.push('/');
+        }
+        self.rebuild_full_location();
+        Ok(self)
     }
 
-    pub fn push(&mut self, segment: &str) -> &mut Self {
-        self.extend([segment]);
-        self
+    /// Append a single path segment. See [`Location::extend`] for rules.
+    ///
+    /// # Errors
+    /// See [`Location::extend`].
+    pub fn push(&mut self, segment: &str) -> Result<&mut Self, LocationParseError> {
+        self.extend([segment])?;
+        Ok(self)
     }
 
-    #[must_use]
-    pub fn cloning_push(&self, segment: &str) -> Self {
-        let mut cloned = self.clone();
-        cloned.push(segment);
-        cloned
-    }
-
-    // /// Clones the location and pushes a segment to the path.
-    // #[must_use]
-    // pub fn cloning_push(&self, segment: &str) -> Self {
-    //     let mut cloned = self.clone();
-    //     cloned.push(segment);
-    //     cloned
-    // }
-
-    // /// Follows the same logic as `url::MutPathSegments::pop`,
-    // /// except that getting `MutPathSegments`is not fallible.
-    // /// Non-fallibility by the constructor which checks
-    // /// cannot-be-a-base.
-    // pub fn pop(&mut self) -> &mut Self {
-    //     if let Ok(mut path) = self.0.path_segments_mut() {
-    //         path.pop();
-    //     }
-    //     self
-    // }
-
-    // Check if the location is a sublocation of the other location.
-    // If the locations are the same, it is considered a sublocation.
+    /// True if `self` is the same as or nested inside `other`.
+    ///
+    /// Operates on canonical strings: `self.as_str()` must start with
+    /// `other.as_str()` plus a `/` boundary (or be byte-equal). No
+    /// allocations.
     #[must_use]
     pub fn is_sublocation_of(&self, other: &Location) -> bool {
-        if self == other {
+        let mine = self.as_str();
+        let theirs = other.as_str();
+        if mine == theirs {
             return true;
         }
-
-        let mut other_folder = other.clone();
-        other_folder.with_trailing_slash();
-
-        self.to_string().starts_with(other_folder.as_str())
+        // `theirs` already ends with `/`: pure prefix check.
+        if let Some(stripped) = theirs.strip_suffix('/') {
+            if mine.len() > stripped.len() && mine.as_bytes()[stripped.len()] == b'/' {
+                return mine.starts_with(stripped);
+            }
+            return false;
+        }
+        // `theirs` has no trailing slash: `mine` must start with `theirs/`.
+        mine.len() > theirs.len()
+            && mine.as_bytes()[theirs.len()] == b'/'
+            && mine.starts_with(theirs)
     }
 
-    #[must_use]
-    pub fn partial_locations<'a>(&'a self) -> impl IntoIterator<Item = &'a str> {
+    pub fn partial_locations(&self) -> impl Iterator<Item = &str> {
         let scheme_index = self.scheme().len() + 3; // 3 for "://"
         let url_string = self.full_location.trim_end_matches('/');
-        let pointer = url_string.rmatch_indices('/');
-
-        let iter: PartialLocationsIter<'a> = PartialLocationsIter {
-            pointer,
+        PartialLocationsIter {
+            pointer: url_string.rmatch_indices('/'),
             loc: url_string,
             full_loc: Some(url_string),
             scheme_index,
-        };
-        iter
+        }
     }
 
     #[must_use]
@@ -233,7 +297,7 @@ impl Location {
         if let Some(last_slash) = self.authority_and_path.trim_end_matches('/').rfind('/') {
             self.authority_and_path.truncate(last_slash + 1); // Keep the trailing slash
         }
-        self.full_location = format!("{}://{}", self.scheme, self.authority_and_path);
+        self.rebuild_full_location();
         self
     }
 }
@@ -272,47 +336,55 @@ impl FromStr for Location {
     type Err = LocationParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let location = url::Url::parse(value).map_err(|e| LocationParseError {
+        // Reject smuggling chars upfront. Verified empirically that
+        // `url::Url::parse` silently strips `\t`/`\n`/`\r` from paths,
+        // which would let unsigned bytes reach downstream consumers.
+        check_smuggling_chars(value).map_err(|reason| LocationParseError {
+            value: value.to_string(),
+            reason,
+        })?;
+
+        let url = url::Url::parse(value).map_err(|e| LocationParseError {
             value: value.to_string(),
             reason: format!("Not a valid URL - `{e}`"),
         })?;
 
-        if location.cannot_be_a_base() {
+        if url.cannot_be_a_base() {
             return Err(LocationParseError {
                 value: value.to_string(),
                 reason: "Malformed URL (Cannot be a base). Adding a relative path to this URL results in a malformed URL.".to_string(),
             });
         }
 
-        if location.fragment().is_some() {
+        if url.fragment().is_some() {
             return Err(LocationParseError {
                 value: value.to_string(),
                 reason: "URL has a fragment (#) — encode `#` in object names as %23".to_string(),
             });
         }
 
-        if location.query().is_some() {
+        if url.query().is_some() {
             return Err(LocationParseError {
                 value: value.to_string(),
                 reason: "URL has a query (?) — encode `?` in object names as %3F".to_string(),
             });
         }
 
-        let (scheme, location) = {
-            let s = value.split("://").collect::<Vec<_>>();
-            if s.len() != 2 {
-                return Err(LocationParseError {
+        // `url.scheme()` is already lowercased by the parser.
+        let scheme = url.scheme().to_string();
+        let authority_and_path =
+            canonicalize_url_to_authority_and_path(value, &url).map_err(|reason| {
+                LocationParseError {
                     value: value.to_string(),
-                    reason: "Expected exactly one :// in the Location".to_string(),
-                });
-            }
-            (s[0].to_string(), s[1].to_string())
-        };
+                    reason,
+                }
+            })?;
 
+        let full_location = format!("{scheme}://{authority_and_path}");
         Ok(Location {
-            full_location: value.to_string(),
+            full_location,
             scheme,
-            authority_and_path: location,
+            authority_and_path,
         })
     }
 }
@@ -323,6 +395,222 @@ impl AsRef<str> for Location {
     }
 }
 
+// --- Canonicalisation helpers --------------------------------------------
+//
+// Built on top of two pre-existing crates:
+//   - `url` (WHATWG): used as a syntax validator + extracts authority parts
+//     (userinfo, host, port). For non-special schemes (s3/abfss/gs/etc.) it
+//     does NOT collapse `..`/`.`, so we can trust its path view too.
+//   - `percent-encoding`: per-segment decode-and-re-encode. The custom
+//     `CANONICAL_PATH_ENCODE_SET` declares "encode everything except
+//     unreserved + sub-delims" — `utf8_percent_encode` then emits uppercase
+//     hex for the kept-encoded bytes, collapsing `%2d`/`%2D`/`-` to `-` and
+//     `%3f`/`%3F` to `%3F`.
+//
+// Layered on top: smuggling-char rejection (because `url::Url` silently
+// strips `\t`/`\n`/`\r`), path-traversal rejection (because we want to
+// REJECT `.`/`..`, not normalize them away), Azure-blob trailing-dot
+// rejection, and consecutive-slash rejection.
+
+/// `AsciiSet` for `utf8_percent_encode` to produce canonical path segments.
+///
+/// Encodes everything except RFC 3986 §3.3 `pchar`:
+///
+/// ```text
+/// pchar      = unreserved / sub-delims / ":" / "@"        §3.3
+/// unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"      §2.3
+/// sub-delims = "!" / "$" / "&" / "'" / "(" / ")"
+///            / "*" / "+" / "," / ";" / "="                §2.2
+/// ```
+///
+/// `NON_ALPHANUMERIC` already encodes everything except alphanumerics,
+/// so we just `remove()` the non-alphanum bytes that pchar keeps literal.
+const CANONICAL_PATH_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    // unreserved (non-alphanumeric part)
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~')
+    // sub-delims
+    .remove(b'!')
+    .remove(b'$')
+    .remove(b'&')
+    .remove(b'\'')
+    .remove(b'(')
+    .remove(b')')
+    .remove(b'*')
+    .remove(b'+')
+    .remove(b',')
+    .remove(b';')
+    .remove(b'=')
+    // pchar extras (gen-delims allowed in a path segment)
+    .remove(b':')
+    .remove(b'@');
+
+/// Reject Unicode control characters (general category `Cc` — C0 controls,
+/// DEL, C1 controls) in the input string. Closes the WHATWG-vs-RFC parser-
+/// discrepancy gap: `url::Url::parse` silently strips `\t`/`\n`/`\r`
+/// (verified empirically), so we must reject before the parser sees them.
+///
+/// Bidi/format chars (`Cf` general category, e.g. `U+200B` ZWSP, `U+202E`
+/// RLO) are intentionally NOT rejected here — they're percent-encoded by
+/// canonicalisation (`<RLO>` → `%E2%80%AE`), so they don't introduce
+/// aliasing. Visual-spoofing defence belongs to the display layer.
+fn check_smuggling_chars(s: &str) -> Result<(), String> {
+    for (idx, c) in s.char_indices() {
+        if c.is_control() {
+            return Err(format!(
+                "control character (U+{:04X}) at byte {idx} in input",
+                c as u32
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Canonicalise a single URL path segment.
+///
+/// Algorithm: percent-decode → security checks on decoded bytes →
+/// re-encode using `CANONICAL_PATH_ENCODE_SET`. Decode-then-re-encode
+/// collapses equivalence classes (`%2D`/`%2d`/`-` all → `-`) and produces
+/// uppercase hex for kept-encoded bytes (`%3f` → `%3F`).
+///
+/// Errors:
+/// - empty segment
+/// - decodes to `.`, `..`, or contains `/` (`%2F` ambiguous nesting)
+/// - decoded byte is a C0 control or DEL
+/// - segment ends in `.` (Azure Blob endpoint aliases `foo.` to `foo`)
+/// - decoded bytes are not valid UTF-8
+fn canonicalize_segment(seg: &str) -> Result<String, String> {
+    if seg.is_empty() {
+        return Err("empty path segment".to_string());
+    }
+    let decoded: Vec<u8> = percent_decode_str(seg).collect();
+    if decoded.iter().any(u8::is_ascii_control) {
+        return Err(format!("decoded ASCII control byte in segment `{seg}`"));
+    }
+    if decoded.contains(&b'/') {
+        return Err(format!("decoded `/` (literal or `%2F`) in segment `{seg}`"));
+    }
+    if decoded.as_slice() == b"." || decoded.as_slice() == b".." {
+        return Err(format!(
+            "path segment decodes to `{}` (path-traversal)",
+            std::str::from_utf8(&decoded).unwrap_or("?")
+        ));
+    }
+    if decoded.last() == Some(&b'.') {
+        // Azure Blob endpoint silently strips trailing dots, S3/GCS preserve.
+        // Reject globally to avoid backend-specific aliasing surprises.
+        return Err(format!(
+            "path segment `{seg}` decodes to a value ending in `.`"
+        ));
+    }
+    let decoded_str = std::str::from_utf8(&decoded)
+        .map_err(|_| format!("path segment `{seg}` decodes to non-UTF-8 bytes"))?;
+    Ok(utf8_percent_encode(decoded_str, CANONICAL_PATH_ENCODE_SET).to_string())
+}
+
+/// Canonicalise a path string (segments joined by `/`, with optional
+/// trailing slash). Rejects empty middle segments (consecutive `/`).
+fn canonicalize_path(path: &str) -> Result<String, String> {
+    if path.is_empty() {
+        return Ok(String::new());
+    }
+    let trailing_slash = path.ends_with('/');
+    let body = path.trim_end_matches('/');
+    if body.is_empty() {
+        return Err("path consists only of slashes".to_string());
+    }
+    let segs: Vec<&str> = body.split('/').collect();
+    let mut out = Vec::with_capacity(segs.len());
+    for seg in segs {
+        if seg.is_empty() {
+            return Err("empty path segment (consecutive `/`)".to_string());
+        }
+        out.push(canonicalize_segment(seg)?);
+    }
+    let mut joined = out.join("/");
+    if trailing_slash {
+        joined.push('/');
+    }
+    Ok(joined)
+}
+
+/// Build the canonical authority+path string from `url::Url`-parsed parts
+/// and the RAW input string.
+///
+/// Why raw input for the path: `url::Url` on non-special schemes still
+/// decodes `%2E`/`%2e` and normalises the resulting `.`/`..` segments
+/// away (verified empirically). We need the raw bytes to enforce
+/// path-traversal rejection.
+///
+/// Why raw input for the authority: we reject two equivalence-class
+/// hazards that `url::Url` would otherwise let through silently:
+/// - **non-ASCII** host bytes — `url::Url` percent-encodes them
+///   (`bückét` → `b%C3%BCck%C3%A9t`) but our backends (S3 buckets, ADLS
+///   accounts, GCS buckets) are restricted ASCII. Encoded forms create
+///   an equivalence class.
+/// - **percent-encoded** host bytes — `url::Url` preserves `%62ucket`
+///   literally as the host, but the cloud server URL-decodes the request
+///   to `bucket`. Two table locations with `%62ucket` vs `bucket` would
+///   alias in cloud storage but be distinct rows in our DB.
+fn canonicalize_url_to_authority_and_path(
+    raw_input: &str,
+    url: &url::Url,
+) -> Result<String, String> {
+    // Split raw at `://` to inspect the original authority bytes.
+    let scheme_end = raw_input
+        .find("://")
+        .ok_or_else(|| "input lacks `://` separator".to_string())?;
+    let after_scheme = &raw_input[scheme_end + 3..];
+    let raw_authority_end = after_scheme.find('/').unwrap_or(after_scheme.len());
+    let raw_authority = &after_scheme[..raw_authority_end];
+    if !raw_authority.is_ascii() {
+        return Err(format!(
+            "non-ASCII bytes in authority `{raw_authority}` (use punycode IDN form for hosts)"
+        ));
+    }
+    if raw_authority.contains('%') {
+        return Err(format!(
+            "percent-encoded byte in authority `{raw_authority}` — hosts must be literal ASCII (cloud servers URL-decode the host, which would alias to a different name)"
+        ));
+    }
+
+    // Authority components: trust `url::Url` for the userinfo/host/port
+    // split (well-tested for IPv6 brackets, port detection, etc.).
+    let host = url
+        .host_str()
+        .ok_or_else(|| "URL has no host".to_string())?;
+    if host.is_empty() {
+        return Err("empty host".to_string());
+    }
+    if host.ends_with('.') {
+        return Err(format!("host has trailing dot: `{host}`"));
+    }
+    let mut authority = host.to_ascii_lowercase();
+    if let Some(port) = url.port() {
+        authority = format!("{authority}:{port}");
+    }
+    if !url.username().is_empty() {
+        let userinfo = match url.password() {
+            Some(p) => format!("{}:{}", url.username(), p),
+            None => url.username().to_string(),
+        };
+        authority = format!("{userinfo}@{authority}");
+    }
+
+    // Path: extract from RAW input. Per-segment canonicalisation handles
+    // the `%2E`-style equivalences explicitly (decode, then check for
+    // `.`/`..`/etc., then re-encode).
+    let raw_path = &after_scheme[raw_authority_end..];
+    if raw_path.is_empty() {
+        return Ok(authority);
+    }
+    debug_assert!(raw_path.starts_with('/'));
+    let canon_path = canonicalize_path(&raw_path[1..])?;
+    Ok(format!("{authority}/{canon_path}"))
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -330,11 +618,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_location_with_whitespace() {
-        let location = Location::from_str("s3://bucket/foo /bar").unwrap();
-        assert_eq!(location.as_str(), "s3://bucket/foo /bar");
-        let location = Location::from_str("s3://bucket/foo%20/bar").unwrap();
-        assert_eq!(location.as_str(), "s3://bucket/foo%20/bar");
+    fn test_location_with_whitespace_canonicalises_to_percent_encoded() {
+        // Literal space and `%20` collapse to the same canonical form
+        // (`%20`). Space is not unreserved per RFC 3986; canonical form
+        // keeps it encoded.
+        let literal = Location::from_str("s3://bucket/foo bar").unwrap();
+        assert_eq!(literal.as_str(), "s3://bucket/foo%20bar");
+        let encoded = Location::from_str("s3://bucket/foo%20bar").unwrap();
+        assert_eq!(encoded.as_str(), "s3://bucket/foo%20bar");
+        assert_eq!(literal, encoded);
     }
 
     #[test]
@@ -445,7 +737,7 @@ mod tests {
 
         for (location, expected) in cases {
             let location = Location::from_str(location).unwrap();
-            let mut result: Vec<_> = location.partial_locations().into_iter().collect();
+            let mut result: Vec<_> = location.partial_locations().collect();
             result.sort_unstable();
             assert_eq!(result, expected);
         }
@@ -454,23 +746,313 @@ mod tests {
     #[test]
     fn test_extend() {
         let mut location = Location::from_str("s3://bucket").unwrap();
-        location.extend(["foo", "bar"]);
+        location.extend(["foo", "bar"]).unwrap();
         assert_eq!(location.as_str(), "s3://bucket/foo/bar");
 
         let mut location = Location::from_str("s3://bucket/").unwrap();
-        location.extend(["foo", "bar"]);
+        location.extend(["foo", "bar"]).unwrap();
         assert_eq!(location.as_str(), "s3://bucket/foo/bar");
     }
 
     #[test]
     fn test_push() {
         let mut location = Location::from_str("s3://bucket").unwrap();
-        location.push("foo");
+        location.push("foo").unwrap();
         assert_eq!(location.as_str(), "s3://bucket/foo");
 
         let mut location = Location::from_str("s3://bucket/").unwrap();
-        location.push("foo");
+        location.push("foo").unwrap();
         assert_eq!(location.as_str(), "s3://bucket/foo");
+    }
+
+    #[test]
+    fn test_extend_canonicalises_appended_segments() {
+        // extend / push must produce a canonical Location, regardless of
+        // which encoded/decoded form the caller passes.
+        let mut a = Location::from_str("s3://bucket").unwrap();
+        a.extend(["foo bar"]).unwrap();
+        let mut b = Location::from_str("s3://bucket").unwrap();
+        b.extend(["foo%20bar"]).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.as_str(), "s3://bucket/foo%20bar");
+
+        // Mixed-hex `%2d` and unreserved `-` collapse the same way.
+        let mut a = Location::from_str("s3://bucket").unwrap();
+        a.extend(["foo-bar"]).unwrap();
+        let mut b = Location::from_str("s3://bucket").unwrap();
+        b.extend(["foo%2dbar"]).unwrap();
+        let mut c = Location::from_str("s3://bucket").unwrap();
+        c.extend(["foo%2Dbar"]).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(a.as_str(), "s3://bucket/foo-bar");
+    }
+
+    #[test]
+    fn test_extend_empty_segment_handling() {
+        let base = || Location::from_str("s3://bucket/foo").unwrap();
+
+        // Trailing empty: preserves trailing slash sentinel.
+        let mut trailing = base();
+        trailing.extend(["bar", ""]).unwrap();
+        assert_eq!(trailing.as_str(), "s3://bucket/foo/bar/");
+
+        // Single trailing empty alone: equivalent to with_trailing_slash.
+        let mut only_trailing = base();
+        only_trailing.extend([""]).unwrap();
+        assert_eq!(only_trailing.as_str(), "s3://bucket/foo/");
+
+        // Leading empty: no-op (extend always inserts a separator).
+        let mut leading = base();
+        leading.extend(["", "bar"]).unwrap();
+        assert_eq!(leading.as_str(), "s3://bucket/foo/bar");
+
+        // Leading + trailing empties around content: leading no-op,
+        // trailing preserved.
+        let mut both = base();
+        both.extend(["", "bar", ""]).unwrap();
+        assert_eq!(both.as_str(), "s3://bucket/foo/bar/");
+
+        // Middle empty between non-empty segments: rejected (would
+        // produce `//` in the canonical path).
+        let mut middle = base();
+        let err = middle.extend(["bar", "", "baz"]).unwrap_err();
+        assert!(err.reason.contains("consecutive `/`"), "{}", err.reason);
+    }
+
+    #[test]
+    fn test_extend_rejects_invalid_segments() {
+        let mut loc = Location::from_str("s3://bucket").unwrap();
+        // Path traversal.
+        assert!(loc.clone().extend(["..", "foo"]).is_err());
+        assert!(loc.clone().extend([".", "foo"]).is_err());
+        // Trailing dot (Azure Blob aliasing).
+        assert!(loc.clone().extend(["foo."]).is_err());
+        // Decoded `/` would create nesting ambiguity.
+        assert!(loc.clone().extend(["foo%2Fbar"]).is_err());
+        // Literal `/` in segment — caller must split.
+        assert!(loc.clone().extend(["foo/bar"]).is_err());
+        // Decoded control byte.
+        assert!(loc.clone().extend(["foo%00bar"]).is_err());
+        // Smuggling char in input.
+        assert!(loc.extend(["foo\tbar"]).is_err());
+    }
+
+    #[test]
+    fn test_idempotent_canonicalisation() {
+        // canonicalize(canonicalize(s)) == canonicalize(s)
+        let inputs = [
+            "s3://bucket/Foo-Bar",
+            "S3://Bucket/Foo%2Dbar",
+            "s3://BUCKET/foo%2dBAR",
+            "abfss://fs@account.dfs.core.windows.net/Foo%21Bar/",
+            "gs://bucket/foo%2Abar",
+        ];
+        for input in inputs {
+            let once = Location::from_str(input).unwrap();
+            let twice = Location::from_str(once.as_str()).unwrap();
+            assert_eq!(once.as_str(), twice.as_str(), "non-idempotent: {input}");
+        }
+    }
+
+    #[test]
+    fn test_canonical_collapses_unreserved_and_subdelim_encodings() {
+        // Equivalence classes from RFC 3986 §6.2.2.2: unreserved chars
+        // and sub-delims are URI-equivalent whether literal or %XX.
+        let pairs = [
+            ("s3://bucket/foo%2Dbar", "s3://bucket/foo-bar"),
+            ("s3://bucket/foo%2Ebar", "s3://bucket/foo.bar"),
+            ("s3://bucket/foo%5Fbar", "s3://bucket/foo_bar"),
+            ("s3://bucket/foo%7Ebar", "s3://bucket/foo~bar"),
+            ("s3://bucket/foo%41bar", "s3://bucket/fooAbar"),
+            ("s3://bucket/foo%2Bbar", "s3://bucket/foo+bar"),
+            ("s3://bucket/foo%2Abar", "s3://bucket/foo*bar"),
+            ("s3://bucket/foo%24bar", "s3://bucket/foo$bar"),
+            ("s3://bucket/foo%27bar", "s3://bucket/foo'bar"),
+        ];
+        for (a, b) in pairs {
+            let la = Location::from_str(a).unwrap();
+            let lb = Location::from_str(b).unwrap();
+            assert_eq!(la, lb, "expected `{a}` and `{b}` to canonicalise equal");
+        }
+    }
+
+    #[test]
+    fn test_canonical_uppercases_hex_in_kept_percent_encodings() {
+        // `?` is reserved (`%3F`) so canonical keeps it encoded — and
+        // uppercases the hex digits.
+        let lower = Location::from_str("s3://bucket/foo%3fbar").unwrap();
+        let upper = Location::from_str("s3://bucket/foo%3Fbar").unwrap();
+        assert_eq!(lower, upper);
+        assert_eq!(lower.as_str(), "s3://bucket/foo%3Fbar");
+    }
+
+    #[test]
+    fn test_canonical_lowercases_scheme_and_host() {
+        let l = Location::from_str("S3://Bucket/Foo").unwrap();
+        assert_eq!(l.as_str(), "s3://bucket/Foo");
+        assert_eq!(l.scheme(), "s3");
+    }
+
+    #[test]
+    fn test_rejects_smuggling_chars() {
+        // Unicode `Cc` (control) — must reject, otherwise `url::Url::parse`
+        // silently strips `\t`/`\n`/`\r` and we lose bytes.
+        for bad in [
+            "s3://bucket/foo\tbar",
+            "s3://bucket/foo\nbar",
+            "s3://bucket/foo\rbar",
+            "s3://bucket/foo\u{0000}bar",
+            "s3://bucket/foo\u{007F}bar",
+            "s3://bucket/foo\u{0085}bar", // C1 next-line
+        ] {
+            assert!(
+                Location::from_str(bad).is_err(),
+                "expected reject for input containing control char: {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_bidi_format_chars_percent_encoded_not_rejected() {
+        // Unicode `Cf` (format/bidi) chars are NOT rejected — they get
+        // percent-encoded by canonicalisation, which makes them
+        // byte-distinct from their ASCII look-alikes (no aliasing).
+        // Visual-spoofing protection is a display-layer concern.
+        let cases = [
+            ("s3://bucket/foo\u{200B}bar", "s3://bucket/foo%E2%80%8Bbar"), // ZWSP
+            ("s3://bucket/foo\u{202E}bar", "s3://bucket/foo%E2%80%AEbar"), // RLO
+            ("s3://bucket/foo\u{FEFF}bar", "s3://bucket/foo%EF%BB%BFbar"), // BOM
+        ];
+        for (input, canonical) in cases {
+            let loc = Location::from_str(input)
+                .unwrap_or_else(|e| panic!("expected accept for {input:?}: {e}"));
+            assert_eq!(loc.as_str(), canonical, "input was {input:?}");
+        }
+    }
+
+    #[test]
+    fn test_rejects_decoded_controls_and_special_segments() {
+        for bad in [
+            "s3://bucket/%2E/foo",    // decodes to `.`
+            "s3://bucket/%2E%2E/foo", // decodes to `..`
+            "s3://bucket/%2F/foo",    // decoded `/`
+            "s3://bucket/foo/%2Fbar", // decoded `/` inside segment
+            "s3://bucket/%00/foo",    // NUL
+            "s3://bucket/%09/foo",    // tab
+            "s3://bucket/%0A/foo",    // LF
+            "s3://bucket/foo./bar",   // segment ends with `.` (Azure aliasing)
+            "s3://bucket/foo%2E/bar", // same after decode
+            "s3://bucket//foo",       // empty middle segment
+            "s3://bucket/foo//bar",   // empty middle segment
+        ] {
+            assert!(
+                Location::from_str(bad).is_err(),
+                "expected reject for: {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rejects_host_trailing_dot_and_non_ascii() {
+        assert!(Location::from_str("s3://bucket./foo").is_err());
+        assert!(Location::from_str("abfss://fs@account.dfs.core.windows.net./x").is_err());
+        assert!(Location::from_str("s3://bückét/foo").is_err());
+    }
+
+    #[test]
+    fn test_rejects_percent_encoded_host() {
+        // Cloud servers URL-decode the host on the wire, so `%62ucket` would
+        // alias to `bucket`. Reject upfront to keep our DB rows in 1:1
+        // correspondence with cloud-side host names.
+        for bad in [
+            "s3://%62ucket/foo",  // %62 = 'b'
+            "s3://%41BC/foo",     // %41 = 'A'
+            "s3://buc%2Eket/foo", // %2E = '.'
+            "abfss://fs@%61ccount.dfs.core.windows.net/x",
+        ] {
+            let err = Location::from_str(bad)
+                .expect_err(&format!("expected reject for percent-encoded host: {bad}"));
+            assert!(
+                err.reason.contains("authority") || err.reason.contains("percent"),
+                "{}",
+                err.reason
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_sublocation_of_collapses_encoding_equivalent_forms() {
+        // Primary security goal of the canonicalisation refactor: two
+        // locations that decode to the same physical cloud path must
+        // canonicalise to byte-equal strings, so `is_sublocation_of`
+        // returns the right answer regardless of how the caller wrote it.
+        let cases = [
+            ("s3://bucket/foo-bar/x", "s3://bucket/foo%2Dbar/", true),
+            ("s3://bucket/foo-bar/x", "s3://bucket/foo%2dbar/", true),
+            ("s3://bucket/foo-bar/x", "s3://bucket/foo%2Dbar", true),
+            ("s3://bucket/Foo/x", "s3://bucket/%46oo/", true),
+            ("s3://bucket/foo-bar/x", "s3://bucket/foo-baz", false),
+        ];
+        for (child, parent, expected) in cases {
+            let c = Location::from_str(child).unwrap();
+            let p = Location::from_str(parent).unwrap();
+            assert_eq!(
+                c.is_sublocation_of(&p),
+                expected,
+                "child={child} parent={parent}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_extend_output_is_idempotent_through_from_str() {
+        let mut loc = Location::from_str("s3://bucket").unwrap();
+        loc.extend(["Foo%2Dbar", "data%2A", "file.parquet"])
+            .unwrap();
+        let canonical = loc.as_str().to_string();
+        let reparsed = Location::from_str(&canonical).unwrap();
+        assert_eq!(reparsed.as_str(), canonical);
+    }
+
+    #[test]
+    fn test_extend_rejects_percent_encoded_control() {
+        let loc = Location::from_str("s3://bucket").unwrap();
+        // %09 is tab, %0A is LF, %1F is unit separator, %7F is DEL.
+        for bad in ["foo%09bar", "foo%0Abar", "foo%1Fbar", "foo%7Fbar"] {
+            assert!(
+                loc.clone().extend([bad]).is_err(),
+                "expected reject for `{bad}`"
+            );
+        }
+    }
+
+    #[test]
+    fn test_extend_multiple_leading_empties_are_no_op() {
+        let mut a = Location::from_str("s3://bucket").unwrap();
+        a.extend(["", "", "foo"]).unwrap();
+        let mut b = Location::from_str("s3://bucket").unwrap();
+        b.extend(["foo"]).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.as_str(), "s3://bucket/foo");
+    }
+
+    #[test]
+    fn test_canonical_preserves_userinfo_and_port() {
+        let l = Location::from_str("s3://user:pass@bucket:9000/foo").unwrap();
+        assert_eq!(l.as_str(), "s3://user:pass@bucket:9000/foo");
+        let l = Location::from_str("s3://user:pass@Bucket:9000/Foo").unwrap();
+        assert_eq!(l.as_str(), "s3://user:pass@bucket:9000/Foo");
+    }
+
+    #[test]
+    fn test_canonical_preserves_trailing_slash() {
+        let with_slash = Location::from_str("s3://bucket/foo/").unwrap();
+        assert_eq!(with_slash.as_str(), "s3://bucket/foo/");
+        let without = Location::from_str("s3://bucket/foo").unwrap();
+        assert_eq!(without.as_str(), "s3://bucket/foo");
+        // Equivalence: trailing-slash is meaningful (different cloud objects).
+        assert_ne!(with_slash, without);
     }
 
     #[test]

--- a/crates/io/src/memory.rs
+++ b/crates/io/src/memory.rs
@@ -151,9 +151,7 @@ fn normalize_memory_path(path: &str) -> Result<String, InvalidLocationError> {
         path.to_string()
     };
 
-    let key = canonical
-        .strip_prefix(MEMORY_PREFIX)
-        .unwrap_or(&canonical);
+    let key = canonical.strip_prefix(MEMORY_PREFIX).unwrap_or(&canonical);
 
     if key.is_empty() {
         return Err(InvalidLocationError::new(

--- a/crates/io/src/memory.rs
+++ b/crates/io/src/memory.rs
@@ -136,11 +136,24 @@ const MEMORY_PREFIX: &str = "memory://";
 /// Normalizes a memory path by stripping the optional "memory://" prefix
 /// and returning the key for storage.
 fn normalize_memory_path(path: &str) -> Result<String, InvalidLocationError> {
-    let key = if let Some(stripped) = path.strip_prefix(MEMORY_PREFIX) {
-        stripped
+    // Canonicalise via `Location` so equivalent inputs (literal vs `%XX`,
+    // mixed-hex, etc.) collide on the same in-memory key — matching how
+    // cloud backends behave (the SDK URL-encodes the wire request and the
+    // server stores at canonical bytes).
+    use std::str::FromStr as _;
+    let canonical = if path.contains("://") {
+        Location::from_str(path)
+            .map_err(|e| InvalidLocationError::new(path.to_string(), e.reason))?
+            .to_string()
     } else {
-        path
+        // Relative paths (no scheme) — treat as already-canonical key bytes.
+        // Test helpers occasionally pass these directly.
+        path.to_string()
     };
+
+    let key = canonical
+        .strip_prefix(MEMORY_PREFIX)
+        .unwrap_or(&canonical);
 
     if key.is_empty() {
         return Err(InvalidLocationError::new(

--- a/crates/io/src/s3/s3_location.rs
+++ b/crates/io/src/s3/s3_location.rs
@@ -51,14 +51,18 @@ impl S3Location {
             )
         })?;
         if !key.is_empty() {
-            location.without_trailing_slash().extend(key.iter());
+            location
+                .without_trailing_slash()
+                .extend(key.iter())
+                .map_err(|e| {
+                    InvalidLocationError::new(
+                        e.value,
+                        format!("Failed to extend location with key segments - {}", e.reason),
+                    )
+                })?;
         }
 
-        Ok(S3Location {
-            // bucket_name,
-            // key,
-            location,
-        })
+        Ok(S3Location { location })
     }
 
     #[must_use]
@@ -74,7 +78,7 @@ impl S3Location {
 
     #[must_use]
     pub fn bucket_name(&self) -> &str {
-        (self.location.host_str()).unwrap_or_default()
+        self.location.host_str()
     }
 
     #[must_use]
@@ -114,12 +118,7 @@ impl S3Location {
             return Err(InvalidLocationError::new(location.to_string(), reason));
         }
 
-        let bucket_name = location.host_str().ok_or_else(|| {
-            InvalidLocationError::new(
-                location.to_string(),
-                "S3 location does not have a bucket name.".to_string(),
-            )
-        })?;
+        let bucket_name = location.host_str();
 
         if is_custom_variant {
             S3Location::new(

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -3,7 +3,9 @@ use std::{future::Future, sync::LazyLock};
 
 use bytes::Bytes;
 use futures::StreamExt;
-use lakekeeper_io::{LakekeeperStorage, StorageBackend, execute_with_parallelism};
+use std::str::FromStr;
+
+use lakekeeper_io::{LakekeeperStorage, Location, StorageBackend, execute_with_parallelism};
 use tokio::{
     runtime::Runtime,
     time::{Duration, Instant, sleep},
@@ -1052,13 +1054,20 @@ async fn test_special_characters_impl(
     let base_dir = config.test_dir_path("special-chars-test");
     let mut written_paths = Vec::new();
 
-    // Write files with special characters
+    // Write files with special characters. Note: `Location::from_str`
+    // canonicalises filenames (literal space → `%20`, non-ASCII →
+    // percent-encoded UTF-8 bytes), so we record the canonical form to
+    // compare against the cloud's `list` output below — the cloud stores
+    // and returns the canonical bytes.
     for filename in &special_files {
-        let path = format!("{base_dir}{filename}");
+        let raw_path = format!("{base_dir}{filename}");
         storage
-            .write(&path, Bytes::from(format!("Content of {filename}")))
+            .write(&raw_path, Bytes::from(format!("Content of {filename}")))
             .await?;
-        written_paths.push(path);
+        let canonical_path = Location::from_str(&raw_path)
+            .map(|l| l.to_string())
+            .unwrap_or(raw_path);
+        written_paths.push(canonical_path);
     }
 
     // Read all files back

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -1062,9 +1062,7 @@ async fn test_special_characters_impl(
         storage
             .write(&raw_path, Bytes::from(format!("Content of {filename}")))
             .await?;
-        let canonical_path = Location::from_str(&raw_path)
-            .map(|l| l.to_string())
-            .unwrap_or(raw_path);
+        let canonical_path = Location::from_str(&raw_path)?.to_string();
         written_paths.push(canonical_path);
     }
 

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -1,10 +1,8 @@
 use core::panic;
-use std::{future::Future, sync::LazyLock};
+use std::{future::Future, str::FromStr, sync::LazyLock};
 
 use bytes::Bytes;
 use futures::StreamExt;
-use std::str::FromStr;
-
 use lakekeeper_io::{LakekeeperStorage, Location, StorageBackend, execute_with_parallelism};
 use tokio::{
     runtime::Runtime,

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -1113,15 +1113,17 @@ async fn test_special_characters_impl(
 }
 
 /// Like `test_special_characters_impl` but the special chars appear as
-/// pre-percent-encoded URL segments (e.g. `%3F`, `%20`) — what
+/// path segments inside URL-style locations — covering both
+/// pre-percent-encoded segments (e.g. `%3F`, `%20`) and raw non-ASCII
+/// Unicode (e.g. `üñîçødé`, `日本語`). Both forms must round-trip
+/// write → read → list when used as a directory name. This is what
 /// Lakekeeper REST receives when a client provides a URL-style location.
 async fn test_special_characters_in_url_segments_impl(
     storage: &StorageBackend,
     config: &TestConfig,
 ) -> anyhow::Result<()> {
-    // Each entry: a URL-encoded path segment that should round-trip through
-    // write → read → list when used as a directory name in a URL location.
-    // Positive: segments that must round-trip end-to-end.
+    // Positive: percent-encoded *and* raw-Unicode segments that must
+    // round-trip end-to-end through write → read → list.
     let positive_segments = vec![
         "%3F",     // ?
         "%22",     // "

--- a/crates/lakekeeper/src/implementations/postgres/tabular/mod.rs
+++ b/crates/lakekeeper/src/implementations/postgres/tabular/mod.rs
@@ -414,7 +414,6 @@ pub(crate) fn get_partial_fs_locations(
 ) -> Result<Vec<String>, InternalParseLocationError> {
     location
         .partial_locations()
-        .into_iter()
         // Keep only the last part of the location
         .map(|l| {
             let location = Location::from_str(l)?;

--- a/crates/lakekeeper/src/implementations/postgres/tabular/table/mod.rs
+++ b/crates/lakekeeper/src/implementations/postgres/tabular/table/mod.rs
@@ -1738,7 +1738,7 @@ pub(crate) mod tests {
         pretty_assertions::assert_eq!(table_info, &table_info_by_location);
 
         let mut subpath = table_info.metadata_location().unwrap().clone();
-        subpath.push("data/foo.parquet");
+        subpath.extend(["data", "foo.parquet"]).unwrap();
         // Subpath works
         let table_info_by_location = get_tabular_infos_by_s3_location(
             warehouse_id,

--- a/crates/lakekeeper/src/server/io.rs
+++ b/crates/lakekeeper/src/server/io.rs
@@ -200,10 +200,14 @@ mod tests {
         let mut location = profile.base_location().unwrap();
         location.without_trailing_slash();
 
-        let folder_1 = location.clone().push("folder").clone();
-        let file_1 = folder_1.clone().push("file1").clone();
-        let folder_2 = location.clone().push("folder-2").clone();
-        let file_2 = folder_2.clone().push("file2").clone();
+        let mut folder_1 = location.clone();
+        folder_1.push("folder").unwrap();
+        let mut file_1 = folder_1.clone();
+        file_1.push("file1").unwrap();
+        let mut folder_2 = location.clone();
+        folder_2.push("folder-2").unwrap();
+        let mut file_2 = folder_2.clone();
+        file_2.push("file2").unwrap();
 
         let data_1 = serde_json::json!({"file": "1"});
         let data_2 = serde_json::json!({"file": "2"});

--- a/crates/lakekeeper/src/server/s3_signer/sign.rs
+++ b/crates/lakekeeper/src/server/s3_signer/sign.rs
@@ -111,9 +111,8 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             body: request_body,
         } = request.clone();
 
-        let decoded_url = urldecode_uri_path_segments(&request_url)?;
         let (parsed_url, operation) = s3_utils::parse_s3_url(
-            &decoded_url,
+            &request_url,
             s3_url_style_detection(&warehouse)?,
             &request_method,
             request_body.as_deref(),
@@ -379,29 +378,6 @@ async fn sign(
     };
 
     Ok(sign_response)
-}
-
-fn urldecode_uri_path_segments(uri: &url::Url) -> Result<url::Url> {
-    // We only modify path segments. Iterate over all path segments and unr urlencoding::decode them.
-    let mut new_uri = uri.clone();
-    let path_segments = new_uri
-        .path_segments()
-        .map(std::iter::Iterator::collect::<Vec<_>>)
-        .unwrap_or_default();
-
-    let mut new_path_segments = Vec::new();
-    for segment in path_segments {
-        new_path_segments.push(urlencoding::decode(segment).map_err(|e| {
-            ErrorModel::bad_request(
-                "Failed to decode URI segment",
-                "FailedToDecodeURISegment",
-                Some(Box::new(e)),
-            )
-        })?);
-    }
-
-    new_uri.set_path(&new_path_segments.join("/"));
-    Ok(new_uri)
 }
 
 fn validate_region(region: &str, storage_profile: &S3Profile) -> Result<()> {
@@ -1138,6 +1114,28 @@ mod test {
             assert_eq!(result, expected);
             assert_eq!(operation, Operation::Delete);
         }
+    }
+
+    /// Iceberg URL-encodes partition values inside a single path segment
+    /// (e.g. partition value `m/y` → segment `m%2Fy` as part of the S3 key
+    /// bytes). The wire URL then encodes that segment a second time, so the
+    /// HTTP request path contains `m%252Fy`. The signer must accept this
+    /// and treat it as a sublocation of the table.
+    #[test]
+    fn test_parse_s3_url_iceberg_partition_path() {
+        let table_location =
+            Location::from_str("s3://tests/wh/aaaa-aaaa-aaaa/bbbb-bbbb-bbbb").unwrap();
+        let wire = "http://minio:9000/tests/wh/aaaa-aaaa-aaaa/bbbb-bbbb-bbbb/data/m%252Fy%2Bfl%2B%2521%253F%2B-_%25C3%25A4%2Boats%3D2.2/00000-data.parquet";
+        let uri = url::Url::parse(wire).unwrap();
+        let (parsed, operation) = parse_s3_url(
+            &uri,
+            S3UrlStyleDetectionMode::Auto,
+            &http::Method::PUT,
+            None,
+        )
+        .expect("partition-encoded URL must parse");
+        assert_eq!(operation, Operation::Write);
+        validate_uri(&parsed, &table_location).expect("parsed URL must be sublocation of table");
     }
 
     #[test]

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -1593,7 +1593,7 @@ async fn try_commit_tables<C: CatalogStore, A: Authorizer + Clone, S: SecretStor
                 &new_compression_codec,
                 Uuid::now_v7(),
                 next_metadata_count,
-            );
+            )?;
 
             let number_added_metadata_log_entries = (new_metadata.metadata_log().len()
                 + number_expired_metadata_log_entries)

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -261,7 +261,7 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
             &CompressionCodec::try_from_maybe_properties(request.properties.as_ref())?,
             metadata_id,
             0,
-        ))
+        )?)
     };
 
     let table_metadata = create_table_request_into_table_metadata(table_id, request.clone())?;

--- a/crates/lakekeeper/src/server/tabular.rs
+++ b/crates/lakekeeper/src/server/tabular.rs
@@ -54,7 +54,15 @@ pub(super) fn determine_tabular_location(
             uuid: *table_id,
         };
 
-        storage_profile.default_tabular_location(&namespace_location, &table_name_context)
+        storage_profile
+            .default_tabular_location(&namespace_location, &table_name_context)
+            .map_err(|e| {
+                ErrorModel::internal(
+                    "Failed to generate default tabular location",
+                    "InvalidDefaultTabularLocation",
+                    Some(Box::new(e)),
+                )
+            })?
     };
     // all locations are without a trailing slash
     location.without_trailing_slash();

--- a/crates/lakekeeper/src/server/views/commit.rs
+++ b/crates/lakekeeper/src/server/views/commit.rs
@@ -232,7 +232,7 @@ async fn try_commit_view<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         &CompressionCodec::try_from_properties(new_metadata.properties())?,
         Uuid::now_v7(),
         extract_count_from_metadata_location(&previous_metadata_location).map_or(0, |v| v + 1),
-    );
+    )?;
 
     if delete_old_location.is_some() {
         ctx.storage_profile

--- a/crates/lakekeeper/src/server/views/create.rs
+++ b/crates/lakekeeper/src/server/views/create.rs
@@ -116,7 +116,7 @@ pub(crate) async fn create_view<C: CatalogStore, A: Authorizer + Clone, S: Secre
         &CompressionCodec::try_from_properties(&request.properties)?,
         *view_id,
         0,
-    );
+    )?;
 
     let view_creation = ViewMetadataBuilder::from_view_creation(ViewCreation {
         name: view.name.clone(),

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -485,6 +485,12 @@ impl AdlsProfile {
         signed_expiry: OffsetDateTime,
         key: impl Into<SasKey>,
     ) -> Result<String, CredentialsError> {
+        // `sas` is a static function and can't read the profile's
+        // `allow_alternative_protocols` flag. Passing `true` here is safe:
+        // `stc_request.table_location` was already validated against the
+        // profile at table registration, so accepting both `abfss://` and
+        // `wasbs://` here only affects `AdlsLocation` construction for SAS
+        // signing — it does not re-grant access to alternative protocols.
         let adls_location = AdlsLocation::try_from_location(&stc_request.table_location, true)
             .map_err(|e| CredentialsError::ShortTermCredential {
                 reason: format!("Invalid ADLS location for SAS signing: {e}"),
@@ -493,7 +499,7 @@ impl AdlsProfile {
         let (canonical_resource, depth) = azure_sas_canonical_path(&adls_location);
 
         tracing::debug!(
-            "Generationg SAS token for resource `{canonical_resource}` with permissions {} valid until {signed_expiry}",
+            "Generating SAS token for resource `{canonical_resource}` with permissions {} valid until {signed_expiry}",
             stc_request.storage_permissions
         );
 

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -310,7 +310,7 @@ impl AdlsProfile {
                     .await?
                 }
                 AzCredential::SharedAccessKey { key } => {
-                    let sas = self.sas(
+                    let sas = Self::sas(
                         &stc_request,
                         requested_sas_token_end,
                         azure_core::auth::Secret::new(key.clone()),
@@ -476,35 +476,24 @@ impl AdlsProfile {
 
         let key = delegation_key.user_deligation_key;
 
-        let sas = self.sas(stc_request, signed_expiry, key)?;
+        let sas = Self::sas(stc_request, signed_expiry, key)?;
         Ok((sas, signed_expiry))
     }
 
     fn sas(
-        &self,
         stc_request: &ShortTermCredentialsRequest,
         signed_expiry: OffsetDateTime,
         key: impl Into<SasKey>,
     ) -> Result<String, CredentialsError> {
-        let path = reduce_scheme_string(stc_request.table_location.as_ref()).map_err(|e| {
-            CredentialsError::ShortTermCredential {
-                reason: format!("Invalid ADLS location for SAS signing: {e}"),
-                source: Some(Box::new(e)),
-            }
+        let adls_location = AdlsLocation::try_from_location(
+            &stc_request.table_location,
+            true,
+        )
+        .map_err(|e| CredentialsError::ShortTermCredential {
+            reason: format!("Invalid ADLS location for SAS signing: {e}"),
+            source: Some(Box::new(e)),
         })?;
-        let rootless_path = path.trim_start_matches('/').trim_end_matches('/');
-        let depth = rootless_path.split('/').count();
-
-        // Azure recomputes the canonical-resource by URL-decoding the request
-        // URL path. Hand-rolling the canonical with the encoded form (e.g.
-        // literal `%3F` or `%20`) produces a signature mismatch.
-        let decoded_path = percent_encoding::percent_decode_str(rootless_path).decode_utf8_lossy();
-        let canonical_resource = format!(
-            "/blob/{}/{}/{}",
-            self.account_name.as_str(),
-            self.filesystem.as_str(),
-            decoded_path
-        );
+        let (canonical_resource, depth) = azure_sas_canonical_path(&adls_location);
 
         tracing::debug!(
             "Generationg SAS token for resource `{canonical_resource}` with permissions {} valid until {signed_expiry}",
@@ -600,12 +589,44 @@ impl AdlsProfile {
     }
 }
 
-/// Removes the hostname and user from the path.
-/// Keeps only the path and optionally the scheme.
-/// Reduce an ADLS URL to its rooted blob path (`/<blob_name>`).
-pub(crate) fn reduce_scheme_string(path: &str) -> Result<String, InvalidLocationError> {
-    let l = AdlsLocation::try_from_str(path, true)?;
-    Ok(format!("/{}", l.blob_name().trim_start_matches('/')))
+
+// --- Egress encoders ---------------------------------------------------
+//
+// Each encoder takes the `Location` (or its components) plus any
+// backend-specific context, and returns the exact byte form a downstream
+// consumer expects. They live next to their consumer so a reviewer can
+// verify the canonical form against the consumer's spec.
+
+/// Build the ADLS SAS canonical-resource string and its directory depth.
+///
+/// Form: `/blob/{account}/{filesystem}/{decoded_path}` where
+/// `decoded_path` is percent-decoded. Azure recomputes the canonical
+/// resource by URL-decoding the request URL path before HMAC; signing
+/// with the encoded form (e.g. literal `%3F` or `%20`) produces a
+/// signature mismatch and a silent 403.
+///
+/// Returns `(canonical_resource, signed_directory_depth)`. Depth counts
+/// non-empty path segments — root locations have depth 0.
+fn azure_sas_canonical_path(loc: &AdlsLocation) -> (String, usize) {
+    let blob_path = loc.blob_name();
+    let rootless_path = blob_path
+        .trim_start_matches('/')
+        .trim_end_matches('/');
+    let depth = if rootless_path.is_empty() {
+        0
+    } else {
+        rootless_path.split('/').count()
+    };
+    let decoded_path = percent_encoding::percent_decode_str(rootless_path).decode_utf8_lossy();
+    (
+        format!(
+            "/blob/{}/{}/{}",
+            loc.account_name(),
+            loc.filesystem(),
+            decoded_path
+        ),
+        depth,
+    )
 }
 
 #[derive(Redact, Hash, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -742,19 +763,6 @@ pub(crate) mod test {
         storage_layout::{NamespaceNameContext, NamespacePath, TabularNameContext},
     };
 
-    #[test]
-    fn test_reduce_scheme_string() {
-        let path = "abfss://filesystem@dfs.windows.net/path/_test";
-        assert_eq!(reduce_scheme_string(path).unwrap(), "/path/_test");
-
-        let wasbs_path = "wasbs://filesystem@account.windows.net/path/to/data";
-        assert_eq!(reduce_scheme_string(wasbs_path).unwrap(), "/path/to/data");
-
-        // Non-ADLS scheme must error rather than silently pass through.
-        let non_matching = "http://example.com/path";
-        assert!(reduce_scheme_string(non_matching).is_err());
-    }
-
     pub(crate) mod azure_integration_tests {
         use crate::{
             api::RequestMetadata,
@@ -850,6 +858,49 @@ pub(crate) mod test {
             DEFAULT_AUTHORITY_HOST.as_str(),
             "https://login.microsoftonline.com/"
         );
+    }
+
+    #[test]
+    fn azure_sas_canonical_path_decodes_percent_encoded_path() {
+        // Azure HMAC's canonical resource is computed against the URL-decoded
+        // request path; the encoded form (`%3F`/`%20`) would mismatch.
+        let loc = AdlsLocation::try_from_str(
+            "abfss://filesystem@account.dfs.core.windows.net/wh/foo%20bar/baz%3Fqux",
+            false,
+        )
+        .unwrap();
+        let (canonical, depth) = azure_sas_canonical_path(&loc);
+        assert_eq!(
+            canonical,
+            "/blob/account/filesystem/wh/foo bar/baz?qux"
+        );
+        assert_eq!(depth, 3);
+    }
+
+    #[test]
+    fn azure_sas_canonical_path_root_has_depth_zero() {
+        // Root location with no path segments must report depth 0
+        // (not 1, which `"".split('/').count()` would give).
+        let loc = AdlsLocation::try_from_str(
+            "abfss://filesystem@account.dfs.core.windows.net/",
+            false,
+        )
+        .unwrap();
+        let (canonical, depth) = azure_sas_canonical_path(&loc);
+        assert_eq!(canonical, "/blob/account/filesystem/");
+        assert_eq!(depth, 0);
+    }
+
+    #[test]
+    fn azure_sas_canonical_path_strips_trailing_slash() {
+        let loc = AdlsLocation::try_from_str(
+            "abfss://filesystem@account.dfs.core.windows.net/wh/table/",
+            false,
+        )
+        .unwrap();
+        let (canonical, depth) = azure_sas_canonical_path(&loc);
+        assert_eq!(canonical, "/blob/account/filesystem/wh/table");
+        assert_eq!(depth, 2);
     }
 
     #[test]

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -880,7 +880,9 @@ pub(crate) mod test {
         };
         let namespace_location = sp.default_namespace_location(&namespace_path).unwrap();
 
-        let location = sp.default_tabular_location(&namespace_location, &tabular_name_context);
+        let location = sp
+            .default_tabular_location(&namespace_location, &tabular_name_context)
+            .unwrap();
         assert_eq!(
             location.to_string(),
             format!(
@@ -894,7 +896,9 @@ pub(crate) mod test {
         let sp: StorageProfile = profile.into();
 
         let namespace_location = sp.default_namespace_location(&namespace_path).unwrap();
-        let location = sp.default_tabular_location(&namespace_location, &tabular_name_context);
+        let location = sp
+            .default_tabular_location(&namespace_location, &tabular_name_context)
+            .unwrap();
         assert_eq!(
             location.to_string(),
             format!("abfss://filesystem@account.blob.com/{namespace_uuid}/{tabular_uuid}")

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -485,14 +485,11 @@ impl AdlsProfile {
         signed_expiry: OffsetDateTime,
         key: impl Into<SasKey>,
     ) -> Result<String, CredentialsError> {
-        let adls_location = AdlsLocation::try_from_location(
-            &stc_request.table_location,
-            true,
-        )
-        .map_err(|e| CredentialsError::ShortTermCredential {
-            reason: format!("Invalid ADLS location for SAS signing: {e}"),
-            source: Some(Box::new(e)),
-        })?;
+        let adls_location = AdlsLocation::try_from_location(&stc_request.table_location, true)
+            .map_err(|e| CredentialsError::ShortTermCredential {
+                reason: format!("Invalid ADLS location for SAS signing: {e}"),
+                source: Some(Box::new(e)),
+            })?;
         let (canonical_resource, depth) = azure_sas_canonical_path(&adls_location);
 
         tracing::debug!(
@@ -589,7 +586,6 @@ impl AdlsProfile {
     }
 }
 
-
 // --- Egress encoders ---------------------------------------------------
 //
 // Each encoder takes the `Location` (or its components) plus any
@@ -609,9 +605,7 @@ impl AdlsProfile {
 /// non-empty path segments — root locations have depth 0.
 fn azure_sas_canonical_path(loc: &AdlsLocation) -> (String, usize) {
     let blob_path = loc.blob_name();
-    let rootless_path = blob_path
-        .trim_start_matches('/')
-        .trim_end_matches('/');
+    let rootless_path = blob_path.trim_start_matches('/').trim_end_matches('/');
     let depth = if rootless_path.is_empty() {
         0
     } else {
@@ -870,10 +864,7 @@ pub(crate) mod test {
         )
         .unwrap();
         let (canonical, depth) = azure_sas_canonical_path(&loc);
-        assert_eq!(
-            canonical,
-            "/blob/account/filesystem/wh/foo bar/baz?qux"
-        );
+        assert_eq!(canonical, "/blob/account/filesystem/wh/foo bar/baz?qux");
         assert_eq!(depth, 3);
     }
 
@@ -881,11 +872,9 @@ pub(crate) mod test {
     fn azure_sas_canonical_path_root_has_depth_zero() {
         // Root location with no path segments must report depth 0
         // (not 1, which `"".split('/').count()` would give).
-        let loc = AdlsLocation::try_from_str(
-            "abfss://filesystem@account.dfs.core.windows.net/",
-            false,
-        )
-        .unwrap();
+        let loc =
+            AdlsLocation::try_from_str("abfss://filesystem@account.dfs.core.windows.net/", false)
+                .unwrap();
         let (canonical, depth) = azure_sas_canonical_path(&loc);
         assert_eq!(canonical, "/blob/account/filesystem/");
         assert_eq!(depth, 0);

--- a/crates/lakekeeper/src/service/storage/gcs/mod.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/mod.rs
@@ -285,17 +285,22 @@ impl GcsProfile {
             .as_ref()
             .map(|s| s.split('/').map(std::borrow::ToOwned::to_owned).collect())
             .unwrap_or_default();
-        Location::from_str(&format!("gs://{}/", self.bucket))
-            .map(|mut l| {
-                l.extend(prefix.iter());
-                l
-            })
-            .map_err(|e| {
-                InvalidLocationError::new(
-                    format!("gs://{}/", self.bucket),
-                    format!("Failed to create base location for GCS profile: {e}"),
-                )
-            })
+        let mut l = Location::from_str(&format!("gs://{}/", self.bucket)).map_err(|e| {
+            InvalidLocationError::new(
+                format!("gs://{}/", self.bucket),
+                format!("Failed to create base location for GCS profile: {e}"),
+            )
+        })?;
+        l.extend(prefix.iter()).map_err(|e| {
+            InvalidLocationError::new(
+                e.value,
+                format!(
+                    "Failed to apply key_prefix to GCS base location: {}",
+                    e.reason
+                ),
+            )
+        })?;
+        Ok(l)
     }
 
     async fn get_token_source(

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -118,25 +118,8 @@ impl Options {
         table_location: &Location,
         storage_permissions: StoragePermissions,
     ) -> Result<Self, TableConfigError> {
-        let mut table_location = table_location.clone();
-        table_location.with_trailing_slash();
-        let bucket_prefix = format!("gs://{bucket}/");
-        let prefixless_location = table_location
-            .as_str()
-            .strip_prefix(&bucket_prefix)
-            .ok_or_else(|| {
-                TableConfigError::Internal(
-                    format!(
-                        "Refusing to build GCS access boundary: table location `{}` is not under bucket `{bucket}`",
-                        table_location.as_str()
-                    ),
-                    None,
-                )
-            })?
-            .to_owned();
-
         let bucket_cel = escape_for_cel_single_quoted(bucket)?;
-        let path_cel = escape_for_cel_single_quoted(&prefixless_location)?;
+        let path_cel = gcs_cel_object_prefix(bucket, table_location)?;
 
         Ok(Options {
             access_boundary: AccessBoundary {
@@ -167,6 +150,48 @@ impl Options {
             },
         })
     }
+}
+
+// --- Egress encoders ---------------------------------------------------
+//
+// Each function here produces the byte form a GCP-side consumer expects
+// from a `Location`. They live next to the CEL access-boundary builder
+// so a reviewer can verify the canonical form matches what GCS does
+// server-side when evaluating the access boundary against
+// `resource.name`.
+
+/// CEL-escaped object-name prefix relative to the bucket root, with a
+/// trailing `/`. Used in the `startsWith(...)` checks of the GCS access
+/// boundary CEL expression.
+///
+/// GCS's `resource.name` for an object is
+/// `projects/_/buckets/{bucket}/objects/{decoded_object_name}` — the
+/// object name is the **decoded** form. CEL `startsWith` is byte-string
+/// compare, so the prefix here must also be decoded, or no request will
+/// match (silent 403). We percent-decode the canonical-encoded path
+/// before escaping for CEL.
+fn gcs_cel_object_prefix(
+    bucket: &str,
+    table_location: &Location,
+) -> Result<String, TableConfigError> {
+    let mut table_location = table_location.clone();
+    table_location.with_trailing_slash();
+    let bucket_prefix = format!("gs://{bucket}/");
+    let prefixless_location = table_location
+        .as_str()
+        .strip_prefix(&bucket_prefix)
+        .ok_or_else(|| {
+            TableConfigError::Internal(
+                format!(
+                    "Refusing to build GCS access boundary: table location `{}` is not under bucket `{bucket}`",
+                    table_location.as_str()
+                ),
+                None,
+            )
+        })?;
+    let decoded_prefix =
+        percent_encoding::percent_decode_str(prefixless_location).decode_utf8_lossy();
+    escape_for_cel_single_quoted(&decoded_prefix)
 }
 
 /// Escape `value` for interpolation inside a CEL single-quoted literal.
@@ -264,7 +289,44 @@ impl From<&GcsServiceKey> for CredentialsFile {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
+
+    #[test]
+    fn gcs_cel_object_prefix_decodes_percent_encoded_path() {
+        // GCS `resource.name` for an object is the **decoded** object name.
+        // The CEL `startsWith` is byte-string compare, so the prefix here
+        // must also be decoded — encoded form would never match.
+        let loc = Location::from_str("gs://my-bucket/wh/foo%20bar/").unwrap();
+        let prefix = gcs_cel_object_prefix("my-bucket", &loc).unwrap();
+        assert_eq!(prefix, "wh/foo bar/");
+    }
+
+    #[test]
+    fn gcs_cel_object_prefix_collapses_mixed_hex_to_same_form() {
+        let a = Location::from_str("gs://b/foo-bar/").unwrap();
+        let b = Location::from_str("gs://b/foo%2Dbar/").unwrap();
+        let c = Location::from_str("gs://b/foo%2dbar/").unwrap();
+        let pa = gcs_cel_object_prefix("b", &a).unwrap();
+        let pb = gcs_cel_object_prefix("b", &b).unwrap();
+        let pc = gcs_cel_object_prefix("b", &c).unwrap();
+        assert_eq!(pa, pb);
+        assert_eq!(pa, pc);
+        assert_eq!(pa, "foo-bar/");
+    }
+
+    #[test]
+    fn gcs_cel_object_prefix_rejects_location_outside_bucket() {
+        let loc = Location::from_str("gs://other-bucket/wh/").unwrap();
+        let err = gcs_cel_object_prefix("my-bucket", &loc).unwrap_err();
+        match err {
+            TableConfigError::Internal(msg, _) => {
+                assert!(msg.contains("not under bucket"), "{msg}");
+            }
+            other => panic!("expected Internal, got {other:?}"),
+        }
+    }
 
     #[test]
     fn escape_for_cel_single_quoted_passes_plain_value() {

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -189,8 +189,20 @@ fn gcs_cel_object_prefix(
                 None,
             )
         })?;
-    let decoded_prefix =
-        percent_encoding::percent_decode_str(prefixless_location).decode_utf8_lossy();
+    // Fail loudly on non-UTF-8 bytes rather than silently substituting
+    // U+FFFD — a corrupted CEL prefix could match the wrong objects or
+    // none, both of which are wrong outcomes for an access-boundary
+    // policy.
+    let decoded_prefix = percent_encoding::percent_decode_str(prefixless_location)
+        .decode_utf8()
+        .map_err(|e| {
+            TableConfigError::Internal(
+                format!(
+                    "GCS access boundary prefix decode failed: invalid UTF-8 in `{prefixless_location}`: {e}"
+                ),
+                Some(Box::new(e)),
+            )
+        })?;
     escape_for_cel_single_quoted(&decoded_prefix)
 }
 

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -164,12 +164,12 @@ impl Options {
 /// trailing `/`. Used in the `startsWith(...)` checks of the GCS access
 /// boundary CEL expression.
 ///
-/// GCS's `resource.name` for an object is
-/// `projects/_/buckets/{bucket}/objects/{decoded_object_name}` — the
-/// object name is the **decoded** form. CEL `startsWith` is byte-string
-/// compare, so the prefix here must also be decoded, or no request will
-/// match (silent 403). We percent-decode the canonical-encoded path
-/// before escaping for CEL.
+/// Uses the canonical-encoded path (no decode). When a client writes to
+/// GCS, the SDK URL-encodes the key for the wire (so a `%` in the key
+/// becomes `%25`); the server URL-decodes once and stores at the
+/// canonical-encoded form. CEL `startsWith` against `resource.name` is
+/// byte-string compare, so the prefix must be the same bytes as the
+/// canonical Location.
 fn gcs_cel_object_prefix(
     bucket: &str,
     table_location: &Location,
@@ -189,21 +189,7 @@ fn gcs_cel_object_prefix(
                 None,
             )
         })?;
-    // Fail loudly on non-UTF-8 bytes rather than silently substituting
-    // U+FFFD — a corrupted CEL prefix could match the wrong objects or
-    // none, both of which are wrong outcomes for an access-boundary
-    // policy.
-    let decoded_prefix = percent_encoding::percent_decode_str(prefixless_location)
-        .decode_utf8()
-        .map_err(|e| {
-            TableConfigError::Internal(
-                format!(
-                    "GCS access boundary prefix decode failed: invalid UTF-8 in `{prefixless_location}`: {e}"
-                ),
-                Some(Box::new(e)),
-            )
-        })?;
-    escape_for_cel_single_quoted(&decoded_prefix)
+    escape_for_cel_single_quoted(prefixless_location)
 }
 
 /// Escape `value` for interpolation inside a CEL single-quoted literal.
@@ -306,17 +292,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn gcs_cel_object_prefix_decodes_percent_encoded_path() {
-        // GCS `resource.name` for an object is the **decoded** object name.
-        // The CEL `startsWith` is byte-string compare, so the prefix here
-        // must also be decoded — encoded form would never match.
+    fn gcs_cel_object_prefix_uses_canonical_encoded_form() {
+        // GCS `resource.name` matches the bytes that GCS actually stores.
+        // Clients URL-encode `%` → `%25` for the wire and the server
+        // decodes once, so a path of `foo%20bar` ends up as the literal
+        // 7-char key `foo%20bar` (not `foo bar`). The CEL `startsWith`
+        // prefix must use the same canonical-encoded form.
         let loc = Location::from_str("gs://my-bucket/wh/foo%20bar/").unwrap();
         let prefix = gcs_cel_object_prefix("my-bucket", &loc).unwrap();
-        assert_eq!(prefix, "wh/foo bar/");
+        assert_eq!(prefix, "wh/foo%20bar/");
     }
 
     #[test]
     fn gcs_cel_object_prefix_collapses_mixed_hex_to_same_form() {
+        // `%2D` and `%2d` and literal `-` all canonicalise to literal `-`
+        // (unreserved char), so the CEL prefix is identical for all three
+        // input forms.
         let a = Location::from_str("gs://b/foo-bar/").unwrap();
         let b = Location::from_str("gs://b/foo%2Dbar/").unwrap();
         let c = Location::from_str("gs://b/foo%2dbar/").unwrap();

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -609,10 +609,6 @@ impl StorageProfile {
         test_file_write
             .push("test")
             .map_err(|e| location_extend_err(e, "Failed to build access-test path"))?;
-        let mut test_file_write = test_file_write.parent();
-        test_file_write
-            .push("test")
-            .map_err(|e| location_extend_err(e, "Failed to build access-test path"))?;
         tracing::debug!("Validating access to: {}", test_file_write);
 
         // Test write

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -46,6 +46,17 @@ use crate::{
     },
 };
 
+/// Wrap a [`LocationParseError`] from `Location::extend`/`push` as a
+/// [`ValidationError::InvalidLocation`] with a callsite-supplied
+/// context string. Centralised so all `extend`/`push` failures format
+/// identically.
+fn location_extend_err(e: LocationParseError, context: &str) -> ValidationError {
+    ValidationError::InvalidLocation(Box::new(InvalidLocationError::new(
+        e.value,
+        format!("{context}: {}", e.reason),
+    )))
+}
+
 /// Storage profile for a warehouse.
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize, derive_more::From)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
@@ -251,7 +262,9 @@ impl StorageProfile {
         let layout = self.layout().unwrap_or_else(|| &DEFAULT_LAYOUT);
 
         let segments = layout.render_namespace_path(namespace_path);
-        base_location.extend(segments);
+        base_location
+            .extend(segments)
+            .map_err(|e| location_extend_err(e, "Failed to extend with namespace path segments"))?;
         Ok(base_location)
     }
 
@@ -361,7 +374,7 @@ impl StorageProfile {
             name: "test_tabular".to_string(),
             uuid: Uuid::now_v7(),
         };
-        let _ = self.default_tabular_location(&ns_location, &tabular_name_context);
+        let _ = self.default_tabular_location(&ns_location, &tabular_name_context)?;
 
         // ------------- Profile specific validations -------------
         match self {
@@ -407,10 +420,10 @@ impl StorageProfile {
             uuid: Uuid::now_v7(),
         };
         let ns_location = self.default_namespace_location(&namespace_path)?;
-        let test_location = location.map_or_else(
-            || self.default_tabular_location(&ns_location, &tabular_name_context),
-            std::borrow::ToOwned::to_owned,
-        );
+        let test_location = match location {
+            Some(l) => l.clone(),
+            None => self.default_tabular_location(&ns_location, &tabular_name_context)?,
+        };
         tracing::debug!("Validating direct read/write access to {test_location}");
 
         // Test vended-credentials access
@@ -488,7 +501,10 @@ impl StorageProfile {
 
         // Create a sub-location for testing vended credentials access
         let mut sub_location = test_location.clone();
-        sub_location.without_trailing_slash().push("vended-test");
+        sub_location
+            .without_trailing_slash()
+            .push("vended-test")
+            .map_err(|e| location_extend_err(e, "Failed to build vended-test sub-location"))?;
 
         let tabular_info = TabularInfo {
             warehouse_id: WarehouseId::new_random(),
@@ -588,11 +604,15 @@ impl StorageProfile {
             &compression_codec,
             uuid::Uuid::now_v7(),
             0,
-        );
+        )?;
         let mut test_file_write = metadata_location.parent();
-        test_file_write.push("test");
+        test_file_write
+            .push("test")
+            .map_err(|e| location_extend_err(e, "Failed to build access-test path"))?;
         let mut test_file_write = test_file_write.parent();
-        test_file_write.push("test");
+        test_file_write
+            .push("test")
+            .map_err(|e| location_extend_err(e, "Failed to build access-test path"))?;
         tracing::debug!("Validating access to: {}", test_file_write);
 
         // Test write
@@ -643,8 +663,11 @@ impl StorageProfile {
             &compression_codec,
             uuid::Uuid::now_v7(),
             0,
-        );
-        test_file_write.pop().push("forbidden-write-test");
+        )?;
+        test_file_write
+            .pop()
+            .push("forbidden-write-test")
+            .map_err(|e| location_extend_err(e, "Failed to build forbidden-write-test path"))?;
 
         tracing::debug!(
             "Validating that write access is denied to: {}",
@@ -792,39 +815,54 @@ impl StorageProfile {
         Ok(())
     }
 
-    #[must_use]
     /// Get the default metadata location for the storage profile.
+    ///
+    /// # Errors
+    /// Fails if the assembled location violates URL canonicalisation
+    /// rules. In practice the inputs (UUID, count, literal `metadata`)
+    /// are statically canonical-safe, but we propagate rather than panic
+    /// to maintain the no-panics invariant.
     pub fn default_metadata_location(
         &self,
         table_location: &Location,
         compression_codec: &CompressionCodec,
         metadata_id: uuid::Uuid,
         metadata_count: usize,
-    ) -> Location {
+    ) -> Result<Location, ValidationError> {
         let filename_extension_compression = compression_codec.as_file_extension();
         let filename = format!(
             "{metadata_count:05}-{metadata_id}{filename_extension_compression}.metadata.json",
         );
         let mut l = table_location.clone();
 
-        l.without_trailing_slash().extend(&["metadata", &filename]);
-        l
+        l.without_trailing_slash()
+            .extend(&["metadata", &filename])
+            .map_err(|e| location_extend_err(e, "Failed to build metadata location"))?;
+        Ok(l)
     }
 
     /// Get the default tabular location for the storage profile.
-    #[must_use]
+    ///
+    /// # Errors
+    /// Fails if the layout-rendered tabular segment violates URL
+    /// canonicalisation rules (e.g. contains `..` or decoded `/`). In
+    /// practice templates produce safe segments, but we propagate rather
+    /// than panic to maintain the no-panics invariant.
     pub fn default_tabular_location(
         &self,
         namespace_location: &Location,
         tabular_name_context: &TabularNameContext,
-    ) -> Location {
+    ) -> Result<Location, ValidationError> {
         let mut location = namespace_location.clone();
 
         let layout = self.layout().unwrap_or_else(|| &DEFAULT_LAYOUT);
 
         let segment = layout.render_tabular_segment(tabular_name_context);
-        location.without_trailing_slash().push(&segment);
         location
+            .without_trailing_slash()
+            .push(&segment)
+            .map_err(|e| location_extend_err(e, "Failed to build tabular location"))?;
+        Ok(location)
     }
 
     #[must_use]
@@ -1153,14 +1191,16 @@ mod tests {
         let target_location = format!("s3://my-bucket/subfolder/{ns_uuid}/{tabular_uuid}");
 
         let namespace_location = profile.default_namespace_location(&namespace_path).unwrap();
-        let tabular_location =
-            profile.default_tabular_location(&namespace_location, &tabular_name_context);
+        let tabular_location = profile
+            .default_tabular_location(&namespace_location, &tabular_name_context)
+            .unwrap();
         assert_eq!(tabular_location.to_string(), target_location);
 
         let mut namespace_location_without_slash = namespace_location.clone();
         namespace_location_without_slash.without_trailing_slash();
         let tabular_location_trailing = profile
-            .default_tabular_location(&namespace_location_without_slash, &tabular_name_context);
+            .default_tabular_location(&namespace_location_without_slash, &tabular_name_context)
+            .unwrap();
         assert!(!namespace_location_without_slash.to_string().ends_with('/'));
         assert_eq!(tabular_location_trailing.to_string(), target_location);
     }
@@ -1483,7 +1523,8 @@ mod tests {
         let mut metadata_location = table_location.clone();
         metadata_location
             .without_trailing_slash()
-            .push("test.gz.metadata.json");
+            .push("test.gz.metadata.json")
+            .unwrap();
 
         let io = profile.file_io(Some(cred)).await.unwrap();
 
@@ -1515,9 +1556,15 @@ mod tests {
             .base_location()
             .expect("Failed to get base location");
         let mut table_location1 = base_location.clone();
-        table_location1.without_trailing_slash().push("test");
+        table_location1
+            .without_trailing_slash()
+            .push("test")
+            .unwrap();
         let mut table_location2 = base_location.clone();
-        table_location2.without_trailing_slash().push("test2");
+        table_location2
+            .without_trailing_slash()
+            .push("test2")
+            .unwrap();
 
         let config1 = profile
             .generate_table_config(
@@ -1586,8 +1633,10 @@ mod tests {
             }
         };
         // can read & write in own locations
-        let test_file1 = table_location1.cloning_push("test.txt");
-        let test_file2 = table_location2.cloning_push("test.txt");
+        let mut test_file1 = table_location1.clone();
+        test_file1.push("test.txt").unwrap();
+        let mut test_file2 = table_location2.clone();
+        test_file2.push("test.txt").unwrap();
 
         downscoped1
             .write(

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -1146,11 +1146,13 @@ mod tests {
 
     #[test]
     fn test_split_location() {
-        let location = Location::from_str("abfss://").unwrap();
+        // Note: a host-less `abfss://` is no longer valid — `Location` now
+        // requires a non-empty host post-canonicalisation.
+        let location = Location::from_str("abfss://foo").unwrap();
         let prefix = location.scheme();
         let full_path = location.authority_and_path();
         assert_eq!(prefix, "abfss");
-        assert_eq!(full_path, "");
+        assert_eq!(full_path, "foo");
         assert_eq!(join_location(prefix, full_path).unwrap(), location);
 
         let location = Location::from_str("abfss://foo/bar").unwrap();

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -958,21 +958,10 @@ impl S3Profile {
                 reason: format!("Could not generate downscoped policy for temporary credentials as location is no valid S3 location: {e}").to_string(),
             }
         })?;
-        let bucket_arn = format!(
-            "arn:aws:s3:::{}",
-            table_location.bucket_name().trim_end_matches('/')
-        );
-        // AWS IAM matches policy `Resource` / `s3:prefix` against the
-        // *decoded* request key (the server URL-decodes before the IAM
-        // check). The canonical Location's segments are URL-encoded —
-        // percent-decode here before glob-escaping so the pattern AWS
-        // sees matches the actual key bytes. (`escape_iam_glob_literal`
-        // then neutralises any literal `*`/`?`/`$` in the path so they're
-        // matched literally rather than as IAM glob metacharacters.)
-        let raw_key = format!("{}/", table_location.key().join("/"));
-        let decoded_key = percent_encoding::percent_decode_str(&raw_key).decode_utf8_lossy();
-        let key = escape_iam_glob_literal(&decoded_key);
-        let key_wildcard = format!("{key}*");
+        let bucket_arn = s3_iam_bucket_arn(&table_location);
+        let key_exact = s3_iam_resource_arn_exact(&table_location);
+        let key_wildcard = s3_iam_resource_arn_wildcard(&table_location);
+        let key_prefix = s3_iam_listbucket_prefix(&table_location);
 
         let actions = Self::permission_to_actions(storage_permissions);
         let mut statements = vec![
@@ -980,19 +969,16 @@ impl S3Profile {
                 "Sid": "TableAccess",
                 "Effect": "Allow",
                 "Action": actions,
-                "Resource": [
-                    format!("{bucket_arn}/{key}"),
-                    format!("{bucket_arn}/{key_wildcard}"),
-                ],
+                "Resource": [key_exact, key_wildcard],
             }),
             json!({
                 "Sid": "ListBucketForFolder",
                 "Effect": "Allow",
                 "Action": "s3:ListBucket",
-                "Resource": bucket_arn,
+                "Resource": &bucket_arn,
                 "Condition": {
                     "StringLike": {
-                        "s3:prefix": key_wildcard,
+                        "s3:prefix": key_prefix,
                     },
                 },
             }),
@@ -1211,6 +1197,56 @@ fn escape_iam_glob_literal(value: &str) -> String {
         }
     }
     out
+}
+
+// --- Egress encoders ---------------------------------------------------
+//
+// Each function here produces the byte form a specific AWS-side consumer
+// expects from a `Location`. They live next to the IAM policy builder
+// so a reviewer can verify the canonical form matches what AWS does
+// server-side (URL-decode + glob-match for IAM `Resource` and `s3:prefix`).
+
+/// `arn:aws:s3:::{bucket}` — the bucket-level ARN, used as the resource
+/// for `s3:ListBucket` and as the prefix for object-level resource ARNs.
+fn s3_iam_bucket_arn(loc: &S3Location) -> String {
+    format!("arn:aws:s3:::{}", loc.bucket_name())
+}
+
+/// Decoded table-key path with a trailing `/` and IAM glob-meta chars
+/// (`*`/`?`/`$`) escaped. AWS IAM matches policy `Resource`/`s3:prefix`
+/// against the **decoded** key (the server URL-decodes the request before
+/// the IAM check), so we percent-decode the canonical-encoded segments
+/// here before emitting. Non-UTF-8 bytes fall back to lossy decode —
+/// IAM patterns are byte-strings, not UTF-8-strict.
+fn s3_iam_decoded_key_with_trailing_slash(loc: &S3Location) -> String {
+    let raw = format!("{}/", loc.key().join("/"));
+    let decoded = percent_encoding::percent_decode_str(&raw).decode_utf8_lossy();
+    escape_iam_glob_literal(&decoded)
+}
+
+/// `arn:aws:s3:::{bucket}/{decoded-prefix}/` — exact-prefix object ARN.
+fn s3_iam_resource_arn_exact(loc: &S3Location) -> String {
+    format!(
+        "{}/{}",
+        s3_iam_bucket_arn(loc),
+        s3_iam_decoded_key_with_trailing_slash(loc)
+    )
+}
+
+/// `arn:aws:s3:::{bucket}/{decoded-prefix}/*` — wildcard object ARN.
+fn s3_iam_resource_arn_wildcard(loc: &S3Location) -> String {
+    format!(
+        "{}/{}*",
+        s3_iam_bucket_arn(loc),
+        s3_iam_decoded_key_with_trailing_slash(loc)
+    )
+}
+
+/// `{decoded-prefix}/*` — value for `s3:prefix` in an `s3:ListBucket`
+/// condition. AWS decodes the request prefix server-side before glob-
+/// matching, so we feed the decoded form here.
+fn s3_iam_listbucket_prefix(loc: &S3Location) -> String {
+    format!("{}*", s3_iam_decoded_key_with_trailing_slash(loc))
 }
 
 fn storage_profile_to_s3_settings(profile: &S3Profile) -> S3Settings {
@@ -2080,6 +2116,40 @@ pub(crate) mod test {
             )
             .unwrap();
         let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
+    }
+
+    #[test]
+    fn s3_iam_encoders_decode_and_glob_escape() {
+        // AWS IAM compares policy `Resource` against the URL-decoded request
+        // key. The encoders decode the canonical-encoded key first, then
+        // escape glob meta-chars (`*`/`?`/`$`) so they match literally.
+        let loc: Location = "s3://my-bucket/wh/ev%3Fl/table".parse().unwrap();
+        let s3loc = S3Location::try_from_location(&loc, true).unwrap();
+        assert_eq!(s3_iam_bucket_arn(&s3loc), "arn:aws:s3:::my-bucket");
+        assert_eq!(
+            s3_iam_resource_arn_exact(&s3loc),
+            "arn:aws:s3:::my-bucket/wh/ev${?}l/table/"
+        );
+        assert_eq!(
+            s3_iam_resource_arn_wildcard(&s3loc),
+            "arn:aws:s3:::my-bucket/wh/ev${?}l/table/*"
+        );
+        assert_eq!(s3_iam_listbucket_prefix(&s3loc), "wh/ev${?}l/table/*");
+    }
+
+    #[test]
+    fn s3_iam_encoders_collapse_mixed_hex_to_same_form() {
+        // `%2D` and `%2d` and literal `-` all canonicalise to literal `-` —
+        // verify the encoder output is identical for all three forms.
+        let a: Location = "s3://my-bucket/foo-bar/x".parse().unwrap();
+        let b: Location = "s3://my-bucket/foo%2Dbar/x".parse().unwrap();
+        let c: Location = "s3://my-bucket/foo%2dbar/x".parse().unwrap();
+        let arn_a = s3_iam_resource_arn_exact(&S3Location::try_from_location(&a, false).unwrap());
+        let arn_b = s3_iam_resource_arn_exact(&S3Location::try_from_location(&b, false).unwrap());
+        let arn_c = s3_iam_resource_arn_exact(&S3Location::try_from_location(&c, false).unwrap());
+        assert_eq!(arn_a, arn_b);
+        assert_eq!(arn_a, arn_c);
+        assert_eq!(arn_a, "arn:aws:s3:::my-bucket/foo-bar/x/");
     }
 
     #[test]

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -962,7 +962,16 @@ impl S3Profile {
             "arn:aws:s3:::{}",
             table_location.bucket_name().trim_end_matches('/')
         );
-        let key = escape_iam_glob_literal(&format!("{}/", table_location.key().join("/")));
+        // AWS IAM matches policy `Resource` / `s3:prefix` against the
+        // *decoded* request key (the server URL-decodes before the IAM
+        // check). The canonical Location's segments are URL-encoded —
+        // percent-decode here before glob-escaping so the pattern AWS
+        // sees matches the actual key bytes. (`escape_iam_glob_literal`
+        // then neutralises any literal `*`/`?`/`$` in the path so they're
+        // matched literally rather than as IAM glob metacharacters.)
+        let raw_key = format!("{}/", table_location.key().join("/"));
+        let decoded_key = percent_encoding::percent_decode_str(&raw_key).decode_utf8_lossy();
+        let key = escape_iam_glob_literal(&decoded_key);
         let key_wildcard = format!("{key}*");
 
         let actions = Self::permission_to_actions(storage_permissions);

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -1204,7 +1204,19 @@ fn escape_iam_glob_literal(value: &str) -> String {
 // Each function here produces the byte form a specific AWS-side consumer
 // expects from a `Location`. They live next to the IAM policy builder
 // so a reviewer can verify the canonical form matches what AWS does
-// server-side (URL-decode + glob-match for IAM `Resource` and `s3:prefix`).
+// server-side.
+//
+// IMPORTANT: encoders use the canonical-encoded path (not decoded). When
+// a client writes to S3, the SDK URL-encodes the key for the wire (so a
+// `%` in the key becomes `%25`); the server URL-decodes once and stores
+// at the canonical-encoded form. IAM matches the policy `Resource`
+// against that stored key, so the policy must contain the same bytes as
+// the canonical Location.
+//
+// Glob meta-chars (`*`/`?`/`$`) that appear *literally* in the canonical
+// path (only `*` and `$` can — `?` is rejected at parse) are escaped via
+// `escape_iam_glob_literal` so AWS treats them as literal characters
+// rather than wildcards.
 
 /// `arn:aws:s3:::{bucket}` — the bucket-level ARN, used as the resource
 /// for `s3:ListBucket` and as the prefix for object-level resource ARNs.
@@ -1212,41 +1224,35 @@ fn s3_iam_bucket_arn(loc: &S3Location) -> String {
     format!("arn:aws:s3:::{}", loc.bucket_name())
 }
 
-/// Decoded table-key path with a trailing `/` and IAM glob-meta chars
-/// (`*`/`?`/`$`) escaped. AWS IAM matches policy `Resource`/`s3:prefix`
-/// against the **decoded** key (the server URL-decodes the request before
-/// the IAM check), so we percent-decode the canonical-encoded segments
-/// here before emitting. Non-UTF-8 bytes fall back to lossy decode —
-/// IAM patterns are byte-strings, not UTF-8-strict.
-fn s3_iam_decoded_key_with_trailing_slash(loc: &S3Location) -> String {
-    let raw = format!("{}/", loc.key().join("/"));
-    let decoded = percent_encoding::percent_decode_str(&raw).decode_utf8_lossy();
-    escape_iam_glob_literal(&decoded)
+/// Canonical-encoded table-key path with a trailing `/` and IAM glob-meta
+/// chars (`*`/`?`/`$`) escaped. The path bytes match the canonical
+/// `Location` form, which is also what S3 stores (clients URL-encode `%`
+/// for the wire so the server stores the percent-encoded form back).
+fn s3_iam_key_with_trailing_slash(loc: &S3Location) -> String {
+    escape_iam_glob_literal(&format!("{}/", loc.key().join("/")))
 }
 
-/// `arn:aws:s3:::{bucket}/{decoded-prefix}/` — exact-prefix object ARN.
+/// `arn:aws:s3:::{bucket}/{prefix}/` — exact-prefix object ARN.
 fn s3_iam_resource_arn_exact(loc: &S3Location) -> String {
     format!(
         "{}/{}",
         s3_iam_bucket_arn(loc),
-        s3_iam_decoded_key_with_trailing_slash(loc)
+        s3_iam_key_with_trailing_slash(loc)
     )
 }
 
-/// `arn:aws:s3:::{bucket}/{decoded-prefix}/*` — wildcard object ARN.
+/// `arn:aws:s3:::{bucket}/{prefix}/*` — wildcard object ARN.
 fn s3_iam_resource_arn_wildcard(loc: &S3Location) -> String {
     format!(
         "{}/{}*",
         s3_iam_bucket_arn(loc),
-        s3_iam_decoded_key_with_trailing_slash(loc)
+        s3_iam_key_with_trailing_slash(loc)
     )
 }
 
-/// `{decoded-prefix}/*` — value for `s3:prefix` in an `s3:ListBucket`
-/// condition. AWS decodes the request prefix server-side before glob-
-/// matching, so we feed the decoded form here.
+/// `{prefix}/*` — value for `s3:prefix` in an `s3:ListBucket` condition.
 fn s3_iam_listbucket_prefix(loc: &S3Location) -> String {
-    format!("{}*", s3_iam_decoded_key_with_trailing_slash(loc))
+    format!("{}*", s3_iam_key_with_trailing_slash(loc))
 }
 
 fn storage_profile_to_s3_settings(profile: &S3Profile) -> S3Settings {
@@ -2119,28 +2125,32 @@ pub(crate) mod test {
     }
 
     #[test]
-    fn s3_iam_encoders_decode_and_glob_escape() {
-        // AWS IAM compares policy `Resource` against the URL-decoded request
-        // key. The encoders decode the canonical-encoded key first, then
-        // escape glob meta-chars (`*`/`?`/`$`) so they match literally.
+    fn s3_iam_encoders_use_canonical_encoded_form() {
+        // The canonical Location keeps `?` percent-encoded as `%3F`. The
+        // S3 IAM Resource ARN must match the bytes that S3 actually stores
+        // — clients URL-encode `%` for the wire (`%3F` → `%253F`), the
+        // server URL-decodes once → `%3F` literal in the key. So the
+        // policy contains `%3F` literal, NOT a decoded `?` (which would
+        // never match).
         let loc: Location = "s3://my-bucket/wh/ev%3Fl/table".parse().unwrap();
         let s3loc = S3Location::try_from_location(&loc, true).unwrap();
         assert_eq!(s3_iam_bucket_arn(&s3loc), "arn:aws:s3:::my-bucket");
         assert_eq!(
             s3_iam_resource_arn_exact(&s3loc),
-            "arn:aws:s3:::my-bucket/wh/ev${?}l/table/"
+            "arn:aws:s3:::my-bucket/wh/ev%3Fl/table/"
         );
         assert_eq!(
             s3_iam_resource_arn_wildcard(&s3loc),
-            "arn:aws:s3:::my-bucket/wh/ev${?}l/table/*"
+            "arn:aws:s3:::my-bucket/wh/ev%3Fl/table/*"
         );
-        assert_eq!(s3_iam_listbucket_prefix(&s3loc), "wh/ev${?}l/table/*");
+        assert_eq!(s3_iam_listbucket_prefix(&s3loc), "wh/ev%3Fl/table/*");
     }
 
     #[test]
     fn s3_iam_encoders_collapse_mixed_hex_to_same_form() {
-        // `%2D` and `%2d` and literal `-` all canonicalise to literal `-` —
-        // verify the encoder output is identical for all three forms.
+        // `%2D` and `%2d` and literal `-` all canonicalise to literal `-`
+        // (unreserved char) — verify the encoder output is identical for
+        // all three forms.
         let a: Location = "s3://my-bucket/foo-bar/x".parse().unwrap();
         let b: Location = "s3://my-bucket/foo%2Dbar/x".parse().unwrap();
         let c: Location = "s3://my-bucket/foo%2dbar/x".parse().unwrap();
@@ -2150,6 +2160,19 @@ pub(crate) mod test {
         assert_eq!(arn_a, arn_b);
         assert_eq!(arn_a, arn_c);
         assert_eq!(arn_a, "arn:aws:s3:::my-bucket/foo-bar/x/");
+    }
+
+    #[test]
+    fn s3_iam_encoders_glob_escape_literal_star_and_dollar() {
+        // `*` and `$` ARE canonical literals (sub-delims, decoded by
+        // canonicalisation). They must be glob-escaped so AWS IAM treats
+        // them as literal characters, not wildcards / variable markers.
+        let loc: Location = "s3://my-bucket/path*with$meta/x".parse().unwrap();
+        let s3loc = S3Location::try_from_location(&loc, false).unwrap();
+        assert_eq!(
+            s3_iam_resource_arn_exact(&s3loc),
+            "arn:aws:s3:::my-bucket/path${*}with${$}meta/x/"
+        );
     }
 
     #[test]
@@ -2204,10 +2227,12 @@ pub(crate) mod test {
 
     #[test]
     fn policy_string_handles_json_special_chars_in_path() {
-        // url::Url::parse percent-encodes `"` and most JSON-breaking chars in
-        // the path, but `\` survives unchanged. With raw format!() this would
-        // produce invalid JSON or worse. With serde_json the value gets
-        // escaped automatically. This test pins that behavior.
+        // `\` is not in RFC 3986 unreserved or sub-delims, so canonicalisation
+        // percent-encodes it to `%5C`. The IAM Resource matches the
+        // canonical-encoded form (which is what S3 actually stores after the
+        // client URL-encodes `%` → `%25` for the wire and the server decodes
+        // once). The `%5C` sequence has no JSON-special chars, so the
+        // serialised policy contains plain `back%5Cslash`.
         let table_location = r"s3://bucket-name/wh/back\slash/table";
         let profile = S3Profile::builder()
             .bucket("bucket-name".to_string())
@@ -2224,26 +2249,28 @@ pub(crate) mod test {
             .unwrap();
         // Must round-trip as valid JSON.
         let parsed: serde_json::Value = serde_json::from_str(&policy).unwrap();
-        // The backslash must appear escaped in the serialized form.
         assert!(
-            policy.contains(r"back\\slash"),
-            "expected `\\\\` in serialized policy, got: {policy}"
+            policy.contains("back%5Cslash"),
+            "expected percent-encoded `\\` in policy, got: {policy}"
         );
-        // And the parsed JSON must contain a single literal backslash.
+        // The parsed JSON must contain the canonical-encoded form (no
+        // raw backslash decoded back).
         let resources = parsed["Statement"][0]["Resource"].as_array().unwrap();
         assert!(
             resources
                 .iter()
-                .any(|r| r.as_str().unwrap().contains(r"back\slash")),
-            "expected literal backslash in parsed Resource, got: {resources:?}"
+                .any(|r| r.as_str().unwrap().contains("back%5Cslash")),
+            "expected `back%5Cslash` in parsed Resource, got: {resources:?}"
         );
     }
 
     #[test]
-    fn policy_string_neutralizes_question_mark_in_table_path() {
-        // `Location::from_str` rejects raw `?` at parse time. The canonical
-        // form for `?` in a path is `%3F` — verify the IAM glob escape
-        // turns the decoded `?` into the AWS-safe `${?}` literal.
+    fn policy_string_keeps_question_mark_encoded_in_table_path() {
+        // `Location::from_str` rejects raw `?` at parse time; the canonical
+        // form keeps it as `%3F`. The IAM Resource must also contain
+        // `%3F` literal — that's what S3 stores (clients URL-encode `%`
+        // → `%25` on the wire, server decodes once → `%3F` literal in the
+        // key). Decoding to `?` here would never match the actual key.
         let table_location: Location = "s3://bucket-name/wh/ev%3Fl/table".parse().unwrap();
         let profile = S3Profile::builder()
             .bucket("bucket-name".to_string())
@@ -2256,12 +2283,16 @@ pub(crate) mod test {
             .get_sts_policy_string(&table_location, StoragePermissions::ReadWriteDelete)
             .unwrap();
         assert!(
-            policy.contains("wh/ev${?}l/table"),
-            "expected escaped `?` in policy, got: {policy}"
+            policy.contains("wh/ev%3Fl/table"),
+            "expected canonical `%3F` in policy, got: {policy}"
         );
         assert!(
             !policy.contains("wh/ev?l/table"),
-            "raw `?` leaked into policy: {policy}"
+            "decoded `?` leaked into policy: {policy}"
+        );
+        assert!(
+            !policy.contains("${?}"),
+            "should not glob-escape `%3F` (it's not a literal `?`): {policy}"
         );
         let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
     }

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -999,10 +999,20 @@ impl S3Profile {
         ];
 
         if let Some(kms_key_arn) = self.aws_kms_key_arn.as_ref() {
+            // Read-only creds only need to decrypt existing data keys.
+            // GenerateDataKey is a write-side action (creates new data
+            // keys to encrypt new objects); granting it on a Read-only
+            // role broadens KMS access beyond the table access mode.
+            let kms_actions: &[&str] = match storage_permissions {
+                StoragePermissions::Read => &["kms:Decrypt"],
+                StoragePermissions::ReadWrite | StoragePermissions::ReadWriteDelete => {
+                    &["kms:Decrypt", "kms:GenerateDataKey"]
+                }
+            };
             statements.push(json!({
                 "Sid": "KmsAccess",
                 "Effect": "Allow",
-                "Action": ["kms:Decrypt", "kms:GenerateDataKey"],
+                "Action": kms_actions,
                 "Resource": kms_key_arn,
             }));
         }
@@ -1579,7 +1589,9 @@ pub(crate) mod test {
         };
         let namespace_location = sp.default_namespace_location(&namespace_path).unwrap();
 
-        let location = sp.default_tabular_location(&namespace_location, &tabular_name_context);
+        let location = sp
+            .default_tabular_location(&namespace_location, &tabular_name_context)
+            .unwrap();
         assert_eq!(
             location.to_string(),
             format!("s3://test-bucket/test_prefix/{namespace_uuid}/{tabular_uuid}")
@@ -1590,7 +1602,9 @@ pub(crate) mod test {
         let sp: StorageProfile = profile.into();
 
         let namespace_location = sp.default_namespace_location(&namespace_path).unwrap();
-        let location = sp.default_tabular_location(&namespace_location, &tabular_name_context);
+        let location = sp
+            .default_tabular_location(&namespace_location, &tabular_name_context)
+            .unwrap();
         assert_eq!(
             location.to_string(),
             format!("s3://test-bucket/{namespace_uuid}/{tabular_uuid}")
@@ -1625,12 +1639,16 @@ pub(crate) mod test {
         // Tabular locations should not have a trailing slash, otherwise pyiceberg fails.
         let expected = format!("s3://test-bucket/foo/{tabular_uuid}");
 
-        let location = profile.default_tabular_location(&namespace_location, &tabular_name_context);
+        let location = profile
+            .default_tabular_location(&namespace_location, &tabular_name_context)
+            .unwrap();
 
         assert_eq!(location.to_string(), expected);
 
         let namespace_location = Location::from_str("s3://test-bucket/foo").unwrap();
-        let location = profile.default_tabular_location(&namespace_location, &tabular_name_context);
+        let location = profile
+            .default_tabular_location(&namespace_location, &tabular_name_context)
+            .unwrap();
         assert_eq!(location.to_string(), expected);
     }
 
@@ -2144,13 +2162,10 @@ pub(crate) mod test {
 
     #[test]
     fn policy_string_neutralizes_question_mark_in_table_path() {
-        // `Location::from_str` now rejects raw `?` at parse time, so this
-        // state can't be reached via REST anymore. Build via `extend()`
-        // (which doesn't re-parse) to defense-in-depth check that the
-        // escape is wired up in the policy path even if some future code
-        // bypasses the parser.
-        let mut table_location: Location = "s3://bucket-name/wh".parse().unwrap();
-        table_location.extend(["ev?l", "table"]);
+        // `Location::from_str` rejects raw `?` at parse time. The canonical
+        // form for `?` in a path is `%3F` — verify the IAM glob escape
+        // turns the decoded `?` into the AWS-safe `${?}` literal.
+        let table_location: Location = "s3://bucket-name/wh/ev%3Fl/table".parse().unwrap();
         let profile = S3Profile::builder()
             .bucket("bucket-name".to_string())
             .key_prefix("wh".to_string())

--- a/tests/python/tests/conftest.py
+++ b/tests/python/tests/conftest.py
@@ -171,7 +171,10 @@ def storage_config(request) -> dict:
                 "path-style-access": path_style_access,
                 "endpoint": settings.s3_endpoint,
                 "key-prefix": test_id,
-                "flavor": "minio",
+                # `s3-compat` is the canonical S3Flavor enum name; `minio`
+                # is a backward-compat serde alias. Use the canonical form
+                # so what tests read from `storage_config` matches.
+                "flavor": "s3-compat",
                 "sts-enabled": request.param["sts-enabled"],
                 "legacy-md5-behavior": legacy_md5_behavior,
                 "layout": layout,

--- a/tests/python/tests/test_special_char_locations.py
+++ b/tests/python/tests/test_special_char_locations.py
@@ -43,9 +43,9 @@ _MINIO_NO_IAM_VARS = "MinIO does not resolve IAM policy variables (${*}/${?}/${$
 # `url::Url`, so they can never round-trip in a URL-based location and are
 # not testable here.
 SPECIAL_CHARS = [
-    SpecialChar("star", "*", expect_deny={("s3", "minio"): _MINIO_NO_IAM_VARS}),
+    SpecialChar("star", "*", expect_deny={("s3", "s3-compat"): _MINIO_NO_IAM_VARS}),
     SpecialChar("question", "%3F"),
-    SpecialChar("dollar", "$", expect_deny={("s3", "minio"): _MINIO_NO_IAM_VARS}),
+    SpecialChar("dollar", "$", expect_deny={("s3", "s3-compat"): _MINIO_NO_IAM_VARS}),
     SpecialChar("squote", "'"),
     SpecialChar("plus", "+"),
     SpecialChar("dquote", "%22"),

--- a/tests/python/tests/test_special_char_locations.py
+++ b/tests/python/tests/test_special_char_locations.py
@@ -44,11 +44,7 @@ _MINIO_NO_IAM_VARS = "MinIO does not resolve IAM policy variables (${*}/${?}/${$
 # not testable here.
 SPECIAL_CHARS = [
     SpecialChar("star", "*", expect_deny={("s3", "s3-compat"): _MINIO_NO_IAM_VARS}),
-    SpecialChar(
-        "question",
-        "%3F",
-        expect_deny={("s3", "s3-compat"): _MINIO_NO_IAM_VARS},
-    ),
+    SpecialChar("question", "%3F"),
     SpecialChar("dollar", "$", expect_deny={("s3", "s3-compat"): _MINIO_NO_IAM_VARS}),
     SpecialChar("squote", "'"),
     SpecialChar("plus", "+"),

--- a/tests/python/tests/test_special_char_locations.py
+++ b/tests/python/tests/test_special_char_locations.py
@@ -44,7 +44,11 @@ _MINIO_NO_IAM_VARS = "MinIO does not resolve IAM policy variables (${*}/${?}/${$
 # not testable here.
 SPECIAL_CHARS = [
     SpecialChar("star", "*", expect_deny={("s3", "s3-compat"): _MINIO_NO_IAM_VARS}),
-    SpecialChar("question", "%3F"),
+    SpecialChar(
+        "question",
+        "%3F",
+        expect_deny={("s3", "s3-compat"): _MINIO_NO_IAM_VARS},
+    ),
     SpecialChar("dollar", "$", expect_deny={("s3", "s3-compat"): _MINIO_NO_IAM_VARS}),
     SpecialChar("squote", "'"),
     SpecialChar("plus", "+"),

--- a/tests/python/tox.ini
+++ b/tests/python/tox.ini
@@ -51,7 +51,9 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
+    # tests/test_special_char_locations.py omitted: requires vended creds
+    # (skips when S3_STS_MODE=disabled).
+    pytest {posargs:tests} tests/test_spark.py -rs
 
 [testenv:spark_minio_s3a]
 description = spark_minio_s3a
@@ -129,7 +131,8 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
+    # tests/test_special_char_locations.py omitted: requires vended creds.
+    pytest {posargs:tests} tests/test_spark.py -rs
 
 [testenv:spark_kv2]
 description = spark_kv2
@@ -142,7 +145,8 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
+    # tests/test_special_char_locations.py omitted: requires vended creds.
+    pytest {posargs:tests} tests/test_spark.py -rs
 
 [testenv:spark_gcs]
 description = spark_gcs
@@ -166,7 +170,8 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
+    # tests/test_special_char_locations.py omitted: requires vended creds.
+    pytest {posargs:tests} tests/test_spark.py -rs
 
 [testenv:spark_aws_sts]
 description = spark_aws_sts
@@ -192,7 +197,8 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
+    # tests/test_special_char_locations.py omitted: requires vended creds.
+    pytest {posargs:tests} tests/test_spark.py -rs
 
 [testenv:spark_aws_system_identity_sts]
 description = spark_aws_system_identity_sts

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -54,18 +54,18 @@ echo "Iceberg version   : ${SPARK_VERSION:-default}" >&2
 COMPOSE_ARGS=("-f" "${SCRIPT_DIR}/docker-compose.yaml")
 if [[ "$SUITE" == *"openfga"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-openfga-overlay.yaml")
-    elif [[ "$SUITE" == *"kv2"* ]]; then
+elif [[ "$SUITE" == *"kv2"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-vault-overlay.yaml")
-    elif [[ "$SUITE" == *"opa"* ]]; then
+elif [[ "$SUITE" == *"opa"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-openfga-overlay.yaml")
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-trino-opa-overlay.yaml")
-    elif [[ "$SUITE" == *"starrocks"* ]]; then
+elif [[ "$SUITE" == *"starrocks"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-starrocks-overlay.yaml")
-    elif [[ "$SUITE" == *"aws_system_identity"* ]]; then
+elif [[ "$SUITE" == *"aws_system_identity"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-s3-system-identity-overlay.yaml")
-    elif [[ "$SUITE" == *"legacy_md5"* ]]; then
+elif [[ "$SUITE" == *"legacy_md5"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-legacy-md5-overlay.yaml")
-    elif [[ "$SUITE" == *"separate_endpoint"* ]]; then
+elif [[ "$SUITE" == *"separate_endpoint"* ]]; then
     COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-sts-endpoint-overlay.yaml")
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter canonicalization and validation of locations and path segments (rejects traversal, control chars, trailing-dot, consecutive/empty or whitespace-only decoded segments); clearer error mapping when location extension/validation fails.

* **Security**
  * Signing and policy generation for ADLS/GCS/S3 now use canonical, percent-decoded paths to produce correct SAS/STS/IAM/KMS resources and prefixes.

* **Tests**
  * Tests updated for canonical round‑trips and new rejection rules; Python tests now use s3-compat.

* **Chores**
  * Test runner/tox and test harness adjustments to skip or reshape special-case runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->