### PR TITLE
feat(server): add read-only maintenance mode

### DIFF
--- a/crates/lakekeeper/src/api/maintenance.rs
+++ b/crates/lakekeeper/src/api/maintenance.rs
@@ -1,0 +1,191 @@
+//! Middleware that rejects mutating requests while the service is in
+//! maintenance mode. Intended to support zero-downtime upgrades performed by a
+//! Kubernetes operator: the operator does a rolling restart that sets
+//! [`MaintenanceMode::ReadOnly`] on every pod, then runs database migrations,
+//! then does a second rolling restart that removes the flag.
+//!
+//! The flag is captured once at startup (see [`crate::config::CONFIG`]) and is
+//! not dynamic. Mutating means anything other than `GET`, `HEAD`, or `OPTIONS`.
+//! Read endpoints with write side-effects (e.g. user auto-registration on
+//! `GET /v1/config`) suppress those side-effects in their own handlers.
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode, header::RETRY_AFTER},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use iceberg_ext::catalog::rest::{ErrorModel, IcebergErrorResponse};
+
+/// HTTP `Retry-After` value (seconds) returned with maintenance-mode 503s.
+///
+/// Iceberg Java honors `Retry-After` for idempotent requests and for
+/// non-idempotent (`updateTable`) requests only when the header is present.
+/// `PyIceberg` ignores it. Sixty seconds is a sensible default for a brief
+/// migration window; jitter is up to the operator (e.g. by staggering new
+/// pod readiness).
+pub const MAINTENANCE_RETRY_AFTER_SECONDS: u64 = 60;
+
+/// Error code returned in [`ErrorModel::r#type`] when a request is blocked
+/// because the server is in maintenance mode. Clients can branch on this to
+/// distinguish a maintenance window from a generic outage.
+pub const MAINTENANCE_ERROR_TYPE: &str = "MaintenanceModeError";
+
+/// Returns `true` for HTTP methods we treat as writes. We deliberately do not
+/// inspect the route: `POST /v1/search` style endpoints are blocked during
+/// maintenance, which is acceptable for a planned upgrade window. The one
+/// `GET`-with-write side-effect we know of (`GET /v1/config` user auto-register)
+/// is suppressed in the handler itself, not here.
+fn is_mutating(method: &Method) -> bool {
+    !matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS)
+}
+
+/// Build the standardized 503 response.
+fn maintenance_response() -> Response {
+    let err: IcebergErrorResponse = ErrorModel::builder()
+        .code(StatusCode::SERVICE_UNAVAILABLE.as_u16())
+        .r#type(MAINTENANCE_ERROR_TYPE.to_string())
+        .message(
+            "Lakekeeper is in read-only maintenance mode. Mutating requests are temporarily rejected; retry after the maintenance window completes."
+                .to_string(),
+        )
+        .build()
+        .into();
+
+    let mut response = (StatusCode::SERVICE_UNAVAILABLE, axum::Json(err)).into_response();
+    response.headers_mut().insert(
+        RETRY_AFTER,
+        MAINTENANCE_RETRY_AFTER_SECONDS.to_string().parse().expect(
+            "MAINTENANCE_RETRY_AFTER_SECONDS formats as ASCII digits, always a valid header value",
+        ),
+    );
+    response
+}
+
+/// Axum middleware. Apply with [`axum::middleware::from_fn`] to a router that
+/// contains only routes that should be subject to the gate (i.e. the merged
+/// `/catalog/v1` + `/management/v1` nest, *not* `/health`).
+#[cfg(feature = "router")]
+pub(crate) async fn maintenance_middleware_fn(request: Request<Body>, next: Next) -> Response {
+    if crate::CONFIG.maintenance_mode.is_read_only() && is_mutating(request.method()) {
+        tracing::debug!(
+            method = %request.method(),
+            path = request.uri().path(),
+            "Rejecting mutating request: maintenance mode active",
+        );
+        return maintenance_response();
+    }
+    next.run(request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{Router, body::Body, middleware, routing::get};
+    use http::{Request, StatusCode};
+    use tower::ServiceExt as _;
+
+    use super::*;
+    use crate::config::MaintenanceMode;
+
+    /// We can't easily flip the global `CONFIG.maintenance_mode` from a test
+    /// without process-wide side effects, so we test the building blocks
+    /// directly: `is_mutating`, `maintenance_response`, and a thin wrapper
+    /// middleware that takes the mode as a parameter.
+    #[test]
+    fn is_mutating_classifies_methods() {
+        assert!(!is_mutating(&Method::GET));
+        assert!(!is_mutating(&Method::HEAD));
+        assert!(!is_mutating(&Method::OPTIONS));
+        assert!(is_mutating(&Method::POST));
+        assert!(is_mutating(&Method::PUT));
+        assert!(is_mutating(&Method::PATCH));
+        assert!(is_mutating(&Method::DELETE));
+    }
+
+    #[test]
+    fn maintenance_response_has_retry_after_and_error_model() {
+        let resp = maintenance_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let retry_after = resp
+            .headers()
+            .get(RETRY_AFTER)
+            .expect("Retry-After header is set on maintenance responses");
+        assert_eq!(retry_after.to_str().unwrap(), "60");
+    }
+
+    /// Parameterized version of [`maintenance_middleware_fn`] used only by
+    /// tests so they can drive the mode explicitly.
+    async fn gate(mode: MaintenanceMode, request: Request<Body>, next: Next) -> Response {
+        if mode.is_read_only() && is_mutating(request.method()) {
+            return maintenance_response();
+        }
+        next.run(request).await
+    }
+
+    fn router_with_mode(mode: MaintenanceMode) -> Router {
+        Router::new()
+            .route("/r", get(|| async { "ok" }).post(|| async { "ok" }))
+            .layer(middleware::from_fn(move |req, next| gate(mode, req, next)))
+    }
+
+    #[tokio::test]
+    async fn read_only_blocks_post_returns_503_with_retry_after() {
+        let app = router_with_mode(MaintenanceMode::ReadOnly);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/r")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            resp.headers().get(RETRY_AFTER).unwrap().to_str().unwrap(),
+            "60"
+        );
+
+        // Body parses as an IcebergErrorResponse with the maintenance type.
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let parsed: IcebergErrorResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.error.r#type, MAINTENANCE_ERROR_TYPE);
+        assert_eq!(parsed.error.code, StatusCode::SERVICE_UNAVAILABLE.as_u16());
+    }
+
+    #[tokio::test]
+    async fn read_only_passes_get() {
+        let app = router_with_mode(MaintenanceMode::ReadOnly);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/r")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn off_passes_post() {
+        let app = router_with_mode(MaintenanceMode::Off);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/r")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/crates/lakekeeper/src/api/mod.rs
+++ b/crates/lakekeeper/src/api/mod.rs
@@ -3,6 +3,8 @@ pub mod management;
 
 pub(crate) mod endpoints;
 #[cfg(feature = "router")]
+pub mod maintenance;
+#[cfg(feature = "router")]
 pub mod router;
 pub use iceberg_ext::catalog::rest::*;
 

--- a/crates/lakekeeper/src/api/router.rs
+++ b/crates/lakekeeper/src/api/router.rs
@@ -127,6 +127,13 @@ pub async fn new_full_router<
     let mut router = Router::new()
         .nest("/catalog/v1", v1_routes)
         .nest("/management/v1", management_routes)
+        // Maintenance gate: rejects mutating requests (POST/PUT/PATCH/DELETE)
+        // with 503 + Retry-After when MAINTENANCE_MODE=read-only. Applied
+        // before `/health` is added so liveness/readiness probes are
+        // unaffected.
+        .layer(axum::middleware::from_fn(
+            crate::api::maintenance::maintenance_middleware_fn,
+        ))
         .layer(DefaultBodyLimit::max(CONFIG.max_request_body_size));
 
     // Apply request body logging middleware FIRST, before any other middleware that might consume the body

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -543,6 +543,43 @@ pub struct DynAppConfig {
         serialize_with = "serialize_std_duration_as_ms"
     )]
     pub max_request_time: Duration,
+
+    // ------------- Maintenance -------------
+    /// Maintenance mode.
+    ///
+    /// `off` (default) serves all requests normally.
+    ///
+    /// `read-only` is intended to be set by a Kubernetes operator during a
+    /// zero-downtime version upgrade: a rolling restart sets the flag on every
+    /// pod, the operator then runs migrations against the database, and a
+    /// second rolling restart removes the flag once new pods are ready. The
+    /// flag is captured once at startup and is not dynamic.
+    ///
+    /// When `read-only`, mutating HTTP requests (anything other than GET, HEAD
+    /// or OPTIONS) on `/catalog/v1` and `/management/v1` are rejected with
+    /// `503 Service Unavailable` and a `Retry-After` header. Built-in task
+    /// queue workers are not started. Per-warehouse user auto-registration on
+    /// `GET /v1/config` is suppressed.
+    #[serde(default)]
+    pub maintenance_mode: MaintenanceMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MaintenanceMode {
+    /// Normal operation.
+    #[default]
+    Off,
+    /// Reject mutating requests with 503, do not start built-in task queue
+    /// workers, suppress side-effecting writes on read endpoints.
+    ReadOnly,
+}
+
+impl MaintenanceMode {
+    #[must_use]
+    pub fn is_read_only(self) -> bool {
+        matches!(self, Self::ReadOnly)
+    }
 }
 
 pub(crate) fn seconds_to_duration<'de, D>(deserializer: D) -> Result<chrono::Duration, D::Error>
@@ -1050,6 +1087,7 @@ impl Default for DynAppConfig {
             audit: AuditConfig {
                 tracing: AuditTracingConfig { enabled: true },
             },
+            maintenance_mode: MaintenanceMode::Off,
         }
     }
 }
