### PR TITLE
feat(authn): support multiple OIDC providers via LAKEKEEPER__OPENID_PROVIDERS

### DIFF
--- a/crates/lakekeeper-bin/src/serve.rs
+++ b/crates/lakekeeper-bin/src/serve.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, vec};
+use std::sync::Arc;
 
 use lakekeeper::{
     implementations::{get_default_catalog_from_config, postgres::PostgresBackend},
@@ -54,6 +54,8 @@ async fn serve_with_authn<C: CatalogStore, S: SecretStore, A: Authorizer>(
     stats: Vec<Arc<dyn EndpointStatisticsSink + 'static>>,
     events: EventDispatcher,
 ) -> anyhow::Result<()> {
+    // Use the upstream config-driven authenticator
+    // Supports both single-provider (OPENID_PROVIDER_URI) and multi-provider (OPENID_PROVIDERS) modes
     let authentication = get_default_authenticator_from_config().await?;
 
     match authentication {

--- a/crates/lakekeeper-bin/src/ui.rs
+++ b/crates/lakekeeper-bin/src/ui.rs
@@ -64,7 +64,7 @@ static UI_CONFIG: LazyLock<LakekeeperConsoleConfig> = LazyLock::new(|| {
                 default_config.idp_token_type
             }
         },
-        enable_authentication: CONFIG.openid_provider_uri.is_some(),
+        enable_authentication: CONFIG.ui_login_enabled(),
         enable_permissions: CONFIG.authz_backend != AuthZBackend::AllowAll,
         app_lakekeeper_url: std::env::var("LAKEKEEPER__UI__LAKEKEEPER_URL")
             .ok()

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -25,7 +25,7 @@ use crate::{
     WarehouseId,
     service::{
         ArcProjectId, UserId,
-        authn::{IDP_SEPARATOR, K8S_IDP_ID},
+        authn::{IDP_SEPARATOR, K8S_IDP_ID, OIDC_IDP_ID},
     },
 };
 
@@ -167,6 +167,10 @@ fn validate_openid_provider_ids(config: &DynAppConfig) {
         assert!(
             !idp_id.eq_ignore_ascii_case(K8S_IDP_ID),
             "Invalid OIDC provider '{idp_id}': IdP ID '{K8S_IDP_ID}' is reserved"
+        );
+        assert!(
+            !idp_id.eq_ignore_ascii_case(OIDC_IDP_ID),
+            "Invalid OIDC provider '{idp_id}': IdP ID '{OIDC_IDP_ID}' is reserved"
         );
     }
 }
@@ -461,8 +465,8 @@ pub struct DynAppConfig {
     /// Supports nested claims using dot notation, e.g., `resource_access.account.roles`
     pub openid_roles_claim: Option<String>,
     /// Multiple OIDC providers keyed by identity provider ID.
-    /// When set, each provider gets its own JWKS authenticator and this takes
-    /// precedence over the single-provider configuration (`openid_provider_uri`).
+    /// When set, each provider gets its own JWKS authenticator and is added
+    /// in addition to the single-provider configuration (`openid_provider_uri`).
     #[serde(default)]
     pub openid_providers: HashMap<String, OidcProviderConfig>,
 
@@ -1148,8 +1152,16 @@ impl DynAppConfig {
         self.default_tabular_expiration_delay_seconds
     }
 
+    /// Is any authentication active? Used by /info to reject anonymous.
     pub fn authn_enabled(&self) -> bool {
-        self.openid_provider_uri.is_some() || !self.openid_providers.is_empty()
+        self.openid_provider_uri.is_some()
+            || !self.openid_providers.is_empty()
+            || self.enable_kubernetes_authentication
+    }
+
+    /// Does the UI have an SSO target? Used by the UI config.
+    pub fn ui_login_enabled(&self) -> bool {
+        self.openid_provider_uri.is_some()
     }
 
     /// Helper for common conversion of optional page size to `i64`.
@@ -2014,6 +2026,19 @@ mod test {
     }
 
     #[test]
+    #[should_panic(expected = "IdP ID 'oidc' is reserved")]
+    fn test_openid_provider_id_rejects_oidc() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OIDC__URI",
+                "https://company.okta.com",
+            );
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
     fn test_user_assignments_cache() {
         figment::Jail::expect_with(|_jail| {
             let config = get_config();
@@ -2168,7 +2193,7 @@ mod test {
                 "trino.run-as-owner",
             );
             jail.set_env(
-                "LAKEKEEPER_TEST__TRUSTED_ENGINES__TRINO__IDENTITIES__OIDC__AUDIENCES",
+                "LAKEKEEPER_TEST__TRUSTED_ENGINES__TRINO__IDENTITIES__prod_AUDIENCES",
                 "[trino_dev, trino_prod]",
             );
             jail.set_env(
@@ -2625,6 +2650,16 @@ mod test {
                 "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__URI",
                 "https://okta.example.com",
             );
+            let config = get_config();
+            assert!(config.authn_enabled());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_authn_enabled_with_kubernetes_only() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__ENABLE_KUBERNETES_AUTHENTICATION", "true");
             let config = get_config();
             assert!(config.authn_enabled());
             Ok(())

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -73,6 +73,22 @@ fn get_config() -> DynAppConfig {
         .extract::<DynAppConfig>()
         .expect("Valid Configuration");
 
+    if let Some(providers) = &config.openid_providers {
+        let mut seen_idp_ids = HashSet::new();
+        for provider in providers {
+            assert!(
+                !provider.idp_id.trim().is_empty(),
+                "Invalid OIDC provider '{}': idp_id must not be empty",
+                provider.uri
+            );
+            assert!(
+                seen_idp_ids.insert(provider.idp_id.clone()),
+                "Invalid OIDC providers: duplicate idp_id '{}'",
+                provider.idp_id
+            );
+        }
+    }
+
     // Ensure base_uri has a trailing slash
     if let Some(base_uri) = config.base_uri.as_mut() {
         let base_uri_path = base_uri.path().to_string();
@@ -438,6 +454,16 @@ pub struct DynAppConfig {
     /// The field should contain an array of strings or a single string.
     /// Supports nested claims using dot notation, e.g., `resource_access.account.roles`
     pub openid_roles_claim: Option<String>,
+    /// Multiple OIDC providers configuration.
+    /// When set, each provider gets its own JWKS authenticator.
+    /// Takes precedence over the single-provider configuration (`openid_provider_uri`).
+    /// Set as a JSON string: `'[{"uri":"https://...", "idp_id":"okta", ...}]'`
+    #[serde(
+        default,
+        deserialize_with = "deserialize_openid_providers",
+        serialize_with = "serialize_openid_providers"
+    )]
+    pub openid_providers: Option<Vec<OidcProviderConfig>>,
 
     // ------------- AUTHORIZATION - OPENFGA -------------
     #[serde(default)]
@@ -618,6 +644,63 @@ where
         .as_deref()
         .map(|value| value.join(","))
         .serialize(serializer)
+}
+
+/// Deserialize OIDC providers from either:
+/// - A JSON string: `'[{"uri":"https://...", "idp_id":"okta", ...}]'`
+/// - A JSON array (when parsing config files)
+fn deserialize_openid_providers<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<OidcProviderConfig>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match value {
+        None => Ok(None),
+        Some(serde_json::Value::String(s)) => {
+            // Parse JSON string
+            let providers: Vec<OidcProviderConfig> =
+                serde_json::from_str(&s).map_err(serde::de::Error::custom)?;
+            if providers.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(providers))
+            }
+        }
+        Some(serde_json::Value::Array(arr)) => {
+            // Parse JSON array directly
+            let providers: Vec<OidcProviderConfig> =
+                serde_json::from_value(serde_json::Value::Array(arr))
+                    .map_err(serde::de::Error::custom)?;
+            if providers.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(providers))
+            }
+        }
+        Some(other) => Err(serde::de::Error::custom(format!(
+            "Expected JSON string or array for openid_providers, got: {}",
+            other
+        ))),
+    }
+}
+
+fn serialize_openid_providers<S>(
+    value: &Option<Vec<OidcProviderConfig>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match value {
+        None => serializer.serialize_none(),
+        Some(providers) => {
+            let json_str =
+                serde_json::to_string(providers).map_err(serde::ser::Error::custom)?;
+            serializer.serialize_str(&json_str)
+        }
+    }
 }
 
 fn deserialize_origin<'de, D>(deserializer: D) -> Result<Option<Vec<HeaderValue>>, D::Error>
@@ -969,6 +1052,54 @@ impl std::default::Default for Tokio {
     }
 }
 
+/// Configuration for a single OIDC provider in multi-provider mode.
+///
+/// When multiple OIDC providers are configured, each provider fetches its own
+/// JWKS keys independently, allowing authentication from multiple identity sources
+/// (e.g., Okta for users + EKS OIDC for Kubernetes service accounts).
+///
+/// # Example Environment Variables
+/// ```bash
+/// LAKEKEEPER__OPENID_PROVIDERS__0__URI=https://company.okta.com
+/// LAKEKEEPER__OPENID_PROVIDERS__0__IDP_ID=okta
+/// LAKEKEEPER__OPENID_PROVIDERS__0__AUDIENCE=https://company.okta.com
+/// LAKEKEEPER__OPENID_PROVIDERS__0__SUBJECT_CLAIMS=sub
+/// ```
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
+pub struct OidcProviderConfig {
+    /// The OIDC provider URI (must expose .well-known/openid-configuration)
+    pub uri: Url,
+    /// Unique identifier for this IdP. Used in user IDs like "{idp_id}~{subject}".
+    /// Examples: "okta", "eks-prod", "entra-id"
+    pub idp_id: String,
+    /// Expected audience(s) for tokens from this provider.
+    /// Specify multiple audiences as a comma-separated list.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_comma_separated",
+        serialize_with = "serialize_comma_separated"
+    )]
+    pub audience: Option<Vec<String>>,
+    /// Additional issuers to trust for this provider.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_comma_separated",
+        serialize_with = "serialize_comma_separated"
+    )]
+    pub additional_issuers: Option<Vec<String>>,
+    /// A scope that must be present in tokens from this provider.
+    #[serde(default)]
+    pub scope: Option<String>,
+    /// Claims to use as the subject (user ID), in order of preference.
+    /// Defaults to ["oid", "sub"] if not specified.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_comma_separated",
+        serialize_with = "serialize_comma_separated"
+    )]
+    pub subject_claims: Option<Vec<String>>,
+}
+
 impl Default for DynAppConfig {
     fn default() -> Self {
         Self {
@@ -1026,6 +1157,7 @@ impl Default for DynAppConfig {
             kubernetes_authentication_accept_legacy_serviceaccount: false,
             openid_subject_claim: None,
             openid_roles_claim: None,
+            openid_providers: None,
             listen_port: 8181,
             bind_ip: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             health_check_frequency_seconds: 10,
@@ -1066,6 +1198,10 @@ impl DynAppConfig {
 
     pub fn authn_enabled(&self) -> bool {
         self.openid_provider_uri.is_some()
+            || self
+                .openid_providers
+                .as_ref()
+                .is_some_and(|p| !p.is_empty())
     }
 
     /// Helper for common conversion of optional page size to `i64`.
@@ -1827,6 +1963,15 @@ mod test {
     }
 
     #[test]
+    fn test_openid_providers_not_set() {
+        figment::Jail::expect_with(|_jail| {
+            let config = get_config();
+            assert!(config.openid_providers.is_none());
+            Ok(())
+        });
+    }
+
+    #[test]
     fn test_user_assignments_cache() {
         figment::Jail::expect_with(|_jail| {
             let config = get_config();
@@ -2319,5 +2464,173 @@ mod test {
         // Audience matches even though subject doesn't
         let auds: HashSet<&str> = ["trino"].into_iter().collect();
         assert!(id.matches(&auds, Some("other")));
+    }
+
+    #[test]
+    fn test_openid_providers_single() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
+                r#"[{"uri":"https://okta.example.com","idp_id":"okta"}]"#,
+            );
+            let config = get_config();
+            assert!(config.openid_providers.is_some());
+            let providers = config.openid_providers.unwrap();
+            assert_eq!(providers.len(), 1);
+            assert_eq!(providers[0].idp_id, "okta");
+            assert_eq!(providers[0].uri.as_str(), "https://okta.example.com/");
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_openid_providers_multiple() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
+                r#"[
+                    {
+                        "uri": "https://company.okta.com",
+                        "idp_id": "okta",
+                        "audience": "https://company.okta.com",
+                        "subject_claims": "sub"
+                    },
+                    {
+                        "uri": "https://oidc.eks.us-east-1.amazonaws.com/id/ABC123",
+                        "idp_id": "eks-prod",
+                        "audience": "sts.amazonaws.com"
+                    }
+                ]"#,
+            );
+
+            let config = get_config();
+            assert!(config.openid_providers.is_some());
+            let providers = config.openid_providers.unwrap();
+            assert_eq!(providers.len(), 2);
+
+            // Check provider 0
+            assert_eq!(providers[0].idp_id, "okta");
+            assert_eq!(
+                providers[0].audience,
+                Some(vec!["https://company.okta.com".to_string()])
+            );
+            assert_eq!(providers[0].subject_claims, Some(vec!["sub".to_string()]));
+
+            // Check provider 1
+            assert_eq!(providers[1].idp_id, "eks-prod");
+            assert_eq!(
+                providers[1].audience,
+                Some(vec!["sts.amazonaws.com".to_string()])
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_openid_providers_with_all_fields() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
+                r#"[{
+                    "uri": "https://login.microsoftonline.com/tenant-id/v2.0",
+                    "idp_id": "entra",
+                    "audience": "api://my-app,second-audience",
+                    "additional_issuers": "https://sts.windows.net/tenant-id/",
+                    "scope": "lakekeeper",
+                    "subject_claims": "oid,sub"
+                }]"#,
+            );
+
+            let config = get_config();
+            assert!(config.openid_providers.is_some());
+            let providers = config.openid_providers.unwrap();
+            assert_eq!(providers.len(), 1);
+
+            let provider = &providers[0];
+            assert_eq!(provider.idp_id, "entra");
+            assert_eq!(
+                provider.audience,
+                Some(vec![
+                    "api://my-app".to_string(),
+                    "second-audience".to_string()
+                ])
+            );
+            assert_eq!(
+                provider.additional_issuers,
+                Some(vec!["https://sts.windows.net/tenant-id/".to_string()])
+            );
+            assert_eq!(provider.scope, Some("lakekeeper".to_string()));
+            assert_eq!(
+                provider.subject_claims,
+                Some(vec!["oid".to_string(), "sub".to_string()])
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_authn_enabled_with_openid_providers() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
+                r#"[{"uri":"https://okta.example.com","idp_id":"okta"}]"#,
+            );
+            let config = get_config();
+            assert!(config.authn_enabled());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_authn_enabled_with_single_provider() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDER_URI",
+                "https://keycloak.example.com/realms/test",
+            );
+            let config = get_config();
+            assert!(config.authn_enabled());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_authn_disabled_by_default() {
+        figment::Jail::expect_with(|_jail| {
+            let config = get_config();
+            assert!(!config.authn_enabled());
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "idp_id must not be empty")]
+    fn test_openid_providers_empty_idp_id_rejected() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
+                r#"[{"uri":"https://okta.example.com","idp_id":""}]"#,
+            );
+            let _ = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate idp_id 'okta'")]
+    fn test_openid_providers_duplicate_idp_id_rejected() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
+                r#"[
+                    {"uri":"https://okta.example.com","idp_id":"okta"},
+                    {"uri":"https://other.example.com","idp_id":"okta"}
+                ]"#,
+            );
+            let _ = get_config();
+            Ok(())
+        });
     }
 }

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -461,7 +461,7 @@ pub struct DynAppConfig {
     )]
     pub openid_subject_claim: Option<Vec<String>>,
     /// Claim to use in provided JWT tokens to extract roles.
