### PR TITLE
fix(view): respect force=true in soft-delete warehouses on drop

### DIFF
--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -1805,7 +1805,7 @@ mod test {
                 },
                 DropParams {
                     purge_requested: true,
-                    force: true,
+                    force: false,
                 },
                 ctx.clone(),
                 RequestMetadata::new_unauthenticated(),

--- a/crates/lakekeeper/src/server/views/drop.rs
+++ b/crates/lakekeeper/src/server/views/drop.rs
@@ -90,8 +90,15 @@ pub(crate) async fn drop_view<C: CatalogStore, A: Authorizer + Clone, S: SecretS
         .into_result()?;
 
     let mut t = C::Transaction::begin_write(state.v1_state.catalog).await?;
+
+    let delete_profile = if force {
+        TabularDeleteProfile::Hard {}
+    } else {
+        warehouse.tabular_delete_profile
+    };
     let project_id = &warehouse.project_id;
-    match warehouse.tabular_delete_profile {
+
+    match delete_profile {
         TabularDeleteProfile::Hard {} => {
             let location = C::drop_tabular(warehouse_id, view_id, force, t.transaction()).await?;
 
@@ -181,10 +188,7 @@ pub(crate) async fn drop_view<C: CatalogStore, A: Authorizer + Clone, S: SecretS
     t.commit().await?;
 
     // Post-commit: best-effort authz cleanup for hard deletes
-    if matches!(
-        warehouse.tabular_delete_profile,
-        TabularDeleteProfile::Hard {}
-    ) {
+    if matches!(delete_profile, TabularDeleteProfile::Hard {}) {
         authorizer
             .delete_view(warehouse_id, view_id)
             .await
@@ -226,7 +230,9 @@ mod test {
         server::views::{
             create::test::create_view, drop::drop_view, load::test::load_view, test::setup,
         },
-        service::tasks::WarehouseTaskEntityId,
+        service::tasks::{
+            WarehouseTaskEntityId, tabular_expiration_queue::QUEUE_NAME as EXPIRATION_QUEUE_NAME,
+        },
         tests::{create_view_request, random_request_metadata},
     };
 
@@ -459,7 +465,7 @@ mod test {
         .expect("Protected View should be droppable via force");
 
         let error = load_view(
-            api_context,
+            api_context.clone(),
             ViewParameters {
                 prefix: Some(Prefix(prefix.clone())),
                 view: TableIdent::from_strs(table_ident).unwrap(),
@@ -469,5 +475,26 @@ mod test {
         .expect_err("View should no longer exist");
 
         assert_eq!(error.error.code, StatusCode::NOT_FOUND);
+
+        // force=true must perform an immediate hard delete even in a soft-delete warehouse:
+        // no tabular_expiration task should be scheduled for the view.
+        let expiration_tasks = ManagementApiServer::list_tasks(
+            whi,
+            ListTasksRequest::builder()
+                .entities(Some(vec![WarehouseTaskEntityFilter::View {
+                    view_id: loaded_view.metadata.uuid().into(),
+                }]))
+                .queue_name(Some(vec![EXPIRATION_QUEUE_NAME.clone()]))
+                .build(),
+            api_context,
+            random_request_metadata(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            expiration_tasks.tasks.len(),
+            0,
+            "force-drop in soft-delete warehouse must not schedule a tabular_expiration task"
+        );
     }
 }


### PR DESCRIPTION
drop_view branched directly on warehouse.tabular_delete_profile, so a soft-delete warehouse always took the soft path — even when the caller passed force=true. This diverged from drop_table, which computes an effective profile (force ? Hard : warehouse.profile) and from the documented force-delete semantics ("overrides soft-deletion mechanisms for immediate hard deletion").

Mirror the table pattern: derive delete_profile and match on it, and gate the post-commit authorizer cleanup on the effective profile so a force-drop also clears authz state immediately.

Strengthen test_can_force_drop_protected_view (which already runs against the default Soft warehouse) to assert no tabular_expiration task is scheduled after force-drop — the previous load=NotFound check passed in both branches because soft-deleted views also drop out of active listings.

Fixes #1771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Force-drop operations now correctly trigger cleanup in soft-delete environments.
  * Prevented scheduling of expiration tasks when a view is force-dropped.
* **Tests**
  * Extended tests to verify that force-drop behavior avoids creating expiration tasks and to cover ownership handling in test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper/pull/1779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->