### PR TITLE
fix(storage): harden STS/CEL credential policies against path injection

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -119,6 +119,8 @@ jobs:
         env:
           VAULT_DEV_ROOT_TOKEN_ID: myroot
           VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+          # GHA runners drop CAP_SETFCAP; skip the entrypoint setcap call.
+          SKIP_SETCAP: "true"
         options: >-
           --health-cmd "vault status -address http://localhost:8200"
           --health-interval 10s

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,7 +2169,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2330,7 +2330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3545,7 +3545,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3920,6 +3920,7 @@ dependencies = [
  "md5",
  "moka",
  "pastey",
+ "percent-encoding",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -3933,6 +3934,7 @@ dependencies = [
  "tracing",
  "tryhard",
  "typed-builder 0.23.2",
+ "unicode-general-category",
  "url",
  "uuid",
  "veil",
@@ -4414,7 +4416,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4699,7 +4701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5396,7 +5398,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6002,7 +6004,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7054,7 +7056,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7675,6 +7677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8099,7 +8107,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,9 +416,8 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dde77d8a733a9dbaf865a9eb65c72e09c88f3d14d3dd0d2aecf511920ee4fe"
+version = "0.46.0"
+source = "git+https://github.com/lakekeeper/nats.rs.git?tag=async-nats%2Fv0.46.0-lakekeeper.1#8c96220b6155c40c1ca454043105af9abea44339"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -426,15 +425,14 @@ dependencies = [
  "futures-util",
  "memchr",
  "nkeys",
- "nuid",
  "once_cell",
  "pin-project",
  "portable-atomic",
  "rand 0.8.5",
  "regex",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
+ "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -442,12 +440,11 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tokio-websockets",
  "tracing",
- "tryhard",
  "url",
 ]
 
@@ -858,23 +855,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.12",
- "http 0.2.12",
+ "h2",
  "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.8.1",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.35",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -1011,7 +1002,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1992,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "delegate-attr"
@@ -2808,25 +2799,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.12.1",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
@@ -3071,30 +3043,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -3103,7 +3051,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -3118,34 +3066,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.35",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.4",
 ]
@@ -3156,7 +3089,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3176,12 +3109,12 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3704,15 +3637,15 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.35",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -4229,7 +4162,7 @@ checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "indexmap 2.12.1",
  "ipnet",
@@ -4417,15 +4350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nuid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
-dependencies = [
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -4701,7 +4625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5358,8 +5282,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.35",
- "socket2 0.6.1",
+ "rustls",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5378,7 +5302,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -5396,7 +5320,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5722,8 +5646,8 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -5732,7 +5656,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
+ "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -5740,7 +5664,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5779,7 +5703,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
@@ -6009,18 +5933,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
@@ -6030,7 +5942,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -6081,30 +5993,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "aws-lc-rs",
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6203,16 +6094,6 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6673,16 +6554,6 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -6763,7 +6634,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.35",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -7232,7 +7103,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -7250,21 +7121,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls",
  "tokio",
 ]
 
@@ -7308,7 +7169,7 @@ dependencies = [
  "rand 0.8.5",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "webpki-roots 0.26.11",
 ]
@@ -7353,20 +7214,20 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.12",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "rustls-native-certs 0.8.3",
- "socket2 0.6.1",
+ "socket2",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -8107,7 +7968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ tracing-test = "0.2.5"
 tryhard = { version = "0.5.1" }
 typed-builder = "^0.23.0"
 unicase = "2.8.1"
+unicode-general-category = "1.1.0"
 
 url = { version = "^2.5", features = ["serde"] }
 urlencoding = "^2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,19 +21,28 @@ anyhow = "^1.0"
 assert-json-diff = "2.0.2"
 async-channel = { version = "2.3.1" }
 async-compression = { version = "^0.4", features = ["tokio", "gzip"] }
-async-nats = { version = "0.45.0", default-features = false, features = [
+async-nats = { git = "https://github.com/lakekeeper/nats.rs.git", tag = "async-nats/v0.46.0-lakekeeper.1", default-features = false, features = [
     "server_2_10",
     "server_2_11",
     "server_2_12",
     "aws-lc-rs",
     "service",
+    "nkeys",
 ] }
 async-stream = "0.3.6"
 async-trait = "0.1.89"
 aws-config = { version = "1.8.10", features = ["behavior-version-latest"] }
 aws-credential-types = { version = "1.2" }
-aws-sdk-s3 = { version = "1.120" }
-aws-sdk-sts = "1.82.0"
+aws-sdk-s3 = { version = "1.120", default-features = false, features = [
+    "sigv4a",
+    "http-1x",
+    "default-https-client",
+    "rt-tokio",
+] }
+aws-sdk-sts = { version = "1.82.0", default-features = false, features = [
+    "default-https-client",
+    "rt-tokio",
+] }
 aws-sigv4 = { version = "1.2" }
 aws-smithy-async = { version = "1.2.5" }
 aws-smithy-http = "0.63.3"

--- a/crates/io/Cargo.toml
+++ b/crates/io/Cargo.toml
@@ -65,6 +65,7 @@ google-cloud-storage = { workspace = true, features = [], optional = true }
 jsonwebtoken = { workspace = true }
 md5 = { workspace = true }
 moka = { workspace = true, optional = true }
+percent-encoding = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { version = "0.4", optional = true }
 reqwest-retry = { version = "0.7", optional = true }
@@ -76,6 +77,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tryhard = { workspace = true }
 typed-builder = { workspace = true }
+unicode-general-category = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 veil = { workspace = true }

--- a/crates/io/src/adls/adls_location.rs
+++ b/crates/io/src/adls/adls_location.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr as _;
 
+use percent_encoding::percent_decode_str;
 use url::Host;
 
 use crate::{
@@ -82,6 +83,29 @@ impl AdlsLocation {
                     format!("ADLS path segment `{path_segment}` must not contain slashes."),
                 ));
             }
+            // Reject segments whose decoded form would create silent
+            // path-divergence bugs. Our `Location` stores the raw URL input,
+            // but `url::Url::parse` (used by the SDK during request-URL
+            // construction) normalises encoded dot-segments and may decode
+            // `%2F`. The result is a Lakekeeper-side path that disagrees with
+            // what Azure actually receives. Reject up-front rather than let
+            // it surface as InvalidUri / silent 403 / wrong-path writes.
+            //   - `%20` (and other whitespace) → Azure rejects InvalidUri
+            //   - `%2E` / `%2E%2E` → `url::Url` strips, path silently shrinks
+            //   - `%2F` (or any encoded slash) → ambiguous nesting
+            let decoded = percent_decode_str(path_segment).decode_utf8_lossy();
+            let invalid = decoded.contains('/')
+                || decoded == "."
+                || decoded == ".."
+                || (!decoded.is_empty() && decoded.trim().is_empty());
+            if invalid {
+                return Err(InvalidLocationError::new(
+                    location_dbg.clone(),
+                    format!(
+                        "ADLS path segment `{path_segment}` decodes to a value that is normalised or rejected by URL/Azure handling."
+                    ),
+                ));
+            }
         }
 
         let endpoint_suffix = normalize_host(host)
@@ -135,11 +159,18 @@ impl AdlsLocation {
 
     #[must_use]
     pub fn blob_name(&self) -> String {
-        self.location
-            .path()
-            .unwrap_or_default()
-            .to_string()
-            .replace('?', "%3F")
+        // The azure_storage_datalake SDK constructs the wire URL via
+        // `Url::join`, which interprets `%XX` triplets in the blob name as
+        // already percent-encoded — so a stored blob name `%41bc` would go
+        // out on the wire as `%41bc` and the server would URL-decode it to
+        // `Abc`, aliasing two distinct keys. To keep the byte-literal model,
+        // pre-encode `%` (and the other URL-syntactic chars `?`/`#`) here so
+        // the SDK's join produces the right wire bytes for one server-side
+        // decode pass to land on our intended key.
+        use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+        const SDK_ESCAPE: &AsciiSet = &CONTROLS.add(b'%').add(b'?').add(b'#');
+        let path = self.location.path().unwrap_or_default();
+        utf8_percent_encode(path, SDK_ESCAPE).to_string()
     }
 
     /// Create a new `AdlsLocation` from a Location.
@@ -496,6 +527,10 @@ mod test {
 
     #[test]
     fn test_invalid_adls_location() {
+        // Each input must be rejected SOMEWHERE in the parse chain — either
+        // by `Location::from_str` (e.g. host trailing dot is now globally
+        // rejected for backend-aliasing safety) or by ADLS-specific
+        // validation. The original test asserted only the latter.
         let cases = vec![
             "abfss://filesystem@account_name",
             "abfss://filesystem@account_name.example.com./foo",
@@ -503,10 +538,49 @@ mod test {
             "abfss://account_name.dfs.core.windows/foo",
         ];
 
-        for location in cases {
-            let location = Location::from_str(location).unwrap();
-            let parsed_location = AdlsLocation::try_from_location(&location, false);
-            assert!(parsed_location.is_err(), "{parsed_location:?}");
+        for input in cases {
+            let result = Location::from_str(input).and_then(|loc| {
+                AdlsLocation::try_from_location(&loc, false).map_err(|e| {
+                    crate::location::LocationParseError {
+                        value: input.to_string(),
+                        reason: e.to_string(),
+                    }
+                })
+            });
+            assert!(
+                result.is_err(),
+                "{input:?} unexpectedly accepted: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rejects_problematic_decoded_segments() {
+        for bad in [
+            // whitespace-only — Azure rejects InvalidUri
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%20/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%09/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%20%20/bar",
+            // dot-segments — `url::Url` normalises these, path silently shrinks
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%2E/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%2e%2e/bar",
+            // encoded slash — ambiguous nesting once decoded
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/%2F/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%2Fy/bar",
+        ] {
+            let loc = Location::from_str(bad).unwrap();
+            let res = AdlsLocation::try_from_location(&loc, false);
+            assert!(res.is_err(), "expected reject for `{bad}`");
+        }
+        // Non-empty segments that include but do not decode-to one of the
+        // forbidden values are fine.
+        for ok in [
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%20y/bar",
+            "abfss://filesystem@account0name.dfs.core.windows.net/foo/x%2Ey/bar",
+        ] {
+            let loc = Location::from_str(ok).unwrap();
+            AdlsLocation::try_from_location(&loc, false)
+                .unwrap_or_else(|e| panic!("expected accept for `{ok}`: {e}"));
         }
     }
 

--- a/crates/io/src/location.rs
+++ b/crates/io/src/location.rs
@@ -1,5 +1,13 @@
 use std::str::{FromStr, RMatchIndices};
 
+use unicode_general_category::{GeneralCategory, get_general_category};
+
+/// Hard cap on accepted Location length. S3 keys are spec'd at 1024 chars,
+/// ADLS path components total under 1KB; multiplying by ~4 for UTF-8 worst
+/// case plus scheme/authority overhead lands at 4 `KiB`. Cap up-front so
+/// error paths can't allocate megabytes from a pathological input.
+const MAX_LOCATION_LEN: usize = 4096;
+
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[allow(clippy::struct_field_names)]
 pub struct Location {
@@ -34,20 +42,19 @@ impl Location {
 
     #[must_use]
     pub fn host_str(&self) -> Option<&str> {
-        // Everything between @ and the first slash
-        let host_part = if let Some(at_pos) = self.authority_and_path.find('@') {
-            // If there's an @ symbol, take everything after it
-            &self.authority_and_path[at_pos + 1..]
-        } else {
-            // If there's no @ symbol, use the whole location
-            &self.authority_and_path
-        };
-
-        // Now find the first slash and return everything before it
-        match host_part.find('/') {
-            Some(slash_pos) => Some(&host_part[..slash_pos]),
-            None => Some(host_part), // No slash found, return the whole host part
-        }
+        // First isolate the authority (everything before the first `/`),
+        // then split userinfo off the authority via the LAST `@` (RFC 3986).
+        // Splitting on `@` before isolating the authority is wrong — a
+        // literal `@` in the path (e.g. `fs@host/foo@bar`) would otherwise
+        // be picked up as the userinfo separator.
+        let authority = self
+            .authority_and_path
+            .split_once('/')
+            .map_or(self.authority_and_path.as_str(), |(a, _)| a);
+        let host_part = authority
+            .rsplit_once('@')
+            .map_or(authority, |(_userinfo, h)| h);
+        Some(host_part)
     }
 
     #[must_use]
@@ -268,10 +275,150 @@ impl std::fmt::Display for Location {
     }
 }
 
+/// Reject characters that `url::Url::parse` silently strips, percent-encodes,
+/// or otherwise normalises in a way that would create a parser-discrepancy
+/// gap (validator sees one string, we store another).
+///
+/// Rejects:
+/// - C0/C1 controls and DEL (Unicode `Cc` general category) — `\t\n\r` are
+///   the most dangerous since `url::Url` strips them silently
+/// - Bidi/format/zero-width chars (Unicode `Cf` general category) —
+///   visual-spoofing AND `url::Url` percent-encodes them silently.
+///   `is_format_or_invisible` defers to the `unicode-general-category`
+///   crate's table, so this covers the entire Cf category (including
+///   the Tag block `U+E0000..U+E007F`, the canonical ASCII-smuggling
+///   vehicle that hand-rolled subsets historically miss).
+fn check_unsafe_chars(s: &str) -> Result<(), String> {
+    for (idx, c) in s.char_indices() {
+        if c.is_control() {
+            return Err(format!(
+                "control character (U+{:04X}) at byte {idx} in input",
+                c as u32
+            ));
+        }
+        if is_format_or_invisible(c) {
+            return Err(format!(
+                "bidi/format/invisible character (U+{:04X}) at byte {idx} in input",
+                c as u32
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// True for any char in Unicode `Cf` general category (bidi controls,
+/// zero-width formatters, BOM, Tag block `U+E0000..U+E007F`, etc.). Uses
+/// the upstream Unicode tables so the rejection set stays current with
+/// new Unicode releases without manual upkeep — and so it's complete:
+/// hand-coded subsets historically miss the Tag block, which is the
+/// canonical "ASCII smuggling" vehicle.
+fn is_format_or_invisible(c: char) -> bool {
+    get_general_category(c) == GeneralCategory::Format
+}
+
+/// Validate the path portion of a Location's `authority_and_path`. Rejects
+/// inputs that `url::Url::parse` would silently collapse (`.`, `..`) or
+/// that downstream URL parsers would interpret inconsistently
+/// (empty middle segments). Trailing slash is allowed and ignored.
+///
+/// Applied **globally** (not gated on scheme). Of our supported backends,
+/// only Azure ADLS uses `Url::join` internally and would actually collapse
+/// these segments — S3/GCS treat keys as opaque bytes and would accept
+/// them. Rejecting globally trades a tiny slice of valid S3/GCS namespace
+/// (object keys with literal `/./`/`/../`/`//`) for one rule that can be
+/// audited without a per-scheme matrix; matches the same trade-off made
+/// for `check_host` on Azure trailing-dot.
+fn check_path_segments(authority_and_path: &str) -> Result<(), String> {
+    let Some((_authority, path)) = authority_and_path.split_once('/') else {
+        return Ok(()); // No path — just authority.
+    };
+    if path.is_empty() {
+        return Ok(());
+    }
+    let body = path.trim_end_matches('/');
+    if body.is_empty() {
+        return Ok(()); // path was just "/".
+    }
+    for seg in body.split('/') {
+        if seg.is_empty() {
+            return Err(format!(
+                "empty path segment (consecutive `/`) in {authority_and_path:?}"
+            ));
+        }
+        if seg == "." || seg == ".." {
+            return Err(format!(
+                "path segment `{seg}` is reserved (`.`/`..` would be \
+                 collapsed by URL parsers — encode as %2E/%2E%2E if \
+                 literal segment intended)"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Reject a host with a trailing dot — Azure Blob Storage aliases
+/// `account.` to `account`, so two byte-distinct catalog entries would
+/// collide on the same storage account. S3/GCS treat them as distinct,
+/// but globally rejecting is simpler than gating per-scheme and the
+/// trailing-dot form is never useful in object-storage URIs.
+fn check_host(authority_and_path: &str) -> Result<(), String> {
+    // Isolate the authority FIRST (everything before the first `/`), then
+    // split userinfo off the authority via the LAST `@`. Doing it in the
+    // other order would let a literal `@` in the path get picked up as
+    // the userinfo separator and produce a phantom "host".
+    let authority = authority_and_path
+        .split_once('/')
+        .map_or(authority_and_path, |(a, _)| a);
+    let after_userinfo = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_userinfo, rest)| rest);
+    let host = after_userinfo
+        .split_once(':')
+        .map_or(after_userinfo, |(h, _)| h);
+    if host.ends_with('.') {
+        return Err(
+            "host has a trailing `.` — Azure Blob aliases `host.` to `host`, \
+             reject globally to avoid backend-specific divergence"
+                .to_string(),
+        );
+    }
+    if host.is_empty() {
+        // Defensive: `url::Url::parse` already rejects empty hosts on
+        // special schemes, but our split-based parser here doesn't depend
+        // on that and the cost of the explicit check is one comparison.
+        return Err("host is empty".to_string());
+    }
+    Ok(())
+}
+
 impl FromStr for Location {
     type Err = LocationParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // Length cap before any further work — every reject path clones
+        // `value` into the error, so an unbounded input would let a caller
+        // turn one bad request into a multi-megabyte allocation per error.
+        // Don't echo the input on this rejection.
+        if value.len() > MAX_LOCATION_LEN {
+            return Err(LocationParseError {
+                value: format!("<{} bytes, truncated>", value.len()),
+                reason: format!(
+                    "Location exceeds {MAX_LOCATION_LEN}-byte limit ({} bytes)",
+                    value.len()
+                ),
+            });
+        }
+
+        // Pre-validate the raw input BEFORE handing to `url::Url::parse`,
+        // because the parser silently mutates several smuggling-relevant
+        // chars (`\t\n\r` stripped, `.`/`..` collapsed, controls / Cf
+        // percent-encoded). We store `value` verbatim, so the validator
+        // must see the same bytes the catalog will see.
+        check_unsafe_chars(value).map_err(|reason| LocationParseError {
+            value: value.to_string(),
+            reason,
+        })?;
+
         let location = url::Url::parse(value).map_err(|e| LocationParseError {
             value: value.to_string(),
             reason: format!("Not a valid URL - `{e}`"),
@@ -287,7 +434,14 @@ impl FromStr for Location {
         if location.fragment().is_some() {
             return Err(LocationParseError {
                 value: value.to_string(),
-                reason: "URL has a fragment (#)".to_string(),
+                reason: "URL has a fragment (#) — encode `#` in object names as %23".to_string(),
+            });
+        }
+
+        if location.query().is_some() {
+            return Err(LocationParseError {
+                value: value.to_string(),
+                reason: "URL has a query (?) — encode `?` in object names as %3F".to_string(),
             });
         }
 
@@ -301,6 +455,15 @@ impl FromStr for Location {
             }
             (s[0].to_string(), s[1].to_string())
         };
+
+        check_host(&location).map_err(|reason| LocationParseError {
+            value: value.to_string(),
+            reason,
+        })?;
+        check_path_segments(&location).map_err(|reason| LocationParseError {
+            value: value.to_string(),
+            reason,
+        })?;
 
         Ok(Location {
             full_location: value.to_string(),
@@ -328,6 +491,164 @@ mod tests {
         assert_eq!(location.as_str(), "s3://bucket/foo /bar");
         let location = Location::from_str("s3://bucket/foo%20/bar").unwrap();
         assert_eq!(location.as_str(), "s3://bucket/foo%20/bar");
+    }
+
+    /// Inputs that must be rejected up-front because either:
+    /// - `url::Url::parse` silently strips/normalises them, creating a
+    ///   parser-discrepancy gap (we'd validate one string and store another)
+    /// - or they trigger backend-specific aliasing (Azure host trailing dot)
+    ///
+    /// Every entry is a (label, input) where `Location::from_str(input)` MUST
+    /// return an error with a reason that mentions the right reject category.
+    #[test]
+    fn test_rejects_smuggling_and_normalisation_vectors() {
+        let cases: &[(&str, &str, &str)] = &[
+            // (label, input, expected substring in error reason)
+            ("tab in path", "s3://bucket/foo\tbar", "control"),
+            ("LF in path", "s3://bucket/foo\nbar", "control"),
+            ("CR in path", "s3://bucket/foo\rbar", "control"),
+            ("NUL in path", "s3://bucket/foo\x00bar", "control"),
+            ("DEL in path", "s3://bucket/foo\x7Fbar", "control"),
+            ("BEL in path", "s3://bucket/foo\x07bar", "control"),
+            // C1 controls (multibyte UTF-8: 0xC2 0x80..0xC2 0x9F)
+            ("NEL in path", "s3://bucket/foo\u{0085}bar", "control"),
+            // Bidi/format chars (Cf category) — visual-spoofing AND
+            // url::Url silently percent-encodes them, so we'd accept inputs
+            // a downstream parser might render differently.
+            ("ZWSP in path", "s3://bucket/foo\u{200B}bar", "format"),
+            ("RLO in path", "s3://bucket/foo\u{202E}bar", "format"),
+            ("BOM in path", "s3://bucket/foo\u{FEFF}bar", "format"),
+            // Tag block (U+E0000..U+E007F) — the canonical "ASCII smuggling"
+            // vehicle. The hand-coded Cf table missed this; the crate-
+            // backed lookup catches it. Pin so the regression couldn't
+            // sneak back in if someone simplifies the check.
+            ("tag char in path", "s3://bucket/foo\u{E0041}bar", "format"),
+            ("language tag char", "s3://bucket/foo\u{E0001}bar", "format"),
+            // Path traversal — url::Url silently collapses these, leaving us
+            // with a stored path that doesn't match what the validator saw.
+            ("dot segment", "s3://bucket/foo/./bar", "path segment"),
+            ("dotdot segment", "s3://bucket/foo/../bar", "path segment"),
+            ("trailing dot segment", "s3://bucket/foo/.", "path segment"),
+            ("empty middle segment", "s3://bucket/foo//bar", "empty"),
+            ("leading double slash", "s3://bucket//foo", "empty"),
+            // Host trailing dot — Azure aliases `host.` to `host`, which
+            // would collapse two byte-distinct catalog entries onto the same
+            // storage account.
+            (
+                "host trailing dot",
+                "abfss://fs@account.dfs.core.windows.net./path",
+                "trailing",
+            ),
+        ];
+        let mut failures = Vec::new();
+        for (label, input, expected) in cases {
+            match Location::from_str(input) {
+                Ok(parsed) => failures.push(format!(
+                    "{label}: input {input:?} unexpectedly accepted as {parsed:?}"
+                )),
+                Err(e) => {
+                    if !e.reason.to_lowercase().contains(&expected.to_lowercase()) {
+                        failures.push(format!(
+                            "{label}: input {input:?} rejected, but reason {:?} \
+                             does not contain expected category {expected:?}",
+                            e.reason
+                        ));
+                    }
+                }
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "{} failure(s):\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
+
+    /// Inputs whose chars LOOK suspicious but are legitimately representable
+    /// (percent-encoded forms of the rejected chars, plus literal sub-delims
+    /// and unreserved chars). The byte-literal model says these survive as-is.
+    #[test]
+    fn test_accepts_percent_encoded_forms_of_rejected_chars() {
+        // Each input must round-trip byte-for-byte.
+        let cases = [
+            "s3://bucket/foo%09bar", // %09 = tab
+            "s3://bucket/foo%0Abar", // %0A = LF
+            "s3://bucket/foo%7Fbar", // %7F = DEL
+            "s3://bucket/foo%2Ebar", // %2E = '.'
+            "s3://bucket/foo+bar",
+            "s3://bucket/foo~bar",
+            "s3://bucket/foo!bar",
+            "s3://bucket/foo'bar",
+            "s3://bucket/foo*bar",
+            "s3://bucket/foo$bar",
+            "s3://bucket/%41bc", // alphanumeric encoded
+            "s3://bucket/Abc",   // alphanumeric literal — distinct from above
+            "s3://bucket/%3F",
+            "s3://bucket/%3f", // hex case kept distinct
+        ];
+        for input in cases {
+            let loc = Location::from_str(input)
+                .unwrap_or_else(|e| panic!("{input:?} rejected: {}", e.reason));
+            assert_eq!(loc.as_str(), input, "{input:?} mutated");
+        }
+    }
+
+    #[test]
+    fn test_rejects_oversized_input() {
+        // Bound-check: cap is at MAX_LOCATION_LEN; one byte over must
+        // reject without echoing the input back into the error.
+        let prefix = "s3://bucket/";
+        let pad = "a".repeat(MAX_LOCATION_LEN - prefix.len() + 1);
+        let oversized = format!("{prefix}{pad}");
+        assert_eq!(oversized.len(), MAX_LOCATION_LEN + 1);
+        let err = Location::from_str(&oversized).unwrap_err();
+        assert!(err.reason.contains("limit"), "{}", err.reason);
+        // Error must NOT echo the megabyte input — keeps logs/db rows bounded.
+        assert!(
+            !err.value.contains("aaaa"),
+            "value should be truncated marker"
+        );
+        // At-cap is fine.
+        let pad = "a".repeat(MAX_LOCATION_LEN - prefix.len());
+        let at_cap = format!("{prefix}{pad}");
+        assert_eq!(at_cap.len(), MAX_LOCATION_LEN);
+        Location::from_str(&at_cap).unwrap();
+    }
+
+    #[test]
+    fn test_host_str_isolates_authority_before_at_split() {
+        // Baseline: simple userinfo@host.
+        let loc = Location::from_str("abfss://user@account.dfs.core.windows.net/foo").unwrap();
+        assert_eq!(loc.host_str(), Some("account.dfs.core.windows.net"));
+
+        // Regression: a literal `@` in the PATH must not be picked up as
+        // the userinfo separator. Earlier versions did `rsplit_once('@')`
+        // on the entire authority_and_path — for this input that took the
+        // path's `@` and yielded host=`bar`. Fix isolates the authority
+        // (first split on `/`) before splitting userinfo.
+        let loc = Location::from_str("abfss://fs@account.dfs.core.windows.net/foo@bar").unwrap();
+        assert_eq!(loc.host_str(), Some("account.dfs.core.windows.net"));
+
+        // Multiple `@` in the authority itself — RFC says the last one
+        // is the userinfo separator. Both accessor and `check_host` use
+        // `rsplit_once`, so they agree.
+        let loc = Location::from_str("s3://x@y@bucket/path").unwrap();
+        assert_eq!(loc.host_str(), Some("bucket"));
+    }
+
+    #[test]
+    fn test_rejects_query_and_fragment() {
+        // Literal `?` and `#` in URL paths get parsed as query/fragment by
+        // `url::Url`, which would diverge from our raw `authority_and_path`
+        // view. Reject up-front and require percent-encoded `%3F`/`%23`.
+        let frag = Location::from_str("s3://bucket/foo#bar").unwrap_err();
+        assert!(frag.reason.contains("fragment"), "{}", frag.reason);
+        let query = Location::from_str("s3://bucket/foo?bar").unwrap_err();
+        assert!(query.reason.contains("query"), "{}", query.reason);
+        // Encoded forms must still work.
+        Location::from_str("s3://bucket/foo%23bar").unwrap();
+        Location::from_str("s3://bucket/foo%3Fbar").unwrap();
     }
 
     #[test]

--- a/crates/io/src/s3/s3_location.rs
+++ b/crates/io/src/s3/s3_location.rs
@@ -319,7 +319,7 @@ mod tests {
 
         for case in cases {
             let result = S3Location::try_from_str(case, false);
-            assert!(result.is_err());
+            assert!(result.is_err(), "expected error for `{case}`");
         }
     }
 

--- a/crates/io/tests/integration_tests.rs
+++ b/crates/io/tests/integration_tests.rs
@@ -239,6 +239,10 @@ test_all_storages!(
 test_all_storages!(test_empty_files, test_empty_files_impl);
 test_all_storages!(test_large_files, test_large_files_impl);
 test_all_storages!(test_special_characters, test_special_characters_impl);
+test_all_storages!(
+    test_special_characters_in_url_segments,
+    test_special_characters_in_url_segments_impl
+);
 test_all_storages!(test_error_handling, test_error_handling_impl);
 test_all_storages!(
     test_delete_non_existent_files,
@@ -251,6 +255,10 @@ test_all_storages!(
 test_all_storages!(
     test_batch_delete_many_items_some_nonexistant,
     test_batch_delete_many_items_some_nonexistant_impl
+);
+test_all_storages!(
+    test_percent_encoding_does_not_alias,
+    test_percent_encoding_does_not_alias_impl
 );
 test_all_storages!(
     test_list_non_existent_directory,
@@ -1022,11 +1030,14 @@ async fn test_special_characters_impl(
     storage: &StorageBackend,
     config: &TestConfig,
 ) -> anyhow::Result<()> {
-    // Names are path of URL string, which may contain urlencoded chars
+    // Sub-delims (`!`, `=`, `-`, `_`, `.`, `+`, `*`, `'`, `$`, `,`, `;`) and
+    // multibyte UTF-8 are accepted literally. Reserved chars `?` and `#`
+    // are rejected by `Location::from_str` and must be percent-encoded;
+    // their round-trip is covered by `test_special_characters_in_url_segments`.
     let special_files = vec![
         "file with spaces.txt",
         "file-with-dashes.txt",
-        "y fl !? -_ä oats=1.2.txt",
+        "y fl ! -_ä oats=1.2.txt",
         "file_with_underscores.txt",
         "file.with.dots.txt",
         "file-with-ue-ü.txt",
@@ -1091,6 +1102,96 @@ async fn test_special_characters_impl(
         );
     }
 
+    Ok(())
+}
+
+/// Like `test_special_characters_impl` but the special chars appear as
+/// pre-percent-encoded URL segments (e.g. `%3F`, `%20`) — what
+/// Lakekeeper REST receives when a client provides a URL-style location.
+async fn test_special_characters_in_url_segments_impl(
+    storage: &StorageBackend,
+    config: &TestConfig,
+) -> anyhow::Result<()> {
+    // Each entry: a URL-encoded path segment that should round-trip through
+    // write → read → list when used as a directory name in a URL location.
+    // Positive: segments that must round-trip end-to-end.
+    let positive_segments = vec![
+        "%3F",     // ?
+        "%22",     // "
+        "x%20y",   // space in the middle
+        "%20x",    // leading space
+        "x%20",    // trailing space
+        "x%20%20", // trailing double space
+        "%2A",     // *
+        "%24",     // $
+        "%27",     // '
+        "%2B",     // +
+        "üñîçødé",
+        "日本語",
+    ];
+    // Negative: segments that must be rejected up-front. The reasons differ
+    // (Azure InvalidUri for whitespace-only; `url::Url` normalises encoded
+    // dot-segments and encoded `/`) but the outcome is the same: silent
+    // path divergence that we surface as a clean parse-time error.
+    let negative_segments = vec![
+        "%20", "%09", "%20%20", // whitespace-only
+        "%2E", "%2e", "%2E%2E", "%2e%2e", // dot-segments
+        "%2F",    // encoded slash
+    ];
+
+    let base_dir = config.test_dir_path("special-chars-url-segments");
+    let mut written_paths = Vec::new();
+    let mut failures = Vec::new();
+
+    for seg in &positive_segments {
+        let path = format!("{base_dir}{seg}/data/metadata/00000-test.metadata.json");
+        match storage
+            .write(&path, Bytes::from(format!("Content for {seg}")))
+            .await
+        {
+            Ok(()) => written_paths.push((seg.to_string(), path)),
+            Err(e) => failures.push(format!("write({seg}): {e}")),
+        }
+    }
+
+    for (seg, path) in &written_paths {
+        match storage.read(path).await {
+            Ok(read) => {
+                let s = String::from_utf8(read.to_vec())?;
+                if s != format!("Content for {seg}") {
+                    failures.push(format!("read({seg}): mismatch (got {s:?})"));
+                }
+            }
+            Err(e) => failures.push(format!("read({seg}): {e}")),
+        }
+    }
+    for (_, path) in &written_paths {
+        let _ = storage.delete(path).await;
+    }
+
+    // The decoded-segment rejections live in `AdlsLocation` only — S3 keys
+    // and GCS object names accept these chars literally, so the test is
+    // ADLS-specific.
+    if matches!(storage, StorageBackend::Adls(_)) {
+        for seg in &negative_segments {
+            let path = format!("{base_dir}{seg}/data/metadata/00000-test.metadata.json");
+            match storage.write(&path, Bytes::from("x")).await {
+                Ok(()) => {
+                    failures.push(format!("write({seg}): expected reject, got Ok"));
+                    let _ = storage.delete(&path).await;
+                }
+                Err(_) => { /* expected */ }
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        anyhow::bail!(
+            "{} segment(s) failed:\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
     Ok(())
 }
 
@@ -1376,6 +1477,111 @@ async fn test_list_prefix_boundaries_impl(
         let _ = storage.delete(&path).await; // Ignore errors during cleanup
     }
 
+    Ok(())
+}
+
+/// Pin the byte-literal storage-key model: two paths that differ only by
+/// percent-encoding of an unreserved/sub-delim character must address two
+/// physically distinct objects. If any backend silently aliases them, the
+/// catalog cannot rely on raw `fs_location` bytes for uniqueness — and
+/// canonicalisation (or backend-specific rejection) becomes mandatory.
+///
+/// This is the empirical premise behind dropping `Location::from_str`
+/// canonicalisation. A failure here is the signal that the byte-literal
+/// model does NOT hold for the failing backend, and policy-level mitigation
+/// is required for that backend specifically.
+async fn test_percent_encoding_does_not_alias_impl(
+    storage: &StorageBackend,
+    config: &TestConfig,
+) -> anyhow::Result<()> {
+    // Pairs of paths that share the same URI-decoded form but differ
+    // byte-for-byte. Under the byte-literal model each pair produces two
+    // distinct storage objects.
+    //
+    // Each entry: (decoded form, percent-encoded form, label).
+    // - "Abc" vs "%41bc": alphanumeric — pchar unreserved
+    // - "foo-bar" vs "foo%2Dbar": `-` — pchar unreserved
+    // - "foo+bar" vs "foo%2Bbar": `+` — pchar sub-delim
+    // - "%3F" vs "%3f": hex case in surviving %XX
+    let pairs: &[(&str, &str, &str)] = &[
+        ("Abc", "%41bc", "alpha-A"),
+        ("foo-bar", "foo%2Dbar", "dash"),
+        ("foo+bar", "foo%2Bbar", "plus"),
+        ("%3F", "%3f", "hex-case-Q"),
+    ];
+
+    let base_dir = config.test_dir_path("percent-alias-test");
+    let mut failures = Vec::new();
+    let mut to_cleanup = Vec::new();
+
+    for (decoded, encoded, label) in pairs {
+        let path_decoded = format!("{base_dir}{decoded}/data.bin");
+        let path_encoded = format!("{base_dir}{encoded}/data.bin");
+
+        // Distinct payloads so we can detect aliasing by content swap.
+        let payload_decoded = Bytes::from(format!("DECODED:{label}"));
+        let payload_encoded = Bytes::from(format!("ENCODED:{label}"));
+
+        // Write the decoded path first, then the encoded path. If the
+        // backend aliases, the second write overwrites the first.
+        if let Err(e) = storage.write(&path_decoded, payload_decoded.clone()).await {
+            failures.push(format!("{label}: write decoded `{decoded}` failed: {e}"));
+            continue;
+        }
+        to_cleanup.push(path_decoded.clone());
+
+        if let Err(e) = storage.write(&path_encoded, payload_encoded.clone()).await {
+            failures.push(format!("{label}: write encoded `{encoded}` failed: {e}"));
+            continue;
+        }
+        to_cleanup.push(path_encoded.clone());
+
+        // Read back from the originally-written paths. If the backend
+        // aliases the two, the decoded-path read returns the encoded-path
+        // payload (or vice versa, depending on which write "won").
+        match storage.read(&path_decoded).await {
+            Ok(got) if got == payload_decoded => {} // expected — distinct
+            Ok(got) if got == payload_encoded => {
+                failures.push(format!(
+                    "{label}: ALIAS DETECTED — decoded path `{decoded}` returned encoded payload (write to `{encoded}` overwrote it)"
+                ));
+            }
+            Ok(got) => {
+                failures.push(format!(
+                    "{label}: decoded path returned unexpected payload: {got:?}"
+                ));
+            }
+            Err(e) => failures.push(format!("{label}: read decoded `{decoded}` failed: {e}")),
+        }
+
+        match storage.read(&path_encoded).await {
+            Ok(got) if got == payload_encoded => {} // expected — distinct
+            Ok(got) if got == payload_decoded => {
+                failures.push(format!(
+                    "{label}: ALIAS DETECTED — encoded path `{encoded}` returned decoded payload"
+                ));
+            }
+            Ok(got) => {
+                failures.push(format!(
+                    "{label}: encoded path returned unexpected payload: {got:?}"
+                ));
+            }
+            Err(e) => failures.push(format!("{label}: read encoded `{encoded}` failed: {e}")),
+        }
+    }
+
+    // Cleanup regardless of outcome.
+    for path in to_cleanup {
+        let _ = storage.delete(&path).await;
+    }
+
+    if !failures.is_empty() {
+        anyhow::bail!(
+            "{} percent-encoding alias check(s) failed:\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
     Ok(())
 }
 

--- a/crates/lakekeeper/src/service/storage/az.rs
+++ b/crates/lakekeeper/src/service/storage/az.rs
@@ -477,15 +477,24 @@ impl AdlsProfile {
         signed_expiry: OffsetDateTime,
         key: impl Into<SasKey>,
     ) -> Result<String, CredentialsError> {
-        let path = reduce_scheme_string(stc_request.table_location.as_ref());
+        let path = reduce_scheme_string(stc_request.table_location.as_ref()).map_err(|e| {
+            CredentialsError::ShortTermCredential {
+                reason: format!("Invalid ADLS location for SAS signing: {e}"),
+                source: Some(Box::new(e)),
+            }
+        })?;
         let rootless_path = path.trim_start_matches('/').trim_end_matches('/');
         let depth = rootless_path.split('/').count();
 
+        // Azure recomputes the canonical-resource by URL-decoding the request
+        // URL path. Hand-rolling the canonical with the encoded form (e.g.
+        // literal `%3F` or `%20`) produces a signature mismatch.
+        let decoded_path = percent_encoding::percent_decode_str(rootless_path).decode_utf8_lossy();
         let canonical_resource = format!(
             "/blob/{}/{}/{}",
             self.account_name.as_str(),
             self.filesystem.as_str(),
-            rootless_path
+            decoded_path
         );
 
         tracing::debug!(
@@ -584,11 +593,10 @@ impl AdlsProfile {
 
 /// Removes the hostname and user from the path.
 /// Keeps only the path and optionally the scheme.
-#[must_use]
-pub(crate) fn reduce_scheme_string(path: &str) -> String {
-    AdlsLocation::try_from_str(path, true)
-        .map(|l| format!("/{}", l.blob_name().clone().trim_start_matches('/')))
-        .unwrap_or(path.to_string())
+/// Reduce an ADLS URL to its rooted blob path (`/<blob_name>`).
+pub(crate) fn reduce_scheme_string(path: &str) -> Result<String, InvalidLocationError> {
+    let l = AdlsLocation::try_from_str(path, true)?;
+    Ok(format!("/{}", l.blob_name().trim_start_matches('/')))
 }
 
 #[derive(Redact, Hash, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -725,19 +733,15 @@ pub(crate) mod test {
 
     #[test]
     fn test_reduce_scheme_string() {
-        // Test abfss protocol
         let path = "abfss://filesystem@dfs.windows.net/path/_test";
-        let reduced_path = reduce_scheme_string(path);
-        assert_eq!(reduced_path, "/path/_test");
+        assert_eq!(reduce_scheme_string(path).unwrap(), "/path/_test");
 
-        // Test wasbs protocol
         let wasbs_path = "wasbs://filesystem@account.windows.net/path/to/data";
-        let reduced_wasbs_path = reduce_scheme_string(wasbs_path);
-        assert_eq!(reduced_wasbs_path, "/path/to/data");
+        assert_eq!(reduce_scheme_string(wasbs_path).unwrap(), "/path/to/data");
 
-        // Test a non-matching path
+        // Non-ADLS scheme must error rather than silently pass through.
         let non_matching = "http://example.com/path";
-        assert_eq!(reduce_scheme_string(non_matching), non_matching);
+        assert!(reduce_scheme_string(non_matching).is_err());
     }
 
     pub(crate) mod azure_integration_tests {

--- a/crates/lakekeeper/src/service/storage/gcs/sts.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/sts.rs
@@ -23,7 +23,7 @@ pub(crate) async fn downscope(
             bucket,
             &stc_request.table_location,
             stc_request.storage_permissions,
-        ),
+        )?,
     )?;
 
     let response = HTTP_CLIENT
@@ -117,13 +117,28 @@ impl Options {
         bucket: &str,
         table_location: &Location,
         storage_permissions: StoragePermissions,
-    ) -> Self {
+    ) -> Result<Self, TableConfigError> {
         let mut table_location = table_location.clone();
         table_location.with_trailing_slash();
+        let bucket_prefix = format!("gs://{bucket}/");
         let prefixless_location = table_location
             .as_str()
-            .replace(&format!("gs://{bucket}/"), "");
-        Options {
+            .strip_prefix(&bucket_prefix)
+            .ok_or_else(|| {
+                TableConfigError::Internal(
+                    format!(
+                        "Refusing to build GCS access boundary: table location `{}` is not under bucket `{bucket}`",
+                        table_location.as_str()
+                    ),
+                    None,
+                )
+            })?
+            .to_owned();
+
+        let bucket_cel = escape_for_cel_single_quoted(bucket)?;
+        let path_cel = escape_for_cel_single_quoted(&prefixless_location)?;
+
+        Ok(Options {
             access_boundary: AccessBoundary {
                 access_boundary_rules: vec![AccessBoundaryRule {
                     available_resource: format!(
@@ -143,15 +158,45 @@ impl Options {
                     },
                     availability_condition: AvailabilityCondition {
                         title: "obj-prefixes".to_string(),
-                        // need the getAttribute to allow Listing operations
+                        // getAttribute is needed for Listing operations.
                         expression: format!(
-                            "resource.name.startsWith('projects/_/buckets/{bucket}/objects/{prefixless_location}') || resource.name.startsWith('projects/_/buckets/{bucket}/folders/{prefixless_location}') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('{prefixless_location}')",
+                            "resource.name.startsWith('projects/_/buckets/{bucket_cel}/objects/{path_cel}') || resource.name.startsWith('projects/_/buckets/{bucket_cel}/folders/{path_cel}') || api.getAttribute('storage.googleapis.com/objectListPrefix', '').startsWith('{path_cel}')",
                         ),
                     }.into(),
                 }],
             },
+        })
+    }
+}
+
+/// Escape `value` for interpolation inside a CEL single-quoted literal.
+/// GCP's access-boundary CEL doesn't accept `r'...'` raw strings or `+`
+/// concat. Control chars without a CEL escape are rejected.
+fn escape_for_cel_single_quoted(value: &str) -> Result<String, TableConfigError> {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\'' => out.push_str("\\'"),
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0C}' => out.push_str("\\f"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => {
+                return Err(TableConfigError::Internal(
+                    format!(
+                        "Refusing to build GCS access boundary: input contains an unsupported control character (U+{:04X})",
+                        c as u32
+                    ),
+                    None,
+                ));
+            }
+            c => out.push(c),
         }
     }
+    Ok(out)
 }
 
 #[derive(Serialize, Deserialize)]
@@ -214,5 +259,115 @@ impl From<&GcsServiceKey> for CredentialsFile {
             quota_project_id: None,
             workforce_pool_user_project: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_for_cel_single_quoted_passes_plain_value() {
+        assert_eq!(escape_for_cel_single_quoted("foo/bar").unwrap(), "foo/bar");
+        assert_eq!(
+            escape_for_cel_single_quoted("foo/bar/üñîçødé").unwrap(),
+            "foo/bar/üñîçødé",
+        );
+    }
+
+    #[test]
+    fn escape_for_cel_single_quoted_escapes_quote_backslash_and_double_quote() {
+        // Injection payload: closing the literal early. The `'` must be
+        // escaped to `\'` so the CEL parser keeps reading inside the literal.
+        assert_eq!(
+            escape_for_cel_single_quoted("') || true || x.startsWith('").unwrap(),
+            "\\') || true || x.startsWith(\\'",
+        );
+        assert_eq!(
+            escape_for_cel_single_quoted(r"foo\bar").unwrap(),
+            r"foo\\bar"
+        );
+        assert_eq!(
+            escape_for_cel_single_quoted(r#"foo"bar"#).unwrap(),
+            r#"foo\"bar"#
+        );
+    }
+
+    #[test]
+    fn escape_for_cel_single_quoted_escapes_handled_control_chars() {
+        assert_eq!(escape_for_cel_single_quoted("a\nb").unwrap(), "a\\nb");
+        assert_eq!(escape_for_cel_single_quoted("a\rb").unwrap(), "a\\rb");
+        assert_eq!(escape_for_cel_single_quoted("a\tb").unwrap(), "a\\tb");
+        assert_eq!(escape_for_cel_single_quoted("a\u{08}b").unwrap(), "a\\bb");
+        assert_eq!(escape_for_cel_single_quoted("a\u{0C}b").unwrap(), "a\\fb");
+    }
+
+    #[test]
+    fn escape_for_cel_single_quoted_rejects_unsupported_control_chars() {
+        // NUL and other unhandled control chars have no CEL escape.
+        for cp in [0x00u32, 0x01, 0x07, 0x0B, 0x1F, 0x7F] {
+            let input = format!("a{}b", char::from_u32(cp).unwrap());
+            let err = escape_for_cel_single_quoted(&input)
+                .expect_err(&format!("U+{cp:04X} must be rejected"));
+            assert!(matches!(err, TableConfigError::Internal(_, _)));
+        }
+    }
+
+    #[test]
+    fn options_neutralizes_cel_injection_in_path() {
+        let bucket = "my-bucket";
+        let location: Location = "gs://my-bucket/wh/safe-prefix/".parse().unwrap();
+        let opts =
+            Options::from_location_and_permissions(bucket, &location, StoragePermissions::Read)
+                .unwrap();
+        let expr = &opts.access_boundary.access_boundary_rules[0]
+            .availability_condition
+            .as_ref()
+            .unwrap()
+            .expression;
+        assert!(
+            expr.contains("/buckets/my-bucket/objects/wh/safe-prefix/"),
+            "expected inline path literal in expression, got: {expr}"
+        );
+        // Guard against regressing to forms GCP rejects.
+        assert!(!expr.contains("r'"), "raw-string literal in: {expr}");
+        assert!(!expr.contains(" + "), "string concat in: {expr}");
+    }
+
+    #[test]
+    fn options_escapes_quote_in_path_instead_of_rejecting() {
+        // A path containing `'` must produce a CEL expression where the quote
+        // is escaped (`\'`), not closed early. The location is accepted, not
+        // rejected.
+        let bucket = "my-bucket";
+        let location: Location = "gs://my-bucket/x'/data/"
+            .parse()
+            .expect("URL parse should accept ' (sub-delim)");
+        let opts =
+            Options::from_location_and_permissions(bucket, &location, StoragePermissions::Read)
+                .unwrap();
+        let expr = &opts.access_boundary.access_boundary_rules[0]
+            .availability_condition
+            .as_ref()
+            .unwrap()
+            .expression;
+        assert!(
+            expr.contains("/objects/x\\'/data/"),
+            "expected escaped `'` in expression, got: {expr}"
+        );
+    }
+
+    #[test]
+    fn options_rejects_cross_bucket_table_location() {
+        let location: Location = "gs://other-bucket/data/".parse().unwrap();
+        let result = Options::from_location_and_permissions(
+            "my-bucket",
+            &location,
+            StoragePermissions::Read,
+        );
+        let Err(err) = result else {
+            panic!("cross-bucket location must be rejected");
+        };
+        assert!(matches!(err, TableConfigError::Internal(_, _)));
     }
 }

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -1073,11 +1073,14 @@ mod tests {
 
     #[test]
     fn test_split_location() {
-        let location = Location::from_str("abfss://").unwrap();
+        // Minimal authority-only Location — `abfss://` (no host) is now
+        // rejected by the validator since an empty host is never useful and
+        // backend-aliasing safety requires a non-empty authority.
+        let location = Location::from_str("abfss://host").unwrap();
         let prefix = location.scheme();
         let full_path = location.authority_and_path();
         assert_eq!(prefix, "abfss");
-        assert_eq!(full_path, "");
+        assert_eq!(full_path, "host");
         assert_eq!(join_location(prefix, full_path).unwrap(), location);
 
         let location = Location::from_str("abfss://foo/bar").unwrap();

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -25,6 +25,7 @@ use lakekeeper_io::{
     },
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use veil::Redact;
 
 use super::ShortTermCredentialsRequest;
@@ -892,13 +893,24 @@ impl S3Profile {
         Ok(identity)
     }
 
-    fn permission_to_actions(storage_permissions: StoragePermissions) -> &'static str {
+    fn permission_to_actions(storage_permissions: StoragePermissions) -> &'static [&'static str] {
         match storage_permissions {
-            StoragePermissions::Read => "\"s3:GetObject\"",
-            StoragePermissions::ReadWrite => "\"s3:GetObject\", \"s3:PutObject\"",
-            StoragePermissions::ReadWriteDelete => {
-                "\"s3:GetObject\", \"s3:PutObject\", \"s3:DeleteObject\""
-            }
+            StoragePermissions::Read => &["s3:GetObject", "s3:GetObjectVersion"],
+            StoragePermissions::ReadWrite => &[
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:PutObject",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts",
+            ],
+            StoragePermissions::ReadWriteDelete => &[
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts",
+            ],
         }
     }
 
@@ -917,62 +929,60 @@ impl S3Profile {
             "arn:aws:s3:::{}",
             table_location.bucket_name().trim_end_matches('/')
         );
-        let key = format!("{}/", table_location.key().join("/"));
+        let key = escape_iam_glob_literal(&format!("{}/", table_location.key().join("/")));
+        let key_wildcard = format!("{key}*");
 
-        let mut statements = format!(
-            r#"
-            {{
+        let actions = Self::permission_to_actions(storage_permissions);
+        let mut statements = vec![
+            json!({
                 "Sid": "TableAccess",
                 "Effect": "Allow",
-                "Action": [
-                    {}
-                ],
+                "Action": actions,
                 "Resource": [
-                    "{bucket_arn}/{key}",
-                    "{bucket_arn}/{key}*"
-                ]
-            }},
-            {{
+                    format!("{bucket_arn}/{key}"),
+                    format!("{bucket_arn}/{key_wildcard}"),
+                ],
+            }),
+            json!({
                 "Sid": "ListBucketForFolder",
                 "Effect": "Allow",
                 "Action": "s3:ListBucket",
-                "Resource": "{bucket_arn}",
-                "Condition": {{
-                    "StringLike": {{
-                        "s3:prefix": "{key}*"
-                    }}
-                }}
-            }}
-        "#,
-            Self::permission_to_actions(storage_permissions),
-        )
-        .replace('\n', "");
+                "Resource": bucket_arn,
+                "Condition": {
+                    "StringLike": {
+                        "s3:prefix": key_wildcard,
+                    },
+                },
+            }),
+            // Some AWS clients call GetBucketLocation to discover the bucket's
+            // region before issuing data-plane requests. Without it, requests
+            // can fail with `IllegalLocationConstraintException`.
+            json!({
+                "Sid": "GetBucketLocation",
+                "Effect": "Allow",
+                "Action": "s3:GetBucketLocation",
+                "Resource": bucket_arn,
+            }),
+        ];
 
         if let Some(kms_key_arn) = self.aws_kms_key_arn.as_ref() {
-            statements = format!(
-                r#"
-                {statements},
-                {{
-                    "Sid": "KmsAccess",
-                    "Effect": "Allow",
-                    "Action": [
-                        "kms:Decrypt",
-                        "kms:GenerateDataKey"
-                    ],
-                    "Resource": "{kms_key_arn}"
-                }}"#
-            );
+            statements.push(json!({
+                "Sid": "KmsAccess",
+                "Effect": "Allow",
+                "Action": ["kms:Decrypt", "kms:GenerateDataKey"],
+                "Resource": kms_key_arn,
+            }));
         }
 
-        Ok(format!(
-            r#"{{
-        "Version": "2012-10-17",
-        "Statement": [
-            {statements}
-        ]
-        }}"#
-        )
-        .replace('\n', ""))
+        let policy = json!({
+            "Version": "2012-10-17",
+            "Statement": statements,
+        });
+
+        serde_json::to_string(&policy).map_err(|e| CredentialsError::ShortTermCredential {
+            source: Some(Box::new(e)),
+            reason: "Failed to serialize STS downscoped policy".to_string(),
+        })
     }
 
     fn validate_session_tags(&self) -> Result<(), ValidationError> {
@@ -1116,6 +1126,22 @@ impl S3Profile {
 
         Ok(())
     }
+}
+
+/// Escape characters that IAM policy strings treat as pattern metacharacters
+/// so the input is matched literally inside `Resource` ARNs and `StringLike`
+/// condition values.
+fn escape_iam_glob_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '*' => out.push_str("${*}"),
+            '?' => out.push_str("${?}"),
+            '$' => out.push_str("${$}"),
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 fn storage_profile_to_s3_settings(profile: &S3Profile) -> S3Settings {
@@ -1785,6 +1811,166 @@ pub(crate) mod test {
             )
             .unwrap();
         let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
+    }
+
+    #[test]
+    fn escape_iam_glob_literal_escapes_pattern_chars() {
+        assert_eq!(escape_iam_glob_literal("plain/key"), "plain/key");
+        assert_eq!(escape_iam_glob_literal("with*star"), "with${*}star");
+        assert_eq!(escape_iam_glob_literal("with?q"), "with${?}q");
+        assert_eq!(escape_iam_glob_literal("with$dollar"), "with${$}dollar");
+        // Adversarial: literal ${aws:username} must not become a live variable.
+        // After escape the `${` opener is broken into `${$}{`, so IAM sees the
+        // valid `${$}` escape (resolves to `$`) followed by literal `{aws:username}`.
+        assert_eq!(
+            escape_iam_glob_literal("${aws:username}"),
+            "${$}{aws:username}"
+        );
+        // Adversarial: combining all metacharacters.
+        assert_eq!(escape_iam_glob_literal("a*b?c$d"), "a${*}b${?}c${$}d");
+    }
+
+    #[test]
+    fn policy_string_neutralizes_wildcard_in_table_path() {
+        // A table location containing `*` must not turn into an IAM wildcard
+        // in the issued credentials — that would broaden the scope to every
+        // key matching the pattern, not just the one table.
+        let table_location = "s3://bucket-name/wh/evil*/table";
+        let profile = S3Profile::builder()
+            .bucket("bucket-name".to_string())
+            .key_prefix("wh".to_string())
+            .region("us-east-1".to_string())
+            .flavor(S3Flavor::S3Compat)
+            .sts_enabled(true)
+            .build();
+        let policy = profile
+            .get_sts_policy_string(
+                &table_location.parse().unwrap(),
+                StoragePermissions::ReadWriteDelete,
+            )
+            .unwrap();
+        // The user-supplied `*` must be escaped; only the trailing `*` we
+        // append ourselves may remain as a live wildcard.
+        assert!(
+            policy.contains("wh/evil${*}/table"),
+            "expected escaped key in policy, got: {policy}"
+        );
+        assert!(
+            !policy.contains("wh/evil*/table"),
+            "raw user-supplied `*` leaked into policy: {policy}"
+        );
+        // Policy must still be valid JSON.
+        let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
+    }
+
+    #[test]
+    fn policy_string_handles_json_special_chars_in_path() {
+        // url::Url::parse percent-encodes `"` and most JSON-breaking chars in
+        // the path, but `\` survives unchanged. With raw format!() this would
+        // produce invalid JSON or worse. With serde_json the value gets
+        // escaped automatically. This test pins that behavior.
+        let table_location = r"s3://bucket-name/wh/back\slash/table";
+        let profile = S3Profile::builder()
+            .bucket("bucket-name".to_string())
+            .key_prefix("wh".to_string())
+            .region("us-east-1".to_string())
+            .flavor(S3Flavor::S3Compat)
+            .sts_enabled(true)
+            .build();
+        let policy = profile
+            .get_sts_policy_string(
+                &table_location.parse().unwrap(),
+                StoragePermissions::ReadWriteDelete,
+            )
+            .unwrap();
+        // Must round-trip as valid JSON.
+        let parsed: serde_json::Value = serde_json::from_str(&policy).unwrap();
+        // The backslash must appear escaped in the serialized form.
+        assert!(
+            policy.contains(r"back\\slash"),
+            "expected `\\\\` in serialized policy, got: {policy}"
+        );
+        // And the parsed JSON must contain a single literal backslash.
+        let resources = parsed["Statement"][0]["Resource"].as_array().unwrap();
+        assert!(
+            resources
+                .iter()
+                .any(|r| r.as_str().unwrap().contains(r"back\slash")),
+            "expected literal backslash in parsed Resource, got: {resources:?}"
+        );
+    }
+
+    #[test]
+    fn policy_string_neutralizes_question_mark_in_table_path() {
+        // `Location::from_str` now rejects raw `?` at parse time, so this
+        // state can't be reached via REST anymore. Build via `extend()`
+        // (which doesn't re-parse) to defense-in-depth check that the
+        // escape is wired up in the policy path even if some future code
+        // bypasses the parser.
+        let mut table_location: Location = "s3://bucket-name/wh".parse().unwrap();
+        table_location.extend(["ev?l", "table"]);
+        let profile = S3Profile::builder()
+            .bucket("bucket-name".to_string())
+            .key_prefix("wh".to_string())
+            .region("us-east-1".to_string())
+            .flavor(S3Flavor::S3Compat)
+            .sts_enabled(true)
+            .build();
+        let policy = profile
+            .get_sts_policy_string(&table_location, StoragePermissions::ReadWriteDelete)
+            .unwrap();
+        assert!(
+            policy.contains("wh/ev${?}l/table"),
+            "expected escaped `?` in policy, got: {policy}"
+        );
+        assert!(
+            !policy.contains("wh/ev?l/table"),
+            "raw `?` leaked into policy: {policy}"
+        );
+        let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
+    }
+
+    #[test]
+    fn test_update_region_allowed_when_endpoint_set() {
+        let profile = S3Profile::builder()
+            .bucket("test-bucket".to_string())
+            .region("us-east-1".to_string())
+            .endpoint("http://localhost:9000".parse().unwrap())
+            .flavor(S3Flavor::S3Compat)
+            .sts_enabled(false)
+            .build();
+
+        let updated = S3Profile::builder()
+            .bucket("test-bucket".to_string())
+            .region("us-west-2".to_string())
+            .endpoint("http://localhost:9000".parse().unwrap())
+            .flavor(S3Flavor::S3Compat)
+            .sts_enabled(false)
+            .build();
+
+        let result = profile.update_with(updated);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().region, "us-west-2");
+    }
+
+    #[test]
+    fn test_update_region_rejected_without_endpoint() {
+        let profile = S3Profile::builder()
+            .bucket("test-bucket".to_string())
+            .region("us-east-1".to_string())
+            .flavor(S3Flavor::Aws)
+            .sts_enabled(false)
+            .build();
+
+        let updated = S3Profile::builder()
+            .bucket("test-bucket".to_string())
+            .region("us-west-2".to_string())
+            .flavor(S3Flavor::Aws)
+            .sts_enabled(false)
+            .build();
+
+        let result = profile.update_with(updated);
+        assert!(result.is_err());
     }
 }
 

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -1929,49 +1929,6 @@ pub(crate) mod test {
         );
         let _ = serde_json::from_str::<serde_json::Value>(&policy).unwrap();
     }
-
-    #[test]
-    fn test_update_region_allowed_when_endpoint_set() {
-        let profile = S3Profile::builder()
-            .bucket("test-bucket".to_string())
-            .region("us-east-1".to_string())
-            .endpoint("http://localhost:9000".parse().unwrap())
-            .flavor(S3Flavor::S3Compat)
-            .sts_enabled(false)
-            .build();
-
-        let updated = S3Profile::builder()
-            .bucket("test-bucket".to_string())
-            .region("us-west-2".to_string())
-            .endpoint("http://localhost:9000".parse().unwrap())
-            .flavor(S3Flavor::S3Compat)
-            .sts_enabled(false)
-            .build();
-
-        let result = profile.update_with(updated);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().region, "us-west-2");
-    }
-
-    #[test]
-    fn test_update_region_rejected_without_endpoint() {
-        let profile = S3Profile::builder()
-            .bucket("test-bucket".to_string())
-            .region("us-east-1".to_string())
-            .flavor(S3Flavor::Aws)
-            .sts_enabled(false)
-            .build();
-
-        let updated = S3Profile::builder()
-            .bucket("test-bucket".to_string())
-            .region("us-west-2".to_string())
-            .flavor(S3Flavor::Aws)
-            .sts_enabled(false)
-            .build();
-
-        let result = profile.update_with(updated);
-        assert!(result.is_err());
-    }
 }
 
 #[cfg(test)]

--- a/tests/python/tests/test_special_char_locations.py
+++ b/tests/python/tests/test_special_char_locations.py
@@ -1,0 +1,501 @@
+"""End-to-end tests for special characters in table locations.
+
+For each char, create a table at a location containing it (via REST, no
+Spark), then use vended creds via the per-cloud SDK to:
+  - write at the table prefix → must succeed (proves encoding consistency)
+  - write at a sibling path → must 403 (proves scope tightness)
+
+`expect_deny` flips the positive write to "must 403" for cloud-side
+limitations (e.g. MinIO doesn't resolve IAM `${*}` → safe over-restrict).
+This pins the safe failure mode and catches a regression to over-permit.
+"""
+
+import dataclasses
+import uuid
+from typing import Optional
+from urllib.parse import quote, urlparse
+
+import conftest
+import pytest
+import requests
+
+
+@dataclasses.dataclass(frozen=True)
+class SpecialChar:
+    """`url_segment` is the form that goes into the URL path — literal for
+    sub-delims (`*`, `+`, `'`, `$`), percent-encoded otherwise."""
+
+    id: str
+    url_segment: str
+    # (provider, flavor) → reason. Flavor `"*"` matches any.
+    # `expect_deny`: cloud-side limitation, asserts positive deny (safe).
+    expect_deny: dict = dataclasses.field(default_factory=dict)
+    # `expect_create_reject`: Lakekeeper rejects createTable up-front
+    # (e.g. ADLS rejects whitespace-only segments since Azure does).
+    expect_create_reject: dict = dataclasses.field(default_factory=dict)
+
+
+# MinIO does not resolve AWS IAM policy variables, so our `${*}`/`${$}`/`${?}`
+# glob-escape is treated as a literal 4-char string. Deny is the safe outcome.
+_MINIO_NO_IAM_VARS = "MinIO does not resolve IAM policy variables (${*}/${?}/${$})"
+
+# Note: `..` and `.` are removed by RFC 3986 path normalisation in
+# `url::Url`, so they can never round-trip in a URL-based location and are
+# not testable here.
+SPECIAL_CHARS = [
+    SpecialChar("star", "*", expect_deny={("s3", "minio"): _MINIO_NO_IAM_VARS}),
+    SpecialChar("question", "%3F"),
+    SpecialChar("dollar", "$", expect_deny={("s3", "minio"): _MINIO_NO_IAM_VARS}),
+    SpecialChar("squote", "'"),
+    SpecialChar("plus", "+"),
+    SpecialChar("dquote", "%22"),
+    SpecialChar(
+        "space",
+        "%20",
+        expect_create_reject={
+            ("adls", "*"): "Azure ADLS rejects whitespace-only path segments"
+        },
+    ),
+]
+
+
+def _lookup(table: dict, provider: str, flavor: Optional[str]) -> Optional[str]:
+    return table.get((provider, flavor or "")) or table.get((provider, "*"))
+
+# Per-request timeout (seconds). Prevents CI hangs on a stalled cloud
+# endpoint or slow Lakekeeper. Generous enough for cold cloud calls.
+HTTP_TIMEOUT = 30
+
+# Minimal Iceberg schema used for every funky-location table.
+SCHEMA = {
+    "type": "struct",
+    "schema-id": 0,
+    "fields": [{"id": 1, "name": "v", "type": "int", "required": False}],
+}
+
+
+def _provider(storage_config: dict) -> str:
+    t = storage_config["storage-profile"]["type"]
+    return "s3" if t in ("s3", "aws") else t
+
+
+def _vending_enabled(storage_config: dict) -> bool:
+    profile = storage_config["storage-profile"]
+    if profile["type"] in ("s3", "aws"):
+        return bool(profile.get("sts-enabled"))
+    return True  # ADLS and GCS always vend
+
+
+def _wh_url(warehouse: conftest.Warehouse) -> str:
+    return (
+        warehouse.server.catalog_url.rstrip("/") + f"/v1/{warehouse.warehouse_id}"
+    )
+
+
+def _auth(warehouse: conftest.Warehouse) -> dict:
+    return {"Authorization": f"Bearer {warehouse.access_token}"}
+
+
+def _create_namespace(warehouse: conftest.Warehouse, namespace: str) -> None:
+    r = requests.post(
+        f"{_wh_url(warehouse)}/namespaces",
+        headers=_auth(warehouse),
+        json={"namespace": [namespace], "properties": {}},
+        timeout=HTTP_TIMEOUT,
+    )
+    r.raise_for_status()
+
+
+def _load_namespace_location(
+    warehouse: conftest.Warehouse, namespace: str
+) -> str:
+    r = requests.get(
+        f"{_wh_url(warehouse)}/namespaces/{quote(namespace, safe='')}",
+        headers=_auth(warehouse),
+        timeout=HTTP_TIMEOUT,
+    )
+    r.raise_for_status()
+    return r.json()["properties"]["location"].rstrip("/")
+
+
+def _create_table(
+    warehouse: conftest.Warehouse,
+    namespace: str,
+    table: str,
+    location: str,
+) -> dict:
+    r = requests.post(
+        f"{_wh_url(warehouse)}/namespaces/{quote(namespace, safe='')}/tables",
+        headers=_auth(warehouse),
+        json={"name": table, "location": location, "schema": SCHEMA},
+        timeout=HTTP_TIMEOUT,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _load_table_with_creds(
+    warehouse: conftest.Warehouse, namespace: str, table: str
+) -> dict:
+    """REST `loadTable` with vended-credentials header. Returns the parsed
+    response (`metadata`, `config`, …)."""
+    r = requests.get(
+        f"{_wh_url(warehouse)}/namespaces/{quote(namespace, safe='')}/tables/{quote(table, safe='')}",
+        headers={
+            **_auth(warehouse),
+            "X-Iceberg-Access-Delegation": "vended-credentials",
+        },
+        timeout=HTTP_TIMEOUT,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _try_write_payload(
+    provider: str, config: dict, target_url: str, payload: bytes
+) -> Optional[str]:
+    """Attempt a small object PUT at `target_url` using vended creds.
+    Returns None on SUCCESS, or a short description of the failure.
+    Caller-supplied payload lets a test write a distinguishing value per
+    table and detect cross-reads."""
+    if provider == "s3":
+        import boto3
+        import botocore.exceptions
+
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=config.get("s3.access-key-id"),
+            aws_secret_access_key=config.get("s3.secret-access-key"),
+            aws_session_token=config.get("s3.session-token"),
+            endpoint_url=config.get("s3.endpoint") or None,
+            region_name=config.get("s3.region") or None,
+        )
+        try:
+            s3.put_object(Bucket=bucket, Key=key, Body=payload)
+        except botocore.exceptions.ClientError as e:
+            return f"s3 ClientError: {e.response.get('Error', {}).get('Code', '?')}"
+        return None
+    if provider == "adls":
+        sas_key = next((k for k in config if k.startswith("adls.sas-token.")), None)
+        assert sas_key, f"no adls.sas-token.* in config: {list(config)}"
+        sas = config[sas_key].lstrip("?")
+        parsed = urlparse(target_url)
+        fs = parsed.username
+        # Vended SAS is a Blob Service SAS — use the blob endpoint (single
+        # PUT) rather than DFS (which would need 3-step create/append/flush).
+        host = (parsed.hostname or "").replace(".dfs.", ".blob.")
+        # Pre-encode `%` → `%25` so that any literal `%XX` in the catalog's
+        # raw fs_location reaches Azure as bytes (server URL-decodes once).
+        # Without this, `Abc` and `%41bc` would alias on the wire — the same
+        # bug we fixed in `AdlsLocation::blob_name` on the Rust side.
+        path = parsed.path.replace("%", "%25")
+        https_url = f"https://{host}/{fs}{path}?{sas}"
+        r = requests.put(
+            https_url,
+            headers={"x-ms-blob-type": "BlockBlob"},
+            data=payload,
+            timeout=HTTP_TIMEOUT,
+        )
+        if 200 <= r.status_code < 300:
+            return None
+        return f"adls HTTP {r.status_code}: {r.text[:200]}"
+    if provider == "gcs":
+        token = config.get("gcs.oauth2.token")
+        assert token, f"no gcs.oauth2.token in config: {list(config)}"
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        https_url = f"https://storage.googleapis.com/{bucket}/{quote(key, safe='/')}"
+        r = requests.put(
+            https_url,
+            headers={"Authorization": f"Bearer {token}"},
+            data=payload,
+            timeout=HTTP_TIMEOUT,
+        )
+        if 200 <= r.status_code < 300:
+            return None
+        return f"gcs HTTP {r.status_code}: {r.text[:200]}"
+    raise AssertionError(f"unknown provider: {provider}")
+
+
+def _safe_url(url: str) -> str:
+    """Strip query and fragment from a URL so it can be safely embedded in
+    error messages without leaking SAS tokens or other auth material."""
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+
+@pytest.mark.parametrize("char", SPECIAL_CHARS, ids=lambda c: c.id)
+def test_special_char_in_location(
+    warehouse: conftest.Warehouse, storage_config, char: SpecialChar
+):
+    if not _vending_enabled(storage_config):
+        pytest.skip("requires vended credentials")
+    provider = _provider(storage_config)
+    flavor: Optional[str] = storage_config["storage-profile"].get("flavor")
+    expect_deny = _lookup(char.expect_deny, provider, flavor)
+    expect_create_reject = _lookup(char.expect_create_reject, provider, flavor)
+
+    ns_name = f"sc_{char.id}_{uuid.uuid4().hex[:8]}"
+    table_name = "data"
+    table_dir = f"sc_{char.id}"
+
+    _create_namespace(warehouse, ns_name)
+    ns_location = _load_namespace_location(warehouse, ns_name)
+
+    table_location = f"{ns_location}/{table_dir}/{char.url_segment}/data/"
+    sibling_location = f"{ns_location}/{table_dir}_evil/canary"
+
+    if expect_create_reject:
+        with pytest.raises(requests.HTTPError) as excinfo:
+            _create_table(warehouse, ns_name, table_name, table_location)
+        assert excinfo.value.response.status_code == 400, (
+            f"expected 400 from createTable for {char.id} on {provider}/{flavor} "
+            f"({expect_create_reject}); got {excinfo.value.response.status_code}"
+        )
+        return
+
+    _create_table(warehouse, ns_name, table_name, table_location)
+
+    loaded = _load_table_with_creds(warehouse, ns_name, table_name)
+    config = loaded.get("config", {})
+    stored_location = loaded["metadata"]["location"].rstrip("/")
+    if char.url_segment not in stored_location:
+        pytest.skip(
+            f"Lakekeeper normalised `{char.url_segment}` out of the location "
+            f"(requested {table_location.rstrip('/')}, stored {stored_location})"
+        )
+
+    # Positive: write at the table prefix.
+    target = f"{stored_location}/canary.txt"
+    err = _try_write_payload(provider, config, target, b"canary")
+    if expect_deny:
+        # Cloud-side limitation (not a Lakekeeper bug). Pin the *safe*
+        # outcome: must deny, not allow. A regression to over-permit would
+        # be a security issue.
+        assert err is not None, (
+            f"expected deny (cloud-side limitation: {expect_deny}) but write "
+            f"to {target} SUCCEEDED — credential scope is over-permissive on "
+            f"{provider}/{flavor} for char {char.id}"
+        )
+        return  # No point testing the negative — creds are already too tight.
+
+    assert err is None, (
+        f"vended credentials failed to write at the table prefix\n"
+        f"  char         = {char.id}\n"
+        f"  table_loc    = {table_location}\n"
+        f"  stored_loc   = {stored_location}\n"
+        f"  target       = {target}\n"
+        f"  config_keys  = {sorted(config)}\n"
+        f"  error        = {err}"
+    )
+
+    # Negative: vended creds for the table must NOT allow a sibling write.
+    err = _try_write_payload(provider, config, sibling_location, b"canary")
+    assert err is not None, (
+        f"vended credentials for {table_location} unexpectedly allowed write "
+        f"to {sibling_location} (provider={provider}, char={char.id}). "
+        f"Credential scope is too broad."
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class AliasPair:
+    """A pair of byte-different path segments that share the same URI-decoded
+    form. Under the byte-literal storage-key model these address two distinct
+    storage objects; the catalog must accept both as distinct rows and the
+    vended creds for one must not unlock the other.
+    """
+
+    id: str
+    lhs: str  # decoded form, e.g. "Abc"
+    rhs: str  # encoded form, e.g. "%41bc"
+
+
+# Pairs that differ only by percent-encoding of an unreserved/sub-delim char,
+# or by hex-case in a surviving %XX. The Rust storage-layer integration test
+# (`test_percent_encoding_does_not_alias`) proves SDK-level distinctness for
+# each pair on every backend; this Python test proves the full Lakekeeper
+# REST → vended-creds → SDK chain preserves it end-to-end.
+ALIAS_DISTINCT_PAIRS = [
+    AliasPair("alpha_A", "Abc", "%41bc"),
+    AliasPair("dash", "foo-bar", "foo%2Dbar"),
+    AliasPair("plus", "foo+bar", "foo%2Bbar"),
+    AliasPair("hex_case_Q", "%3F", "%3f"),
+]
+
+
+def _try_read(provider: str, config: dict, target_url: str) -> Optional[bytes]:
+    """Attempt a small object GET at `target_url` using vended creds.
+    Returns the body on SUCCESS, or None on access denial / not-found.
+    Any unexpected error raises so the test fails loudly rather than
+    silently masking a regression."""
+    if provider == "s3":
+        import boto3
+        import botocore.exceptions
+
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=config.get("s3.access-key-id"),
+            aws_secret_access_key=config.get("s3.secret-access-key"),
+            aws_session_token=config.get("s3.session-token"),
+            endpoint_url=config.get("s3.endpoint") or None,
+            region_name=config.get("s3.region") or None,
+        )
+        try:
+            obj = s3.get_object(Bucket=bucket, Key=key)
+            return obj["Body"].read()
+        except botocore.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "?")
+            if code in ("AccessDenied", "NoSuchKey", "403", "404"):
+                return None
+            raise
+    if provider == "adls":
+        sas_key = next((k for k in config if k.startswith("adls.sas-token.")), None)
+        assert sas_key, f"no adls.sas-token.* in config: {list(config)}"
+        sas = config[sas_key].lstrip("?")
+        parsed = urlparse(target_url)
+        fs = parsed.username
+        host = (parsed.hostname or "").replace(".dfs.", ".blob.")
+        # urlparse keeps the path raw — but the Azure server URL-decodes
+        # exactly once. We need the wire bytes to match the catalog's raw
+        # fs_location, so any literal `%` in the user-supplied path must
+        # itself be wire-encoded (`%` → `%25`). This is the same fix we
+        # made in the Rust SDK call site (`AdlsLocation::blob_name`).
+        path = parsed.path.replace("%", "%25")
+        https_url = f"https://{host}/{fs}{path}?{sas}"
+        r = requests.get(https_url, timeout=HTTP_TIMEOUT)
+        if 200 <= r.status_code < 300:
+            return r.content
+        if r.status_code in (403, 404):
+            return None
+        raise AssertionError(
+            f"adls GET {_safe_url(https_url)} HTTP {r.status_code} "
+            f"({r.reason}): {r.text[:200]}"
+        )
+    if provider == "gcs":
+        token = config.get("gcs.oauth2.token")
+        assert token, f"no gcs.oauth2.token in config: {list(config)}"
+        parsed = urlparse(target_url)
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        https_url = f"https://storage.googleapis.com/{bucket}/{quote(key, safe='/')}"
+        r = requests.get(
+            https_url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=HTTP_TIMEOUT,
+        )
+        if 200 <= r.status_code < 300:
+            return r.content
+        if r.status_code in (403, 404):
+            return None
+        raise AssertionError(
+            f"gcs GET {_safe_url(https_url)} HTTP {r.status_code} "
+            f"({r.reason}): {r.text[:200]}"
+        )
+    raise AssertionError(f"unknown provider: {provider}")
+
+
+@pytest.mark.parametrize("pair", ALIAS_DISTINCT_PAIRS, ids=lambda p: p.id)
+def test_alias_distinct_pair_credential_isolation(
+    warehouse: conftest.Warehouse, storage_config, pair: AliasPair
+):
+    """End-to-end proof of the byte-literal model: two byte-different paths
+    that the URI spec considers "equivalent" produce two genuinely separate
+    tables, and the vended credentials for one cannot reach the other.
+
+    Catches three regression classes:
+    1. Catalog re-introduces canonicalisation (one of the two creates fails).
+    2. Vended-cred prefix scope decodes the stored fs_location (an over-broad
+       prefix would cover BOTH storage paths, allowing cross-table access).
+    3. Storage SDK aliases the two keys at the wire layer (regresses the
+       fix in `AdlsLocation::blob_name` or its analogue on other clouds).
+    """
+    if not _vending_enabled(storage_config):
+        pytest.skip("requires vended credentials")
+    provider = _provider(storage_config)
+
+    ns_name = f"alias_{pair.id}_{uuid.uuid4().hex[:8]}"
+    _create_namespace(warehouse, ns_name)
+    ns_location = _load_namespace_location(warehouse, ns_name)
+
+    # Same parent directory — only the trailing segment differs. This is the
+    # tightest test of byte-literal isolation: if anything in the chain
+    # collapses lhs↔rhs, the second create fails or the cross-table read
+    # succeeds.
+    parent = f"{ns_location}/aliasdir"
+    loc_a = f"{parent}/{pair.lhs}/data/"
+    loc_b = f"{parent}/{pair.rhs}/data/"
+    table_a = "table_a"
+    table_b = "table_b"
+
+    # Both creates must succeed. If catalog canonicalisation collapses the
+    # two locations, the second create raises 409 / LocationAlreadyTaken.
+    _create_table(warehouse, ns_name, table_a, loc_a)
+    _create_table(warehouse, ns_name, table_b, loc_b)
+
+    loaded_a = _load_table_with_creds(warehouse, ns_name, table_a)
+    loaded_b = _load_table_with_creds(warehouse, ns_name, table_b)
+    config_a = loaded_a.get("config", {})
+    config_b = loaded_b.get("config", {})
+    stored_a = loaded_a["metadata"]["location"].rstrip("/")
+    stored_b = loaded_b["metadata"]["location"].rstrip("/")
+
+    # If the catalog round-tripped a different string than what we sent,
+    # canonicalisation has crept back in. Skip rather than misdiagnose
+    # (the createTable success above already proved no collision).
+    if pair.lhs not in stored_a or pair.rhs not in stored_b:
+        pytest.skip(
+            f"catalog rewrote location segment(s) — "
+            f"sent {loc_a!r}/{loc_b!r}, stored {stored_a!r}/{stored_b!r}"
+        )
+    assert stored_a != stored_b, (
+        f"catalog returned identical stored locations for byte-different "
+        f"inputs ({pair.lhs!r}, {pair.rhs!r}) — alias collapse: {stored_a!r}"
+    )
+
+    # 1. Write a distinguishing payload to A using A's vended creds.
+    payload_a = f"PAYLOAD-A-{pair.id}".encode()
+    target_a = f"{stored_a}/canary.txt"
+    err = _try_write_payload(provider, config_a, target_a, payload_a)
+    assert err is None, (
+        f"A's vended creds failed at A's own path {target_a!r}: {err}"
+    )
+
+    # 2. Try to read A's payload using B's vended creds at A's wire URL.
+    # If cred scope leaks (e.g. prefix decoded), this returns the bytes.
+    leaked = _try_read(provider, config_b, target_a)
+    assert leaked is None, (
+        f"ALIAS / SCOPE LEAK: B's vended creds for {stored_b!r} read A's "
+        f"object at {target_a!r} (got {leaked!r}). Either the SDK aliased "
+        f"the two paths or the cred prefix decoded byte-different forms."
+    )
+
+    # 3. Try to read A's payload using B's wire URL with B's creds — i.e.
+    # if the SDK or server aliases lhs↔rhs at wire time, B's creds + B's
+    # URL would resolve to A's storage object.
+    target_b = f"{stored_b}/canary.txt"
+    body_b = _try_read(provider, config_b, target_b)
+    # Object at B's path doesn't exist yet — must NOT return A's bytes.
+    assert body_b is None or body_b != payload_a, (
+        f"WIRE-LEVEL ALIAS: reading B's path {target_b!r} returned A's "
+        f"payload. SDK or server collapsed {pair.lhs!r}↔{pair.rhs!r}."
+    )
+
+    # 4. B remains independently functional — write at its own prefix.
+    payload_b = f"PAYLOAD-B-{pair.id}".encode()
+    err = _try_write_payload(provider, config_b, target_b, payload_b)
+    assert err is None, (
+        f"B's vended creds failed at B's own path {target_b!r}: {err}"
+    )
+    body_b = _try_read(provider, config_b, target_b)
+    assert body_b == payload_b, (
+        f"B's creds at B's path returned wrong bytes: got {body_b!r}, "
+        f"expected {payload_b!r}"
+    )

--- a/tests/python/tox.ini
+++ b/tests/python/tox.ini
@@ -51,7 +51,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_minio_s3a]
 description = spark_minio_s3a
@@ -91,7 +91,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_adls]
 description = spark_adls
@@ -102,7 +102,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_openfga]
 description = spark_openfga
@@ -115,7 +115,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_kv2]
 description = spark_kv2
@@ -128,7 +128,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_gcs]
 description = spark_gcs
@@ -139,7 +139,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_aws_remote_signing]
 description = spark_aws_remote_signing
@@ -152,7 +152,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_aws_sts]
 description = spark_aws_sts
@@ -165,7 +165,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_aws_system_identity_remote_signing]
 description = spark_aws_system_identity_remote_signing
@@ -178,7 +178,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 [testenv:spark_aws_system_identity_sts]
 description = spark_aws_system_identity_sts
@@ -191,7 +191,7 @@ deps =
     {[testenv]deps}
     findspark
 commands =
-    pytest {posargs:tests} tests/test_spark.py -rs
+    pytest {posargs:tests} tests/test_spark.py tests/test_special_char_locations.py -rs
 
 
 [testenv:trino]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,65 +1,21 @@
 #!/bin/bash
-# run.sh — dual-mode test runner.
-#
-# HOST mode (default): selects the right Spark Docker image from the Iceberg
-#   version suffix, picks the correct docker-compose overlay files, and
-#   re-invokes this script inside the container.
-#
-# CONTAINER mode (LAKEKEEPER_IN_CONTAINER=1): runs tox directly.
-#
-# Usage (host):
-#   cd tests && bash run.sh <tox-env>[-<iceberg-version>] [extra pytest args...]
-#   e.g.  bash run.sh spark_minio_sts-1.10.1
-#         bash run.sh pyiceberg
-#         bash run.sh trino_opa
-#         bash run.sh spark_minio_sts-1.10.1 -k test_special_char_in_location
+# This script is meant to run in  apache/spark:3.5.1-java17-python3 like docker images
 set -eo pipefail
 
 source common.sh
 
-SUITE="$1"
-if [ -z "$SUITE" ]; then
-    echo "usage: bash run.sh <tox-env>[-<iceberg-version>] [extra pytest args...]" >&2
-    echo "  e.g.  bash run.sh spark_minio_sts-1.10.1" >&2
-    exit 2
-fi
-TOX_NAME="${SUITE%%-*}"
-SPARK_VERSION="${SUITE#*-}"
-# No version suffix → SPARK_VERSION equals TOX_NAME; normalise to empty.
-[ "$SPARK_VERSION" = "$TOX_NAME" ] && SPARK_VERSION=""
-shift
-PYTEST_ARGS=("$@")
+setup_python
 
-# ── Container-side execution ──────────────────────────────────────────────────
-if [ "${LAKEKEEPER_IN_CONTAINER:-0}" = "1" ]; then
-    setup_python
-    if [[ "$SPARK_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-        export LAKEKEEPER_TEST__SPARK_ICEBERG_VERSION="$SPARK_VERSION"
-    fi
-    echo "Running tests: $TOX_NAME  iceberg version: ${LAKEKEEPER_TEST__SPARK_ICEBERG_VERSION:-default}"
-    cd "${SCRIPT_DIR}/python"
-    exec tox -qe "${TOX_NAME}" -- "${PYTEST_ARGS[@]}"
+TOX_NAME="${1%%-*}"
+SPARK_VERSION="${1#*-}"
+
+# unset if empty else export
+if [ "$SPARK_VERSION" != "$TOX_NAME" ]; then
+  export LAKEKEEPER_TEST__SPARK_ICEBERG_VERSION="$SPARK_VERSION"
 fi
 
 
-# Build the docker compose -f arguments, mirroring overlay rules from CI.
-# The order of the elif chain matters: 'openfga' must be checked before 'opa'.
-COMPOSE_ARGS=("-f" "${SCRIPT_DIR}/docker-compose.yaml")
-if [[ "$SUITE" == *"openfga"* ]]; then
-    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-openfga-overlay.yaml")
-    elif [[ "$SUITE" == *"kv2"* ]]; then
-    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-vault-overlay.yaml")
-    elif [[ "$SUITE" == *"opa"* ]]; then
-    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-openfga-overlay.yaml")
-    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-trino-opa-overlay.yaml")
-    elif [[ "$SUITE" == *"starrocks"* ]]; then
-    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-starrocks-overlay.yaml")
-    elif [[ "$SUITE" == *"aws_system_identity"* ]]; then
-    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-s3-system-identity-overlay.yaml")
-    elif [[ "$SUITE" == *"legacy_md5"* ]]; then
-    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-legacy-md5-overlay.yaml")
-fi
-
-exec docker compose "${COMPOSE_ARGS[@]}" run --quiet-pull spark \
-/opt/entrypoint.sh bash -c \
-'cd /opt/tests && LAKEKEEPER_IN_CONTAINER=1 bash run.sh "$@"' -- "$SUITE" "${PYTEST_ARGS[@]}"
+# Running tests
+echo "Running tests test: $TOX_NAME iceberg version: $LAKEKEEPER_TEST__SPARK_ICEBERG_VERSION..."
+cd python
+tox -qe "${TOX_NAME}"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,21 +1,65 @@
 #!/bin/bash
-# This script is meant to run in  apache/spark:3.5.1-java17-python3 like docker images
+# run.sh — dual-mode test runner.
+#
+# HOST mode (default): selects the right Spark Docker image from the Iceberg
+#   version suffix, picks the correct docker-compose overlay files, and
+#   re-invokes this script inside the container.
+#
+# CONTAINER mode (LAKEKEEPER_IN_CONTAINER=1): runs tox directly.
+#
+# Usage (host):
+#   cd tests && bash run.sh <tox-env>[-<iceberg-version>] [extra pytest args...]
+#   e.g.  bash run.sh spark_minio_sts-1.10.1
+#         bash run.sh pyiceberg
+#         bash run.sh trino_opa
+#         bash run.sh spark_minio_sts-1.10.1 -k test_special_char_in_location
 set -eo pipefail
 
 source common.sh
 
-setup_python
+SUITE="$1"
+if [ -z "$SUITE" ]; then
+    echo "usage: bash run.sh <tox-env>[-<iceberg-version>] [extra pytest args...]" >&2
+    echo "  e.g.  bash run.sh spark_minio_sts-1.10.1" >&2
+    exit 2
+fi
+TOX_NAME="${SUITE%%-*}"
+SPARK_VERSION="${SUITE#*-}"
+# No version suffix → SPARK_VERSION equals TOX_NAME; normalise to empty.
+[ "$SPARK_VERSION" = "$TOX_NAME" ] && SPARK_VERSION=""
+shift
+PYTEST_ARGS=("$@")
 
-TOX_NAME="${1%%-*}"
-SPARK_VERSION="${1#*-}"
-
-# unset if empty else export
-if [ "$SPARK_VERSION" != "$TOX_NAME" ]; then
-  export LAKEKEEPER_TEST__SPARK_ICEBERG_VERSION="$SPARK_VERSION"
+# ── Container-side execution ──────────────────────────────────────────────────
+if [ "${LAKEKEEPER_IN_CONTAINER:-0}" = "1" ]; then
+    setup_python
+    if [[ "$SPARK_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+        export LAKEKEEPER_TEST__SPARK_ICEBERG_VERSION="$SPARK_VERSION"
+    fi
+    echo "Running tests: $TOX_NAME  iceberg version: ${LAKEKEEPER_TEST__SPARK_ICEBERG_VERSION:-default}"
+    cd "${SCRIPT_DIR}/python"
+    exec tox -qe "${TOX_NAME}" -- "${PYTEST_ARGS[@]}"
 fi
 
 
-# Running tests
-echo "Running tests test: $TOX_NAME iceberg version: $LAKEKEEPER_TEST__SPARK_ICEBERG_VERSION..."
-cd python
-tox -qe "${TOX_NAME}"
+# Build the docker compose -f arguments, mirroring overlay rules from CI.
+# The order of the elif chain matters: 'openfga' must be checked before 'opa'.
+COMPOSE_ARGS=("-f" "${SCRIPT_DIR}/docker-compose.yaml")
+if [[ "$SUITE" == *"openfga"* ]]; then
+    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-openfga-overlay.yaml")
+    elif [[ "$SUITE" == *"kv2"* ]]; then
+    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-vault-overlay.yaml")
+    elif [[ "$SUITE" == *"opa"* ]]; then
+    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-openfga-overlay.yaml")
+    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-trino-opa-overlay.yaml")
+    elif [[ "$SUITE" == *"starrocks"* ]]; then
+    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-starrocks-overlay.yaml")
+    elif [[ "$SUITE" == *"aws_system_identity"* ]]; then
+    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-s3-system-identity-overlay.yaml")
+    elif [[ "$SUITE" == *"legacy_md5"* ]]; then
+    COMPOSE_ARGS+=("-f" "${SCRIPT_DIR}/docker-compose-legacy-md5-overlay.yaml")
+fi
+
+exec docker compose "${COMPOSE_ARGS[@]}" run --quiet-pull spark \
+/opt/entrypoint.sh bash -c \
+'cd /opt/tests && LAKEKEEPER_IN_CONTAINER=1 bash run.sh "$@"' -- "$SUITE" "${PYTEST_ARGS[@]}"


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(storage): harden STS/CEL credential policies against path injection

fix(deps): bump rustls-webpki & aws sdk, async-nats for RUSTSEC-2026-0049/0098/0099/0104
END_COMMIT_OVERRIDE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added robust handling of special characters and percent-encoded variants in storage location paths

* **Bug Fixes**
  * Strengthened path validation and security to prevent path-traversal and normalization attacks
  * Enhanced credential scope isolation for cloud storage operations to prevent cross-path access
  * Made error handling stricter for invalid or non-compliant storage locations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper/pull/1748)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->