-    /// The field should contain an array of strings or a single string.
+    /// The field should contain a single string claim path.
     /// Supports nested claims using dot notation, e.g., `resource_access.account.roles`
     pub openid_roles_claim: Option<String>,
     /// Multiple OIDC providers keyed by identity provider ID.
@@ -1047,7 +1047,7 @@ pub struct OidcProviderConfig {
     )]
     pub subject_claims: Option<Vec<String>>,
     /// Claim to use in provided JWT tokens to extract roles.
-    /// The field should contain an array of strings or a single string.
+    /// The field should contain a single string claim path.
     /// Supports nested claims using dot notation, e.g., `resource_access.account.roles`
     #[serde(default)]
     pub roles_claim: Option<String>,

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -23,7 +23,10 @@ use veil::Redact;
 
 use crate::{
     WarehouseId,
-    service::{ArcProjectId, UserId},
+    service::{
+        ArcProjectId, UserId,
+        authn::{IDP_SEPARATOR, K8S_IDP_ID},
+    },
 };
 
 const DEFAULT_RESERVED_NAMESPACES: [&str; 3] = ["system", "examples", "information_schema"];
@@ -73,21 +76,7 @@ fn get_config() -> DynAppConfig {
         .extract::<DynAppConfig>()
         .expect("Valid Configuration");
 
-    if let Some(providers) = &config.openid_providers {
-        let mut seen_idp_ids = HashSet::new();
-        for provider in providers {
-            assert!(
-                !provider.idp_id.trim().is_empty(),
-                "Invalid OIDC provider '{}': idp_id must not be empty",
-                provider.uri
-            );
-            assert!(
-                seen_idp_ids.insert(provider.idp_id.clone()),
-                "Invalid OIDC providers: duplicate idp_id '{}'",
-                provider.idp_id
-            );
-        }
-    }
+    validate_openid_provider_ids(&config);
 
     // Ensure base_uri has a trailing slash
     if let Some(base_uri) = config.base_uri.as_mut() {
@@ -163,6 +152,23 @@ fn get_config() -> DynAppConfig {
     }
 
     config
+}
+
+fn validate_openid_provider_ids(config: &DynAppConfig) {
+    for idp_id in config.openid_providers.keys() {
+        assert!(
+            !idp_id.trim().is_empty(),
+            "Invalid OIDC provider: IdP ID must not be empty"
+        );
+        assert!(
+            !idp_id.contains(IDP_SEPARATOR),
+            "Invalid OIDC provider '{idp_id}': IdP ID must not contain '{IDP_SEPARATOR}'"
+        );
+        assert!(
+            !idp_id.eq_ignore_ascii_case(K8S_IDP_ID),
+            "Invalid OIDC provider '{idp_id}': IdP ID '{K8S_IDP_ID}' is reserved"
+        );
+    }
 }
 
 /// Identifies who is trusted to act as this engine from a specific `IdP`.
@@ -454,16 +460,11 @@ pub struct DynAppConfig {
     /// The field should contain an array of strings or a single string.
     /// Supports nested claims using dot notation, e.g., `resource_access.account.roles`
     pub openid_roles_claim: Option<String>,
-    /// Multiple OIDC providers configuration.
-    /// When set, each provider gets its own JWKS authenticator.
-    /// Takes precedence over the single-provider configuration (`openid_provider_uri`).
-    /// Set as a JSON string: `'[{"uri":"https://...", "idp_id":"okta", ...}]'`
-    #[serde(
-        default,
-        deserialize_with = "deserialize_openid_providers",
-        serialize_with = "serialize_openid_providers"
-    )]
-    pub openid_providers: Option<Vec<OidcProviderConfig>>,
+    /// Multiple OIDC providers keyed by identity provider ID.
+    /// When set, each provider gets its own JWKS authenticator and this takes
+    /// precedence over the single-provider configuration (`openid_provider_uri`).
+    #[serde(default)]
+    pub openid_providers: HashMap<String, OidcProviderConfig>,
 
     // ------------- AUTHORIZATION - OPENFGA -------------
     #[serde(default)]
@@ -646,61 +647,8 @@ where
         .serialize(serializer)
 }
 
-/// Deserialize OIDC providers from either:
-/// - A JSON string: `'[{"uri":"https://...", "idp_id":"okta", ...}]'`
-/// - A JSON array (when parsing config files)
-fn deserialize_openid_providers<'de, D>(
-    deserializer: D,
-) -> Result<Option<Vec<OidcProviderConfig>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
-    match value {
-        None => Ok(None),
-        Some(serde_json::Value::String(s)) => {
-            // Parse JSON string
-            let providers: Vec<OidcProviderConfig> =
-                serde_json::from_str(&s).map_err(serde::de::Error::custom)?;
-            if providers.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(providers))
-            }
-        }
-        Some(serde_json::Value::Array(arr)) => {
-            // Parse JSON array directly
-            let providers: Vec<OidcProviderConfig> =
-                serde_json::from_value(serde_json::Value::Array(arr))
-                    .map_err(serde::de::Error::custom)?;
-            if providers.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(providers))
-            }
-        }
-        Some(other) => Err(serde::de::Error::custom(format!(
-            "Expected JSON string or array for openid_providers, got: {}",
-            other
-        ))),
-    }
-}
-
-fn serialize_openid_providers<S>(
-    value: &Option<Vec<OidcProviderConfig>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    match value {
-        None => serializer.serialize_none(),
-        Some(providers) => {
-            let json_str =
-                serde_json::to_string(providers).map_err(serde::ser::Error::custom)?;
-            serializer.serialize_str(&json_str)
-        }
-    }
+const fn default_true() -> bool {
+    true
 }
 
 fn deserialize_origin<'de, D>(deserializer: D) -> Result<Option<Vec<HeaderValue>>, D::Error>
@@ -1060,18 +1008,14 @@ impl std::default::Default for Tokio {
 ///
 /// # Example Environment Variables
 /// ```bash
-/// LAKEKEEPER__OPENID_PROVIDERS__0__URI=https://company.okta.com
-/// LAKEKEEPER__OPENID_PROVIDERS__0__IDP_ID=okta
-/// LAKEKEEPER__OPENID_PROVIDERS__0__AUDIENCE=https://company.okta.com
-/// LAKEKEEPER__OPENID_PROVIDERS__0__SUBJECT_CLAIMS=sub
+/// LAKEKEEPER__OPENID_PROVIDERS__OKTA__URI=https://company.okta.com
+/// LAKEKEEPER__OPENID_PROVIDERS__OKTA__AUDIENCE=https://company.okta.com
+/// LAKEKEEPER__OPENID_PROVIDERS__OKTA__SUBJECT_CLAIMS=sub
 /// ```
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
 pub struct OidcProviderConfig {
     /// The OIDC provider URI (must expose .well-known/openid-configuration)
     pub uri: Url,
-    /// Unique identifier for this IdP. Used in user IDs like "{idp_id}~{subject}".
-    /// Examples: "okta", "eks-prod", "entra-id"
-    pub idp_id: String,
     /// Expected audience(s) for tokens from this provider.
     /// Specify multiple audiences as a comma-separated list.
     #[serde(
@@ -1091,13 +1035,21 @@ pub struct OidcProviderConfig {
     #[serde(default)]
     pub scope: Option<String>,
     /// Claims to use as the subject (user ID), in order of preference.
-    /// Defaults to ["oid", "sub"] if not specified.
+    /// Defaults to `oid`, then `sub` if not specified.
     #[serde(
         default,
         deserialize_with = "deserialize_comma_separated",
         serialize_with = "serialize_comma_separated"
     )]
     pub subject_claims: Option<Vec<String>>,
+    /// Claim to use in provided JWT tokens to extract roles.
+    /// The field should contain an array of strings or a single string.
+    /// Supports nested claims using dot notation, e.g., `resource_access.account.roles`
+    #[serde(default)]
+    pub roles_claim: Option<String>,
+    /// If true, fail startup when this provider's OIDC/JWKS configuration cannot be loaded.
+    #[serde(default = "default_true")]
+    pub require_connected_on_startup: bool,
 }
 
 impl Default for DynAppConfig {
@@ -1157,7 +1109,7 @@ impl Default for DynAppConfig {
             kubernetes_authentication_accept_legacy_serviceaccount: false,
             openid_subject_claim: None,
             openid_roles_claim: None,
-            openid_providers: None,
+            openid_providers: HashMap::new(),
             listen_port: 8181,
             bind_ip: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             health_check_frequency_seconds: 10,
@@ -1197,11 +1149,7 @@ impl DynAppConfig {
     }
 
     pub fn authn_enabled(&self) -> bool {
-        self.openid_provider_uri.is_some()
-            || self
-                .openid_providers
-                .as_ref()
-                .is_some_and(|p| !p.is_empty())
+        self.openid_provider_uri.is_some() || !self.openid_providers.is_empty()
     }
 
     /// Helper for common conversion of optional page size to `i64`.
@@ -1966,7 +1914,101 @@ mod test {
     fn test_openid_providers_not_set() {
         figment::Jail::expect_with(|_jail| {
             let config = get_config();
-            assert!(config.openid_providers.is_none());
+            assert!(config.openid_providers.is_empty());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_openid_providers_structured_env() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__URI",
+                "https://company.okta.com",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__AUDIENCE",
+                "lakekeeper,warehouse",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__ADDITIONAL_ISSUERS",
+                "https://issuer.example.com",
+            );
+            jail.set_env("LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__SCOPE", "openid");
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__SUBJECT_CLAIMS",
+                "sub,oid",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__ROLES_CLAIM",
+                "resource_access.lakekeeper.roles",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__REQUIRE_CONNECTED_ON_STARTUP",
+                "false",
+            );
+
+            let config = get_config();
+            let provider = config.openid_providers.get("okta").unwrap();
+            assert_eq!(provider.uri.as_str(), "https://company.okta.com/");
+            assert_eq!(
+                provider.audience,
+                Some(vec!["lakekeeper".to_string(), "warehouse".to_string()])
+            );
+            assert_eq!(
+                provider.additional_issuers,
+                Some(vec!["https://issuer.example.com".to_string()])
+            );
+            assert_eq!(provider.scope, Some("openid".to_string()));
+            assert_eq!(
+                provider.subject_claims,
+                Some(vec!["sub".to_string(), "oid".to_string()])
+            );
+            assert_eq!(
+                provider.roles_claim,
+                Some("resource_access.lakekeeper.roles".to_string())
+            );
+            assert!(!provider.require_connected_on_startup);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_openid_provider_require_connected_defaults_to_true() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__URI",
+                "https://company.okta.com",
+            );
+            let config = get_config();
+            let provider = config.openid_providers.get("okta").unwrap();
+            assert!(provider.require_connected_on_startup);
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "IdP ID must not contain '~'")]
+    fn test_openid_provider_id_rejects_separator() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA~PROD__URI",
+                "https://company.okta.com",
+            );
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "IdP ID 'kubernetes' is reserved")]
+    fn test_openid_provider_id_rejects_kubernetes() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__KUBERNETES__URI",
+                "https://company.okta.com",
+            );
+            let _config = get_config();
             Ok(())
         });
     }