@@ -1305,6 +1343,34 @@ mod test {
                 result.is_err(),
                 "bare string must not be accepted as a single-element list, got {result:?}",
             );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_maintenance_mode_default_off() {
+        let config = get_config();
+        assert_eq!(config.maintenance_mode, MaintenanceMode::Off);
+        assert!(!config.maintenance_mode.is_read_only());
+    }
+
+    #[test]
+    fn test_maintenance_mode_read_only_via_env() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__MAINTENANCE_MODE", "read-only");
+            let config = get_config();
+            assert_eq!(config.maintenance_mode, MaintenanceMode::ReadOnly);
+            assert!(config.maintenance_mode.is_read_only());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_maintenance_mode_off_via_env() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__MAINTENANCE_MODE", "off");
+            let config = get_config();
+            assert_eq!(config.maintenance_mode, MaintenanceMode::Off);
             Ok(())
         });
     }

--- a/crates/lakekeeper/src/serve.rs
+++ b/crates/lakekeeper/src/serve.rs
@@ -428,7 +428,16 @@ async fn serve_inner<
 
     // Task queues
     let task_queue_registry = TaskQueueRegistry::new();
-    if enable_built_in_queues {
+    // In read-only maintenance mode we don't start built-in queue workers:
+    // the operator drains writes before running schema migrations, and
+    // workers would otherwise tick against a half-migrated DB.
+    let skip_built_in_queues_for_maintenance = CONFIG.maintenance_mode.is_read_only();
+    if skip_built_in_queues_for_maintenance {
+        tracing::info!(
+            "Maintenance mode is read-only: skipping built-in task queue worker registration."
+        );
+    }
+    if enable_built_in_queues && !skip_built_in_queues_for_maintenance {
         task_queue_registry
             .register_built_in_queues::<C, _, _>(
                 catalog_state.clone(),

--- a/crates/lakekeeper/src/server/config.rs
+++ b/crates/lakekeeper/src/server/config.rs
@@ -10,6 +10,7 @@ use crate::{
         },
         management::v1::user::{UserLastUpdatedWith, parse_create_user_request},
     },
+    config::MaintenanceMode,
     request_metadata::RequestMetadata,
     service::{
         CatalogStore, CatalogWarehouseOps, ProjectId, SecretStore, State, Transaction,
@@ -33,7 +34,15 @@ impl<A: Authorizer + Clone, C: CatalogStore, S: SecretStore>
     ) -> Result<CatalogConfig> {
         let authorizer = api_context.v1_state.authz;
 
-        maybe_register_user::<C>(&request_metadata, api_context.v1_state.catalog.clone()).await?;
+        // Maintenance mode: the catalog is in a read-only window (typically a
+        // Kubernetes operator running a schema migration). Skip the
+        // first-touch user-register side-effect so `GET /v1/config` stays a
+        // pure read. Returning the catalog config itself is still valuable —
+        // existing clients need it to keep reading.
+        if matches!(CONFIG.maintenance_mode, MaintenanceMode::Off) {
+            maybe_register_user::<C>(&request_metadata, api_context.v1_state.catalog.clone())
+                .await?;
+        }
 
         let request_metadata_arc = Arc::new(request_metadata);
 

--- a/crates/lakekeeper/src/service/health.rs
+++ b/crates/lakekeeper/src/service/health.rs
@@ -170,6 +170,7 @@ impl ServiceHealthProvider {
                 HealthStatus::Unhealthy
             },
             services,
+            maintenance_mode: crate::CONFIG.maintenance_mode,
         }
     }
 }
