### PR TITLE
fix(adls): pre-encode `%` in blob name to defeat SDK alias collapse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,7 +2078,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2230,7 +2230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3781,6 +3781,7 @@ dependencies = [
  "tracing",
  "tryhard",
  "typed-builder 0.23.2",
+ "unicode-general-category",
  "url",
  "uuid",
  "veil",
@@ -4262,7 +4263,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4504,7 +4505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5122,7 +5123,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5651,7 +5652,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5732,7 +5733,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6648,7 +6649,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7276,6 +7277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7741,7 +7748,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ tracing-test = "0.2.5"
 tryhard = { version = "0.5.1" }
 typed-builder = "^0.23.0"
 unicase = "2.8.1"
+unicode-general-category = "1.1.0"
 
 url = { version = "^2.5", features = ["serde"] }
 urlencoding = "^2.1"

--- a/crates/io/Cargo.toml
+++ b/crates/io/Cargo.toml
@@ -85,6 +85,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tryhard = { workspace = true }
 typed-builder = { workspace = true }
+unicode-general-category = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 veil = { workspace = true }

--- a/crates/io/src/adls/adls_location.rs
+++ b/crates/io/src/adls/adls_location.rs
@@ -539,16 +539,18 @@ mod test {
         ];
 
         for input in cases {
-            let result = Location::from_str(input)
-                .and_then(|loc| {
-                    AdlsLocation::try_from_location(&loc, false).map_err(|e| {
-                        crate::location::LocationParseError {
-                            value: input.to_string(),
-                            reason: e.to_string(),
-                        }
-                    })
-                });
-            assert!(result.is_err(), "{input:?} unexpectedly accepted: {result:?}");
+            let result = Location::from_str(input).and_then(|loc| {
+                AdlsLocation::try_from_location(&loc, false).map_err(|e| {
+                    crate::location::LocationParseError {
+                        value: input.to_string(),
+                        reason: e.to_string(),
+                    }
+                })
+            });
+            assert!(
+                result.is_err(),
+                "{input:?} unexpectedly accepted: {result:?}"
+            );
         }
     }
 