@@ -2470,15 +2512,13 @@ mod test {
     fn test_openid_providers_single() {
         figment::Jail::expect_with(|jail| {
             jail.set_env(
-                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
-                r#"[{"uri":"https://okta.example.com","idp_id":"okta"}]"#,
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__URI",
+                "https://okta.example.com",
             );
             let config = get_config();
-            assert!(config.openid_providers.is_some());
-            let providers = config.openid_providers.unwrap();
-            assert_eq!(providers.len(), 1);
-            assert_eq!(providers[0].idp_id, "okta");
-            assert_eq!(providers[0].uri.as_str(), "https://okta.example.com/");
+            let provider = config.openid_providers.get("okta").unwrap();
+            assert_eq!(config.openid_providers.len(), 1);
+            assert_eq!(provider.uri.as_str(), "https://okta.example.com/");
             Ok(())
         });
     }
@@ -2487,41 +2527,38 @@ mod test {
     fn test_openid_providers_multiple() {
         figment::Jail::expect_with(|jail| {
             jail.set_env(
-                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
-                r#"[
-                    {
-                        "uri": "https://company.okta.com",
-                        "idp_id": "okta",
-                        "audience": "https://company.okta.com",
-                        "subject_claims": "sub"
-                    },
-                    {
-                        "uri": "https://oidc.eks.us-east-1.amazonaws.com/id/ABC123",
-                        "idp_id": "eks-prod",
-                        "audience": "sts.amazonaws.com"
-                    }
-                ]"#,
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__URI",
+                "https://company.okta.com",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__AUDIENCE",
+                "https://company.okta.com",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__SUBJECT_CLAIMS",
+                "sub",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__EKS-PROD__URI",
+                "https://oidc.eks.us-east-1.amazonaws.com/id/ABC123",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__EKS-PROD__AUDIENCE",
+                "sts.amazonaws.com",
             );
 
             let config = get_config();
-            assert!(config.openid_providers.is_some());
-            let providers = config.openid_providers.unwrap();
-            assert_eq!(providers.len(), 2);
+            assert_eq!(config.openid_providers.len(), 2);
 
-            // Check provider 0
-            assert_eq!(providers[0].idp_id, "okta");
+            let okta = config.openid_providers.get("okta").unwrap();
             assert_eq!(
-                providers[0].audience,
+                okta.audience,
                 Some(vec!["https://company.okta.com".to_string()])
             );
-            assert_eq!(providers[0].subject_claims, Some(vec!["sub".to_string()]));
+            assert_eq!(okta.subject_claims, Some(vec!["sub".to_string()]));
 
-            // Check provider 1
-            assert_eq!(providers[1].idp_id, "eks-prod");
-            assert_eq!(
-                providers[1].audience,
-                Some(vec!["sts.amazonaws.com".to_string()])
-            );
+            let eks = config.openid_providers.get("eks-prod").unwrap();
+            assert_eq!(eks.audience, Some(vec!["sts.amazonaws.com".to_string()]));
 
             Ok(())
         });
@@ -2531,24 +2568,34 @@ mod test {
     fn test_openid_providers_with_all_fields() {
         figment::Jail::expect_with(|jail| {
             jail.set_env(
-                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
-                r#"[{
-                    "uri": "https://login.microsoftonline.com/tenant-id/v2.0",
-                    "idp_id": "entra",
-                    "audience": "api://my-app,second-audience",
-                    "additional_issuers": "https://sts.windows.net/tenant-id/",
-                    "scope": "lakekeeper",
-                    "subject_claims": "oid,sub"
-                }]"#,
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__ENTRA__URI",
+                "https://login.microsoftonline.com/tenant-id/v2.0",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__ENTRA__AUDIENCE",
+                "api://my-app,second-audience",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__ENTRA__ADDITIONAL_ISSUERS",
+                "https://sts.windows.net/tenant-id/",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__ENTRA__SCOPE",
+                "lakekeeper",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__ENTRA__SUBJECT_CLAIMS",
+                "oid,sub",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__ENTRA__ROLES_CLAIM",
+                "groups",
             );
 
             let config = get_config();
-            assert!(config.openid_providers.is_some());
-            let providers = config.openid_providers.unwrap();
-            assert_eq!(providers.len(), 1);
+            assert_eq!(config.openid_providers.len(), 1);
 
-            let provider = &providers[0];
-            assert_eq!(provider.idp_id, "entra");
+            let provider = config.openid_providers.get("entra").unwrap();
             assert_eq!(
                 provider.audience,
                 Some(vec![
@@ -2565,6 +2612,7 @@ mod test {
                 provider.subject_claims,
                 Some(vec!["oid".to_string(), "sub".to_string()])
             );
+            assert_eq!(provider.roles_claim, Some("groups".to_string()));
 
             Ok(())
         });
@@ -2574,8 +2622,8 @@ mod test {
     fn test_authn_enabled_with_openid_providers() {
         figment::Jail::expect_with(|jail| {
             jail.set_env(
-                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
-                r#"[{"uri":"https://okta.example.com","idp_id":"okta"}]"#,
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__URI",
+                "https://okta.example.com",
             );
             let config = get_config();
             assert!(config.authn_enabled());
@@ -2601,35 +2649,6 @@ mod test {
         figment::Jail::expect_with(|_jail| {
             let config = get_config();
             assert!(!config.authn_enabled());
-            Ok(())
-        });
-    }
-
-    #[test]
-    #[should_panic(expected = "idp_id must not be empty")]
-    fn test_openid_providers_empty_idp_id_rejected() {
-        figment::Jail::expect_with(|jail| {
-            jail.set_env(
-                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
-                r#"[{"uri":"https://okta.example.com","idp_id":""}]"#,
-            );
-            let _ = get_config();
-            Ok(())
-        });
-    }
-
-    #[test]
-    #[should_panic(expected = "duplicate idp_id 'okta'")]
-    fn test_openid_providers_duplicate_idp_id_rejected() {
-        figment::Jail::expect_with(|jail| {
-            jail.set_env(
-                "LAKEKEEPER_TEST__OPENID_PROVIDERS",
-                r#"[
-                    {"uri":"https://okta.example.com","idp_id":"okta"},
-                    {"uri":"https://other.example.com","idp_id":"okta"}
-                ]"#,
-            );
-            let _ = get_config();
             Ok(())
         });
     }

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -2193,7 +2193,7 @@ mod test {
                 "trino.run-as-owner",
             );
             jail.set_env(
-                "LAKEKEEPER_TEST__TRUSTED_ENGINES__TRINO__IDENTITIES__prod_AUDIENCES",
+                "LAKEKEEPER_TEST__TRUSTED_ENGINES__TRINO__IDENTITIES__OIDC__AUDIENCES",
                 "[trino_dev, trino_prod]",
             );
             jail.set_env(

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -25,7 +25,7 @@ use crate::{
     WarehouseId,
     service::{
         ArcProjectId, UserId,
-        authn::{IDP_SEPARATOR, K8S_IDP_ID, OIDC_IDP_ID},
+        authn::{K8S_IDP_ID, OIDC_IDP_ID, OidcProviderConfig},
     },
 };
 
@@ -77,6 +77,15 @@ fn get_config() -> DynAppConfig {
         .expect("Valid Configuration");
 
     validate_openid_provider_ids(&config);
+
+    if !config.openid_providers.is_empty() && config.openid_provider_uri.is_none() {
+        tracing::warn!(
+            "LAKEKEEPER__OPENID_PROVIDERS is set but LAKEKEEPER__OPENID_PROVIDER_URI is not. \
+             API authentication will work, but the UI login button is disabled — the UI \
+             redirects only to the primary provider. Set LAKEKEEPER__OPENID_PROVIDER_URI to \
+             enable UI login."
+        );
+    }
 
     // Ensure base_uri has a trailing slash
     if let Some(base_uri) = config.base_uri.as_mut() {
@@ -155,21 +164,30 @@ fn get_config() -> DynAppConfig {
 }
 
 fn validate_openid_provider_ids(config: &DynAppConfig) {
+    // Grammar `[a-z0-9-]+` (same shape as `RoleProviderId`). Lowercase-only
+    // means env-var (which figment lowercases) and YAML/TOML keys agree on
+    // one canonical form, so case-collisions, control characters, the
+    // `~` separator, and case-insensitive reserved-name aliases are all
+    // forbidden by the grammar — no separate checks needed.
     for idp_id in config.openid_providers.keys() {
         assert!(
-            !idp_id.trim().is_empty(),
+            !idp_id.is_empty(),
             "Invalid OIDC provider: IdP ID must not be empty"
         );
         assert!(
-            !idp_id.contains(IDP_SEPARATOR),
-            "Invalid OIDC provider '{idp_id}': IdP ID must not contain '{IDP_SEPARATOR}'"
+            idp_id
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+            "Invalid OIDC provider '{idp_id}': IdP ID must match `[a-z0-9-]+`"
         );
+        // Reserved names — direct equality is sufficient because the grammar
+        // already excludes any case variant.
         assert!(
-            !idp_id.eq_ignore_ascii_case(K8S_IDP_ID),
+            idp_id != K8S_IDP_ID,
             "Invalid OIDC provider '{idp_id}': IdP ID '{K8S_IDP_ID}' is reserved"
         );
         assert!(
-            !idp_id.eq_ignore_ascii_case(OIDC_IDP_ID),
+            idp_id != OIDC_IDP_ID,
             "Invalid OIDC provider '{idp_id}': IdP ID '{OIDC_IDP_ID}' is reserved"
         );
     }
@@ -623,7 +641,9 @@ where
     format!("{}ms", duration.as_millis()).serialize(serializer)
 }
 
-fn deserialize_comma_separated<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+pub(crate) fn deserialize_comma_separated<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<String>>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -638,7 +658,7 @@ where
     .transpose()
 }
 
-fn serialize_comma_separated<S>(
+pub(crate) fn serialize_comma_separated<S>(
     value: &Option<Vec<String>>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
@@ -649,10 +669,6 @@ where
         .as_deref()
         .map(|value| value.join(","))
         .serialize(serializer)
-}
-
-const fn default_true() -> bool {
-    true
 }
 
 fn deserialize_origin<'de, D>(deserializer: D) -> Result<Option<Vec<HeaderValue>>, D::Error>
@@ -1002,58 +1018,6 @@ impl std::default::Default for Tokio {
             report_interval: Duration::from_secs(30),
         }
     }
-}
-
-/// Configuration for a single OIDC provider in multi-provider mode.
-///
-/// When multiple OIDC providers are configured, each provider fetches its own
-/// JWKS keys independently, allowing authentication from multiple identity sources
-/// (e.g., Okta for users + EKS OIDC for Kubernetes service accounts).
-///
-/// # Example Environment Variables
-/// ```bash
-/// LAKEKEEPER__OPENID_PROVIDERS__OKTA__URI=https://company.okta.com
-/// LAKEKEEPER__OPENID_PROVIDERS__OKTA__AUDIENCE=https://company.okta.com
-/// LAKEKEEPER__OPENID_PROVIDERS__OKTA__SUBJECT_CLAIMS=sub
-/// ```
-#[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
-pub struct OidcProviderConfig {
-    /// The OIDC provider URI (must expose .well-known/openid-configuration)
-    pub uri: Url,
-    /// Expected audience(s) for tokens from this provider.
-    /// Specify multiple audiences as a comma-separated list.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_comma_separated",
-        serialize_with = "serialize_comma_separated"
-    )]
-    pub audience: Option<Vec<String>>,
-    /// Additional issuers to trust for this provider.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_comma_separated",
-        serialize_with = "serialize_comma_separated"
-    )]
-    pub additional_issuers: Option<Vec<String>>,
-    /// A scope that must be present in tokens from this provider.
-    #[serde(default)]
-    pub scope: Option<String>,
-    /// Claims to use as the subject (user ID), in order of preference.
-    /// Defaults to `oid`, then `sub` if not specified.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_comma_separated",
-        serialize_with = "serialize_comma_separated"
-    )]
-    pub subject_claims: Option<Vec<String>>,
-    /// Claim to use in provided JWT tokens to extract roles.
-    /// The field should contain a single string claim path.
-    /// Supports nested claims using dot notation, e.g., `resource_access.account.roles`
-    #[serde(default)]
-    pub roles_claim: Option<String>,
-    /// If true, fail startup when this provider's OIDC/JWKS configuration cannot be loaded.
-    #[serde(default = "default_true")]
-    pub require_connected_on_startup: bool,
 }
 
 impl Default for DynAppConfig {
@@ -2000,12 +1964,28 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "IdP ID must not contain '~'")]
+    #[should_panic(expected = "IdP ID must match `[a-z0-9-]+`")]
     fn test_openid_provider_id_rejects_separator() {
         figment::Jail::expect_with(|jail| {
             jail.set_env(
                 "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA~PROD__URI",
                 "https://company.okta.com",
+            );
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "IdP ID must match `[a-z0-9-]+`")]
+    fn test_openid_provider_id_rejects_underscore() {
+        // Underscores were tolerated by the old check but excluded by the new
+        // grammar — pin that behavior since the doc still mentioned `my_provider`
+        // before the grammar was tightened.
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__MY_PROVIDER__URI",
+                "https://example.com",
             );
             let _config = get_config();
             Ok(())

--- a/crates/lakekeeper/src/service/authn.rs
+++ b/crates/lakekeeper/src/service/authn.rs
@@ -19,7 +19,7 @@ use iceberg_ext::catalog::rest::ErrorModel;
 use limes::{AuthenticatorEnum, Subject, format_subject, parse_subject};
 use serde::{Deserialize, Serialize};
 
-use crate::{CONFIG, api, config::OidcProviderConfig, service::ArcRole};
+use crate::{CONFIG, api, service::ArcRole};
 #[cfg(feature = "router")]
 use crate::{
     XXHashSet,
@@ -69,6 +69,74 @@ pub type UserIdRef = std::sync::Arc<UserId>;
 pub(crate) const OIDC_IDP_ID: &str = "oidc";
 pub(crate) const K8S_IDP_ID: &str = "kubernetes";
 
+/// Default subject-claim preference order applied when a provider does not set
+/// `subject_claims` explicitly. Kept in sync with the `subject_claims` doc on
+/// [`OidcProviderConfig`].
+///
+/// `oid` is preferred so Entra-ID gets the stable per-tenant identifier
+/// out-of-the-box; everything else falls through to `sub`.
+const DEFAULT_SUBJECT_CLAIMS: &[&str] = &["oid", "sub"];
+
+/// Configuration for a single OIDC provider in multi-provider mode.
+///
+/// Lives next to the rest of the OIDC machinery (`build_oidc_authenticator`,
+/// the chain assembly, the IdP-ID constants) so the type and its consumers
+/// share one module. `DynAppConfig` only holds a `HashMap<String, _>` of these.
+///
+/// Each provider fetches its own JWKS keys independently, allowing
+/// authentication from multiple identity sources (e.g., Okta for users + EKS
+/// OIDC for Kubernetes service accounts).
+///
+/// # Example Environment Variables
+/// ```bash
+/// LAKEKEEPER__OPENID_PROVIDERS__OKTA__URI=https://company.okta.com
+/// LAKEKEEPER__OPENID_PROVIDERS__OKTA__AUDIENCE=https://company.okta.com
+/// LAKEKEEPER__OPENID_PROVIDERS__OKTA__SUBJECT_CLAIMS=sub
+/// ```
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+pub struct OidcProviderConfig {
+    /// The OIDC provider URI (must expose .well-known/openid-configuration)
+    pub uri: url::Url,
+    /// Expected audience(s) for tokens from this provider.
+    /// Specify multiple audiences as a comma-separated list.
+    #[serde(
+        default,
+        deserialize_with = "crate::config::deserialize_comma_separated",
+        serialize_with = "crate::config::serialize_comma_separated"
+    )]
+    pub audience: Option<Vec<String>>,
+    /// Additional issuers to trust for this provider.
+    #[serde(
+        default,
+        deserialize_with = "crate::config::deserialize_comma_separated",
+        serialize_with = "crate::config::serialize_comma_separated"
+    )]
+    pub additional_issuers: Option<Vec<String>>,
+    /// A scope that must be present in tokens from this provider.
+    #[serde(default)]
+    pub scope: Option<String>,
+    /// Claims to use as the subject (user ID), in order of preference.
+    /// Defaults to `oid`, then `sub` if not specified.
+    #[serde(
+        default,
+        deserialize_with = "crate::config::deserialize_comma_separated",
+        serialize_with = "crate::config::serialize_comma_separated"
+    )]
+    pub subject_claims: Option<Vec<String>>,
+    /// Claim to use in provided JWT tokens to extract roles.
+    /// The field should contain a single string claim path.
+    /// Supports nested claims using dot notation, e.g., `resource_access.account.roles`
+    #[serde(default)]
+    pub roles_claim: Option<String>,
+    /// If true, fail startup when this provider's OIDC/JWKS configuration cannot be loaded.
+    #[serde(default = "default_true")]
+    pub require_connected_on_startup: bool,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone)]
 pub enum BuiltInAuthenticators {
     Single(AuthenticatorEnum),
@@ -86,6 +154,11 @@ pub enum BuiltInAuthenticators {
 #[allow(clippy::too_many_lines)]
 pub async fn get_default_authenticator_from_config() -> anyhow::Result<Option<BuiltInAuthenticators>>
 {
+    // K8s has no `require_connected_on_startup` analog: there's only ever one
+    // cluster, so a failure here is always fatal. Unlike OIDC (where N
+    // independent providers can each be marked optional), an unavailable K8s
+    // API at boot means we can't authenticate service-account tokens at all,
+    // which would silently degrade authn — so we fail closed via `?` below.
     let authn_k8s_audience = if CONFIG.enable_kubernetes_authentication {
         Some(
             limes::kubernetes::KubernetesAuthenticator::try_new_with_default_client(
@@ -129,24 +202,51 @@ pub async fn get_default_authenticator_from_config() -> anyhow::Result<Option<Bu
         None
     };
 
-    let oidc_provider_configs = oidc_provider_configs_from_config(&CONFIG);
+    assemble_authenticator_chain(
+        &CONFIG,
+        authn_k8s_audience.map(AuthenticatorEnum::from),
+        authn_k8s_legacy.map(AuthenticatorEnum::from),
+    )
+    .await
+}
+
+/// Build the OIDC list, apply the fail-closed guard, then assemble the
+/// final chain with any pre-built K8s authenticators. Shared by the
+/// production entry point and tests so the fail-closed error message
+/// has exactly one source of truth.
+async fn assemble_authenticator_chain(
+    config: &crate::config::DynAppConfig,
+    authn_k8s_audience: Option<AuthenticatorEnum>,
+    authn_k8s_legacy: Option<AuthenticatorEnum>,
+) -> anyhow::Result<Option<BuiltInAuthenticators>> {
+    let oidc_provider_configs = oidc_provider_configs_from_config(config);
+    let configured_provider_count = oidc_provider_configs.len();
     let authn_oidc_list = if oidc_provider_configs.is_empty() {
         tracing::info!("Running without OIDC authentication.");
         vec![]
     } else {
-        tracing::info!(
-            "Configuring {} OIDC provider(s)",
-            oidc_provider_configs.len()
-        );
+        tracing::info!("Configuring {configured_provider_count} OIDC provider(s)");
         build_oidc_authenticators(oidc_provider_configs).await?
     };
 
+    // `require_connected_on_startup=false` gates only THIS provider's boot-time
+    // failure; it must not allow the whole auth system to silently disable
+    // itself. If every configured provider was skipped, refuse to boot.
+    if configured_provider_count > 0 && authn_oidc_list.is_empty() {
+        return Err(anyhow::anyhow!(
+            "All {configured_provider_count} configured OIDC provider(s) failed to initialize. \
+             Refusing to start with authentication disabled. Fix the providers' OIDC discovery \
+             endpoints, or remove `REQUIRE_CONNECTED_ON_STARTUP=false` from at least one to \
+             surface the underlying error."
+        ));
+    }
+
     // Collect all authenticators into a chain: OIDC first (priority), then any additional
     let mut all_authenticators: Vec<AuthenticatorEnum> = authn_oidc_list;
-    if let Some(authn) = authn_k8s_audience.map(AuthenticatorEnum::from) {
+    if let Some(authn) = authn_k8s_audience {
         all_authenticators.push(authn);
     }
-    if let Some(authn) = authn_k8s_legacy.map(AuthenticatorEnum::from) {
+    if let Some(authn) = authn_k8s_legacy {
         all_authenticators.push(authn);
     }
 
@@ -200,6 +300,10 @@ fn oidc_provider_configs_from_config(
 }
 
 /// Build authenticators for configured OIDC providers.
+///
+/// `providers` must be supplied in the order they should appear in the
+/// authenticator chain — sort upstream (see `oidc_provider_configs_from_config`).
+/// `Vec` is used over `HashMap` precisely to carry this ordering.
 async fn build_oidc_authenticators(
     providers: Vec<(String, OidcProviderConfig)>,
 ) -> anyhow::Result<Vec<AuthenticatorEnum>> {
@@ -267,14 +371,17 @@ async fn build_oidc_authenticator(
         tracing::debug!("Setting subject claims for {idp_id}: {claims:?}");
         authenticator = authenticator.with_subject_claims(claims.clone());
     } else {
-        // "oid" should be used for entra-id, as the `sub` is different between applications.
-        // We prefer oid here by default as no other IdP sets this field (that we know of) and
-        // we can provide an out-of-the-box experience for users.
-        // Nevertheless, we document this behavior in the docs and recommend as part of the
-        // `production` checklist to set the claim explicitly.
-        tracing::debug!("Defaulting subject claims for {idp_id} to: oid, sub");
-        authenticator =
-            authenticator.with_subject_claims(vec!["oid".to_string(), "sub".to_string()]);
+        tracing::debug!(
+            "Defaulting subject claims for {idp_id} to: {DEFAULT_SUBJECT_CLAIMS:?}. \
+             We prefer `oid` for Entra-ID (where `sub` differs per application); other IdPs \
+             fall through to `sub`. Set `subject_claims` explicitly in production."
+        );
+        authenticator = authenticator.with_subject_claims(
+            DEFAULT_SUBJECT_CLAIMS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        );
     }
 
     if let Some(roles_claim) = &provider.roles_claim {
@@ -770,39 +877,6 @@ mod tests {
         (good_base, bad_base, handle)
     }
 
-    async fn get_default_authenticator_from_config_with(
-        config: &DynAppConfig,
-        authn_k8s_audience: Option<AuthenticatorEnum>,
-        authn_k8s_legacy: Option<AuthenticatorEnum>,
-    ) -> anyhow::Result<Option<BuiltInAuthenticators>> {
-        let oidc_provider_configs = oidc_provider_configs_from_config(config);
-        let authn_oidc_list = if oidc_provider_configs.is_empty() {
-            vec![]
-        } else {
-            build_oidc_authenticators(oidc_provider_configs).await?
-        };
-
-        let mut all_authenticators: Vec<AuthenticatorEnum> = authn_oidc_list;
-        if let Some(authn) = authn_k8s_audience {
-            all_authenticators.push(authn);
-        }
-        if let Some(authn) = authn_k8s_legacy {
-            all_authenticators.push(authn);
-        }
-
-        match all_authenticators.len() {
-            0 => Ok(None),
-            1 => Ok(Some(all_authenticators.remove(0).into())),
-            _ => {
-                let mut chain_builder = limes::AuthenticatorChain::<AuthenticatorEnum>::builder();
-                for auth in all_authenticators {
-                    chain_builder = chain_builder.add_authenticator(auth);
-                }
-                Ok(Some(chain_builder.build().into()))
-            }
-        }
-    }
-
     #[test]
     fn oidc_provider_configs_from_config_uses_legacy_provider_id_and_roles_claim() {
         let mut config = DynAppConfig::default();
@@ -852,9 +926,44 @@ mod tests {
 
         assert_eq!(providers.len(), 2);
         assert_eq!(providers[0].0, OIDC_IDP_ID);
+        // Primary's `require_connected_on_startup` is hardcoded `true` in
+        // `oidc_provider_configs_from_config` and must stay that way even when
+        // optional extras are also configured. Pinning the invariant.
+        assert!(providers[0].1.require_connected_on_startup);
         assert_eq!(providers[1].0, "okta");
         assert_eq!(providers[1].1.roles_claim, Some("groups".to_string()));
         assert!(!providers[1].1.require_connected_on_startup);
+    }
+
+    /// Multiple extras are returned in deterministic alphabetical order of
+    /// `idp_id`. This is operator-visible (chain order ⇒ which provider gets
+    /// tried first for an ambiguous token) and `HashMap`'s iteration order is
+    /// non-deterministic, so the explicit sort must hold.
+    #[test]
+    fn oidc_provider_configs_from_config_sorts_extras_alphabetically() {
+        let mut config = DynAppConfig::default();
+        // Insert in a non-alphabetical order so a naive "iteration order" sort
+        // would still produce the wrong result.
+        for name in ["zapier", "entra", "okta"] {
+            config.openid_providers.insert(
+                name.to_string(),
+                OidcProviderConfig {
+                    uri: url::Url::parse(&format!("https://{name}.example.com")).unwrap(),
+                    audience: None,
+                    additional_issuers: None,
+                    scope: None,
+                    subject_claims: None,
+                    roles_claim: None,
+                    require_connected_on_startup: true,
+                },
+            );
+        }
+
+        let providers = oidc_provider_configs_from_config(&config);
+        let ids: Vec<&str> = providers.iter().map(|(id, _)| id.as_str()).collect();
+
+        // No primary URI → just the extras, alphabetically.
+        assert_eq!(ids, vec!["entra", "okta", "zapier"]);
     }
 
     #[tokio::test]
@@ -883,14 +992,11 @@ mod tests {
         .expect("k8s stub authenticator")
         .set_idp_id(K8S_IDP_ID);
 
-        let authenticator = get_default_authenticator_from_config_with(
-            &config,
-            Some(AuthenticatorEnum::from(k8s_stub)),
-            None,
-        )
-        .await
-        .expect("build authenticators")
-        .expect("authn enabled");
+        let authenticator =
+            assemble_authenticator_chain(&config, Some(AuthenticatorEnum::from(k8s_stub)), None)
+                .await
+                .expect("build authenticators")
+                .expect("authn enabled");
 
         let idp_ids = match authenticator {
             BuiltInAuthenticators::Single(auth) => auth
@@ -934,7 +1040,7 @@ mod tests {
             },
         );
 
-        let authenticator = get_default_authenticator_from_config_with(&config, None, None)
+        let authenticator = assemble_authenticator_chain(&config, None, None)
             .await
             .expect("build authenticators")
             .expect("authn enabled");
@@ -974,8 +1080,99 @@ mod tests {
             },
         );
 
-        let result = get_default_authenticator_from_config_with(&config, None, None).await;
+        let result = assemble_authenticator_chain(&config, None, None).await;
         assert!(result.is_err());
+
+        server.abort();
+    }
+
+    /// `require_connected_on_startup=false` must not let the whole auth system
+    /// silently disable itself: when every configured provider is optional and
+    /// all of them fail, refuse to boot.
+    #[tokio::test]
+    async fn get_default_authenticator_refuses_when_all_optional_providers_fail() {
+        let (_good_base, bad_base, server) = spawn_oidc_test_server().await;
+        let mut config = DynAppConfig::default();
+        // No primary URI, no K8s — only an optional provider that will fail discovery.
+        config.openid_providers.insert(
+            "bad".to_string(),
+            OidcProviderConfig {
+                uri: bad_base,
+                audience: None,
+                additional_issuers: None,
+                scope: None,
+                subject_claims: None,
+                roles_claim: None,
+                require_connected_on_startup: false,
+            },
+        );
+
+        let result = assemble_authenticator_chain(&config, None, None).await;
+        let err = result.expect_err(
+            "must refuse to boot when every configured provider failed, even if all optional",
+        );
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("Refusing to start with authentication disabled"),
+            "error must explain the refusal, got: {chain}",
+        );
+
+        server.abort();
+    }
+
+    /// EKS-only shape: no primary `OPENID_PROVIDER_URI`, one extra OIDC provider
+    /// for Kubernetes workloads, and `enable_kubernetes_authentication` for
+    /// in-cluster service accounts. The chain must contain exactly the extra
+    /// provider followed by the K8s authenticator — no `OIDC_IDP_ID` link.
+    #[tokio::test]
+    async fn get_default_authenticator_from_config_k8s_and_provider_no_primary() {
+        let (good_base, _bad_base, server) = spawn_oidc_test_server().await;
+        let mut config = DynAppConfig::default();
+        // Intentionally no `openid_provider_uri` — only an extra provider + K8s.
+        config.openid_providers.insert(
+            "ekscluster".to_string(),
+            OidcProviderConfig {
+                uri: good_base.clone(),
+                audience: None,
+                additional_issuers: None,
+                scope: None,
+                subject_claims: None,
+                roles_claim: None,
+                require_connected_on_startup: true,
+            },
+        );
+
+        let k8s_stub = limes::jwks::JWKSWebAuthenticator::new(
+            good_base.as_str(),
+            Some(Duration::from_hours(1)),
+        )
+        .await
+        .expect("k8s stub authenticator")
+        .set_idp_id(K8S_IDP_ID);
+
+        let authenticator =
+            assemble_authenticator_chain(&config, Some(AuthenticatorEnum::from(k8s_stub)), None)
+                .await
+                .expect("build authenticators")
+                .expect("authn enabled");
+
+        let idp_ids = match authenticator {
+            BuiltInAuthenticators::Single(auth) => auth
+                .idp_ids()
+                .into_iter()
+                .map(|id| id.map(str::to_string))
+                .collect::<Vec<_>>(),
+            BuiltInAuthenticators::Chain(chain) => chain
+                .idp_ids()
+                .into_iter()
+                .map(|id| id.map(str::to_string))
+                .collect::<Vec<_>>(),
+        };
+        assert_eq!(
+            idp_ids,
+            vec![Some("ekscluster".to_string()), Some(K8S_IDP_ID.to_string()),],
+            "chain must be extra-provider then K8s, with no primary `oidc` link",
+        );
 
         server.abort();
     }

--- a/crates/lakekeeper/src/service/authn.rs
+++ b/crates/lakekeeper/src/service/authn.rs
@@ -19,7 +19,7 @@ use iceberg_ext::catalog::rest::ErrorModel;
 use limes::{AuthenticatorEnum, Subject, format_subject, parse_subject};
 use serde::{Deserialize, Serialize};
 
-use crate::{CONFIG, api, service::ArcRole};
+use crate::{CONFIG, api, config::OidcProviderConfig, service::ArcRole};
 #[cfg(feature = "router")]
 use crate::{
     XXHashSet,
@@ -66,8 +66,8 @@ pub struct UserId(Subject);
 
 pub type UserIdRef = std::sync::Arc<UserId>;
 
-const OIDC_IDP_ID: &str = "oidc";
-const K8S_IDP_ID: &str = "kubernetes";
+pub(crate) const OIDC_IDP_ID: &str = "oidc";
+pub(crate) const K8S_IDP_ID: &str = "kubernetes";
 
 #[derive(Debug, Clone)]
 pub enum BuiltInAuthenticators {
@@ -78,7 +78,7 @@ pub enum BuiltInAuthenticators {
 /// Get the default authenticator configuration from the environment.
 ///
 /// Supports both single-provider mode (via `OPENID_PROVIDER_URI`) and
-/// multi-provider mode (via `OPENID_PROVIDERS` array). Multi-provider mode
+/// multi-provider mode (via `OPENID_PROVIDERS` map). Multi-provider mode
 /// takes precedence if configured.
 ///
 /// # Errors
@@ -129,72 +129,17 @@ pub async fn get_default_authenticator_from_config() -> anyhow::Result<Option<Bu
         None
     };
 
-    // Build OIDC authenticator(s)
-    // Multi-provider mode takes precedence over single-provider mode
-    let authn_oidc_list: Vec<AuthenticatorEnum> =
-        if let Some(providers) = &CONFIG.openid_providers {
-            if providers.is_empty() {
-                tracing::warn!("OPENID_PROVIDERS is configured but empty.");
-                vec![]
-            } else {
-                tracing::info!(
-                    "Multi-provider OIDC mode: configuring {} provider(s)",
-                    providers.len()
-                );
-                build_multi_oidc_authenticators(providers).await
-            }
-        } else if let Some(uri) = CONFIG.openid_provider_uri.clone() {
-            let mut authenticator = limes::jwks::JWKSWebAuthenticator::new(
-                uri.as_ref(),
-                Some(std::time::Duration::from_hours(1)),
-            )
-            .await?
-            .set_idp_id(OIDC_IDP_ID);
-            if let Some(aud) = &CONFIG.openid_audience {
-                tracing::debug!("Setting accepted audiences: {aud:?}");
-                authenticator = authenticator.set_accepted_audiences(aud.clone());
-            }
-            if let Some(iss) = &CONFIG.openid_additional_issuers {
-                tracing::debug!("Setting openid_additional_issuers: {iss:?}");
-                authenticator = authenticator.add_additional_issuers(iss.clone());
-            }
-            if let Some(scope) = &CONFIG.openid_scope {
-                tracing::debug!("Setting openid_scope: {scope}");
-                authenticator = authenticator.set_scope(scope.clone());
-            }
-            if let Some(subject_claims) = &CONFIG.openid_subject_claim {
-                tracing::debug!("Setting openid_subject_claim: {subject_claims:?}");
-                authenticator = authenticator.with_subject_claims(subject_claims.clone());
-            } else {
-                // "oid" should be used for entra-id, as the `sub` is different between applications.
-                // We prefer oid here by default as no other IdP sets this field (that we know of) and
-                // we can provide an out-of-the-box experience for users.
-                // Nevertheless, we document this behavior in the docs and recommend as part of the
-                // `production` checklist to set the claim explicitly.
-                tracing::debug!("Defaulting openid_subject_claim to: oid, sub");
-                authenticator = authenticator
-                    .with_subject_claims(vec!["oid".to_string(), "sub".to_string()]);
-            }
-            if let Some(roles_claim) = &CONFIG.openid_roles_claim {
-                tracing::debug!("Setting openid_roles_claim: {roles_claim}");
-                authenticator = authenticator.with_role_claim(roles_claim.clone());
-            }
-            tracing::info!("Running with OIDC authentication.");
-            vec![AuthenticatorEnum::from(authenticator)]
-        } else {
-            tracing::info!("Running without OIDC authentication.");
-            vec![]
-        };
-
-    let multi_provider_configured = CONFIG
-        .openid_providers
-        .as_ref()
-        .is_some_and(|p| !p.is_empty());
-    if multi_provider_configured && authn_oidc_list.is_empty() {
-        return Err(anyhow::anyhow!(
-            "OPENID_PROVIDERS is configured, but no OIDC provider could be initialized"
-        ));
-    }
+    let oidc_provider_configs = oidc_provider_configs_from_config(&CONFIG);
+    let authn_oidc_list = if oidc_provider_configs.is_empty() {
+        tracing::info!("Running without OIDC authentication.");
+        vec![]
+    } else {
+        tracing::info!(
+            "Configuring {} OIDC provider(s)",
+            oidc_provider_configs.len()
+        );
+        build_oidc_authenticators(oidc_provider_configs).await?
+    };
 
     // Collect all authenticators into a chain: OIDC first (priority), then any additional
     let mut all_authenticators: Vec<AuthenticatorEnum> = authn_oidc_list;
@@ -221,73 +166,65 @@ pub async fn get_default_authenticator_from_config() -> anyhow::Result<Option<Bu
     }
 }
 
-/// Build authenticators for multiple OIDC providers.
-/// Failed providers are logged and skipped - one broken provider shouldn't break everything.
-async fn build_multi_oidc_authenticators(
-    providers: &[crate::config::OidcProviderConfig],
-) -> Vec<AuthenticatorEnum> {
+fn oidc_provider_configs_from_config(
+    config: &crate::config::DynAppConfig,
+) -> Vec<(String, OidcProviderConfig)> {
+    if !config.openid_providers.is_empty() {
+        let mut providers = config
+            .openid_providers
+            .iter()
+            .map(|(idp_id, provider)| (idp_id.clone(), provider.clone()))
+            .collect::<Vec<_>>();
+        providers.sort_by(|(left, _), (right, _)| left.cmp(right));
+        return providers;
+    }
+
+    let Some(uri) = config.openid_provider_uri.clone() else {
+        return vec![];
+    };
+
+    vec![(
+        OIDC_IDP_ID.to_string(),
+        OidcProviderConfig {
+            uri,
+            audience: config.openid_audience.clone(),
+            additional_issuers: config.openid_additional_issuers.clone(),
+            scope: config.openid_scope.clone(),
+            subject_claims: config.openid_subject_claim.clone(),
+            roles_claim: config.openid_roles_claim.clone(),
+            require_connected_on_startup: true,
+        },
+    )]
+}
+
+/// Build authenticators for configured OIDC providers.
+async fn build_oidc_authenticators(
+    providers: Vec<(String, OidcProviderConfig)>,
+) -> anyhow::Result<Vec<AuthenticatorEnum>> {
     let mut authenticators = Vec::new();
 
-    for provider in providers {
+    for (idp_id, provider) in providers {
         tracing::info!(
             "Creating OIDC authenticator for {} ({})",
-            provider.idp_id,
+            idp_id,
             provider.uri
         );
 
-        match limes::jwks::JWKSWebAuthenticator::new(
-            provider.uri.as_ref(),
-            Some(std::time::Duration::from_secs(3600)),
-        )
-        .await
-        {
-            Ok(mut authenticator) => {
-                authenticator = authenticator.set_idp_id(&provider.idp_id);
-
-                if let Some(audiences) = &provider.audience {
-                    tracing::debug!(
-                        "Setting accepted audiences for {}: {:?}",
-                        provider.idp_id,
-                        audiences
-                    );
-                    authenticator = authenticator.set_accepted_audiences(audiences.clone());
-                }
-
-                if let Some(issuers) = &provider.additional_issuers {
-                    tracing::debug!(
-                        "Setting additional issuers for {}: {:?}",
-                        provider.idp_id,
-                        issuers
-                    );
-                    authenticator = authenticator.add_additional_issuers(issuers.clone());
-                }
-
-                if let Some(scope) = &provider.scope {
-                    tracing::debug!("Setting scope for {}: {}", provider.idp_id, scope);
-                    authenticator = authenticator.set_scope(scope.clone());
-                }
-
-                if let Some(claims) = &provider.subject_claims {
-                    tracing::debug!(
-                        "Setting subject claims for {}: {:?}",
-                        provider.idp_id,
-                        claims
-                    );
-                    authenticator = authenticator.with_subject_claims(claims.clone());
-                } else {
-                    // Default to "oid", "sub" for Entra ID compatibility
-                    authenticator = authenticator
-                        .with_subject_claims(vec!["oid".to_string(), "sub".to_string()]);
-                }
-
+        match build_oidc_authenticator(&idp_id, &provider).await {
+            Ok(authenticator) => {
                 authenticators.push(AuthenticatorEnum::from(authenticator));
-                tracing::info!("Successfully added OIDC authenticator: {}", provider.idp_id);
+                tracing::info!("Successfully added OIDC authenticator: {}", idp_id);
             }
             Err(e) => {
-                // Log error but continue - one failed provider shouldn't break everything
+                if provider.require_connected_on_startup {
+                    return Err(anyhow::anyhow!(
+                        "Failed to create required OIDC authenticator for {idp_id} ({uri}): {e}",
+                        uri = provider.uri
+                    ));
+                }
                 tracing::error!(
                     "Failed to create OIDC authenticator for {} ({}): {}. Skipping this provider.",
-                    provider.idp_id,
+                    idp_id,
                     provider.uri,
                     e
                 );
@@ -295,9 +232,56 @@ async fn build_multi_oidc_authenticators(
         }
     }
 
-    authenticators
+    Ok(authenticators)
 }
 
+async fn build_oidc_authenticator(
+    idp_id: &str,
+    provider: &OidcProviderConfig,
+) -> anyhow::Result<limes::jwks::JWKSWebAuthenticator> {
+    let mut authenticator = limes::jwks::JWKSWebAuthenticator::new(
+        provider.uri.as_ref(),
+        Some(std::time::Duration::from_hours(1)),
+    )
+    .await?
+    .set_idp_id(idp_id);
+
+    if let Some(audiences) = &provider.audience {
+        tracing::debug!("Setting accepted audiences for {idp_id}: {audiences:?}");
+        authenticator = authenticator.set_accepted_audiences(audiences.clone());
+    }
+
+    if let Some(issuers) = &provider.additional_issuers {
+        tracing::debug!("Setting additional issuers for {idp_id}: {issuers:?}");
+        authenticator = authenticator.add_additional_issuers(issuers.clone());
+    }
+
+    if let Some(scope) = &provider.scope {
+        tracing::debug!("Setting scope for {idp_id}: {scope}");
+        authenticator = authenticator.set_scope(scope.clone());
+    }
+
+    if let Some(claims) = &provider.subject_claims {
+        tracing::debug!("Setting subject claims for {idp_id}: {claims:?}");
+        authenticator = authenticator.with_subject_claims(claims.clone());
+    } else {
+        // "oid" should be used for entra-id, as the `sub` is different between applications.
+        // We prefer oid here by default as no other IdP sets this field (that we know of) and
+        // we can provide an out-of-the-box experience for users.
+        // Nevertheless, we document this behavior in the docs and recommend as part of the
+        // `production` checklist to set the claim explicitly.
+        tracing::debug!("Defaulting subject claims for {idp_id} to: oid, sub");
+        authenticator =
+            authenticator.with_subject_claims(vec!["oid".to_string(), "sub".to_string()]);
+    }
+
+    if let Some(roles_claim) = &provider.roles_claim {
+        tracing::debug!("Setting roles claim for {idp_id}: {roles_claim}");
+        authenticator = authenticator.with_role_claim(roles_claim.clone());
+    }
+
+    Ok(authenticator)
+}
 
 #[cfg(feature = "router")]
 #[allow(clippy::too_many_lines)]
@@ -725,7 +709,60 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::service::RoleId;
+    use crate::{config::DynAppConfig, service::RoleId};
+
+    #[test]
+    fn oidc_provider_configs_from_config_uses_legacy_provider_id_and_roles_claim() {
+        let mut config = DynAppConfig::default();
+        config.openid_provider_uri = Some(url::Url::parse("https://issuer.example.com").unwrap());
+        config.openid_audience = Some(vec!["lakekeeper".to_string()]);
+        config.openid_additional_issuers = Some(vec!["https://sts.example.com".to_string()]);
+        config.openid_scope = Some("openid".to_string());
+        config.openid_subject_claim = Some(vec!["sub".to_string()]);
+        config.openid_roles_claim = Some("roles".to_string());
+
+        let providers = oidc_provider_configs_from_config(&config);
+
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].0, OIDC_IDP_ID);
+        assert_eq!(
+            providers[0].1.audience,
+            Some(vec!["lakekeeper".to_string()])
+        );
+        assert_eq!(
+            providers[0].1.additional_issuers,
+            Some(vec!["https://sts.example.com".to_string()])
+        );
+        assert_eq!(providers[0].1.scope, Some("openid".to_string()));
+        assert_eq!(providers[0].1.subject_claims, Some(vec!["sub".to_string()]));
+        assert_eq!(providers[0].1.roles_claim, Some("roles".to_string()));
+        assert!(providers[0].1.require_connected_on_startup);
+    }
+
+    #[test]
+    fn oidc_provider_configs_from_config_prefers_multi_provider_config() {
+        let mut config = DynAppConfig::default();
+        config.openid_provider_uri = Some(url::Url::parse("https://legacy.example.com").unwrap());
+        config.openid_providers.insert(
+            "okta".to_string(),
+            OidcProviderConfig {
+                uri: url::Url::parse("https://company.okta.com").unwrap(),
+                audience: None,
+                additional_issuers: None,
+                scope: None,
+                subject_claims: None,
+                roles_claim: Some("groups".to_string()),
+                require_connected_on_startup: false,
+            },
+        );
+
+        let providers = oidc_provider_configs_from_config(&config);
+
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].0, "okta");
+        assert_eq!(providers[0].1.roles_claim, Some("groups".to_string()));
+        assert!(!providers[0].1.require_connected_on_startup);
+    }
 
     #[test]
     fn test_user_id() {

--- a/crates/lakekeeper/src/service/authn.rs
+++ b/crates/lakekeeper/src/service/authn.rs
@@ -79,7 +79,7 @@ pub enum BuiltInAuthenticators {
 ///
 /// Supports both single-provider mode (via `OPENID_PROVIDER_URI`) and
 /// multi-provider mode (via `OPENID_PROVIDERS` map). Multi-provider mode
-/// takes precedence if configured.
+/// is additive and extends the single-provider configuration.
 ///
 /// # Errors
 /// If the authenticator cannot be created, or if the configuration is invalid.
@@ -169,32 +169,34 @@ pub async fn get_default_authenticator_from_config() -> anyhow::Result<Option<Bu
 fn oidc_provider_configs_from_config(
     config: &crate::config::DynAppConfig,
 ) -> Vec<(String, OidcProviderConfig)> {
+    let mut providers = Vec::new();
+
+    if let Some(uri) = config.openid_provider_uri.clone() {
+        providers.push((
+            OIDC_IDP_ID.to_string(),
+            OidcProviderConfig {
+                uri,
+                audience: config.openid_audience.clone(),
+                additional_issuers: config.openid_additional_issuers.clone(),
+                scope: config.openid_scope.clone(),
+                subject_claims: config.openid_subject_claim.clone(),
+                roles_claim: config.openid_roles_claim.clone(),
+                require_connected_on_startup: true,
+            },
+        ));
+    }
+
     if !config.openid_providers.is_empty() {
-        let mut providers = config
+        let mut extras = config
             .openid_providers
             .iter()
             .map(|(idp_id, provider)| (idp_id.clone(), provider.clone()))
             .collect::<Vec<_>>();
-        providers.sort_by(|(left, _), (right, _)| left.cmp(right));
-        return providers;
+        extras.sort_by(|(left, _), (right, _)| left.cmp(right));
+        providers.extend(extras);
     }
 
-    let Some(uri) = config.openid_provider_uri.clone() else {
-        return vec![];
-    };
-
-    vec![(
-        OIDC_IDP_ID.to_string(),
-        OidcProviderConfig {
-            uri,
-            audience: config.openid_audience.clone(),
-            additional_issuers: config.openid_additional_issuers.clone(),
-            scope: config.openid_scope.clone(),
-            subject_claims: config.openid_subject_claim.clone(),
-            roles_claim: config.openid_roles_claim.clone(),
-            require_connected_on_startup: true,
-        },
-    )]
+    providers
 }
 
 /// Build authenticators for configured OIDC providers.
@@ -706,10 +708,100 @@ impl From<limes::AuthenticatorChain<AuthenticatorEnum>> for BuiltInAuthenticator
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use axum::{Json, Router, routing::get};
+    use limes::Authenticator;
+    use serde_json::json;
+    use tokio::{net::TcpListener, task::JoinHandle};
+    use url::Url;
     use uuid::Uuid;
 
     use super::*;
     use crate::{config::DynAppConfig, service::RoleId};
+
+    async fn spawn_oidc_test_server() -> (Url, Url, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind oidc test server");
+        let addr = listener.local_addr().expect("oidc test server addr");
+        let base = Url::parse(&format!("http://{addr}")).expect("oidc test server base url");
+        let good_base = base.join("good/").expect("good base url");
+        let bad_base = base.join("bad/").expect("bad base url");
+
+        let good_config = json!({
+            "issuer": good_base.as_str(),
+            "jwks_uri": format!("{good_base}jwks"),
+        });
+        let bad_config = json!({
+            "issuer": bad_base.as_str(),
+        });
+        let jwks = json!({ "keys": [] });
+
+        let app = Router::new()
+            .route(
+                "/good/.well-known/openid-configuration",
+                get({
+                    let good_config = good_config.clone();
+                    move || async move { Json(good_config) }
+                }),
+            )
+            .route(
+                "/bad/.well-known/openid-configuration",
+                get({
+                    let bad_config = bad_config.clone();
+                    move || async move { Json(bad_config) }
+                }),
+            )
+            .route(
+                "/good/jwks",
+                get({
+                    let jwks = jwks.clone();
+                    move || async move { Json(jwks) }
+                }),
+            );
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("oidc test server failed");
+        });
+
+        (good_base, bad_base, handle)
+    }
+
+    async fn get_default_authenticator_from_config_with(
+        config: &DynAppConfig,
+        authn_k8s_audience: Option<AuthenticatorEnum>,
+        authn_k8s_legacy: Option<AuthenticatorEnum>,
+    ) -> anyhow::Result<Option<BuiltInAuthenticators>> {
+        let oidc_provider_configs = oidc_provider_configs_from_config(config);
+        let authn_oidc_list = if oidc_provider_configs.is_empty() {
+            vec![]
+        } else {
+            build_oidc_authenticators(oidc_provider_configs).await?
+        };
+
+        let mut all_authenticators: Vec<AuthenticatorEnum> = authn_oidc_list;
+        if let Some(authn) = authn_k8s_audience {
+            all_authenticators.push(authn);
+        }
+        if let Some(authn) = authn_k8s_legacy {
+            all_authenticators.push(authn);
+        }
+
+        match all_authenticators.len() {
+            0 => Ok(None),
+            1 => Ok(Some(all_authenticators.remove(0).into())),
+            _ => {
+                let mut chain_builder = limes::AuthenticatorChain::<AuthenticatorEnum>::builder();
+                for auth in all_authenticators {
+                    chain_builder = chain_builder.add_authenticator(auth);
+                }
+                Ok(Some(chain_builder.build().into()))
+            }
+        }
+    }
 
     #[test]
     fn oidc_provider_configs_from_config_uses_legacy_provider_id_and_roles_claim() {
@@ -740,7 +832,7 @@ mod tests {
     }
 
     #[test]
-    fn oidc_provider_configs_from_config_prefers_multi_provider_config() {
+    fn oidc_provider_configs_from_config_adds_multi_provider_config() {
         let mut config = DynAppConfig::default();
         config.openid_provider_uri = Some(url::Url::parse("https://legacy.example.com").unwrap());
         config.openid_providers.insert(
@@ -758,10 +850,134 @@ mod tests {
 
         let providers = oidc_provider_configs_from_config(&config);
 
-        assert_eq!(providers.len(), 1);
-        assert_eq!(providers[0].0, "okta");
-        assert_eq!(providers[0].1.roles_claim, Some("groups".to_string()));
-        assert!(!providers[0].1.require_connected_on_startup);
+        assert_eq!(providers.len(), 2);
+        assert_eq!(providers[0].0, OIDC_IDP_ID);
+        assert_eq!(providers[1].0, "okta");
+        assert_eq!(providers[1].1.roles_claim, Some("groups".to_string()));
+        assert!(!providers[1].1.require_connected_on_startup);
+    }
+
+    #[tokio::test]
+    async fn get_default_authenticator_from_config_chain_order_primary_additional_k8s() {
+        let (good_base, _bad_base, server) = spawn_oidc_test_server().await;
+        let mut config = DynAppConfig::default();
+        config.openid_provider_uri = Some(good_base.clone());
+        config.openid_providers.insert(
+            "okta".to_string(),
+            OidcProviderConfig {
+                uri: good_base.clone(),
+                audience: None,
+                additional_issuers: None,
+                scope: None,
+                subject_claims: None,
+                roles_claim: None,
+                require_connected_on_startup: true,
+            },
+        );
+
+        let k8s_stub = limes::jwks::JWKSWebAuthenticator::new(
+            good_base.as_str(),
+            Some(Duration::from_hours(1)),
+        )
+        .await
+        .expect("k8s stub authenticator")
+        .set_idp_id(K8S_IDP_ID);
+
+        let authenticator = get_default_authenticator_from_config_with(
+            &config,
+            Some(AuthenticatorEnum::from(k8s_stub)),
+            None,
+        )
+        .await
+        .expect("build authenticators")
+        .expect("authn enabled");
+
+        let idp_ids = match authenticator {
+            BuiltInAuthenticators::Single(auth) => auth
+                .idp_ids()
+                .into_iter()
+                .map(|id| id.map(str::to_string))
+                .collect::<Vec<_>>(),
+            BuiltInAuthenticators::Chain(chain) => chain
+                .idp_ids()
+                .into_iter()
+                .map(|id| id.map(str::to_string))
+                .collect::<Vec<_>>(),
+        };
+        assert_eq!(
+            idp_ids,
+            vec![
+                Some(OIDC_IDP_ID.to_string()),
+                Some("okta".to_string()),
+                Some(K8S_IDP_ID.to_string()),
+            ]
+        );
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn get_default_authenticator_from_config_skips_optional_provider() {
+        let (good_base, bad_base, server) = spawn_oidc_test_server().await;
+        let mut config = DynAppConfig::default();
+        config.openid_provider_uri = Some(good_base);
+        config.openid_providers.insert(
+            "bad".to_string(),
+            OidcProviderConfig {
+                uri: bad_base,
+                audience: None,
+                additional_issuers: None,
+                scope: None,
+                subject_claims: None,
+                roles_claim: None,
+                require_connected_on_startup: false,
+            },
+        );
+
+        let authenticator = get_default_authenticator_from_config_with(&config, None, None)
+            .await
+            .expect("build authenticators")
+            .expect("authn enabled");
+
+        let idp_ids = match authenticator {
+            BuiltInAuthenticators::Single(auth) => auth
+                .idp_ids()
+                .into_iter()
+                .map(|id| id.map(str::to_string))
+                .collect::<Vec<_>>(),
+            BuiltInAuthenticators::Chain(chain) => chain
+                .idp_ids()
+                .into_iter()
+                .map(|id| id.map(str::to_string))
+                .collect::<Vec<_>>(),
+        };
+        assert_eq!(idp_ids, vec![Some(OIDC_IDP_ID.to_string())]);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn get_default_authenticator_from_config_fails_required_provider() {
+        let (good_base, bad_base, server) = spawn_oidc_test_server().await;
+        let mut config = DynAppConfig::default();
+        config.openid_provider_uri = Some(good_base);
+        config.openid_providers.insert(
+            "bad".to_string(),
+            OidcProviderConfig {
+                uri: bad_base,
+                audience: None,
+                additional_issuers: None,
+                scope: None,
+                subject_claims: None,
+                roles_claim: None,
+                require_connected_on_startup: true,
+            },
+        );
+
+        let result = get_default_authenticator_from_config_with(&config, None, None).await;
+        assert!(result.is_err());
+
+        server.abort();
     }
 
     #[test]

--- a/crates/lakekeeper/src/service/authn.rs
+++ b/crates/lakekeeper/src/service/authn.rs
@@ -77,6 +77,10 @@ pub enum BuiltInAuthenticators {
 
 /// Get the default authenticator configuration from the environment.
 ///
+/// Supports both single-provider mode (via `OPENID_PROVIDER_URI`) and
+/// multi-provider mode (via `OPENID_PROVIDERS` array). Multi-provider mode
+/// takes precedence if configured.
+///
 /// # Errors
 /// If the authenticator cannot be created, or if the configuration is invalid.
 #[allow(clippy::too_many_lines)]
@@ -125,78 +129,175 @@ pub async fn get_default_authenticator_from_config() -> anyhow::Result<Option<Bu
         None
     };
 
-    let authn_oidc = if let Some(uri) = CONFIG.openid_provider_uri.clone() {
-        let mut authenticator = limes::jwks::JWKSWebAuthenticator::new(
-            uri.as_ref(),
-            Some(std::time::Duration::from_hours(1)),
-        )
-        .await?
-        .set_idp_id(OIDC_IDP_ID);
-        if let Some(aud) = &CONFIG.openid_audience {
-            tracing::debug!("Setting accepted audiences: {aud:?}");
-            authenticator = authenticator.set_accepted_audiences(aud.clone());
-        }
-        if let Some(iss) = &CONFIG.openid_additional_issuers {
-            tracing::debug!("Setting openid_additional_issuers: {iss:?}");
-            authenticator = authenticator.add_additional_issuers(iss.clone());
-        }
-        if let Some(scope) = &CONFIG.openid_scope {
-            tracing::debug!("Setting openid_scope: {scope}");
-            authenticator = authenticator.set_scope(scope.clone());
-        }
-        if let Some(subject_claims) = &CONFIG.openid_subject_claim {
-            tracing::debug!("Setting openid_subject_claim: {subject_claims:?}");
-            authenticator = authenticator.with_subject_claims(subject_claims.clone());
+    // Build OIDC authenticator(s)
+    // Multi-provider mode takes precedence over single-provider mode
+    let authn_oidc_list: Vec<AuthenticatorEnum> =
+        if let Some(providers) = &CONFIG.openid_providers {
+            if providers.is_empty() {
+                tracing::warn!("OPENID_PROVIDERS is configured but empty.");
+                vec![]
+            } else {
+                tracing::info!(
+                    "Multi-provider OIDC mode: configuring {} provider(s)",
+                    providers.len()
+                );
+                build_multi_oidc_authenticators(providers).await
+            }
+        } else if let Some(uri) = CONFIG.openid_provider_uri.clone() {
+            let mut authenticator = limes::jwks::JWKSWebAuthenticator::new(
+                uri.as_ref(),
+                Some(std::time::Duration::from_hours(1)),
+            )
+            .await?
+            .set_idp_id(OIDC_IDP_ID);
+            if let Some(aud) = &CONFIG.openid_audience {
+                tracing::debug!("Setting accepted audiences: {aud:?}");
+                authenticator = authenticator.set_accepted_audiences(aud.clone());
+            }
+            if let Some(iss) = &CONFIG.openid_additional_issuers {
+                tracing::debug!("Setting openid_additional_issuers: {iss:?}");
+                authenticator = authenticator.add_additional_issuers(iss.clone());
+            }
+            if let Some(scope) = &CONFIG.openid_scope {
+                tracing::debug!("Setting openid_scope: {scope}");
+                authenticator = authenticator.set_scope(scope.clone());
+            }
+            if let Some(subject_claims) = &CONFIG.openid_subject_claim {
+                tracing::debug!("Setting openid_subject_claim: {subject_claims:?}");
+                authenticator = authenticator.with_subject_claims(subject_claims.clone());
+            } else {
+                // "oid" should be used for entra-id, as the `sub` is different between applications.
+                // We prefer oid here by default as no other IdP sets this field (that we know of) and
+                // we can provide an out-of-the-box experience for users.
+                // Nevertheless, we document this behavior in the docs and recommend as part of the
+                // `production` checklist to set the claim explicitly.
+                tracing::debug!("Defaulting openid_subject_claim to: oid, sub");
+                authenticator = authenticator
+                    .with_subject_claims(vec!["oid".to_string(), "sub".to_string()]);
+            }
+            if let Some(roles_claim) = &CONFIG.openid_roles_claim {
+                tracing::debug!("Setting openid_roles_claim: {roles_claim}");
+                authenticator = authenticator.with_role_claim(roles_claim.clone());
+            }
+            tracing::info!("Running with OIDC authentication.");
+            vec![AuthenticatorEnum::from(authenticator)]
         } else {
-            // "oid" should be used for entra-id, as the `sub` is different between applications.
-            // We prefer oid here by default as no other IdP sets this field (that we know of) and
-            // we can provide an out-of-the-box experience for users.
-            // Nevertheless, we document this behavior in the docs and recommend as part of the
-            // `production` checklist to set the claim explicitly.
-            tracing::debug!("Defaulting openid_subject_claim to: oid, sub");
-            authenticator =
-                authenticator.with_subject_claims(vec!["oid".to_string(), "sub".to_string()]);
-        }
-        if let Some(roles_claim) = &CONFIG.openid_roles_claim {
-            tracing::debug!("Setting openid_roles_claim: {roles_claim}");
-            authenticator = authenticator.with_role_claim(roles_claim.clone());
-        }
-        tracing::info!("Running with OIDC authentication.");
-        Some(authenticator)
-    } else {
-        tracing::info!("Running without OIDC authentication.");
-        None
-    };
+            tracing::info!("Running without OIDC authentication.");
+            vec![]
+        };
 
-    let authn_k8s = authn_k8s_audience.map(AuthenticatorEnum::from);
-    let authn_k8s_legacy = authn_k8s_legacy.map(AuthenticatorEnum::from);
-    let authn_oidc = authn_oidc.map(AuthenticatorEnum::from);
-    match (authn_k8s, authn_oidc, authn_k8s_legacy) {
-        (Some(k8s), Some(oidc), Some(authn_k8s_legacy)) => {
-            Ok(Some(limes::AuthenticatorChain::<AuthenticatorEnum>::builder()
-                .add_authenticator(oidc)
-                .add_authenticator(k8s)
-                .add_authenticator(authn_k8s_legacy)
-                .build().into()))
-        }
-        (None, Some(auth1), Some(auth2))
-        | (Some(auth1), None, Some(auth2))
-        // OIDC has priority over k8s if specified
-        | (Some(auth2), Some(auth1), None) => {
-            Ok(Some(limes::AuthenticatorChain::<AuthenticatorEnum>::builder()
-                .add_authenticator(auth1)
-                .add_authenticator(auth2)
-                .build().into()))
-        }
-        (Some(auth), None, None) | (None, Some(auth), None) | (None, None, Some(auth)) => {
-            Ok(Some(auth.into()))
-        }
-        (None, None, None) => {
+    let multi_provider_configured = CONFIG
+        .openid_providers
+        .as_ref()
+        .is_some_and(|p| !p.is_empty());
+    if multi_provider_configured && authn_oidc_list.is_empty() {
+        return Err(anyhow::anyhow!(
+            "OPENID_PROVIDERS is configured, but no OIDC provider could be initialized"
+        ));
+    }
+
+    // Collect all authenticators into a chain: OIDC first (priority), then any additional
+    let mut all_authenticators: Vec<AuthenticatorEnum> = authn_oidc_list;
+    if let Some(authn) = authn_k8s_audience.map(AuthenticatorEnum::from) {
+        all_authenticators.push(authn);
+    }
+    if let Some(authn) = authn_k8s_legacy.map(AuthenticatorEnum::from) {
+        all_authenticators.push(authn);
+    }
+
+    match all_authenticators.len() {
+        0 => {
             tracing::warn!("Authentication is disabled. This is not suitable for production!");
             Ok(None)
         }
+        1 => Ok(Some(all_authenticators.remove(0).into())),
+        _ => {
+            let mut chain_builder = limes::AuthenticatorChain::<AuthenticatorEnum>::builder();
+            for auth in all_authenticators {
+                chain_builder = chain_builder.add_authenticator(auth);
+            }
+            Ok(Some(chain_builder.build().into()))
+        }
     }
 }
+
+/// Build authenticators for multiple OIDC providers.
+/// Failed providers are logged and skipped - one broken provider shouldn't break everything.
+async fn build_multi_oidc_authenticators(
+    providers: &[crate::config::OidcProviderConfig],
+) -> Vec<AuthenticatorEnum> {
+    let mut authenticators = Vec::new();
+
+    for provider in providers {
+        tracing::info!(
+            "Creating OIDC authenticator for {} ({})",
+            provider.idp_id,
+            provider.uri
+        );
+
+        match limes::jwks::JWKSWebAuthenticator::new(
+            provider.uri.as_ref(),
+            Some(std::time::Duration::from_secs(3600)),
+        )
+        .await
+        {
+            Ok(mut authenticator) => {
+                authenticator = authenticator.set_idp_id(&provider.idp_id);
+
+                if let Some(audiences) = &provider.audience {
+                    tracing::debug!(
+                        "Setting accepted audiences for {}: {:?}",
+                        provider.idp_id,
+                        audiences
+                    );
+                    authenticator = authenticator.set_accepted_audiences(audiences.clone());
+                }
+
+                if let Some(issuers) = &provider.additional_issuers {
+                    tracing::debug!(
+                        "Setting additional issuers for {}: {:?}",
+                        provider.idp_id,
+                        issuers
+                    );
+                    authenticator = authenticator.add_additional_issuers(issuers.clone());
+                }
+
+                if let Some(scope) = &provider.scope {
+                    tracing::debug!("Setting scope for {}: {}", provider.idp_id, scope);
+                    authenticator = authenticator.set_scope(scope.clone());
+                }
+
+                if let Some(claims) = &provider.subject_claims {
+                    tracing::debug!(
+                        "Setting subject claims for {}: {:?}",
+                        provider.idp_id,
+                        claims
+                    );
+                    authenticator = authenticator.with_subject_claims(claims.clone());
+                } else {
+                    // Default to "oid", "sub" for Entra ID compatibility
+                    authenticator = authenticator
+                        .with_subject_claims(vec!["oid".to_string(), "sub".to_string()]);
+                }
+
+                authenticators.push(AuthenticatorEnum::from(authenticator));
+                tracing::info!("Successfully added OIDC authenticator: {}", provider.idp_id);
+            }
+            Err(e) => {
+                // Log error but continue - one failed provider shouldn't break everything
+                tracing::error!(
+                    "Failed to create OIDC authenticator for {} ({}): {}. Skipping this provider.",
+                    provider.idp_id,
+                    provider.uri,
+                    e
+                );
+            }
+        }
+    }
+
+    authenticators
+}
+
 
 #[cfg(feature = "router")]
 #[allow(clippy::too_many_lines)]

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -484,6 +484,10 @@ User IDs include the provider's `IDP_ID` as a prefix: `{idp_id}~{subject}`. For 
 
 This allows you to distinguish users from different identity providers when granting permissions.
 
+### UI Login
+
+The Lakekeeper UI can redirect to only one OIDC provider for SSO — the primary provider configured via `LAKEKEEPER__OPENID_PROVIDER_URI`. Providers added under `LAKEKEEPER__OPENID_PROVIDERS` are used for API token validation only. If `LAKEKEEPER__OPENID_PROVIDER_URI` is not set, the UI login button is disabled by design; clients must obtain tokens out-of-band and call the API directly.
+
 ### Resilient Initialization
 
 By default, Lakekeeper refuses to start if a configured provider's OIDC/JWKS configuration cannot be loaded. Set `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__REQUIRE_CONNECTED_ON_STARTUP=false` for providers that should be skipped while Lakekeeper continues starting with the remaining authenticators. The primary provider configured via `LAKEKEEPER__OPENID_PROVIDER_URI` always requires a successful connection on startup.

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -460,7 +460,7 @@ When multiple providers are configured, each provider fetches its own JWKS keys 
 
 ### Configuration
 
-Configure each provider under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__`. This configuration takes precedence over the single-provider `LAKEKEEPER__OPENID_PROVIDER_URI` if both are set.
+Configure each provider under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__`. These providers are added in addition to the single-provider `LAKEKEEPER__OPENID_PROVIDER_URI`, which remains the primary provider (`idp_id = "oidc"`).
 
 ```bash
 LAKEKEEPER__OPENID_PROVIDERS__OKTA__URI=https://company.okta.com
@@ -486,7 +486,7 @@ This allows you to distinguish users from different identity providers when gran
 
 ### Resilient Initialization
 
-By default, Lakekeeper refuses to start if a configured provider's OIDC/JWKS configuration cannot be loaded. Set `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__REQUIRE_CONNECTED_ON_STARTUP=false` for providers that should be skipped while Lakekeeper continues starting with the remaining authenticators.
+By default, Lakekeeper refuses to start if a configured provider's OIDC/JWKS configuration cannot be loaded. Set `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__REQUIRE_CONNECTED_ON_STARTUP=false` for providers that should be skipped while Lakekeeper continues starting with the remaining authenticators. The primary provider configured via `LAKEKEEPER__OPENID_PROVIDER_URI` always requires a successful connection on startup.
 
 ### When to Use Multiple Providers
 
@@ -497,6 +497,8 @@ Common use cases include:
 - **Migration scenarios**: Gradually migrating from one IdP to another while both remain active
 
 See the [Configuration Reference](./configuration.md#multiple-oidc-providers) for the full list of available options per provider.
+
+**Identity continuity note:** Existing user IDs are formatted as `oidc~<subject>` from the primary provider configured via `LAKEKEEPER__OPENID_PROVIDER_URI`. Do not move that provider into `OPENID_PROVIDERS` under a different `IDP_ID` (e.g., `okta`), or existing role/user assignments will no longer match.
 
 ## Kubernetes
 If `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION` is set to true, Lakekeeper validates incoming tokens against the default kubernetes context of the system. Lakekeeper uses the [`TokenReview`](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) to determine the validity of a token. By default the `TokenReview` resource is protected. When deploying Lakekeeper on Kubernetes, make sure to grant the `system:auth-delegator` Cluster Role to the service account used by Lakekeeper:

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -460,42 +460,33 @@ When multiple providers are configured, each provider fetches its own JWKS keys 
 
 ### Configuration
 
-Use the `LAKEKEEPER__OPENID_PROVIDERS` environment variable with a JSON array to configure multiple providers. This configuration takes precedence over the single-provider `LAKEKEEPER__OPENID_PROVIDER_URI` if both are set.
+Configure each provider under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__`. This configuration takes precedence over the single-provider `LAKEKEEPER__OPENID_PROVIDER_URI` if both are set.
 
 ```bash
-LAKEKEEPER__OPENID_PROVIDERS='[
-  {
-    "uri": "https://company.okta.com",
-    "idp_id": "okta",
-    "audience": "https://company.okta.com",
-    "subject_claims": "sub"
-  },
-  {
-    "uri": "https://oidc.eks.us-east-1.amazonaws.com/id/ABC123DEF456",
-    "idp_id": "eks-cluster-a",
-    "audience": "sts.amazonaws.com",
-    "subject_claims": "sub"
-  },
-  {
-    "uri": "https://oidc.eks.us-east-1.amazonaws.com/id/XYZ789GHI012",
-    "idp_id": "eks-cluster-b",
-    "audience": "sts.amazonaws.com",
-    "subject_claims": "sub"
-  }
-]'
+LAKEKEEPER__OPENID_PROVIDERS__OKTA__URI=https://company.okta.com
+LAKEKEEPER__OPENID_PROVIDERS__OKTA__AUDIENCE=https://company.okta.com
+LAKEKEEPER__OPENID_PROVIDERS__OKTA__SUBJECT_CLAIMS=sub
+
+LAKEKEEPER__OPENID_PROVIDERS__EKSCLUSTERA__URI=https://oidc.eks.us-east-1.amazonaws.com/id/ABC123DEF456
+LAKEKEEPER__OPENID_PROVIDERS__EKSCLUSTERA__AUDIENCE=sts.amazonaws.com
+LAKEKEEPER__OPENID_PROVIDERS__EKSCLUSTERA__SUBJECT_CLAIMS=sub
+
+LAKEKEEPER__OPENID_PROVIDERS__EKSCLUSTERB__URI=https://oidc.eks.us-east-1.amazonaws.com/id/XYZ789GHI012
+LAKEKEEPER__OPENID_PROVIDERS__EKSCLUSTERB__AUDIENCE=sts.amazonaws.com
+LAKEKEEPER__OPENID_PROVIDERS__EKSCLUSTERB__SUBJECT_CLAIMS=sub
 ```
 
 ### User Identity Format
 
 User IDs include the provider's `IDP_ID` as a prefix: `{idp_id}~{subject}`. For example:
 - `okta~user@example.com` for a user from Okta
-- `eks-cluster-a~system:serviceaccount:namespace:my-app` for a Kubernetes service account
+- `eksclustera~system:serviceaccount:namespace:my-app` for a Kubernetes service account
 
 This allows you to distinguish users from different identity providers when granting permissions.
 
 ### Resilient Initialization
 
-If a provider fails to initialize (e.g., the OIDC endpoint is temporarily unreachable), Lakekeeper logs an error but continues starting with the remaining providers. This ensures one misconfigured or unreachable provider doesn't prevent the entire service from starting.
+By default, Lakekeeper refuses to start if a configured provider's OIDC/JWKS configuration cannot be loaded. Set `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__REQUIRE_CONNECTED_ON_STARTUP=false` for providers that should be skipped while Lakekeeper continues starting with the remaining authenticators.
 
 ### When to Use Multiple Providers
 

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -498,7 +498,7 @@ Common use cases include:
 
 See the [Configuration Reference](./configuration.md#multiple-oidc-providers) for the full list of available options per provider.
 
-**Identity continuity note:** Existing user IDs are formatted as `oidc~<subject>` from the primary provider configured via `LAKEKEEPER__OPENID_PROVIDER_URI`. Do not move that provider into `OPENID_PROVIDERS` under a different `IDP_ID` (e.g., `okta`), or existing role/user assignments will no longer match.
+**Identity continuity note:** Existing user IDs are formatted as `oidc~<subject>` from the primary provider configured via `LAKEKEEPER__OPENID_PROVIDER_URI`. Do not move that provider into `LAKEKEEPER__OPENID_PROVIDERS` under a different `IDP_ID` (e.g., `okta`), or existing role/user assignments will no longer match.
 
 ## Kubernetes
 If `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION` is set to true, Lakekeeper validates incoming tokens against the default kubernetes context of the system. Lakekeeper uses the [`TokenReview`](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) to determine the validity of a token. By default the `TokenReview` resource is protected. When deploying Lakekeeper on Kubernetes, make sure to grant the `system:auth-delegator` Cluster Role to the service account used by Lakekeeper:

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -452,6 +452,61 @@ We are now ready to deploy Lakekeeper and login via the UI. Set the following en
     ```
 We are now able to login and bootstrap Lakekeeper.
 
+## Multiple OIDC Providers
+
+For scenarios where you need to authenticate tokens from multiple identity providers simultaneously—such as Okta for human users and EKS OIDC for Kubernetes service accounts—Lakekeeper supports configuring multiple OIDC providers.
+
+When multiple providers are configured, each provider fetches its own JWKS keys independently. Incoming tokens are checked against each provider in order until one successfully validates the token.
+
+### Configuration
+
+Use the `LAKEKEEPER__OPENID_PROVIDERS` environment variable with a JSON array to configure multiple providers. This configuration takes precedence over the single-provider `LAKEKEEPER__OPENID_PROVIDER_URI` if both are set.
+
+```bash
+LAKEKEEPER__OPENID_PROVIDERS='[
+  {
+    "uri": "https://company.okta.com",
+    "idp_id": "okta",
+    "audience": "https://company.okta.com",
+    "subject_claims": "sub"
+  },
+  {
+    "uri": "https://oidc.eks.us-east-1.amazonaws.com/id/ABC123DEF456",
+    "idp_id": "eks-cluster-a",
+    "audience": "sts.amazonaws.com",
+    "subject_claims": "sub"
+  },
+  {
+    "uri": "https://oidc.eks.us-east-1.amazonaws.com/id/XYZ789GHI012",
+    "idp_id": "eks-cluster-b",
+    "audience": "sts.amazonaws.com",
+    "subject_claims": "sub"
+  }
+]'
+```
+
+### User Identity Format
+
+User IDs include the provider's `IDP_ID` as a prefix: `{idp_id}~{subject}`. For example:
+- `okta~user@example.com` for a user from Okta
+- `eks-cluster-a~system:serviceaccount:namespace:my-app` for a Kubernetes service account
+
+This allows you to distinguish users from different identity providers when granting permissions.
+
+### Resilient Initialization
+
+If a provider fails to initialize (e.g., the OIDC endpoint is temporarily unreachable), Lakekeeper logs an error but continues starting with the remaining providers. This ensures one misconfigured or unreachable provider doesn't prevent the entire service from starting.
+
+### When to Use Multiple Providers
+
+Common use cases include:
+
+- **Okta/Entra + EKS OIDC**: Human users authenticate via corporate IdP, while Kubernetes workloads use EKS OIDC tokens
+- **Multi-cluster Kubernetes**: Different EKS/GKE clusters each have their own OIDC provider
+- **Migration scenarios**: Gradually migrating from one IdP to another while both remain active
+
+See the [Configuration Reference](./configuration.md#multiple-oidc-providers) for the full list of available options per provider.
+
 ## Kubernetes
 If `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION` is set to true, Lakekeeper validates incoming tokens against the default kubernetes context of the system. Lakekeeper uses the [`TokenReview`](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) to determine the validity of a token. By default the `TokenReview` resource is protected. When deploying Lakekeeper on Kubernetes, make sure to grant the `system:auth-delegator` Cluster Role to the service account used by Lakekeeper:
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -190,6 +190,7 @@ To prohibit unwanted access to data, we recommend to enable Authentication.
 Authentication is enabled if:
 
 * `LAKEKEEPER__OPENID_PROVIDER_URI` is set OR
+* `LAKEKEEPER__OPENID_PROVIDERS` has at least one configured provider OR
 * `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION` is set to true
 
 In Lakekeeper multiple Authentication mechanisms can be enabled together, for example OpenID + Kubernetes. Lakekeeper builds an internal Authenticator chain of up to three identity providers. Incoming tokens need to be JWT tokens - Opaque tokens are not yet supported. Incoming tokens are introspected, and each Authentication provider checks if the given token can be handled by this provider. If it can be handled, the token is authenticated against this provider, otherwise the next Authenticator in the chain is checked.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -237,9 +237,9 @@ Please check the [Authentication Guide](./authentication.md) for more details.
 
 #### Multiple OIDC Providers
 
-For advanced scenarios requiring multiple OIDC providers (e.g., Okta for users + EKS OIDC for Kubernetes workloads), configure providers under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__`. When set, this takes precedence over `LAKEKEEPER__OPENID_PROVIDER_URI`.
+For advanced scenarios requiring multiple OIDC providers (e.g., Okta for users + EKS OIDC for Kubernetes workloads), configure providers under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__`. These providers are added in addition to `LAKEKEEPER__OPENID_PROVIDER_URI` (the primary provider, `idp_id = "oidc"`).
 
-The `<IDP_ID>` key is the identity-provider ID used in user IDs like `<idp_id>~<subject>`. It must not contain `~`; `kubernetes` is reserved for the built-in Kubernetes authenticator.
+The `<IDP_ID>` key is the identity-provider ID used in user IDs like `<idp_id>~<subject>`. Figment lowercases env var segments and uses `__` as a nesting separator, so `LAKEKEEPER__OPENID_PROVIDERS__MY_PROVIDER__URI=...` yields `idp_id = "my_provider"`; avoid extra `__` in the IDP segment because it creates nested keys. The ID must not contain `~`; `oidc` and `kubernetes` are reserved.
 
 **Provider Fields:**
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -227,7 +227,7 @@ Please check the [Authentication Guide](./authentication.md) for more details.
 | Variable                                                                  | Example                                      | Description |
 |---------------------------------------------------------------------------|----------------------------------------------|-----|
 | <nobr>`LAKEKEEPER__OPENID_PROVIDER_URI`</nobr>                            | `https://keycloak.local/realms/{your-realm}` | OpenID Provider URL. Lakekeeper expects to find `<LAKEKEEPER__OPENID_PROVIDER_URI>/.well-known/openid-configuration` and load JWKS tokens from there. Do not include the `/.well-known/openid-configuration` in the provided URL. |
-| `LAKEKEEPER__OPENID_AUDIENCE`                                             | `the-client-id-of-my-app`                    | If set, the `aud` of the provided token must match the value provided. Multiple allowed audiences can be provided as a comma separated list. |
+| `LAKEKEEPER__OPENID_AUDIENCE`                                             | `the-client-id-of-my-app`                    | Strongly recommended. If set, the `aud` of the provided token must match the value provided. Multiple allowed audiences can be provided as a comma separated list. If unset, audience validation is **skipped** — tokens for any audience are accepted as long as signature and issuer validate. Set this in production. |
 | `LAKEKEEPER__OPENID_ADDITIONAL_ISSUERS`                                   | `https://sts.windows.net/<Tenant>/`          | A comma separated list of additional issuers to trust. The issuer defined in the `issuer` field of the `.well-known/openid-configuration` is always trusted. `LAKEKEEPER__OPENID_ADDITIONAL_ISSUERS` has no effect if `LAKEKEEPER__OPENID_PROVIDER_URI` is not set. |
 | `LAKEKEEPER__OPENID_SCOPE`                                                | `lakekeeper`                                 | Specify a scope that must be present in provided tokens received from the openid provider. |
 | `LAKEKEEPER__OPENID_SUBJECT_CLAIM`                                        | `sub` or `oid,sub`                           | Specify the claim(s) in the user's JWT used to identify a User. Accepts a single claim name or a comma-separated list of claim names; the first claim present in the token is used. By default Lakekeeper tries `oid` first, then falls back to `sub`. We strongly recommend setting this configuration explicitly in production deployments. Entra-ID users want to use `oid`; users from all other IdPs most likely want to use `sub`. |
@@ -240,14 +240,18 @@ Please check the [Authentication Guide](./authentication.md) for more details.
 
 For advanced scenarios requiring multiple OIDC providers (e.g., Okta for users + EKS OIDC for Kubernetes workloads), configure providers under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__`. These providers are added in addition to `LAKEKEEPER__OPENID_PROVIDER_URI` (the primary provider, `idp_id = "oidc"`).
 
-The `<IDP_ID>` key is the identity-provider ID used in user IDs like `<idp_id>~<subject>`. Figment lowercases env var segments and uses `__` as a nesting separator, so `LAKEKEEPER__OPENID_PROVIDERS__MY_PROVIDER__URI=...` yields `idp_id = "my_provider"`; avoid extra `__` in the IDP segment because it creates nested keys. The ID must not contain `~`; `oidc` and `kubernetes` are reserved.
+The `<IDP_ID>` key is the identity-provider ID used in user IDs like `<idp_id>~<subject>`. Each `<IDP_ID>` must match `[a-z0-9-]+` — lowercase letters, digits, and hyphens. Figment lowercases env var segments and uses `__` as a nesting separator, so `LAKEKEEPER__OPENID_PROVIDERS__MY-PROVIDER__URI=...` yields `idp_id = "my-provider"`; use a single `-` to separate words (a `__` in the IDP segment would create a nested key, not part of the name). `oidc` and `kubernetes` are reserved.
+
+**Chain order.** Tokens are tried against authenticators in this order: the primary provider from `LAKEKEEPER__OPENID_PROVIDER_URI` (if set), then providers from `LAKEKEEPER__OPENID_PROVIDERS` in **alphabetical order of `idp_id`**, then Kubernetes (if enabled).
+
+A token is routed to the **first** authenticator whose `iss` set contains the token's `iss` claim **and** whose `aud` set intersects the token's `aud` claim (an unset issuer or audience matches everything). Once routed, that authenticator performs full signature + issuer + audience validation; if validation fails the request is rejected — the chain does **not** fall through to the next link. As a consequence, if two providers' (issuer, audience) criteria overlap, the first chain link owns the overlap. Make `iss` × `aud` pairs disjoint across providers to avoid surprises.
 
 **Provider Fields:**
 
 | Variable suffix | Required | Example | Description |
 |-----------------|----------|---------|-------------|
 | `__URI` | Yes | `https://company.okta.com` | OIDC provider URI (must expose `.well-known/openid-configuration`). |
-| `__AUDIENCE` | No | `lakekeeper,warehouse` | Expected audience(s) for tokens. Comma-separated for multiple. |
+| `__AUDIENCE` | No (strongly recommended) | `lakekeeper,warehouse` | Expected audience(s) for tokens. Comma-separated for multiple. If unset, audience validation is **skipped** — tokens for any audience are accepted as long as signature and issuer validate. Set this in production. |
 | `__ADDITIONAL_ISSUERS` | No | `https://sts.windows.net/tenant/` | Additional issuers to trust (comma-separated). |
 | `__SCOPE` | No | `lakekeeper` | Scope that must be present in tokens. |
 | `__SUBJECT_CLAIMS` | No | `sub` or `oid,sub` | Claims to use as user ID (comma-separated, in order of preference). Defaults to `oid,sub`. |

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -235,6 +235,48 @@ Please check the [Authentication Guide](./authentication.md) for more details.
 | `LAKEKEEPER__KUBERNETES_AUTHENTICATION_AUDIENCE`                          | `https://kubernetes.default.svc`             | Audiences that are expected in Kubernetes tokens. Only has an effect if `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION` is true. |
 | `LAKEKEEPER_TEST__KUBERNETES_AUTHENTICATION_ACCEPT_LEGACY_SERVICEACCOUNT` | `false`                                      | Add an authenticator that handles tokens with no audiences and the issuer set to `kubernetes/serviceaccount`. Only has an effect if `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION` is true. |
 
+#### Multiple OIDC Providers
+
+For advanced scenarios requiring multiple OIDC providers (e.g., Okta for users + EKS OIDC for Kubernetes workloads), use the `LAKEKEEPER__OPENID_PROVIDERS` configuration. When set, this takes precedence over `LAKEKEEPER__OPENID_PROVIDER_URI`.
+
+The configuration is a JSON array of provider objects:
+
+| Variable                              | Description |
+|---------------------------------------|-------------|
+| <nobr>`LAKEKEEPER__OPENID_PROVIDERS`</nobr> | JSON array of OIDC provider configurations. Each object supports: `uri` (required), `idp_id` (required), `audience`, `additional_issuers`, `scope`, `subject_claims`. |
+
+**Provider Object Fields:**
+
+| Field               | Required | Example                                   | Description |
+|---------------------|----------|-------------------------------------------|-------------|
+| `uri`               | Yes      | `https://company.okta.com`                | OIDC provider URI (must expose `.well-known/openid-configuration`). |
+| `idp_id`            | Yes      | `okta`                                    | Unique identifier for this IdP. Used in user IDs like `{idp_id}~{subject}`. |
+| `audience`          | No       | `https://company.okta.com`                | Expected audience(s) for tokens. Comma-separated for multiple. |
+| `additional_issuers`| No       | `https://sts.windows.net/tenant/`         | Additional issuers to trust (comma-separated). |
+| `scope`             | No       | `lakekeeper`                              | Scope that must be present in tokens. |
+| `subject_claims`    | No       | `sub` or `oid,sub`                        | Claims to use as user ID (comma-separated, in order of preference). Defaults to `oid,sub`. |
+
+**Example: Okta + EKS OIDC**
+
+```bash
+LAKEKEEPER__OPENID_PROVIDERS='[
+  {
+    "uri": "https://company.okta.com",
+    "idp_id": "okta",
+    "audience": "https://company.okta.com",
+    "subject_claims": "sub"
+  },
+  {
+    "uri": "https://oidc.eks.us-east-1.amazonaws.com/id/ABC123DEF456",
+    "idp_id": "eks-prod",
+    "audience": "sts.amazonaws.com",
+    "subject_claims": "sub"
+  }
+]'
+```
+
+!!! note
+    If a provider fails to initialize (e.g., unreachable OIDC endpoint), it is skipped with an error log. Other providers continue to work normally.
 
 ### Authorization
 Authorization is only effective if [Authentication](#authentication) is enabled.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -230,53 +230,45 @@ Please check the [Authentication Guide](./authentication.md) for more details.
 | `LAKEKEEPER__OPENID_ADDITIONAL_ISSUERS`                                   | `https://sts.windows.net/<Tenant>/`          | A comma separated list of additional issuers to trust. The issuer defined in the `issuer` field of the `.well-known/openid-configuration` is always trusted. `LAKEKEEPER__OPENID_ADDITIONAL_ISSUERS` has no effect if `LAKEKEEPER__OPENID_PROVIDER_URI` is not set. |
 | `LAKEKEEPER__OPENID_SCOPE`                                                | `lakekeeper`                                 | Specify a scope that must be present in provided tokens received from the openid provider. |
 | `LAKEKEEPER__OPENID_SUBJECT_CLAIM`                                        | `sub` or `oid,sub`                           | Specify the claim(s) in the user's JWT used to identify a User. Accepts a single claim name or a comma-separated list of claim names; the first claim present in the token is used. By default Lakekeeper tries `oid` first, then falls back to `sub`. We strongly recommend setting this configuration explicitly in production deployments. Entra-ID users want to use `oid`; users from all other IdPs most likely want to use `sub`. |
-| `LAKEKEEPER__OPENID_ROLES_CLAIM`                                          | `resource_access.lakekeeper.roles`           | Specify the claim to use in provided JWT tokens to extract roles. The field should contain an array of strings or a single string. Supports nested claims using dot notation, e.g., "resource_access.account.roles". Currently only has an effect when using the Cedar Authorizer. Requires a project ID to be set via the `x-project-id` header or `LAKEKEEPER__DEFAULT_PROJECT_ID`. |
+| `LAKEKEEPER__OPENID_ROLES_CLAIM`                                          | `resource_access.lakekeeper.roles`           | Specify the claim to use in provided JWT tokens to extract roles. The field should contain an array of strings or a single string. Supports nested claims using dot notation, e.g., "resource_access.account.roles". Used by authorizers that consume token roles, including Cedar and custom implementations. The default OpenFGA implementation does not use token roles. Requires a project ID to be set via the `x-project-id` header or `LAKEKEEPER__DEFAULT_PROJECT_ID`. |
 | `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION`                            | true                                         | If true, kubernetes service accounts can authenticate to Lakekeeper. This option is compatible with `LAKEKEEPER__OPENID_PROVIDER_URI` - multiple IdPs (OIDC and Kubernetes) can be enabled simultaneously. |
 | `LAKEKEEPER__KUBERNETES_AUTHENTICATION_AUDIENCE`                          | `https://kubernetes.default.svc`             | Audiences that are expected in Kubernetes tokens. Only has an effect if `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION` is true. |
 | `LAKEKEEPER_TEST__KUBERNETES_AUTHENTICATION_ACCEPT_LEGACY_SERVICEACCOUNT` | `false`                                      | Add an authenticator that handles tokens with no audiences and the issuer set to `kubernetes/serviceaccount`. Only has an effect if `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION` is true. |
 
 #### Multiple OIDC Providers
 
-For advanced scenarios requiring multiple OIDC providers (e.g., Okta for users + EKS OIDC for Kubernetes workloads), use the `LAKEKEEPER__OPENID_PROVIDERS` configuration. When set, this takes precedence over `LAKEKEEPER__OPENID_PROVIDER_URI`.
+For advanced scenarios requiring multiple OIDC providers (e.g., Okta for users + EKS OIDC for Kubernetes workloads), configure providers under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__`. When set, this takes precedence over `LAKEKEEPER__OPENID_PROVIDER_URI`.
 
-The configuration is a JSON array of provider objects:
+The `<IDP_ID>` key is the identity-provider ID used in user IDs like `<idp_id>~<subject>`. It must not contain `~`; `kubernetes` is reserved for the built-in Kubernetes authenticator.
 
-| Variable                              | Description |
-|---------------------------------------|-------------|
-| <nobr>`LAKEKEEPER__OPENID_PROVIDERS`</nobr> | JSON array of OIDC provider configurations. Each object supports: `uri` (required), `idp_id` (required), `audience`, `additional_issuers`, `scope`, `subject_claims`. |
+**Provider Fields:**
 
-**Provider Object Fields:**
-
-| Field               | Required | Example                                   | Description |
-|---------------------|----------|-------------------------------------------|-------------|
-| `uri`               | Yes      | `https://company.okta.com`                | OIDC provider URI (must expose `.well-known/openid-configuration`). |
-| `idp_id`            | Yes      | `okta`                                    | Unique identifier for this IdP. Used in user IDs like `{idp_id}~{subject}`. |
-| `audience`          | No       | `https://company.okta.com`                | Expected audience(s) for tokens. Comma-separated for multiple. |
-| `additional_issuers`| No       | `https://sts.windows.net/tenant/`         | Additional issuers to trust (comma-separated). |
-| `scope`             | No       | `lakekeeper`                              | Scope that must be present in tokens. |
-| `subject_claims`    | No       | `sub` or `oid,sub`                        | Claims to use as user ID (comma-separated, in order of preference). Defaults to `oid,sub`. |
+| Variable suffix | Required | Example | Description |
+|-----------------|----------|---------|-------------|
+| `__URI` | Yes | `https://company.okta.com` | OIDC provider URI (must expose `.well-known/openid-configuration`). |
+| `__AUDIENCE` | No | `lakekeeper,warehouse` | Expected audience(s) for tokens. Comma-separated for multiple. |
+| `__ADDITIONAL_ISSUERS` | No | `https://sts.windows.net/tenant/` | Additional issuers to trust (comma-separated). |
+| `__SCOPE` | No | `lakekeeper` | Scope that must be present in tokens. |
+| `__SUBJECT_CLAIMS` | No | `sub` or `oid,sub` | Claims to use as user ID (comma-separated, in order of preference). Defaults to `oid,sub`. |
+| `__ROLES_CLAIM` | No | `resource_access.lakekeeper.roles` | Claim to use in provided JWT tokens to extract roles. |
+| `__REQUIRE_CONNECTED_ON_STARTUP` | No | `true` | When `true` (default), Lakekeeper refuses to start if this provider's OIDC/JWKS configuration cannot be loaded. Set to `false` to skip this provider while continuing startup. |
 
 **Example: Okta + EKS OIDC**
 
 ```bash
-LAKEKEEPER__OPENID_PROVIDERS='[
-  {
-    "uri": "https://company.okta.com",
-    "idp_id": "okta",
-    "audience": "https://company.okta.com",
-    "subject_claims": "sub"
-  },
-  {
-    "uri": "https://oidc.eks.us-east-1.amazonaws.com/id/ABC123DEF456",
-    "idp_id": "eks-prod",
-    "audience": "sts.amazonaws.com",
-    "subject_claims": "sub"
-  }
-]'
+LAKEKEEPER__OPENID_PROVIDERS__OKTA__URI=https://company.okta.com
+LAKEKEEPER__OPENID_PROVIDERS__OKTA__AUDIENCE=https://company.okta.com
+LAKEKEEPER__OPENID_PROVIDERS__OKTA__SUBJECT_CLAIMS=sub
+LAKEKEEPER__OPENID_PROVIDERS__OKTA__ROLES_CLAIM=resource_access.lakekeeper.roles
+
+LAKEKEEPER__OPENID_PROVIDERS__EKSPROD__URI=https://oidc.eks.us-east-1.amazonaws.com/id/ABC123DEF456
+LAKEKEEPER__OPENID_PROVIDERS__EKSPROD__AUDIENCE=sts.amazonaws.com
+LAKEKEEPER__OPENID_PROVIDERS__EKSPROD__SUBJECT_CLAIMS=sub
+LAKEKEEPER__OPENID_PROVIDERS__EKSPROD__REQUIRE_CONNECTED_ON_STARTUP=false
 ```
 
 !!! note
-    If a provider fails to initialize (e.g., unreachable OIDC endpoint), it is skipped with an error log. Other providers continue to work normally.
+    Providers fail startup by default if their OIDC endpoint cannot be loaded. Set `REQUIRE_CONNECTED_ON_STARTUP=false` for providers that should be skipped while Lakekeeper continues starting.
 
 ### Authorization
 Authorization is only effective if [Authentication](#authentication) is enabled.


### PR DESCRIPTION
## Summary

This is that implementation.

In issue #1571 (now closed), @c-thiel commented:

> "if someone would build a more generic configuration for OSS that is backwards compatible, we would gladly include that too"

This PR adds `LAKEKEEPER__OPENID_PROVIDERS` — a config-driven, backwards-compatible way to authenticate tokens from multiple OIDC providers simultaneously (e.g. Okta for users + EKS OIDC for Kubernetes service accounts). The existing `OPENID_PROVIDER_URI` and `OPENID_ADDITIONAL_ISSUERS` can't do this: `additional_issuers` only validates the issuer claim but doesn't fetch JWKS from those URIs, leading to "Key id not found in JWKS" failures.

## Configuration

```bash
LAKEKEEPER__OPENID_PROVIDERS='[
  {
    "uri": "https://company.okta.com",
    "idp_id": "okta",
    "audience": "https://company.okta.com",
    "subject_claims": "sub"
  },
  {
    "uri": "https://oidc.eks.us-east-1.amazonaws.com/id/CLUSTER_ID",
    "idp_id": "eks-prod",
    "audience": "sts.amazonaws.com"
  }
]'
```

Per-provider fields:

| Field | Required | Description |
|-------|----------|-------------|
| `uri` | yes | OIDC provider URI (must expose `.well-known/openid-configuration`) |
| `idp_id` | yes | Prefix used in user IDs: `{idp_id}~{subject}` |
| `audience` | no | Comma-separated accepted audiences |
| `additional_issuers` | no | Comma-separated additional trusted issuers |
| `scope` | no | Required scope claim |
| `subject_claims` | no | Comma-separated claims to use as subject, in preference order. Defaults to `oid,sub`. |

## Design

- **Backwards compatible**: `LAKEKEEPER__OPENID_PROVIDER_URI` continues to work unchanged. Multi-provider mode only activates when `LAKEKEEPER__OPENID_PROVIDERS` is set.
- Failed providers are logged and skipped — one misconfigured provider doesn't block the others.
- Multi-provider mode uses `{idp_id}~{subject}` (e.g. `okta~alice@co.com`). Single-provider mode is unchanged.

## Files changed

- `crates/lakekeeper/src/config.rs` — `OidcProviderConfig` struct, `openid_providers` field, serde helpers, `authn_enabled()` update, 6 new unit tests
- `crates/lakekeeper/src/service/authn.rs` — `build_multi_oidc_authenticators()`, `build_single_oidc_authenticator()` extracted, dynamic chain builder
- `crates/lakekeeper-bin/src/serve.rs` — minor import fix
- `docs/docs/authentication.md` — "Multiple OIDC Providers" section
- `docs/docs/configuration.md` — `LAKEKEEPER__OPENID_PROVIDERS` reference and example

## Testing

- 6 new unit tests in `config.rs`
- Manually tested against Okta + EKS OIDC

## Breaking changes

None — purely additive.

Relates to #1571


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure multiple OIDC identity providers with per-provider settings, deterministic ordering, and provider-scoped user IDs
  * Mark secondary providers optional at startup (failures skip) while required providers still block startup
  * UI login enablement follows consolidated authentication-enabled logic

* **Documentation**
  * Added guides and examples for multi-provider configuration, startup resilience, and identity-continuity guidance

* **Tests**
  * Expanded tests for parsing, ordering, startup behavior, and authn-enabled cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper/pull/1760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->