### PR TITLE
feat(role): store RoleIdent.provider as Arc<RoleProviderId> for cheap reuse

### DIFF
--- a/crates/lakekeeper/src/service/identifier/role.rs
+++ b/crates/lakekeeper/src/service/identifier/role.rs
@@ -271,15 +271,34 @@ impl FromStr for RoleSourceId {
 /// or `"oidc~admin-group"`). This composite string is used in REST path parameters
 /// and the `x-assume-role` header. The two parts are also exposed individually in
 /// API responses (`provider-id` and `source-id` fields) to support filtering by provider.
+/// `provider` is stored as `Arc<RoleProviderId>` so that producers emitting many
+/// idents that share one provider (e.g. an LDAP role provider returning every
+/// group a user belongs to) can avoid cloning the underlying `String` per ident.
+/// Cloning a `RoleIdent` is a refcount bump on the provider portion plus the
+/// `RoleSourceId` string clone.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RoleIdent {
-    provider: RoleProviderId,
+    provider: Arc<RoleProviderId>,
     source_id: RoleSourceId,
 }
 
 impl RoleIdent {
     #[must_use]
     pub fn new(provider: RoleProviderId, source_id: RoleSourceId) -> Self {
+        Self {
+            provider: Arc::new(provider),
+            source_id,
+        }
+    }
+
+    /// Construct a [`RoleIdent`] that shares an already-allocated [`RoleProviderId`].
+    ///
+    /// Use this in tight loops that emit many idents for the same provider
+    /// (e.g. converting an LDAP search result into one [`RoleIdent`] per
+    /// returned group): the caller allocates the `Arc` once and each call
+    /// here is a refcount bump rather than a `String` clone.
+    #[must_use]
+    pub fn with_provider_arc(provider: Arc<RoleProviderId>, source_id: RoleSourceId) -> Self {
         Self {
             provider,
             source_id,
@@ -303,7 +322,7 @@ impl RoleIdent {
     #[must_use]
     pub fn new_random() -> Self {
         Self {
-            provider: RoleProviderId(LAKEKEEPER_ROLE_PROVIDER_ID.to_string()),
+            provider: Arc::new(RoleProviderId(LAKEKEEPER_ROLE_PROVIDER_ID.to_string())),
             source_id: RoleSourceId(Uuid::now_v7().to_string()),
         }
     }
@@ -312,7 +331,7 @@ impl RoleIdent {
     #[must_use]
     pub fn new_internal_with_role_id(role_id: RoleId) -> Self {
         Self {
-            provider: RoleProviderId(LAKEKEEPER_ROLE_PROVIDER_ID.to_string()),
+            provider: Arc::new(RoleProviderId(LAKEKEEPER_ROLE_PROVIDER_ID.to_string())),
             source_id: RoleSourceId(role_id.to_string()),
         }
     }
@@ -328,7 +347,7 @@ impl RoleIdent {
     #[must_use]
     pub fn new_unchecked(provider: impl Into<String>, source_id: impl Into<String>) -> Self {
         Self {
-            provider: RoleProviderId(provider.into()),
+            provider: Arc::new(RoleProviderId(provider.into())),
             source_id: RoleSourceId(source_id.into()),
         }
     }
@@ -345,7 +364,7 @@ impl RoleIdent {
     #[doc(hidden)]
     pub fn from_db_unchecked(provider: impl Into<String>, source_id: impl Into<String>) -> Self {
         Self {
-            provider: RoleProviderId(provider.into()),
+            provider: Arc::new(RoleProviderId(provider.into())),
             source_id: RoleSourceId(source_id.into()),
         }
     }
@@ -353,7 +372,15 @@ impl RoleIdent {
     /// Returns the provider portion.
     #[must_use]
     pub fn provider_id(&self) -> &RoleProviderId {
-        &self.provider
+        self.provider.as_ref()
+    }
+
+    /// Returns the provider portion as a shared `Arc`, for callers that want
+    /// to construct further [`RoleIdent`]s with the same provider without
+    /// re-allocating the underlying string. Companion to [`Self::with_provider_arc`].
+    #[must_use]
+    pub fn provider_id_arc(&self) -> Arc<RoleProviderId> {
+        Arc::clone(&self.provider)
     }
 
     /// Returns the source ID portion.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal performance optimization for role identifier handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper/pull/1757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->