@@ -178,4 +179,10 @@ impl ServiceHealthProvider {
 pub struct HealthState {
     pub health: HealthStatus,
     pub services: HashMap<String, Vec<Health>>,
+    /// Current maintenance mode. A Kubernetes operator can rely on this to
+    /// confirm that every pod in a Deployment has picked up the
+    /// `LAKEKEEPER__MAINTENANCE_MODE=read-only` env var after a rolling
+    /// restart, before running database migrations.
+    #[serde(default)]
+    pub maintenance_mode: crate::config::MaintenanceMode,
 }

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -445,6 +445,19 @@ Lakekeeper allows you to configure limits on incoming requests to protect agains
 | <nobr>`LAKEKEEPER__MAX_REQUEST_BODY_SIZE`</nobr> | `2097152` | Maximum request body size in bytes. Default: `2097152` (2 MB) |
 | <nobr>`LAKEKEEPER__MAX_REQUEST_TIME`</nobr>      | `30s`     | Maximum time allowed for a request to complete. Accepts format `{number}{ms\|s}`. Default: `30s` |
 
+### Maintenance Mode
+
+Captured at startup; not dynamic. While `read-only`:
+
+- Mutating requests (anything other than `GET`/`HEAD`/`OPTIONS`) on `/catalog/v1` and `/management/v1` return `503` with `Retry-After: 60` and `error.type = "MaintenanceModeError"`. `/health` is unaffected.
+- Built-in task queue workers are not started.
+- `GET /v1/config` skips user auto-registration.
+- `GET /health` exposes the current mode as `maintenance_mode` for operator fan-out checks.
+
+| Variable                                       | Example     | Description |
+|------------------------------------------------|-------------|-------------|
+| <nobr>`LAKEKEEPER__MAINTENANCE_MODE`</nobr>    | `read-only` | `off` (default) or `read-only`. Captured at startup; not dynamic. |
+
 ### Idempotency
 
 Lakekeeper supports the [Iceberg REST Catalog Idempotency](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml) specification. When enabled, clients can send an `Idempotency-Key` header on mutation requests to guarantee at-most-once execution. The server advertises support via the `idempotency-key-lifetime` field in the `GET /v1/config` response.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced maintenance mode configuration with `read-only` option to block write operations
  * Mutating requests return 503 with `Retry-After` header when in read-only maintenance
  * Health endpoint now reports maintenance mode status

* **Documentation**
  * Added maintenance mode configuration guide

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper/pull/1765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->