### PR TITLE
fix(kv2): replace stale vault health status

### DIFF
--- a/crates/lakekeeper/src/implementations/kv2.rs
+++ b/crates/lakekeeper/src/implementations/kv2.rs
@@ -217,12 +217,6 @@ impl SecretsState {
             }
         }
     }
-
-    async fn set_health_status(&self, status: HealthStatus) {
-        let mut lock = self.health.write().await;
-        lock.clear();
-        lock.extend([Health::now("vault", status)]);
-    }
 }
 
 #[async_trait]
@@ -237,14 +231,20 @@ impl HealthExt for SecretsState {
         match t {
             Ok(_) => {
                 tracing::debug!("Vault is healthy");
-                self.set_health_status(HealthStatus::Healthy).await;
+                set_vault_health(&self.health, HealthStatus::Healthy).await;
             }
             Err(err) => {
                 tracing::error!(?err, "Vault is unhealthy");
-                self.set_health_status(HealthStatus::Unhealthy).await;
+                set_vault_health(&self.health, HealthStatus::Unhealthy).await;
             }
         }
     }
+}
+
+async fn set_vault_health(health: &Arc<RwLock<Vec<Health>>>, status: HealthStatus) {
+    let mut lock = health.write().await;
+    lock.clear();
+    lock.extend([Health::now("vault", status)]);
 }
 
 impl std::fmt::Debug for SecretsState {
@@ -265,38 +265,18 @@ fn secret_ident_to_key(secret_id: SecretId) -> String {
 
 #[cfg(test)]
 mod tests {
-    use vaultrs::client::VaultClientSettingsBuilder;
-
     use super::*;
 
-    fn test_state() -> SecretsState {
-        SecretsState {
-            vault_client: Arc::new(RwLock::new(
-                VaultClient::new(
-                    VaultClientSettingsBuilder::default()
-                        .address("http://127.0.0.1:8200".to_string())
-                        .build()
-                        .expect("vault settings"),
-                )
-                .expect("vault client"),
-            )),
-            secret_mount: "secret".to_string(),
-            vault_user: "user".to_string(),
-            vault_password: "password".to_string(),
-            health: Arc::new(RwLock::new(Vec::new())),
-        }
-    }
-
     #[tokio::test]
-    async fn test_set_health_status_replaces_previous_entry() {
-        let state = test_state();
+    async fn test_set_vault_health_replaces_previous_entry() {
+        let health = Arc::default();
 
-        state.set_health_status(HealthStatus::Unhealthy).await;
-        state.set_health_status(HealthStatus::Healthy).await;
+        set_vault_health(&health, HealthStatus::Unhealthy).await;
+        set_vault_health(&health, HealthStatus::Healthy).await;
 
-        let health = state.health().await;
-        assert_eq!(health.len(), 1);
-        assert_eq!(health[0].status(), HealthStatus::Healthy);
+        let entries = health.read().await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].status(), HealthStatus::Healthy);
     }
 
     mod kv2_integration_tests {

--- a/crates/lakekeeper/src/implementations/kv2.rs
+++ b/crates/lakekeeper/src/implementations/kv2.rs
@@ -217,6 +217,12 @@ impl SecretsState {
             }
         }
     }
+
+    async fn set_health_status(&self, status: HealthStatus) {
+        let mut lock = self.health.write().await;
+        lock.clear();
+        lock.extend([Health::now("vault", status)]);
+    }
 }
 
 #[async_trait]
@@ -231,17 +237,11 @@ impl HealthExt for SecretsState {
         match t {
             Ok(_) => {
                 tracing::debug!("Vault is healthy");
-                self.health
-                    .write()
-                    .await
-                    .push(Health::now("vault", HealthStatus::Healthy));
+                self.set_health_status(HealthStatus::Healthy).await;
             }
             Err(err) => {
                 tracing::error!(?err, "Vault is unhealthy");
-                self.health
-                    .write()
-                    .await
-                    .push(Health::now("vault", HealthStatus::Unhealthy));
+                self.set_health_status(HealthStatus::Unhealthy).await;
             }
         }
     }
@@ -265,6 +265,40 @@ fn secret_ident_to_key(secret_id: SecretId) -> String {
 
 #[cfg(test)]
 mod tests {
+    use vaultrs::client::VaultClientSettingsBuilder;
+
+    use super::*;
+
+    fn test_state() -> SecretsState {
+        SecretsState {
+            vault_client: Arc::new(RwLock::new(
+                VaultClient::new(
+                    VaultClientSettingsBuilder::default()
+                        .address("http://127.0.0.1:8200".to_string())
+                        .build()
+                        .expect("vault settings"),
+                )
+                .expect("vault client"),
+            )),
+            secret_mount: "secret".to_string(),
+            vault_user: "user".to_string(),
+            vault_password: "password".to_string(),
+            health: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_set_health_status_replaces_previous_entry() {
+        let state = test_state();
+
+        state.set_health_status(HealthStatus::Unhealthy).await;
+        state.set_health_status(HealthStatus::Healthy).await;
+
+        let health = state.health().await;
+        assert_eq!(health.len(), 1);
+        assert_eq!(health[0].status(), HealthStatus::Healthy);
+    }
+
     mod kv2_integration_tests {
         use super::super::*;
         use crate::{


### PR DESCRIPTION
## Summary
KV2/Vault health checks were appending a new `vault` entry on every update instead of replacing the current status.

Because `/health` folds over every stored status for a provider, one stale `Unhealthy` entry could keep the service unhealthy after Vault recovered. The in-memory health vector also grew over time.

## What changed
- replace the KV2 health entry on each update instead of appending
- add a regression test that verifies the KV2 provider keeps only the current Vault status

## Impact
Lakekeeper now reports the current Vault health state correctly when using the KV2 secret backend, rather than retaining old failures indefinitely.

## Validation
- `cargo fmt --all`
- `cargo test -p lakekeeper test_set_health_status_replaces_previous_entry`

Closes #1772


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health tracking now replaces prior vault health entries with the latest status, preventing accumulation of duplicate entries.

* **Tests**
  * Added a unit test verifying that updating vault health replaces the previous entry and stores only the most recent status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper/pull/1773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->