--- a/crates/io/src/adls/adls_location.rs
+++ b/crates/io/src/adls/adls_location.rs
@@ -159,11 +159,18 @@ impl AdlsLocation {
 
     #[must_use]
     pub fn blob_name(&self) -> String {
-        self.location
-            .path()
-            .unwrap_or_default()
-            .to_string()
-            .replace('?', "%3F")
+        // The azure_storage_datalake SDK constructs the wire URL via
+        // `Url::join`, which interprets `%XX` triplets in the blob name as
+        // already percent-encoded — so a stored blob name `%41bc` would go
+        // out on the wire as `%41bc` and the server would URL-decode it to
+        // `Abc`, aliasing two distinct keys. To keep the byte-literal model,
+        // pre-encode `%` (and the other URL-syntactic chars `?`/`#`) here so
+        // the SDK's join produces the right wire bytes for one server-side
+        // decode pass to land on our intended key.
+        use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+        const SDK_ESCAPE: &AsciiSet = &CONTROLS.add(b'%').add(b'?').add(b'#');
+        let path = self.location.path().unwrap_or_default();
+        utf8_percent_encode(path, SDK_ESCAPE).to_string()
     }
 
     /// Create a new `AdlsLocation` from a Location.

--- a/crates/io/src/adls/adls_location.rs
+++ b/crates/io/src/adls/adls_location.rs
@@ -527,6 +527,10 @@ mod test {
 
     #[test]
     fn test_invalid_adls_location() {
+        // Each input must be rejected SOMEWHERE in the parse chain — either
+        // by `Location::from_str` (e.g. host trailing dot is now globally
+        // rejected for backend-aliasing safety) or by ADLS-specific
+        // validation. The original test asserted only the latter.
         let cases = vec![
             "abfss://filesystem@account_name",
             "abfss://filesystem@account_name.example.com./foo",
@@ -534,10 +538,17 @@ mod test {
             "abfss://account_name.dfs.core.windows/foo",
         ];
 
-        for location in cases {
-            let location = Location::from_str(location).unwrap();
-            let parsed_location = AdlsLocation::try_from_location(&location, false);
-            assert!(parsed_location.is_err(), "{parsed_location:?}");
+        for input in cases {
+            let result = Location::from_str(input)
+                .and_then(|loc| {
+                    AdlsLocation::try_from_location(&loc, false).map_err(|e| {
+                        crate::location::LocationParseError {
+                            value: input.to_string(),
+                            reason: e.to_string(),
+                        }
+                    })
+                });
+            assert!(result.is_err(), "{input:?} unexpectedly accepted: {result:?}");
         }
     }
 

--- a/crates/io/src/location.rs
+++ b/crates/io/src/location.rs
@@ -1,5 +1,13 @@
 use std::str::{FromStr, RMatchIndices};
 
+use unicode_general_category::{GeneralCategory, get_general_category};
+
+/// Hard cap on accepted Location length. S3 keys are spec'd at 1024 chars,
+/// ADLS path components total under 1KB; multiplying by ~4 for UTF-8 worst
+/// case plus scheme/authority overhead lands at 4 KiB. Cap up-front so error
+/// paths can't allocate megabytes from a pathological input.
+const MAX_LOCATION_LEN: usize = 4096;
+
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[allow(clippy::struct_field_names)]
 pub struct Location {
@@ -34,14 +42,14 @@ impl Location {
 
     #[must_use]
     pub fn host_str(&self) -> Option<&str> {
-        // Everything between @ and the first slash
-        let host_part = if let Some(at_pos) = self.authority_and_path.find('@') {
-            // If there's an @ symbol, take everything after it
-            &self.authority_and_path[at_pos + 1..]
-        } else {
-            // If there's no @ symbol, use the whole location
-            &self.authority_and_path
-        };
+        // RFC 3986: the LAST `@` separates userinfo from host. Aligned
+        // with `check_host` so accessor and validator agree on what the
+        // host is for inputs like `s3://x@y@bucket/path` (legitimate or
+        // not, both must read the same host).
+        let host_part = self
+            .authority_and_path
+            .rsplit_once('@')
+            .map_or(self.authority_and_path.as_str(), |(_userinfo, h)| h);
 
         // Now find the first slash and return everything before it
         match host_part.find('/') {
@@ -268,10 +276,145 @@ impl std::fmt::Display for Location {
     }
 }
 
+/// Reject characters that `url::Url::parse` silently strips, percent-encodes,
+/// or otherwise normalises in a way that would create a parser-discrepancy
+/// gap (validator sees one string, we store another).
+///
+/// Rejects:
+/// - C0/C1 controls and DEL (Unicode `Cc` general category) — `\t\n\r` are
+///   the most dangerous since `url::Url` strips them silently
+/// - Bidi/format/zero-width chars (Unicode `Cf` general category) —
+///   visual-spoofing AND `url::Url` percent-encodes them silently. We
+///   enumerate the well-known dangerous ranges; this is not a full Cf
+///   table but covers every char the reviewer specified plus the common
+///   ZWSP/RLO/BOM/LRM cluster.
+fn check_unsafe_chars(s: &str) -> Result<(), String> {
+    for (idx, c) in s.char_indices() {
+        if c.is_control() {
+            return Err(format!(
+                "control character (U+{:04X}) at byte {idx} in input",
+                c as u32
+            ));
+        }
+        if is_format_or_invisible(c) {
+            return Err(format!(
+                "bidi/format/invisible character (U+{:04X}) at byte {idx} in input",
+                c as u32
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// True for any char in Unicode `Cf` general category (bidi controls,
+/// zero-width formatters, BOM, Tag block `U+E0000..U+E007F`, etc.). Uses
+/// the upstream Unicode tables so the rejection set stays current with
+/// new Unicode releases without manual upkeep — and so it's complete:
+/// hand-coded subsets historically miss the Tag block, which is the
+/// canonical "ASCII smuggling" vehicle.
+fn is_format_or_invisible(c: char) -> bool {
+    get_general_category(c) == GeneralCategory::Format
+}
+
+/// Validate the path portion of a Location's `authority_and_path`. Rejects
+/// inputs that `url::Url::parse` would silently collapse (`.`, `..`) or
+/// that downstream URL parsers would interpret inconsistently
+/// (empty middle segments). Trailing slash is allowed and ignored.
+///
+/// Applied **globally** (not gated on scheme). Of our supported backends,
+/// only Azure ADLS uses `Url::join` internally and would actually collapse
+/// these segments — S3/GCS treat keys as opaque bytes and would accept
+/// them. Rejecting globally trades a tiny slice of valid S3/GCS namespace
+/// (object keys with literal `/./`/`/../`/`//`) for one rule that can be
+/// audited without a per-scheme matrix; matches the same trade-off made
+/// for `check_host` on Azure trailing-dot.
+fn check_path_segments(authority_and_path: &str) -> Result<(), String> {
+    let path = match authority_and_path.split_once('/') {
+        Some((_authority, p)) => p,
+        None => return Ok(()), // No path — just authority.
+    };
+    if path.is_empty() {
+        return Ok(());
+    }
+    let body = path.trim_end_matches('/');
+    if body.is_empty() {
+        return Ok(()); // path was just "/".
+    }
+    for seg in body.split('/') {
+        if seg.is_empty() {
+            return Err(format!(
+                "empty path segment (consecutive `/`) in {authority_and_path:?}"
+            ));
+        }
+        if seg == "." || seg == ".." {
+            return Err(format!(
+                "path segment `{seg}` is reserved (`.`/`..` would be \
+                 collapsed by URL parsers — encode as %2E/%2E%2E if \
+                 literal segment intended)"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Reject a host with a trailing dot — Azure Blob Storage aliases
+/// `account.` to `account`, so two byte-distinct catalog entries would
+/// collide on the same storage account. S3/GCS treat them as distinct,
+/// but globally rejecting is simpler than gating per-scheme and the
+/// trailing-dot form is never useful in object-storage URIs.
+fn check_host(authority_and_path: &str) -> Result<(), String> {
+    let after_userinfo = match authority_and_path.rsplit_once('@') {
+        Some((_userinfo, rest)) => rest,
+        None => authority_and_path,
+    };
+    let host = after_userinfo
+        .split_once('/')
+        .map_or(after_userinfo, |(h, _)| h);
+    let host = host.split_once(':').map_or(host, |(h, _)| h);
+    if host.ends_with('.') {
+        return Err(
+            "host has a trailing `.` — Azure Blob aliases `host.` to `host`, \
+             reject globally to avoid backend-specific divergence"
+                .to_string(),
+        );
+    }
+    if host.is_empty() {
+        // Defensive: `url::Url::parse` already rejects empty hosts on
+        // special schemes, but our split-based parser here doesn't depend
+        // on that and the cost of the explicit check is one comparison.
+        return Err("host is empty".to_string());
+    }
+    Ok(())
+}
+
 impl FromStr for Location {
     type Err = LocationParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // Length cap before any further work — every reject path clones
+        // `value` into the error, so an unbounded input would let a caller
+        // turn one bad request into a multi-megabyte allocation per error.
+        // Don't echo the input on this rejection.
+        if value.len() > MAX_LOCATION_LEN {
+            return Err(LocationParseError {
+                value: format!("<{} bytes, truncated>", value.len()),
+                reason: format!(
+                    "Location exceeds {MAX_LOCATION_LEN}-byte limit ({} bytes)",
+                    value.len()
+                ),
+            });
+        }
+
+        // Pre-validate the raw input BEFORE handing to `url::Url::parse`,
+        // because the parser silently mutates several smuggling-relevant
+        // chars (`\t\n\r` stripped, `.`/`..` collapsed, controls / Cf
+        // percent-encoded). We store `value` verbatim, so the validator
+        // must see the same bytes the catalog will see.
+        check_unsafe_chars(value).map_err(|reason| LocationParseError {
+            value: value.to_string(),
+            reason,
+        })?;
+
         let location = url::Url::parse(value).map_err(|e| LocationParseError {
             value: value.to_string(),
             reason: format!("Not a valid URL - `{e}`"),
@@ -309,6 +452,15 @@ impl FromStr for Location {
             (s[0].to_string(), s[1].to_string())
         };
 
+        check_host(&location).map_err(|reason| LocationParseError {
+            value: value.to_string(),
+            reason,
+        })?;
+        check_path_segments(&location).map_err(|reason| LocationParseError {
+            value: value.to_string(),
+            reason,
+        })?;
+
         Ok(Location {
             full_location: value.to_string(),
             scheme,
@@ -335,6 +487,136 @@ mod tests {
         assert_eq!(location.as_str(), "s3://bucket/foo /bar");
         let location = Location::from_str("s3://bucket/foo%20/bar").unwrap();
         assert_eq!(location.as_str(), "s3://bucket/foo%20/bar");
+    }
+
+    /// Inputs that must be rejected up-front because either:
+    /// - `url::Url::parse` silently strips/normalises them, creating a
+    ///   parser-discrepancy gap (we'd validate one string and store another)
+    /// - or they trigger backend-specific aliasing (Azure host trailing dot)
+    ///
+    /// Every entry is a (label, input) where `Location::from_str(input)` MUST
+    /// return an error with a reason that mentions the right reject category.
+    #[test]
+    fn test_rejects_smuggling_and_normalisation_vectors() {
+        let cases: &[(&str, &str, &str)] = &[
+            // (label, input, expected substring in error reason)
+            ("tab in path", "s3://bucket/foo\tbar", "control"),
+            ("LF in path", "s3://bucket/foo\nbar", "control"),
+            ("CR in path", "s3://bucket/foo\rbar", "control"),
+            ("NUL in path", "s3://bucket/foo\x00bar", "control"),
+            ("DEL in path", "s3://bucket/foo\x7Fbar", "control"),
+            ("BEL in path", "s3://bucket/foo\x07bar", "control"),
+            // C1 controls (multibyte UTF-8: 0xC2 0x80..0xC2 0x9F)
+            ("NEL in path", "s3://bucket/foo\u{0085}bar", "control"),
+            // Bidi/format chars (Cf category) — visual-spoofing AND
+            // url::Url silently percent-encodes them, so we'd accept inputs
+            // a downstream parser might render differently.
+            ("ZWSP in path", "s3://bucket/foo\u{200B}bar", "format"),
+            ("RLO in path", "s3://bucket/foo\u{202E}bar", "format"),
+            ("BOM in path", "s3://bucket/foo\u{FEFF}bar", "format"),
+            // Tag block (U+E0000..U+E007F) — the canonical "ASCII smuggling"
+            // vehicle. The hand-coded Cf table missed this; the crate-
+            // backed lookup catches it. Pin so the regression couldn't
+            // sneak back in if someone simplifies the check.
+            ("tag char in path", "s3://bucket/foo\u{E0041}bar", "format"),
+            ("language tag char", "s3://bucket/foo\u{E0001}bar", "format"),
+            // Path traversal — url::Url silently collapses these, leaving us
+            // with a stored path that doesn't match what the validator saw.
+            ("dot segment", "s3://bucket/foo/./bar", "path segment"),
+            ("dotdot segment", "s3://bucket/foo/../bar", "path segment"),
+            ("trailing dot segment", "s3://bucket/foo/.", "path segment"),
+            ("empty middle segment", "s3://bucket/foo//bar", "empty"),
+            ("leading double slash", "s3://bucket//foo", "empty"),
+            // Host trailing dot — Azure aliases `host.` to `host`, which
+            // would collapse two byte-distinct catalog entries onto the same
+            // storage account.
+            (
+                "host trailing dot",
+                "abfss://fs@account.dfs.core.windows.net./path",
+                "trailing",
+            ),
+        ];
+        let mut failures = Vec::new();
+        for (label, input, expected) in cases {
+            match Location::from_str(input) {
+                Ok(parsed) => failures.push(format!(
+                    "{label}: input {input:?} unexpectedly accepted as {parsed:?}"
+                )),
+                Err(e) => {
+                    if !e.reason.to_lowercase().contains(&expected.to_lowercase()) {
+                        failures.push(format!(
+                            "{label}: input {input:?} rejected, but reason {:?} \
+                             does not contain expected category {expected:?}",
+                            e.reason
+                        ));
+                    }
+                }
+            }
+        }
+        assert!(failures.is_empty(), "{} failure(s):\n  {}", failures.len(), failures.join("\n  "));
+    }
+
+    /// Inputs whose chars LOOK suspicious but are legitimately representable
+    /// (percent-encoded forms of the rejected chars, plus literal sub-delims
+    /// and unreserved chars). The byte-literal model says these survive as-is.
+    #[test]
+    fn test_accepts_percent_encoded_forms_of_rejected_chars() {
+        // Each input must round-trip byte-for-byte.
+        let cases = [
+            "s3://bucket/foo%09bar",   // %09 = tab
+            "s3://bucket/foo%0Abar",   // %0A = LF
+            "s3://bucket/foo%7Fbar",   // %7F = DEL
+            "s3://bucket/foo%2Ebar",   // %2E = '.'
+            "s3://bucket/foo+bar",
+            "s3://bucket/foo~bar",
+            "s3://bucket/foo!bar",
+            "s3://bucket/foo'bar",
+            "s3://bucket/foo*bar",
+            "s3://bucket/foo$bar",
+            "s3://bucket/%41bc",       // alphanumeric encoded
+            "s3://bucket/Abc",         // alphanumeric literal — distinct from above
+            "s3://bucket/%3F",
+            "s3://bucket/%3f",         // hex case kept distinct
+        ];
+        for input in cases {
+            let loc = Location::from_str(input)
+                .unwrap_or_else(|e| panic!("{input:?} rejected: {}", e.reason));
+            assert_eq!(loc.as_str(), input, "{input:?} mutated");
+        }
+    }
+
+    #[test]
+    fn test_rejects_oversized_input() {
+        // Bound-check: cap is at MAX_LOCATION_LEN; one byte over must
+        // reject without echoing the input back into the error.
+        let prefix = "s3://bucket/";
+        let pad = "a".repeat(MAX_LOCATION_LEN - prefix.len() + 1);
+        let oversized = format!("{prefix}{pad}");
+        assert_eq!(oversized.len(), MAX_LOCATION_LEN + 1);
+        let err = Location::from_str(&oversized).unwrap_err();
+        assert!(err.reason.contains("limit"), "{}", err.reason);
+        // Error must NOT echo the megabyte input — keeps logs/db rows bounded.
+        assert!(!err.value.contains("aaaa"), "value should be truncated marker");
+        // At-cap is fine.
+        let pad = "a".repeat(MAX_LOCATION_LEN - prefix.len());
+        let at_cap = format!("{prefix}{pad}");
+        assert_eq!(at_cap.len(), MAX_LOCATION_LEN);
+        Location::from_str(&at_cap).unwrap();
+    }
+
+    #[test]
+    fn test_host_str_uses_last_at() {
+        // For a path containing literal `@` after the authority — `host_str`
+        // must agree with `check_host` on which `@` separates userinfo
+        // from host (the LAST one before the path), so accessor and
+        // validator can't drift.
+        let loc = Location::from_str("abfss://user@account.dfs.core.windows.net/foo").unwrap();
+        assert_eq!(loc.host_str(), Some("account.dfs.core.windows.net"));
+        // Note: `s3://x@y@bucket/...` — pre-validator currently allows it
+        // (`@` isn't a control or Cf char). What matters is that accessor
+        // and validator both pick the LAST `@` so they see the same host.
+        let loc = Location::from_str("s3://x@y@bucket/path").unwrap();
+        assert_eq!(loc.host_str(), Some("bucket"));
     }
 
     #[test]

--- a/crates/io/src/location.rs
+++ b/crates/io/src/location.rs
@@ -42,20 +42,19 @@ impl Location {
 
     #[must_use]
     pub fn host_str(&self) -> Option<&str> {
-        // RFC 3986: the LAST `@` separates userinfo from host. Aligned
-        // with `check_host` so accessor and validator agree on what the
-        // host is for inputs like `s3://x@y@bucket/path` (legitimate or
-        // not, both must read the same host).
-        let host_part = self
+        // First isolate the authority (everything before the first `/`),
+        // then split userinfo off the authority via the LAST `@` (RFC 3986).
+        // Splitting on `@` before isolating the authority is wrong — a
+        // literal `@` in the path (e.g. `fs@host/foo@bar`) would otherwise
+        // be picked up as the userinfo separator.
+        let authority = self
             .authority_and_path
+            .split_once('/')
+            .map_or(self.authority_and_path.as_str(), |(a, _)| a);
+        let host_part = authority
             .rsplit_once('@')
-            .map_or(self.authority_and_path.as_str(), |(_userinfo, h)| h);
-
-        // Now find the first slash and return everything before it
-        match host_part.find('/') {
-            Some(slash_pos) => Some(&host_part[..slash_pos]),
-            None => Some(host_part), // No slash found, return the whole host part
-        }
+            .map_or(authority, |(_userinfo, h)| h);
+        Some(host_part)
     }
 
     #[must_use]
@@ -284,10 +283,11 @@ impl std::fmt::Display for Location {
 /// - C0/C1 controls and DEL (Unicode `Cc` general category) — `\t\n\r` are
 ///   the most dangerous since `url::Url` strips them silently
 /// - Bidi/format/zero-width chars (Unicode `Cf` general category) —
-///   visual-spoofing AND `url::Url` percent-encodes them silently. We
-///   enumerate the well-known dangerous ranges; this is not a full Cf
-///   table but covers every char the reviewer specified plus the common
-///   ZWSP/RLO/BOM/LRM cluster.
+///   visual-spoofing AND `url::Url` percent-encodes them silently.
+///   `is_format_or_invisible` defers to the `unicode-general-category`
+///   crate's table, so this covers the entire Cf category (including
+///   the Tag block `U+E0000..U+E007F`, the canonical ASCII-smuggling
+///   vehicle that hand-rolled subsets historically miss).
 fn check_unsafe_chars(s: &str) -> Result<(), String> {
     for (idx, c) in s.char_indices() {
         if c.is_control() {
@@ -362,14 +362,19 @@ fn check_path_segments(authority_and_path: &str) -> Result<(), String> {
 /// but globally rejecting is simpler than gating per-scheme and the
 /// trailing-dot form is never useful in object-storage URIs.
 fn check_host(authority_and_path: &str) -> Result<(), String> {
-    let after_userinfo = match authority_and_path.rsplit_once('@') {
-        Some((_userinfo, rest)) => rest,
-        None => authority_and_path,
-    };
-    let host = after_userinfo
+    // Isolate the authority FIRST (everything before the first `/`), then
+    // split userinfo off the authority via the LAST `@`. Doing it in the
+    // other order would let a literal `@` in the path get picked up as
+    // the userinfo separator and produce a phantom "host".
+    let authority = authority_and_path
         .split_once('/')
+        .map_or(authority_and_path, |(a, _)| a);
+    let after_userinfo = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_userinfo, rest)| rest);
+    let host = after_userinfo
+        .split_once(':')
         .map_or(after_userinfo, |(h, _)| h);
-    let host = host.split_once(':').map_or(host, |(h, _)| h);
     if host.ends_with('.') {
         return Err(
             "host has a trailing `.` — Azure Blob aliases `host.` to `host`, \
@@ -612,16 +617,22 @@ mod tests {
     }
 
     #[test]
-    fn test_host_str_uses_last_at() {
-        // For a path containing literal `@` after the authority — `host_str`
-        // must agree with `check_host` on which `@` separates userinfo
-        // from host (the LAST one before the path), so accessor and
-        // validator can't drift.
+    fn test_host_str_isolates_authority_before_at_split() {
+        // Baseline: simple userinfo@host.
         let loc = Location::from_str("abfss://user@account.dfs.core.windows.net/foo").unwrap();
         assert_eq!(loc.host_str(), Some("account.dfs.core.windows.net"));
-        // Note: `s3://x@y@bucket/...` — pre-validator currently allows it
-        // (`@` isn't a control or Cf char). What matters is that accessor
-        // and validator both pick the LAST `@` so they see the same host.
+
+        // Regression: a literal `@` in the PATH must not be picked up as
+        // the userinfo separator. Earlier versions did `rsplit_once('@')`
+        // on the entire authority_and_path — for this input that took the
+        // path's `@` and yielded host=`bar`. Fix isolates the authority
+        // (first split on `/`) before splitting userinfo.
+        let loc = Location::from_str("abfss://fs@account.dfs.core.windows.net/foo@bar").unwrap();
+        assert_eq!(loc.host_str(), Some("account.dfs.core.windows.net"));
+
+        // Multiple `@` in the authority itself — RFC says the last one
+        // is the userinfo separator. Both accessor and `check_host` use
+        // `rsplit_once`, so they agree.
         let loc = Location::from_str("s3://x@y@bucket/path").unwrap();
         assert_eq!(loc.host_str(), Some("bucket"));
     }

--- a/crates/io/src/location.rs
+++ b/crates/io/src/location.rs
@@ -4,8 +4,8 @@ use unicode_general_category::{GeneralCategory, get_general_category};
 
 /// Hard cap on accepted Location length. S3 keys are spec'd at 1024 chars,
 /// ADLS path components total under 1KB; multiplying by ~4 for UTF-8 worst
-/// case plus scheme/authority overhead lands at 4 KiB. Cap up-front so error
-/// paths can't allocate megabytes from a pathological input.
+/// case plus scheme/authority overhead lands at 4 `KiB`. Cap up-front so
+/// error paths can't allocate megabytes from a pathological input.
 const MAX_LOCATION_LEN: usize = 4096;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -329,9 +329,8 @@ fn is_format_or_invisible(c: char) -> bool {
 /// audited without a per-scheme matrix; matches the same trade-off made
 /// for `check_host` on Azure trailing-dot.
 fn check_path_segments(authority_and_path: &str) -> Result<(), String> {
-    let path = match authority_and_path.split_once('/') {
-        Some((_authority, p)) => p,
-        None => return Ok(()), // No path — just authority.
+    let Some((_authority, path)) = authority_and_path.split_once('/') else {
+        return Ok(()); // No path — just authority.
     };
     if path.is_empty() {
         return Ok(());

--- a/crates/io/src/location.rs
+++ b/crates/io/src/location.rs
@@ -553,7 +553,12 @@ mod tests {
                 }
             }
         }
-        assert!(failures.is_empty(), "{} failure(s):\n  {}", failures.len(), failures.join("\n  "));
+        assert!(
+            failures.is_empty(),
+            "{} failure(s):\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
     }
 
     /// Inputs whose chars LOOK suspicious but are legitimately representable
@@ -563,20 +568,20 @@ mod tests {
     fn test_accepts_percent_encoded_forms_of_rejected_chars() {
         // Each input must round-trip byte-for-byte.
         let cases = [
-            "s3://bucket/foo%09bar",   // %09 = tab
-            "s3://bucket/foo%0Abar",   // %0A = LF
-            "s3://bucket/foo%7Fbar",   // %7F = DEL
-            "s3://bucket/foo%2Ebar",   // %2E = '.'
+            "s3://bucket/foo%09bar", // %09 = tab
+            "s3://bucket/foo%0Abar", // %0A = LF
+            "s3://bucket/foo%7Fbar", // %7F = DEL
+            "s3://bucket/foo%2Ebar", // %2E = '.'
             "s3://bucket/foo+bar",
             "s3://bucket/foo~bar",
             "s3://bucket/foo!bar",
             "s3://bucket/foo'bar",
             "s3://bucket/foo*bar",
             "s3://bucket/foo$bar",
-            "s3://bucket/%41bc",       // alphanumeric encoded
-            "s3://bucket/Abc",         // alphanumeric literal — distinct from above
+            "s3://bucket/%41bc", // alphanumeric encoded
+            "s3://bucket/Abc",   // alphanumeric literal — distinct from above
             "s3://bucket/%3F",
-            "s3://bucket/%3f",         // hex case kept distinct
+            "s3://bucket/%3f", // hex case kept distinct
         ];
         for input in cases {
             let loc = Location::from_str(input)
@@ -596,7 +601,10 @@ mod tests {
         let err = Location::from_str(&oversized).unwrap_err();
         assert!(err.reason.contains("limit"), "{}", err.reason);
         // Error must NOT echo the megabyte input — keeps logs/db rows bounded.
-        assert!(!err.value.contains("aaaa"), "value should be truncated marker");
+        assert!(
+            !err.value.contains("aaaa"),
+            "value should be truncated marker"
+        );
         // At-cap is fine.
         let pad = "a".repeat(MAX_LOCATION_LEN - prefix.len());
         let at_cap = format!("{prefix}{pad}");

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -258,6 +258,10 @@ test_all_storages!(
     test_batch_delete_many_items_some_nonexistant_impl
 );
 test_all_storages!(
+    test_percent_encoding_does_not_alias,
+    test_percent_encoding_does_not_alias_impl
+);
+test_all_storages!(
     test_list_non_existent_directory,
     test_list_non_existent_directory_impl
 );
@@ -1491,6 +1495,111 @@ async fn test_list_prefix_boundaries_impl(
         let _ = storage.delete(&path).await; // Ignore errors during cleanup
     }
 
+    Ok(())
+}
+
+/// Pin the byte-literal storage-key model: two paths that differ only by
+/// percent-encoding of an unreserved/sub-delim character must address two
+/// physically distinct objects. If any backend silently aliases them, the
+/// catalog cannot rely on raw `fs_location` bytes for uniqueness — and
+/// canonicalisation (or backend-specific rejection) becomes mandatory.
+///
+/// This is the empirical premise behind dropping `Location::from_str`
+/// canonicalisation. A failure here is the signal that the byte-literal
+/// model does NOT hold for the failing backend, and policy-level mitigation
+/// is required for that backend specifically.
+async fn test_percent_encoding_does_not_alias_impl(
+    storage: &StorageBackend,
+    config: &TestConfig,
+) -> anyhow::Result<()> {
+    // Pairs of paths that share the same URI-decoded form but differ
+    // byte-for-byte. Under the byte-literal model each pair produces two
+    // distinct storage objects.
+    //
+    // Each entry: (decoded form, percent-encoded form, label).
+    // - "Abc" vs "%41bc": alphanumeric — pchar unreserved
+    // - "foo-bar" vs "foo%2Dbar": `-` — pchar unreserved
+    // - "foo+bar" vs "foo%2Bbar": `+` — pchar sub-delim
+    // - "%3F" vs "%3f": hex case in surviving %XX
+    let pairs: &[(&str, &str, &str)] = &[
+        ("Abc", "%41bc", "alpha-A"),
+        ("foo-bar", "foo%2Dbar", "dash"),
+        ("foo+bar", "foo%2Bbar", "plus"),
+        ("%3F", "%3f", "hex-case-Q"),
+    ];
+
+    let base_dir = config.test_dir_path("percent-alias-test");
+    let mut failures = Vec::new();
+    let mut to_cleanup = Vec::new();
+
+    for (decoded, encoded, label) in pairs {
+        let path_decoded = format!("{base_dir}{decoded}/data.bin");
+        let path_encoded = format!("{base_dir}{encoded}/data.bin");
+
+        // Distinct payloads so we can detect aliasing by content swap.
+        let payload_decoded = Bytes::from(format!("DECODED:{label}"));
+        let payload_encoded = Bytes::from(format!("ENCODED:{label}"));
+
+        // Write the decoded path first, then the encoded path. If the
+        // backend aliases, the second write overwrites the first.
+        if let Err(e) = storage.write(&path_decoded, payload_decoded.clone()).await {
+            failures.push(format!("{label}: write decoded `{decoded}` failed: {e}"));
+            continue;
+        }
+        to_cleanup.push(path_decoded.clone());
+
+        if let Err(e) = storage.write(&path_encoded, payload_encoded.clone()).await {
+            failures.push(format!("{label}: write encoded `{encoded}` failed: {e}"));
+            continue;
+        }
+        to_cleanup.push(path_encoded.clone());
+
+        // Read back from the originally-written paths. If the backend
+        // aliases the two, the decoded-path read returns the encoded-path
+        // payload (or vice versa, depending on which write "won").
+        match storage.read(&path_decoded).await {
+            Ok(got) if got == payload_decoded => {} // expected — distinct
+            Ok(got) if got == payload_encoded => {
+                failures.push(format!(
+                    "{label}: ALIAS DETECTED — decoded path `{decoded}` returned encoded payload (write to `{encoded}` overwrote it)"
+                ));
+            }
+            Ok(got) => {
+                failures.push(format!(
+                    "{label}: decoded path returned unexpected payload: {got:?}"
+                ));
+            }
+            Err(e) => failures.push(format!("{label}: read decoded `{decoded}` failed: {e}")),
+        }
+
+        match storage.read(&path_encoded).await {
+            Ok(got) if got == payload_encoded => {} // expected — distinct
+            Ok(got) if got == payload_decoded => {
+                failures.push(format!(
+                    "{label}: ALIAS DETECTED — encoded path `{encoded}` returned decoded payload"
+                ));
+            }
+            Ok(got) => {
+                failures.push(format!(
+                    "{label}: encoded path returned unexpected payload: {got:?}"
+                ));
+            }
+            Err(e) => failures.push(format!("{label}: read encoded `{encoded}` failed: {e}")),
+        }
+    }
+
+    // Cleanup regardless of outcome.
+    for path in to_cleanup {
+        let _ = storage.delete(&path).await;
+    }
+
+    if !failures.is_empty() {
+        anyhow::bail!(
+            "{} percent-encoding alias check(s) failed:\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
     Ok(())
 }
 

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -1108,11 +1108,14 @@ mod tests {
 
     #[test]
     fn test_split_location() {
-        let location = Location::from_str("abfss://").unwrap();
+        // Minimal authority-only Location — `abfss://` (no host) is now
+        // rejected by the validator since an empty host is never useful and
+        // backend-aliasing safety requires a non-empty authority.
+        let location = Location::from_str("abfss://host").unwrap();
         let prefix = location.scheme();
         let full_path = location.authority_and_path();
         assert_eq!(prefix, "abfss");
-        assert_eq!(full_path, "");
+        assert_eq!(full_path, "host");
         assert_eq!(join_location(prefix, full_path).unwrap(), location);
 
         let location = Location::from_str("abfss://foo/bar").unwrap();

--- a/tests/python/tests/test_special_char_locations.py
+++ b/tests/python/tests/test_special_char_locations.py
@@ -285,3 +285,259 @@ def test_special_char_in_location(
         f"to {sibling_location} (provider={provider}, char={char.id}). "
         f"Credential scope is too broad."
     )
+
+
+@dataclasses.dataclass(frozen=True)
+class AliasPair:
+    """A pair of byte-different path segments that share the same URI-decoded
+    form. Under the byte-literal storage-key model these address two distinct
+    storage objects; the catalog must accept both as distinct rows and the
+    vended creds for one must not unlock the other.
+    """
+
+    id: str
+    lhs: str  # decoded form, e.g. "Abc"
+    rhs: str  # encoded form, e.g. "%41bc"
+
+
+# Pairs that differ only by percent-encoding of an unreserved/sub-delim char,
+# or by hex-case in a surviving %XX. The Rust storage-layer integration test
+# (`test_percent_encoding_does_not_alias`) proves SDK-level distinctness for
+# each pair on every backend; this Python test proves the full Lakekeeper
+# REST → vended-creds → SDK chain preserves it end-to-end.
+ALIAS_DISTINCT_PAIRS = [
+    AliasPair("alpha_A", "Abc", "%41bc"),
+    AliasPair("dash", "foo-bar", "foo%2Dbar"),
+    AliasPair("plus", "foo+bar", "foo%2Bbar"),
+    AliasPair("hex_case_Q", "%3F", "%3f"),
+]
+
+
+def _try_read(provider: str, config: dict, target_url: str) -> Optional[bytes]:
+    """Attempt a small object GET at `target_url` using vended creds.
+    Returns the body on SUCCESS, or None on access denial / not-found.
+    Any unexpected error raises so the test fails loudly rather than
+    silently masking a regression."""
+    if provider == "s3":
+        import boto3
+        import botocore.exceptions
+
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=config.get("s3.access-key-id"),
+            aws_secret_access_key=config.get("s3.secret-access-key"),
+            aws_session_token=config.get("s3.session-token"),
+            endpoint_url=config.get("s3.endpoint") or None,
+            region_name=config.get("s3.region") or None,
+        )
+        try:
+            obj = s3.get_object(Bucket=bucket, Key=key)
+            return obj["Body"].read()
+        except botocore.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "?")
+            if code in ("AccessDenied", "NoSuchKey", "403", "404"):
+                return None
+            raise
+    if provider == "adls":
+        sas_key = next((k for k in config if k.startswith("adls.sas-token.")), None)
+        assert sas_key, f"no adls.sas-token.* in config: {list(config)}"
+        sas = config[sas_key].lstrip("?")
+        parsed = urlparse(target_url)
+        fs = parsed.username
+        host = (parsed.hostname or "").replace(".dfs.", ".blob.")
+        # urlparse keeps the path raw — but the Azure server URL-decodes
+        # exactly once. We need the wire bytes to match the catalog's raw
+        # fs_location, so any literal `%` in the user-supplied path must
+        # itself be wire-encoded (`%` → `%25`). This is the same fix we
+        # made in the Rust SDK call site (`AdlsLocation::blob_name`).
+        path = parsed.path.replace("%", "%25")
+        https_url = f"https://{host}/{fs}{path}?{sas}"
+        r = requests.get(https_url, timeout=HTTP_TIMEOUT)
+        if 200 <= r.status_code < 300:
+            return r.content
+        if r.status_code in (403, 404):
+            return None
+        raise AssertionError(f"adls GET {https_url} HTTP {r.status_code}: {r.text[:200]}")
+    if provider == "gcs":
+        token = config.get("gcs.oauth2.token")
+        assert token, f"no gcs.oauth2.token in config: {list(config)}"
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        https_url = f"https://storage.googleapis.com/{bucket}/{quote(key, safe='/')}"
+        r = requests.get(
+            https_url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=HTTP_TIMEOUT,
+        )
+        if 200 <= r.status_code < 300:
+            return r.content
+        if r.status_code in (403, 404):
+            return None
+        raise AssertionError(f"gcs GET {https_url} HTTP {r.status_code}: {r.text[:200]}")
+    raise AssertionError(f"unknown provider: {provider}")
+
+
+@pytest.mark.parametrize("pair", ALIAS_DISTINCT_PAIRS, ids=lambda p: p.id)
+def test_alias_distinct_pair_credential_isolation(
+    warehouse: conftest.Warehouse, storage_config, pair: AliasPair
+):
+    """End-to-end proof of the byte-literal model: two byte-different paths
+    that the URI spec considers "equivalent" produce two genuinely separate
+    tables, and the vended credentials for one cannot reach the other.
+
+    Catches three regression classes:
+    1. Catalog re-introduces canonicalisation (one of the two creates fails).
+    2. Vended-cred prefix scope decodes the stored fs_location (an over-broad
+       prefix would cover BOTH storage paths, allowing cross-table access).
+    3. Storage SDK aliases the two keys at the wire layer (regresses the
+       fix in `AdlsLocation::blob_name` or its analogue on other clouds).
+    """
+    if not _vending_enabled(storage_config):
+        pytest.skip("requires vended credentials")
+    provider = _provider(storage_config)
+
+    ns_name = f"alias_{pair.id}_{uuid.uuid4().hex[:8]}"
+    _create_namespace(warehouse, ns_name)
+    ns_location = _load_namespace_location(warehouse, ns_name)
+
+    # Same parent directory — only the trailing segment differs. This is the
+    # tightest test of byte-literal isolation: if anything in the chain
+    # collapses lhs↔rhs, the second create fails or the cross-table read
+    # succeeds.
+    parent = f"{ns_location}/aliasdir"
+    loc_a = f"{parent}/{pair.lhs}/data/"
+    loc_b = f"{parent}/{pair.rhs}/data/"
+    table_a = "table_a"
+    table_b = "table_b"
+
+    # Both creates must succeed. If catalog canonicalisation collapses the
+    # two locations, the second create raises 409 / LocationAlreadyTaken.
+    _create_table(warehouse, ns_name, table_a, loc_a)
+    _create_table(warehouse, ns_name, table_b, loc_b)
+
+    loaded_a = _load_table_with_creds(warehouse, ns_name, table_a)
+    loaded_b = _load_table_with_creds(warehouse, ns_name, table_b)
+    config_a = loaded_a.get("config", {})
+    config_b = loaded_b.get("config", {})
+    stored_a = loaded_a["metadata"]["location"].rstrip("/")
+    stored_b = loaded_b["metadata"]["location"].rstrip("/")
+
+    # If the catalog round-tripped a different string than what we sent,
+    # canonicalisation has crept back in. Skip rather than misdiagnose
+    # (the createTable success above already proved no collision).
+    if pair.lhs not in stored_a or pair.rhs not in stored_b:
+        pytest.skip(
+            f"catalog rewrote location segment(s) — "
+            f"sent {loc_a!r}/{loc_b!r}, stored {stored_a!r}/{stored_b!r}"
+        )
+    assert stored_a != stored_b, (
+        f"catalog returned identical stored locations for byte-different "
+        f"inputs ({pair.lhs!r}, {pair.rhs!r}) — alias collapse: {stored_a!r}"
+    )
+
+    # 1. Write a distinguishing payload to A using A's vended creds.
+    payload_a = f"PAYLOAD-A-{pair.id}".encode()
+    target_a = f"{stored_a}/canary.txt"
+    err = _try_write_payload(provider, config_a, target_a, payload_a)
+    assert err is None, (
+        f"A's vended creds failed at A's own path {target_a!r}: {err}"
+    )
+
+    # 2. Try to read A's payload using B's vended creds at A's wire URL.
+    # If cred scope leaks (e.g. prefix decoded), this returns the bytes.
+    leaked = _try_read(provider, config_b, target_a)
+    assert leaked is None, (
+        f"ALIAS / SCOPE LEAK: B's vended creds for {stored_b!r} read A's "
+        f"object at {target_a!r} (got {leaked!r}). Either the SDK aliased "
+        f"the two paths or the cred prefix decoded byte-different forms."
+    )
+
+    # 3. Try to read A's payload using B's wire URL with B's creds — i.e.
+    # if the SDK or server aliases lhs↔rhs at wire time, B's creds + B's
+    # URL would resolve to A's storage object.
+    target_b = f"{stored_b}/canary.txt"
+    body_b = _try_read(provider, config_b, target_b)
+    # Object at B's path doesn't exist yet — must NOT return A's bytes.
+    assert body_b is None or body_b != payload_a, (
+        f"WIRE-LEVEL ALIAS: reading B's path {target_b!r} returned A's "
+        f"payload. SDK or server collapsed {pair.lhs!r}↔{pair.rhs!r}."
+    )
+
+    # 4. B remains independently functional — write at its own prefix.
+    payload_b = f"PAYLOAD-B-{pair.id}".encode()
+    err = _try_write_payload(provider, config_b, target_b, payload_b)
+    assert err is None, (
+        f"B's vended creds failed at B's own path {target_b!r}: {err}"
+    )
+    body_b = _try_read(provider, config_b, target_b)
+    assert body_b == payload_b, (
+        f"B's creds at B's path returned wrong bytes: got {body_b!r}, "
+        f"expected {payload_b!r}"
+    )
+
+
+def _try_write_payload(
+    provider: str, config: dict, target_url: str, payload: bytes
+) -> Optional[str]:
+    """Like `_try_write` but with a caller-supplied payload, so the alias
+    test can write a distinguishing value per table and detect cross-reads."""
+    if provider == "s3":
+        import boto3
+        import botocore.exceptions
+
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=config.get("s3.access-key-id"),
+            aws_secret_access_key=config.get("s3.secret-access-key"),
+            aws_session_token=config.get("s3.session-token"),
+            endpoint_url=config.get("s3.endpoint") or None,
+            region_name=config.get("s3.region") or None,
+        )
+        try:
+            s3.put_object(Bucket=bucket, Key=key, Body=payload)
+        except botocore.exceptions.ClientError as e:
+            return f"s3 ClientError: {e.response.get('Error', {}).get('Code', '?')}"
+        return None
+    if provider == "adls":
+        sas_key = next((k for k in config if k.startswith("adls.sas-token.")), None)
+        assert sas_key, f"no adls.sas-token.* in config: {list(config)}"
+        sas = config[sas_key].lstrip("?")
+        parsed = urlparse(target_url)
+        fs = parsed.username
+        host = (parsed.hostname or "").replace(".dfs.", ".blob.")
+        # See `_try_read` for why `%` must be wire-encoded.
+        path = parsed.path.replace("%", "%25")
+        https_url = f"https://{host}/{fs}{path}?{sas}"
+        r = requests.put(
+            https_url,
+            headers={"x-ms-blob-type": "BlockBlob"},
+            data=payload,
+            timeout=HTTP_TIMEOUT,
+        )
+        if 200 <= r.status_code < 300:
+            return None
+        return f"adls HTTP {r.status_code}: {r.text[:200]}"
+    if provider == "gcs":
+        token = config.get("gcs.oauth2.token")
+        assert token, f"no gcs.oauth2.token in config: {list(config)}"
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        https_url = f"https://storage.googleapis.com/{bucket}/{quote(key, safe='/')}"
+        r = requests.put(
+            https_url,
+            headers={"Authorization": f"Bearer {token}"},
+            data=payload,
+            timeout=HTTP_TIMEOUT,
+        )
+        if 200 <= r.status_code < 300:
+            return None
+        return f"gcs HTTP {r.status_code}: {r.text[:200]}"
+    raise AssertionError(f"unknown provider: {provider}")

--- a/tests/python/tests/test_special_char_locations.py
+++ b/tests/python/tests/test_special_char_locations.py
@@ -151,9 +151,13 @@ def _load_table_with_creds(
     return r.json()
 
 
-def _try_write(provider: str, config: dict, target_url: str) -> Optional[str]:
+def _try_write_payload(
+    provider: str, config: dict, target_url: str, payload: bytes
+) -> Optional[str]:
     """Attempt a small object PUT at `target_url` using vended creds.
-    Returns None on SUCCESS, or a short description of the failure."""
+    Returns None on SUCCESS, or a short description of the failure.
+    Caller-supplied payload lets a test write a distinguishing value per
+    table and detect cross-reads."""
     if provider == "s3":
         import boto3
         import botocore.exceptions
@@ -170,7 +174,7 @@ def _try_write(provider: str, config: dict, target_url: str) -> Optional[str]:
             region_name=config.get("s3.region") or None,
         )
         try:
-            s3.put_object(Bucket=bucket, Key=key, Body=b"canary")
+            s3.put_object(Bucket=bucket, Key=key, Body=payload)
         except botocore.exceptions.ClientError as e:
             return f"s3 ClientError: {e.response.get('Error', {}).get('Code', '?')}"
         return None
@@ -183,12 +187,16 @@ def _try_write(provider: str, config: dict, target_url: str) -> Optional[str]:
         # Vended SAS is a Blob Service SAS — use the blob endpoint (single
         # PUT) rather than DFS (which would need 3-step create/append/flush).
         host = (parsed.hostname or "").replace(".dfs.", ".blob.")
-        path = parsed.path
+        # Pre-encode `%` → `%25` so that any literal `%XX` in the catalog's
+        # raw fs_location reaches Azure as bytes (server URL-decodes once).
+        # Without this, `Abc` and `%41bc` would alias on the wire — the same
+        # bug we fixed in `AdlsLocation::blob_name` on the Rust side.
+        path = parsed.path.replace("%", "%25")
         https_url = f"https://{host}/{fs}{path}?{sas}"
         r = requests.put(
             https_url,
             headers={"x-ms-blob-type": "BlockBlob"},
-            data=b"canary",
+            data=payload,
             timeout=HTTP_TIMEOUT,
         )
         if 200 <= r.status_code < 300:
@@ -204,13 +212,20 @@ def _try_write(provider: str, config: dict, target_url: str) -> Optional[str]:
         r = requests.put(
             https_url,
             headers={"Authorization": f"Bearer {token}"},
-            data=b"canary",
+            data=payload,
             timeout=HTTP_TIMEOUT,
         )
         if 200 <= r.status_code < 300:
             return None
         return f"gcs HTTP {r.status_code}: {r.text[:200]}"
     raise AssertionError(f"unknown provider: {provider}")
+
+
+def _safe_url(url: str) -> str:
+    """Strip query and fragment from a URL so it can be safely embedded in
+    error messages without leaking SAS tokens or other auth material."""
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
 
 
 @pytest.mark.parametrize("char", SPECIAL_CHARS, ids=lambda c: c.id)
@@ -256,7 +271,7 @@ def test_special_char_in_location(
 
     # Positive: write at the table prefix.
     target = f"{stored_location}/canary.txt"
-    err = _try_write(provider, config, target)
+    err = _try_write_payload(provider, config, target, b"canary")
     if expect_deny:
         # Cloud-side limitation (not a Lakekeeper bug). Pin the *safe*
         # outcome: must deny, not allow. A regression to over-permit would
@@ -279,7 +294,7 @@ def test_special_char_in_location(
     )
 
     # Negative: vended creds for the table must NOT allow a sibling write.
-    err = _try_write(provider, config, sibling_location)
+    err = _try_write_payload(provider, config, sibling_location, b"canary")
     assert err is not None, (
         f"vended credentials for {table_location} unexpectedly allowed write "
         f"to {sibling_location} (provider={provider}, char={char.id}). "
@@ -360,7 +375,10 @@ def _try_read(provider: str, config: dict, target_url: str) -> Optional[bytes]:
             return r.content
         if r.status_code in (403, 404):
             return None
-        raise AssertionError(f"adls GET {https_url} HTTP {r.status_code}: {r.text[:200]}")
+        raise AssertionError(
+            f"adls GET {_safe_url(https_url)} HTTP {r.status_code} "
+            f"({r.reason}): {r.text[:200]}"
+        )
     if provider == "gcs":
         token = config.get("gcs.oauth2.token")
         assert token, f"no gcs.oauth2.token in config: {list(config)}"
@@ -377,7 +395,10 @@ def _try_read(provider: str, config: dict, target_url: str) -> Optional[bytes]:
             return r.content
         if r.status_code in (403, 404):
             return None
-        raise AssertionError(f"gcs GET {https_url} HTTP {r.status_code}: {r.text[:200]}")
+        raise AssertionError(
+            f"gcs GET {_safe_url(https_url)} HTTP {r.status_code} "
+            f"({r.reason}): {r.text[:200]}"
+        )
     raise AssertionError(f"unknown provider: {provider}")
 
 
@@ -478,66 +499,3 @@ def test_alias_distinct_pair_credential_isolation(
         f"B's creds at B's path returned wrong bytes: got {body_b!r}, "
         f"expected {payload_b!r}"
     )
-
-
-def _try_write_payload(
-    provider: str, config: dict, target_url: str, payload: bytes
-) -> Optional[str]:
-    """Like `_try_write` but with a caller-supplied payload, so the alias
-    test can write a distinguishing value per table and detect cross-reads."""
-    if provider == "s3":
-        import boto3
-        import botocore.exceptions
-
-        parsed = urlparse(target_url)
-        bucket = parsed.netloc
-        key = parsed.path.lstrip("/")
-        s3 = boto3.client(
-            "s3",
-            aws_access_key_id=config.get("s3.access-key-id"),
-            aws_secret_access_key=config.get("s3.secret-access-key"),
-            aws_session_token=config.get("s3.session-token"),
-            endpoint_url=config.get("s3.endpoint") or None,
-            region_name=config.get("s3.region") or None,
-        )
-        try:
-            s3.put_object(Bucket=bucket, Key=key, Body=payload)
-        except botocore.exceptions.ClientError as e:
-            return f"s3 ClientError: {e.response.get('Error', {}).get('Code', '?')}"
-        return None
-    if provider == "adls":
-        sas_key = next((k for k in config if k.startswith("adls.sas-token.")), None)
-        assert sas_key, f"no adls.sas-token.* in config: {list(config)}"
-        sas = config[sas_key].lstrip("?")
-        parsed = urlparse(target_url)
-        fs = parsed.username
-        host = (parsed.hostname or "").replace(".dfs.", ".blob.")
-        # See `_try_read` for why `%` must be wire-encoded.
-        path = parsed.path.replace("%", "%25")
-        https_url = f"https://{host}/{fs}{path}?{sas}"
-        r = requests.put(
-            https_url,
-            headers={"x-ms-blob-type": "BlockBlob"},
-            data=payload,
-            timeout=HTTP_TIMEOUT,
-        )
-        if 200 <= r.status_code < 300:
-            return None
-        return f"adls HTTP {r.status_code}: {r.text[:200]}"
-    if provider == "gcs":
-        token = config.get("gcs.oauth2.token")
-        assert token, f"no gcs.oauth2.token in config: {list(config)}"
-        parsed = urlparse(target_url)
-        bucket = parsed.netloc
-        key = parsed.path.lstrip("/")
-        https_url = f"https://storage.googleapis.com/{bucket}/{quote(key, safe='/')}"
-        r = requests.put(
-            https_url,
-            headers={"Authorization": f"Bearer {token}"},
-            data=payload,
-            timeout=HTTP_TIMEOUT,
-        )
-        if 200 <= r.status_code < 300:
-            return None
-        return f"gcs HTTP {r.status_code}: {r.text[:200]}"
-    raise AssertionError(f"unknown provider: {provider}")


### PR DESCRIPTION
`azure_storage_datalake`'s `FileClient::url()` builds the wire URL via
`Url::join`, which interprets `%XX` triplets in the blob name as already
percent-encoded. So a stored fs_location like `prefix/%41bc` was sent on
the wire as `%41bc` literal, the Azure server URL-decoded it once, and
two byte-different keys (`Abc` and `%41bc`) collapsed to the same blob —
breaking the byte-literal storage-key model the catalog now relies on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter location parsing and validation (rejects unsafe/control characters, path-host anomalies, and oversized inputs) and improved percent-encoding to prevent URL aliasing.

* **Tests**
  * New integration test ensuring percent-encoded paths remain distinct across backends.
  * New end-to-end tests for special-character handling, credential isolation, and payload-aware write/read checks.

* **Chores**
  * Added a workspace dependency to support Unicode character-category checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper/pull/1746)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->