### PR TITLE
fix(postgres): apply pg_acquire_timeout to all pool initializations

### DIFF
--- a/crates/lakekeeper-bin/src/healthcheck.rs
+++ b/crates/lakekeeper-bin/src/healthcheck.rs
@@ -44,22 +44,12 @@ pub(crate) async fn health(check_db: bool, check_server: bool) -> anyhow::Result
 }
 
 pub(crate) async fn db_health_check() -> anyhow::Result<()> {
-    let reader = get_reader_pool(
-        CONFIG
-            .to_pool_opts()
-            .acquire_timeout(std::time::Duration::from_secs(CONFIG.pg_acquire_timeout))
-            .max_connections(1),
-    )
-    .await
-    .with_context(|| "Read pool failed.")?;
-    let writer = get_writer_pool(
-        CONFIG
-            .to_pool_opts()
-            .acquire_timeout(std::time::Duration::from_secs(CONFIG.pg_acquire_timeout))
-            .max_connections(1),
-    )
-    .await
-    .with_context(|| "Write pool failed.")?;
+    let reader = get_reader_pool(CONFIG.to_pool_opts().max_connections(1))
+        .await
+        .with_context(|| "Read pool failed.")?;
+    let writer = get_writer_pool(CONFIG.to_pool_opts().max_connections(1))
+        .await
+        .with_context(|| "Write pool failed.")?;
 
     let db = ReadWrite::from_pools(reader.clone(), writer.clone());
     db.update_health().await;

--- a/crates/lakekeeper-bin/src/main.rs
+++ b/crates/lakekeeper-bin/src/main.rs
@@ -290,12 +290,8 @@ async fn reopen_bootstrap(yes: bool) -> anyhow::Result<()> {
         );
     }
 
-    let write_pool = lakekeeper::implementations::postgres::get_writer_pool(
-        CONFIG
-            .to_pool_opts()
-            .acquire_timeout(std::time::Duration::from_secs(CONFIG.pg_acquire_timeout)),
-    )
-    .await?;
+    let write_pool =
+        lakekeeper::implementations::postgres::get_writer_pool(CONFIG.to_pool_opts()).await?;
     let catalog_state = CatalogState::from_pools(write_pool.clone(), write_pool);
 
     let server_id =
@@ -393,12 +389,8 @@ async fn openfga_reconcile(
 
 async fn migrate() -> anyhow::Result<()> {
     tracing::info!("Migrating database...");
-    let write_pool = lakekeeper::implementations::postgres::get_writer_pool(
-        CONFIG
-            .to_pool_opts()
-            .acquire_timeout(std::time::Duration::from_secs(CONFIG.pg_acquire_timeout)),
-    )
-    .await?;
+    let write_pool =
+        lakekeeper::implementations::postgres::get_writer_pool(CONFIG.to_pool_opts()).await?;
 
     // This embeds database migrations in the application binary so we can ensure the database
     // is migrated correctly on startup

--- a/crates/lakekeeper-bin/src/wait_for_db.rs
+++ b/crates/lakekeeper-bin/src/wait_for_db.rs
@@ -36,11 +36,7 @@ pub(crate) async fn wait_for_db(
     if check_migrations {
         let mut counter = 0;
         loop {
-            let opts = CONFIG
-                .to_pool_opts()
-                .acquire_timeout(std::time::Duration::from_secs(CONFIG.pg_acquire_timeout));
-
-            let read_pool = get_reader_pool(opts).await?;
+            let read_pool = get_reader_pool(CONFIG.to_pool_opts()).await?;
             let migrations =
                 lakekeeper::implementations::postgres::migrations::check_migration_status(
                     &read_pool,

--- a/crates/lakekeeper/src/implementations/postgres/mod.rs
+++ b/crates/lakekeeper/src/implementations/postgres/mod.rs
@@ -242,6 +242,7 @@ impl DynAppConfig {
     pub fn to_pool_opts(&self) -> PgPoolOptions {
         sqlx::pool::PoolOptions::default()
             .test_before_acquire(self.pg_test_before_acquire)
+            .acquire_timeout(core::time::Duration::from_secs(self.pg_acquire_timeout))
             .max_lifetime(
                 self.pg_connection_max_lifetime
                     .map(core::time::Duration::from_secs),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated database pool configuration initialization across the application.
  * Centralized database connection timeout settings management for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->