### PR TITLE
feat(users): drop unique-email constraint

### DIFF
--- a/crates/lakekeeper/migrations/20260513091606_drop_unique_user_email.sql
+++ b/crates/lakekeeper/migrations/20260513091606_drop_unique_user_email.sql
@@ -1,0 +1,7 @@
+-- Drop the unique-email constraint on users. Email is metadata only:
+-- nothing in lakekeeper resolves identity by email (all lookups go via
+-- users.id), no FK references it, and Cedar already exposes it as optional.
+-- Identity providers in the wild legitimately yield shared/default emails for
+-- service principals, which today rejects valid role-provider batch syncs and
+-- /v1/config auto-provisioning with a 409 EntityAlreadyExists.
+DROP INDEX IF EXISTS unique_user_email;

--- a/docs/docs/api/lakekeeper.cedarschema
+++ b/docs/docs/api/lakekeeper.cedarschema
@@ -94,6 +94,9 @@ namespace Lakekeeper {
   entity User in [Role, Server] {
     // Email of the user, extracted from the authentication token.
     // Not available for all token types.
+    // Lakekeeper does not enforce email uniqueness. Two distinct
+    // users may share an email (e.g. service principals using a
+    // shared mailbox, or default emails issued by an IDP).
     email?: String,
     // Provider-resolved role memberships as Cedar Role entity UIDs.
     // The user entity is a Cedar parent of every role in this set, so

--- a/docs/docs/authorization-cedar.md
+++ b/docs/docs/authorization-cedar.md
@@ -50,6 +50,8 @@ The `Lakekeeper::User` entity also carries `provider_id` and `source_id` attribu
 | <nobr>`project_roles`</nobr>   | `[{provider_id: "oidc", source_id: "admins"}]` | Provider-resolved role memberships as `{provider_id, source_id}` records. Includes roles from token claims and role providers (e.g. LDAP) relevant to the current project. |
 | <nobr>`global_role_ids`</nobr> | `["admins", "developers"]`                     | `source_id` of every provider-resolved role as a plain `Set<String>`. Only populated when `LAKEKEEPER__CEDAR__GLOBAL_ROLE_IDS_ENABLED=true`. See below. |
 
+The `Lakekeeper::User` entity also exposes an optional `email` attribute extracted from the authentication token. Email uniqueness is not enforced — two distinct users may share an email.
+
 ### When to use `project_roles` vs `global_role_ids` vs `principal in Role::...`
 
 | Scenario                                                         | Recommended approach |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Email uniqueness is no longer enforced, allowing multiple distinct users to share the same email address. This resolves conflicts when identity providers emit non-unique or shared email addresses.

* **Documentation**
  * Updated authorization and schema documentation to clarify that the email attribute is treated as metadata rather than an identity key and is not enforced as unique.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper/pull/1755)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->