### PR TITLE
feat(tasks): add POST .../task-queue/{queue_name}/schedule endpoint

### DIFF
--- a/.sqlx/query-3f118743d59e0e035f57c9106816533c092fead83b8420cdab3149b040664910.json
+++ b/.sqlx/query-3f118743d59e0e035f57c9106816533c092fead83b8420cdab3149b040664910.json
@@ -117,7 +117,8 @@
                 "management-v1-get-project-task-queue-config",
                 "management-v1-control-project-tasks",
                 "management-v1-get-project-task-details",
-                "management-v1-list-project-tasks"
+                "management-v1-list-project-tasks",
+                "management-v1-schedule-task"
               ]
             }
           }

--- a/.sqlx/query-62b9aeb0ed103e7f63a42f246d713b7727307c032df2c983e7ab8a72d569ddb1.json
+++ b/.sqlx/query-62b9aeb0ed103e7f63a42f246d713b7727307c032df2c983e7ab8a72d569ddb1.json
@@ -132,7 +132,8 @@
                       "management-v1-get-project-task-queue-config",
                       "management-v1-control-project-tasks",
                       "management-v1-get-project-task-details",
-                      "management-v1-list-project-tasks"
+                      "management-v1-list-project-tasks",
+                      "management-v1-schedule-task"
                     ]
                   }
                 }

--- a/.sqlx/query-6eb81444b25f070f01777ccbbc5f7b662bb3ed494b55616479cd36c66694f968.json
+++ b/.sqlx/query-6eb81444b25f070f01777ccbbc5f7b662bb3ed494b55616479cd36c66694f968.json
@@ -122,7 +122,8 @@
                       "management-v1-get-project-task-queue-config",
                       "management-v1-control-project-tasks",
                       "management-v1-get-project-task-details",
-                      "management-v1-list-project-tasks"
+                      "management-v1-list-project-tasks",
+                      "management-v1-schedule-task"
                     ]
                   }
                 }

--- a/.sqlx/query-f0f4d3b6d69711b2bb9c94ea2ed752dfb1b220cf4ddb02f02c6a3b6ebebdf5d6.json
+++ b/.sqlx/query-f0f4d3b6d69711b2bb9c94ea2ed752dfb1b220cf4ddb02f02c6a3b6ebebdf5d6.json
@@ -125,7 +125,8 @@
                 "management-v1-get-project-task-queue-config",
                 "management-v1-control-project-tasks",
                 "management-v1-get-project-task-details",
-                "management-v1-list-project-tasks"
+                "management-v1-list-project-tasks",
+                "management-v1-schedule-task"
               ]
             }
           }

--- a/crates/lakekeeper/migrations/20260527120000_add_schedule_task_endpoint.sql
+++ b/crates/lakekeeper/migrations/20260527120000_add_schedule_task_endpoint.sql
@@ -1,0 +1,1 @@
+ALTER TYPE api_endpoints ADD VALUE IF NOT EXISTS 'management-v1-schedule-task';

--- a/crates/lakekeeper/src/api/endpoints.rs
+++ b/crates/lakekeeper/src/api/endpoints.rs
@@ -513,6 +513,9 @@ mod test {
                 !path.starts_with(
                     "management/v1/warehouse/{warehouse_id}/task-queue/{queue_name}/config",
                 ) && !path.starts_with("management/v1/project/task-queue/{queue_name}/config")
+                    && !path.starts_with(
+                        "management/v1/warehouse/{warehouse_id}/task-queue/{queue_name}/schedule",
+                    )
             })
             .collect_vec();
         if !extra_endpoints.is_empty() {

--- a/crates/lakekeeper/src/api/endpoints.rs
+++ b/crates/lakekeeper/src/api/endpoints.rs
@@ -228,6 +228,7 @@ generate_endpoints! {
         SetWarehouseProtection(POST, "/management/v1/warehouse/{warehouse_id}/protection"),
         SetTaskQueueConfig(POST, "/management/v1/warehouse/{warehouse_id}/task-queue/{queue_name}/config"),
         GetTaskQueueConfig(GET, "/management/v1/warehouse/{warehouse_id}/task-queue/{queue_name}/config"),
+        ScheduleTask(POST, "/management/v1/warehouse/{warehouse_id}/task-queue/{queue_name}/schedule"),
         ListTasks(POST, "/management/v1/warehouse/{warehouse_id}/task/list"),
         GetTaskDetails(GET, "/management/v1/warehouse/{warehouse_id}/task/by-id/{task_id}"),
         ControlTasks(POST, "/management/v1/warehouse/{warehouse_id}/task/control"),

--- a/crates/lakekeeper/src/api/management/mod.rs
+++ b/crates/lakekeeper/src/api/management/mod.rs
@@ -1795,19 +1795,18 @@ pub mod v1 {
         Ok(StatusCode::NO_CONTENT)
     }
 
-    /// Schedule a fresh task on a queue for a specific entity (currently
-    /// table only; views are not supported for v1 schedulable queues).
+    /// Schedule a task for an entity.
     ///
-    /// Only queues that opted in via `TaskConfig::user_schedulable()` accept
-    /// requests on this endpoint. The endpoint also runs a queue-specific
-    /// pre-check via `TaskConfig::check_schedule_eligibility` so misconfig
-    /// (e.g. `gc.enabled=false`, per-table opt-out, warehouse queue
-    /// disabled) fails loudly here instead of producing a no-op task.
+    /// Pre-checks run against the warehouse config and target entity
+    /// properties before the task is enqueued. A failure surfaces as `400`
+    /// with a specific error code (see the operator guide for the full set
+    /// of pre-check codes).
     ///
-    /// On conflict (a task for the same `(warehouse, entity, queue)` triple
-    /// is already active) the response is 409 with the existing `task_id`
-    /// in the message so the operator can chain to `POST /task/control`
-    /// with `run-now` or `run-at` to retime it.
+    /// When a task is already active for the same (warehouse, entity,
+    /// queue) triple, the call returns `409 TaskAlreadyActive` with the
+    /// existing `task-id` in the body — chain to `POST /task/control`
+    /// with `run-now` or `run-at` to retime it without an extra
+    /// `task/list` round-trip.
     #[cfg_attr(feature = "open-api", utoipa::path(
         post,
         tag = "tasks",
@@ -1816,9 +1815,9 @@ pub mod v1 {
         request_body = ScheduleTaskRequest,
         responses(
             (status = 200, body = ScheduleTaskResponse, description = "Task scheduled"),
-            (status = 400, body = IcebergErrorResponse, description = "Validation or eligibility check failed (e.g. queue not user-schedulable, view entity, scheduled-for too far in the future, gc.enabled=false, per-table opt-out, warehouse queue disabled)."),
-            (status = 404, body = IcebergErrorResponse, description = "Queue or target entity not found in this warehouse."),
-            (status = 409, body = IcebergErrorResponse, description = "A task is already active for this (warehouse, entity, queue). The error message includes the existing task_id; retime or cancel via POST /task/control."),
+            (status = 400, body = IcebergErrorResponse, description = "Pre-check failed (e.g. scheduling disabled at the warehouse, entity opted out, unsupported entity type) or the request violates a shape limit (e.g. scheduled-for too far in the future)."),
+            (status = 404, body = IcebergErrorResponse, description = "Target entity not found in this warehouse."),
+            (status = 409, body = IcebergErrorResponse, description = "A task is already active for this (warehouse, entity, queue). The error message includes the existing task-id; retime or cancel via POST /task/control."),
             (status = "4XX", body = IcebergErrorResponse),
         )
     ))]

--- a/crates/lakekeeper/src/api/management/mod.rs
+++ b/crates/lakekeeper/src/api/management/mod.rs
@@ -119,7 +119,10 @@ pub mod v1 {
                     UpdateRoleSourceSystemRequest,
                 },
                 tabular::{SearchTabularRequest, SearchTabularResponse},
-                task_queue::{GetTaskQueueConfigResponse, SetTaskQueueConfigRequest},
+                task_queue::{
+                    GetTaskQueueConfigResponse, ScheduleTaskRequest, ScheduleTaskResponse,
+                    SetTaskQueueConfigRequest,
+                },
                 tasks::{
                     ControlTasksRequest, GetProjectTaskDetailsResponse, GetTaskDetailsQuery,
                     GetTaskDetailsResponseRef, ListProjectTasksRequest, ListProjectTasksResponse,
@@ -1791,6 +1794,51 @@ pub mod v1 {
             .await?;
         Ok(StatusCode::NO_CONTENT)
     }
+
+    /// Schedule a fresh task on a queue for a specific entity (currently
+    /// table only; views are not supported for v1 schedulable queues).
+    ///
+    /// Only queues that opted in via `TaskConfig::user_schedulable()` accept
+    /// requests on this endpoint. The endpoint also runs a queue-specific
+    /// pre-check via `TaskConfig::check_schedule_eligibility` so misconfig
+    /// (e.g. `gc.enabled=false`, per-table opt-out, warehouse queue
+    /// disabled) fails loudly here instead of producing a no-op task.
+    ///
+    /// On conflict (a task for the same `(warehouse, entity, queue)` triple
+    /// is already active) the response is 409 with the existing `task_id`
+    /// in the message so the operator can chain to `POST /task/control`
+    /// with `run-now` or `run-at` to retime it.
+    #[cfg_attr(feature = "open-api", utoipa::path(
+        post,
+        tag = "tasks",
+        path = ManagementV1Endpoint::ScheduleTask.path(),
+        params(("warehouse_id" = Uuid,), ("queue_name" = String,)),
+        request_body = ScheduleTaskRequest,
+        responses(
+            (status = 200, body = ScheduleTaskResponse, description = "Task scheduled"),
+            (status = 400, body = IcebergErrorResponse, description = "Validation or eligibility check failed (e.g. queue not user-schedulable, view entity, scheduled-for too far in the future, gc.enabled=false, per-table opt-out, warehouse queue disabled)."),
+            (status = 404, body = IcebergErrorResponse, description = "Queue or target entity not found in this warehouse."),
+            (status = 409, body = IcebergErrorResponse, description = "A task is already active for this (warehouse, entity, queue). The error message includes the existing task_id; retime or cancel via POST /task/control."),
+            (status = "4XX", body = IcebergErrorResponse),
+        )
+    ))]
+    async fn schedule_task<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
+        Path((warehouse_id, queue_name)): Path<(uuid::Uuid, String)>,
+        Extension(metadata): Extension<RequestMetadata>,
+        AxumState(api_context): AxumState<ApiContext<State<A, C, S>>>,
+        Json(request): Json<ScheduleTaskRequest>,
+    ) -> Result<ScheduleTaskResponse> {
+        let queue_name = TaskQueueName::from(queue_name);
+        ApiServer::<C, A, S>::schedule_task(
+            warehouse_id.into(),
+            &queue_name,
+            request,
+            api_context,
+            metadata,
+        )
+        .await
+    }
+
     /// Set the configuration for a Project-level Task Queue.
     ///
     /// These configurations are global per project and shared across all instances of this kind of task.
@@ -2170,6 +2218,10 @@ pub mod v1 {
                 .route(
                     ManagementV1Endpoint::ControlTasks.path_in_management_v1(),
                     post(control_tasks),
+                )
+                .route(
+                    ManagementV1Endpoint::ScheduleTask.path_in_management_v1(),
+                    post(schedule_task),
                 )
                 .route(
                     ManagementV1Endpoint::SetProjectTaskQueueConfig.path_in_management_v1(),

--- a/crates/lakekeeper/src/api/management/v1/openapi.rs
+++ b/crates/lakekeeper/src/api/management/v1/openapi.rs
@@ -102,6 +102,7 @@ use crate::{
         super::set_namespace_protection,
         super::set_project_task_queue_config,
         super::set_table_protection,
+        super::schedule_task,
         super::set_task_queue_config,
         super::set_view_protection,
         super::set_warehouse_protection,
@@ -163,7 +164,71 @@ pub fn api_doc<A: Authorizer>(
         ManagementV1Endpoint::SetProjectTaskQueueConfig.path(),
     );
 
+    fix_task_queue_schedule_paths(
+        &mut doc,
+        queue_api_configs,
+        ManagementV1Endpoint::ScheduleTask.path(),
+    );
+
     doc
+}
+
+/// Materialise per-queue schedule paths.
+///
+/// The utoipa-registered placeholder uses `{queue_name}` as a path parameter.
+/// For each queue that opted in via `TaskConfig::user_schedulable()` we clone
+/// the placeholder, hard-code its `queue_name` into the path, and rewrite the
+/// operation id so each queue gets a distinct OpenAPI operation. The
+/// placeholder itself is removed at the end. Queues that did not opt in are
+/// invisible in the generated spec, even if they're registered.
+fn fix_task_queue_schedule_paths(
+    doc: &mut utoipa::openapi::OpenApi,
+    queue_api_configs: &[&QueueApiConfig],
+    schedule_path: &str,
+) {
+    let paths = &mut doc.paths.paths;
+    let Some(placeholder) = paths.remove(schedule_path) else {
+        tracing::warn!(
+            "No path found for ScheduleTask placeholder '{schedule_path}'; \
+             skipping per-queue schedule path materialisation."
+        );
+        return;
+    };
+
+    for QueueApiConfig {
+        queue_name,
+        user_schedulable,
+        scope: _,
+        utoipa_type_name: _,
+        utoipa_schema: _,
+    } in queue_api_configs
+    {
+        if !*user_schedulable {
+            continue;
+        }
+
+        let concrete_path = schedule_path.replace("{queue_name}", queue_name);
+        let mut path_item = placeholder.clone();
+
+        let Some(post) = path_item.post.as_mut() else {
+            // Skip this queue rather than bailing out of the entire loop —
+            // one malformed item shouldn't hide the rest from the spec.
+            tracing::warn!(
+                "No POST method on ScheduleTask placeholder '{schedule_path}'; \
+                 not materialising schedule path for queue '{queue_name}'."
+            );
+            continue;
+        };
+        post.parameters = post.parameters.take().map(|params| {
+            params
+                .into_iter()
+                .filter(|p| p.name != "queue_name")
+                .collect()
+        });
+        post.operation_id = Some(format!("schedule_task_{}", queue_name.replace('-', "_")));
+
+        paths.insert(concrete_path, path_item);
+    }
 }
 
 #[allow(clippy::too_many_lines)]
@@ -191,6 +256,7 @@ fn fix_task_queue_config_paths(
         utoipa_type_name,
         utoipa_schema,
         scope,
+        user_schedulable: _,
     } in queue_api_configs
     {
         let operation_object = match scope {
@@ -268,10 +334,11 @@ fn fix_task_queue_config_paths(
 
         let Some(post) = p.post.as_mut() else {
             tracing::warn!(
-                "No post method found for '{}', not patching queue configs into the ApiDoc.",
+                "No post method found for '{}' for queue '{queue_name}'; \
+                 skipping this queue and continuing with the rest.",
                 set_task_queue_config_path
             );
-            return;
+            continue;
         };
         post.parameters = post.parameters.take().map(|params| {
             params
@@ -285,10 +352,11 @@ fn fix_task_queue_config_paths(
         ));
         let Some(body) = post.request_body.as_mut() else {
             tracing::warn!(
-                "No request body found for the '{}', not patching queue configs into the ApiDoc.",
+                "No request body found for '{}' for queue '{queue_name}'; \
+                 skipping this queue and continuing with the rest.",
                 set_task_queue_config_path
             );
-            return;
+            continue;
         };
         body.content.insert(
             "application/json".to_string(),
@@ -298,10 +366,11 @@ fn fix_task_queue_config_paths(
         );
         let Some(get) = p.get.as_mut() else {
             tracing::warn!(
-                "No get method found for '{}', not patching queue configs into the ApiDoc.",
+                "No get method found for '{}' for queue '{queue_name}'; \
+                 skipping this queue and continuing with the rest.",
                 set_task_queue_config_path
             );
-            return;
+            continue;
         };
         get.parameters = get.parameters.take().map(|params| {
             params

--- a/crates/lakekeeper/src/api/management/v1/openapi.rs
+++ b/crates/lakekeeper/src/api/management/v1/openapi.rs
@@ -10,11 +10,13 @@ use utoipa::{
 use crate::{
     api::{
         endpoints::ManagementV1Endpoint,
-        management::v1::task_queue::{GetTaskQueueConfigResponse, SetTaskQueueConfigRequest},
+        management::v1::task_queue::{
+            GetTaskQueueConfigResponse, ScheduleTaskRequest, SetTaskQueueConfigRequest,
+        },
     },
     service::{
         authz::Authorizer,
-        tasks::{BUILT_IN_DEPENDENT_SCHEMAS, QueueApiConfig, QueueScope},
+        tasks::{BUILT_IN_DEPENDENT_SCHEMAS, QueueApiConfig, QueueScope, UserScheduling},
     },
 };
 
@@ -173,19 +175,39 @@ pub fn api_doc<A: Authorizer>(
     doc
 }
 
-/// Materialise per-queue schedule paths.
+/// Materialise per-queue schedule paths and request schemas.
 ///
-/// The utoipa-registered placeholder uses `{queue_name}` as a path parameter.
-/// For each queue that opted in via `TaskConfig::user_schedulable()` we clone
-/// the placeholder, hard-code its `queue_name` into the path, and rewrite the
-/// operation id so each queue gets a distinct OpenAPI operation. The
-/// placeholder itself is removed at the end. Queues that did not opt in are
-/// invisible in the generated spec, even if they're registered.
+/// The utoipa-registered placeholder uses `{queue_name}` as a path
+/// parameter and a single generic `ScheduleTaskRequest` body. For each
+/// queue that opted in via `TaskConfig::user_schedulable()` we:
+///
+/// - Clone the placeholder, hard-code its `queue_name` into the URL, and
+///   rewrite `operation_id` to `schedule_task_<queue>` so each queue is a
+///   distinct `OpenAPI` operation.
+/// - Clone `ScheduleTaskRequest::schema()` and strip the generic `payload`
+///   property when the queue declares no payload (`utoipa_payload_schema =
+///   None`), or rewrite it to reference the queue's payload schema when
+///   provided. Either way the published request body is type-correct per
+///   queue rather than the generic "any JSON" the placeholder shows.
+/// - Insert the per-queue request schema as `Schedule{TypeName}TaskRequest`
+///   in components.
+///
+/// Finally the generic `ScheduleTaskRequest` placeholder is removed from
+/// `components/schemas`. Queues that did not opt in are invisible in the
+/// generated spec.
+#[allow(clippy::too_many_lines)]
 fn fix_task_queue_schedule_paths(
     doc: &mut utoipa::openapi::OpenApi,
     queue_api_configs: &[&QueueApiConfig],
     schedule_path: &str,
 ) {
+    let Some(comps) = doc.components.as_mut() else {
+        tracing::warn!(
+            "No components found in the OpenAPI document; \
+             not patching per-queue schedule schemas in."
+        );
+        return;
+    };
     let paths = &mut doc.paths.paths;
     let Some(placeholder) = paths.remove(schedule_path) else {
         tracing::warn!(
@@ -197,15 +219,50 @@ fn fix_task_queue_schedule_paths(
 
     for QueueApiConfig {
         queue_name,
-        user_schedulable,
+        utoipa_type_name,
+        user_scheduling,
         scope: _,
-        utoipa_type_name: _,
         utoipa_schema: _,
     } in queue_api_configs
     {
-        if !*user_schedulable {
+        let UserScheduling::Enabled { payload_schema } = user_scheduling else {
             continue;
+        };
+
+        // Build the per-queue request schema by cloning the placeholder
+        // and adjusting its `payload` property to match what the queue
+        // actually accepts.
+        let mut per_queue_request_schema = ScheduleTaskRequest::schema();
+        match &mut per_queue_request_schema {
+            RefOr::Ref(_) => {
+                unreachable!("ScheduleTaskRequest::schema() returns an inline schema");
+            }
+            RefOr::T(Schema::Object(obj)) => match payload_schema.as_ref() {
+                None => {
+                    obj.properties.remove("payload");
+                    obj.required.retain(|r| r != "payload");
+                }
+                Some(payload_ref) => {
+                    obj.properties
+                        .insert("payload".to_string(), payload_ref.clone());
+                }
+            },
+            RefOr::T(_) => {
+                unreachable!("ScheduleTaskRequest::schema() returns an Object schema");
+            }
         }
+        // The display stem for the schedule request schema. We strip a
+        // trailing `QueueConfig` from the config type name so we get e.g.
+        // `ScheduleRemoveOrphanFilesTaskRequest` instead of
+        // `ScheduleRemoveOrphanFilesQueueConfigTaskRequest`.
+        let display_stem = utoipa_type_name
+            .strip_suffix("QueueConfig")
+            .unwrap_or(utoipa_type_name);
+        let per_queue_request_name = format!("Schedule{display_stem}TaskRequest");
+
+        comps
+            .schemas
+            .insert(per_queue_request_name.clone(), per_queue_request_schema);
 
         let concrete_path = schedule_path.replace("{queue_name}", queue_name);
         let mut path_item = placeholder.clone();
@@ -226,9 +283,27 @@ fn fix_task_queue_schedule_paths(
                 .collect()
         });
         post.operation_id = Some(format!("schedule_task_{}", queue_name.replace('-', "_")));
+        if let Some(body) = post.request_body.as_mut() {
+            body.content.insert(
+                "application/json".to_string(),
+                utoipa::openapi::ContentBuilder::new()
+                    .schema(Some(RefOr::Ref(
+                        utoipa::openapi::schema::RefBuilder::new()
+                            .ref_location_from_schema_name(per_queue_request_name)
+                            .build(),
+                    )))
+                    .build(),
+            );
+        }
 
         paths.insert(concrete_path, path_item);
     }
+
+    // Remove the generic placeholder schema — every callable schedule path
+    // now references a concrete `Schedule{TypeName}TaskRequest`.
+    comps
+        .schemas
+        .remove(&ScheduleTaskRequest::name().to_string());
 }
 
 #[allow(clippy::too_many_lines)]
@@ -256,7 +331,7 @@ fn fix_task_queue_config_paths(
         utoipa_type_name,
         utoipa_schema,
         scope,
-        user_schedulable: _,
+        user_scheduling: _,
     } in queue_api_configs
     {
         let operation_object = match scope {
@@ -419,15 +494,18 @@ fn fix_task_queue_config_paths(
         comps
             .schemas
             .insert(get_queue_config_type_name, get_queue_config_schema);
-
-        // Remove original SetTaskQueueConfigRequest and GetTaskQueueConfigResponse schemas
-        comps
-            .schemas
-            .remove(&SetTaskQueueConfigRequest::name().to_string());
-        comps
-            .schemas
-            .remove(&GetTaskQueueConfigResponse::name().to_string());
     }
+
+    // Remove the generic placeholder schemas — every callable path now
+    // references a concrete per-queue type. Doing this after the loop
+    // ensures the placeholders are dropped even when `queue_api_configs`
+    // is empty.
+    comps
+        .schemas
+        .remove(&SetTaskQueueConfigRequest::name().to_string());
+    comps
+        .schemas
+        .remove(&GetTaskQueueConfigResponse::name().to_string());
 }
 
 fn add_dependent_schemas(

--- a/crates/lakekeeper/src/api/management/v1/task_queue.rs
+++ b/crates/lakekeeper/src/api/management/v1/task_queue.rs
@@ -94,7 +94,7 @@ pub(crate) async fn set_task_queue_config<C: CatalogStore, A: Authorizer, S: Sec
 }
 
 /// Request body for scheduling a task.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct ScheduleTaskRequest {

--- a/crates/lakekeeper/src/api/management/v1/task_queue.rs
+++ b/crates/lakekeeper/src/api/management/v1/task_queue.rs
@@ -93,29 +93,29 @@ pub(crate) async fn set_task_queue_config<C: CatalogStore, A: Authorizer, S: Sec
     Ok(())
 }
 
-/// Request body for `POST .../task-queue/{queue_name}/schedule`.
-///
-/// Schedules a single new task on the named queue for the given entity.
-/// The queue must have opted in via `TaskConfig::user_schedulable() = true`.
+/// Request body for scheduling a task.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct ScheduleTaskRequest {
-    /// The entity to schedule a task for. Today only tables and views are
-    /// accepted; warehouse- or project-scoped queues are not user-schedulable.
+    /// Entity to schedule the task for. Unsupported entity types return
+    /// `400` from the pre-check.
     pub entity: WarehouseTaskEntityId,
-    /// When the task should run. `None` means immediately (the worker picks
-    /// it up on its next poll). RFC 3339 / ISO 8601 format.
+    /// When the task should run. Omit (or pass `null`) to run on the next
+    /// worker poll. RFC 3339 / ISO 8601 format. Must be within roughly one
+    /// year of now; further-out values return
+    /// `400 ScheduledForTooFarInFuture`.
     #[serde(default)]
     #[cfg_attr(feature = "open-api", schema(example = "2026-12-31T23:59:59Z"))]
     pub scheduled_for: Option<chrono::DateTime<chrono::Utc>>,
-    /// Optional queue-specific payload. Defaults to `{}` when omitted.
-    /// Validated against the queue's payload schema.
+    /// Optional payload. Validated against the expected shape before
+    /// enqueue; a mismatch returns `400 InvalidTaskPayload`. Omit unless a
+    /// payload is documented for this endpoint.
     #[serde(default)]
     pub payload: Option<serde_json::Value>,
 }
 
-/// Response from `POST .../task-queue/{queue_name}/schedule`.
+/// Response returned on a successful schedule call.
 #[derive(Debug, Serialize)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
 #[serde(rename_all = "kebab-case")]
@@ -152,9 +152,10 @@ pub(crate) async fn get_task_queue_config<C: CatalogStore, A: Authorizer, S: Sec
 ///
 /// Callers must have performed warehouse/entity resolution and authz before
 /// invoking this. The function gates on registry membership +
-/// `user_schedulable`, then enqueues via `C::enqueue_task`. On the unique
+/// `user_schedulable`, runs the queue-specific eligibility and payload
+/// validators, then enqueues via `C::enqueue_task`. On the unique
 /// `(warehouse_id, entity_type, entity_id, queue_name)` index conflict it
-/// returns a 409.
+/// returns a 409 enriched with the existing `task_id`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn schedule_task<C: CatalogStore, A: Authorizer, S: SecretStore>(
     project_id: ArcProjectId,
@@ -162,14 +163,55 @@ pub(crate) async fn schedule_task<C: CatalogStore, A: Authorizer, S: SecretStore
     queue_name: &TaskQueueName,
     entity_id: WarehouseTaskEntityId,
     entity_name: Vec<String>,
-    table_properties: HashMap<String, String>,
+    entity_properties: HashMap<String, String>,
     request: ScheduleTaskRequest,
     context: ApiContext<State<A, C, S>>,
 ) -> Result<ScheduleTaskResponse> {
     let task_queues = &context.v1_state.registered_task_queues;
     let catalog_state = context.v1_state.catalog.clone();
 
-    // ----- queue registration + schedulability gate -----
+    let queue_name_static = resolve_schedulable_queue(task_queues, queue_name).await?;
+
+    run_eligibility_check::<C>(
+        task_queues,
+        catalog_state.clone(),
+        warehouse_id,
+        queue_name,
+        queue_name_static,
+        entity_properties,
+        entity_id,
+    )
+    .await?;
+
+    let payload = validate_and_default_payload(task_queues, queue_name, request.payload).await?;
+    let task_input = build_task_input(
+        project_id.clone(),
+        warehouse_id,
+        entity_id,
+        entity_name,
+        request.scheduled_for,
+        payload,
+    );
+
+    enqueue_or_format_conflict::<C>(
+        catalog_state,
+        warehouse_id,
+        project_id,
+        queue_name,
+        queue_name_static,
+        entity_id,
+        task_input,
+    )
+    .await
+}
+
+/// Reject the schedule call early when the queue is unknown or has not
+/// opted in via `TaskConfig::user_schedulable()`. Returns the
+/// `&'static TaskQueueName` the registry holds (needed by `enqueue_task`).
+async fn resolve_schedulable_queue(
+    task_queues: &crate::service::tasks::RegisteredTaskQueues,
+    queue_name: &TaskQueueName,
+) -> Result<&'static TaskQueueName> {
     match task_queues.is_user_schedulable(queue_name).await {
         Some(true) => {}
         Some(false) => {
@@ -198,7 +240,7 @@ pub(crate) async fn schedule_task<C: CatalogStore, A: Authorizer, S: SecretStore
         }
     }
 
-    let queue_name_static: &'static TaskQueueName = task_queues
+    task_queues
         .static_queue_name(queue_name)
         .await
         .ok_or_else(|| {
@@ -207,17 +249,28 @@ pub(crate) async fn schedule_task<C: CatalogStore, A: Authorizer, S: SecretStore
                 "QueueRaceDuringSchedule",
                 None,
             )
-        })?;
+            .into()
+        })
+}
 
-    // ----- eligibility check (queue-specific; mirrors the hook's gates) -----
-    // Fetches the warehouse's queue config and hands it, along with the
-    // entity's table properties, to `TaskConfig::check_schedule_eligibility`.
-    // Catches the "create then no-op at pickup" footgun for disabled queues
-    // / `gc.enabled=false` / per-table veto.
+/// Fetch the warehouse's queue config and hand it, with the entity's table
+/// properties, to `TaskConfig::check_schedule_eligibility`. Catches the
+/// "create then no-op at pickup" footgun for disabled queues /
+/// `gc.enabled=false` / per-table veto.
+#[allow(clippy::too_many_arguments)]
+async fn run_eligibility_check<C: CatalogStore>(
+    task_queues: &crate::service::tasks::RegisteredTaskQueues,
+    catalog_state: C::State,
+    warehouse_id: WarehouseId,
+    queue_name: &TaskQueueName,
+    queue_name_static: &'static TaskQueueName,
+    entity_properties: HashMap<String, String>,
+    entity_id: WarehouseTaskEntityId,
+) -> Result<()> {
     let raw_queue_config = C::get_task_queue_config(
         &TaskQueueConfigFilter::WarehouseId { warehouse_id },
         queue_name_static,
-        catalog_state.clone(),
+        catalog_state,
     )
     .await?
     .map_or_else(
@@ -234,66 +287,115 @@ pub(crate) async fn schedule_task<C: CatalogStore, A: Authorizer, S: SecretStore
                 None,
             )
         })?;
-    eligibility_fn(raw_queue_config, table_properties, entity_id)?;
+    eligibility_fn(raw_queue_config, entity_properties, entity_id)?;
+    Ok(())
+}
 
-    // ----- build task input -----
-    let metadata = crate::service::tasks::ScheduleTaskMetadata {
-        project_id: project_id.clone(),
-        parent_task_id: None,
-        scheduled_for: request.scheduled_for,
-        entity: crate::service::tasks::TaskEntity::EntityInWarehouse {
-            warehouse_id,
-            entity_id,
-            entity_name,
+/// Structurally validate the user-supplied payload against the queue's
+/// `TaskData` type (registered at queue-registration time). Returns the
+/// payload to forward into `TaskInput`, defaulting to `{}` when omitted —
+/// queues with an empty `TaskData` accept this, queues with required
+/// fields reject it. Fails with `400 InvalidTaskPayload` on a structural
+/// mismatch so a bad shape never reaches the worker.
+async fn validate_and_default_payload(
+    task_queues: &crate::service::tasks::RegisteredTaskQueues,
+    queue_name: &TaskQueueName,
+    payload: Option<serde_json::Value>,
+) -> Result<serde_json::Value> {
+    let payload = payload.unwrap_or_else(|| serde_json::json!({}));
+    let validator = task_queues
+        .payload_validator_fn(queue_name)
+        .await
+        .ok_or_else(|| {
+            ErrorModel::internal(
+                format!("Queue '{queue_name}' lost its payload validator between gate and check"),
+                "PayloadValidatorRaceDuringSchedule",
+                None,
+            )
+        })?;
+    validator(payload.clone()).map_err(|e| {
+        ErrorModel::bad_request(
+            format!(
+                "Payload does not match queue '{queue_name}' schema. \
+                 The schedulable queues today take no payload; omit the field \
+                 unless the queue documents a specific shape. Underlying error: {e}"
+            ),
+            "InvalidTaskPayload",
+            Some(Box::new(e)),
+        )
+    })?;
+    Ok(payload)
+}
+
+fn build_task_input(
+    project_id: ArcProjectId,
+    warehouse_id: WarehouseId,
+    entity_id: WarehouseTaskEntityId,
+    entity_name: Vec<String>,
+    scheduled_for: Option<chrono::DateTime<chrono::Utc>>,
+    payload: serde_json::Value,
+) -> crate::service::tasks::TaskInput {
+    crate::service::tasks::TaskInput {
+        task_metadata: crate::service::tasks::ScheduleTaskMetadata {
+            project_id,
+            parent_task_id: None,
+            scheduled_for,
+            entity: crate::service::tasks::TaskEntity::EntityInWarehouse {
+                warehouse_id,
+                entity_id,
+                entity_name,
+            },
         },
-    };
-    let payload = request.payload.unwrap_or_else(|| serde_json::json!({}));
-    let task_input = crate::service::tasks::TaskInput {
-        task_metadata: metadata,
         payload,
-    };
+    }
+}
 
-    // ----- enqueue (idempotent via DB unique index) -----
+/// Run the actual `enqueue_task` write and translate the result into either
+/// `200 { task_id }` or `409 TaskAlreadyActive` with the existing `task_id`
+/// in the body (best-effort lookup; misbehaving catalog logs a warning and
+/// falls back to the generic message).
+#[allow(clippy::too_many_arguments)]
+async fn enqueue_or_format_conflict<C: CatalogStore>(
+    catalog_state: C::State,
+    warehouse_id: WarehouseId,
+    project_id: ArcProjectId,
+    queue_name: &TaskQueueName,
+    queue_name_static: &'static TaskQueueName,
+    entity_id: WarehouseTaskEntityId,
+    task_input: crate::service::tasks::TaskInput,
+) -> Result<ScheduleTaskResponse> {
     let mut tx = C::Transaction::begin_write(catalog_state.clone()).await?;
     let inserted = C::enqueue_task(queue_name_static, task_input, tx.transaction()).await?;
     tx.commit().await?;
 
-    match inserted {
-        Some(task_id) => Ok(ScheduleTaskResponse { task_id }),
-        None => {
-            // Look up the existing active task so the 409 body carries the
-            // task_id; saves the operator a `task/list` round-trip when
-            // chaining to `task/control RunNow` / `RunAt`. Best-effort: if
-            // the lookup itself fails, log it and fall back to the generic
-            // message — a misbehaving catalog should not be invisible.
-            //
-            // Tiny race: the unique-index conflict could have cleared by
-            // the time the lookup runs (worker finished, task became
-            // terminal). In that case the lookup returns no rows and the
-            // 409 prints the generic message; the next schedule attempt
-            // would succeed.
-            let existing_task_id = match lookup_active_task_id::<C>(
-                warehouse_id,
-                project_id,
-                queue_name_static,
-                entity_id,
-                catalog_state,
-            )
-            .await
-            {
-                Ok(found) => found,
-                Err(e) => {
-                    tracing::warn!(
-                        warehouse_id = %warehouse_id,
-                        queue = %queue_name,
-                        "Failed to look up existing active task_id for 409 body: {e}"
-                    );
-                    None
-                }
-            };
-            Err(format_task_already_active_error(queue_name, existing_task_id).into())
-        }
+    if let Some(task_id) = inserted {
+        return Ok(ScheduleTaskResponse { task_id });
     }
+
+    // Tiny race: the conflicting row may have been moved to `task_log`
+    // between the failing insert and this lookup (worker finished). Then
+    // the lookup returns no rows and the 409 prints the generic message;
+    // the next schedule attempt would succeed.
+    let existing_task_id = match lookup_active_task_id::<C>(
+        warehouse_id,
+        project_id,
+        queue_name_static,
+        entity_id,
+        catalog_state,
+    )
+    .await
+    {
+        Ok(found) => found,
+        Err(e) => {
+            tracing::warn!(
+                warehouse_id = %warehouse_id,
+                queue = %queue_name,
+                "Failed to look up existing active task_id for 409 body: {e}"
+            );
+            None
+        }
+    };
+    Err(format_task_already_active_error(queue_name, existing_task_id).into())
 }
 
 /// Build the 409 conflict body for "schedule attempted but a task is
@@ -317,9 +419,9 @@ fn format_task_already_active_error(
     ErrorModel::conflict(msg, "TaskAlreadyActive", None)
 }
 
-/// Find the single active task_id for `(warehouse, entity, queue)`, used to
+/// Find the single active `task_id` for `(warehouse, entity, queue)`, used to
 /// enrich the 409 body returned by `schedule_task`. Best-effort: a lookup
-/// failure is downgraded to "task_id unknown" in the error message rather
+/// failure is downgraded to "`task_id` unknown" in the error message rather
 /// than failing the call.
 ///
 /// Reads from the `task` table only, which by schema holds only active
@@ -345,9 +447,7 @@ async fn lookup_active_task_id<C: CatalogStore>(
     };
 
     let entity_filter = match entity_id {
-        WarehouseTaskEntityId::Table { table_id } => {
-            WarehouseTaskEntityFilter::Table { table_id }
-        }
+        WarehouseTaskEntityId::Table { table_id } => WarehouseTaskEntityFilter::Table { table_id },
         WarehouseTaskEntityId::View { view_id } => WarehouseTaskEntityFilter::View { view_id },
     };
     let query = ListTasksRequest::builder()
@@ -376,14 +476,16 @@ mod test {
     #[test]
     fn task_already_active_error_includes_task_id_when_found() {
         let queue: TaskQueueName = "remove_orphan_files".into();
-        let id = TaskId::from(uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap());
+        let id =
+            TaskId::from(uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap());
 
         let err = format_task_already_active_error(&queue, Some(id));
 
         assert_eq!(err.code, 409);
         assert_eq!(err.r#type, "TaskAlreadyActive");
         assert!(
-            err.message.contains("task-id=550e8400-e29b-41d4-a716-446655440000"),
+            err.message
+                .contains("task-id=550e8400-e29b-41d4-a716-446655440000"),
             "409 body must include the existing task-id so operators can chain to /task/control without an extra /task/list round-trip; got: {}",
             err.message
         );

--- a/crates/lakekeeper/src/api/management/v1/task_queue.rs
+++ b/crates/lakekeeper/src/api/management/v1/task_queue.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use iceberg_ext::catalog::rest::ErrorModel;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -7,7 +9,9 @@ use crate::{
     api::{ApiContext, Result},
     service::{
         ArcProjectId, CatalogStore, CatalogTaskOps, SecretStore, State, Transaction,
-        authz::Authorizer, task_configs::TaskQueueConfigFilter, tasks::TaskQueueName,
+        authz::Authorizer,
+        task_configs::TaskQueueConfigFilter,
+        tasks::{TaskFilter, TaskId, TaskQueueName, WarehouseTaskEntityId},
     },
 };
 
@@ -89,6 +93,44 @@ pub(crate) async fn set_task_queue_config<C: CatalogStore, A: Authorizer, S: Sec
     Ok(())
 }
 
+/// Request body for `POST .../task-queue/{queue_name}/schedule`.
+///
+/// Schedules a single new task on the named queue for the given entity.
+/// The queue must have opted in via `TaskConfig::user_schedulable() = true`.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[serde(rename_all = "kebab-case")]
+pub struct ScheduleTaskRequest {
+    /// The entity to schedule a task for. Today only tables and views are
+    /// accepted; warehouse- or project-scoped queues are not user-schedulable.
+    pub entity: WarehouseTaskEntityId,
+    /// When the task should run. `None` means immediately (the worker picks
+    /// it up on its next poll). RFC 3339 / ISO 8601 format.
+    #[serde(default)]
+    #[cfg_attr(feature = "open-api", schema(example = "2026-12-31T23:59:59Z"))]
+    pub scheduled_for: Option<chrono::DateTime<chrono::Utc>>,
+    /// Optional queue-specific payload. Defaults to `{}` when omitted.
+    /// Validated against the queue's payload schema.
+    #[serde(default)]
+    pub payload: Option<serde_json::Value>,
+}
+
+/// Response from `POST .../task-queue/{queue_name}/schedule`.
+#[derive(Debug, Serialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[serde(rename_all = "kebab-case")]
+pub struct ScheduleTaskResponse {
+    /// The id of the newly scheduled task.
+    #[cfg_attr(feature = "open-api", schema(value_type = uuid::Uuid))]
+    pub task_id: TaskId,
+}
+
+impl axum::response::IntoResponse for ScheduleTaskResponse {
+    fn into_response(self) -> axum::http::Response<axum::body::Body> {
+        (http::StatusCode::OK, axum::Json(self)).into_response()
+    }
+}
+
 pub(crate) async fn get_task_queue_config<C: CatalogStore, A: Authorizer, S: SecretStore>(
     filter: &TaskQueueConfigFilter,
     queue_name: &TaskQueueName,
@@ -104,4 +146,267 @@ pub(crate) async fn get_task_queue_config<C: CatalogStore, A: Authorizer, S: Sec
             max_seconds_since_last_heartbeat: None,
         });
     Ok(config)
+}
+
+/// Schedule a single task on `queue_name` for a previously-resolved entity.
+///
+/// Callers must have performed warehouse/entity resolution and authz before
+/// invoking this. The function gates on registry membership +
+/// `user_schedulable`, then enqueues via `C::enqueue_task`. On the unique
+/// `(warehouse_id, entity_type, entity_id, queue_name)` index conflict it
+/// returns a 409.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn schedule_task<C: CatalogStore, A: Authorizer, S: SecretStore>(
+    project_id: ArcProjectId,
+    warehouse_id: WarehouseId,
+    queue_name: &TaskQueueName,
+    entity_id: WarehouseTaskEntityId,
+    entity_name: Vec<String>,
+    table_properties: HashMap<String, String>,
+    request: ScheduleTaskRequest,
+    context: ApiContext<State<A, C, S>>,
+) -> Result<ScheduleTaskResponse> {
+    let task_queues = &context.v1_state.registered_task_queues;
+    let catalog_state = context.v1_state.catalog.clone();
+
+    // ----- queue registration + schedulability gate -----
+    match task_queues.is_user_schedulable(queue_name).await {
+        Some(true) => {}
+        Some(false) => {
+            let schedulable = task_queues.user_schedulable_queue_names().await;
+            let schedulable = schedulable.iter().join(", ");
+            return Err(ErrorModel::bad_request(
+                format!(
+                    "Queue '{queue_name}' is not user-schedulable. \
+                     Schedulable queues: [{schedulable}]"
+                ),
+                "QueueNotUserSchedulable",
+                None,
+            )
+            .into());
+        }
+        None => {
+            let mut existing = task_queues.queue_names().await;
+            existing.sort_unstable();
+            let existing = existing.iter().join(", ");
+            return Err(ErrorModel::not_found(
+                format!("Queue '{queue_name}' not found. Registered queues: [{existing}]"),
+                "QueueNotFound",
+                None,
+            )
+            .into());
+        }
+    }
+
+    let queue_name_static: &'static TaskQueueName = task_queues
+        .static_queue_name(queue_name)
+        .await
+        .ok_or_else(|| {
+            ErrorModel::internal(
+                format!("Queue '{queue_name}' vanished between schedulability check and enqueue"),
+                "QueueRaceDuringSchedule",
+                None,
+            )
+        })?;
+
+    // ----- eligibility check (queue-specific; mirrors the hook's gates) -----
+    // Fetches the warehouse's queue config and hands it, along with the
+    // entity's table properties, to `TaskConfig::check_schedule_eligibility`.
+    // Catches the "create then no-op at pickup" footgun for disabled queues
+    // / `gc.enabled=false` / per-table veto.
+    let raw_queue_config = C::get_task_queue_config(
+        &TaskQueueConfigFilter::WarehouseId { warehouse_id },
+        queue_name_static,
+        catalog_state.clone(),
+    )
+    .await?
+    .map_or_else(
+        || serde_json::json!({}),
+        |resp| resp.queue_config.config.clone(),
+    );
+    let eligibility_fn = task_queues
+        .schedule_eligibility_fn(queue_name)
+        .await
+        .ok_or_else(|| {
+            ErrorModel::internal(
+                format!("Queue '{queue_name}' lost its eligibility fn between gate and check"),
+                "EligibilityFnRaceDuringSchedule",
+                None,
+            )
+        })?;
+    eligibility_fn(raw_queue_config, table_properties, entity_id)?;
+
+    // ----- build task input -----
+    let metadata = crate::service::tasks::ScheduleTaskMetadata {
+        project_id: project_id.clone(),
+        parent_task_id: None,
+        scheduled_for: request.scheduled_for,
+        entity: crate::service::tasks::TaskEntity::EntityInWarehouse {
+            warehouse_id,
+            entity_id,
+            entity_name,
+        },
+    };
+    let payload = request.payload.unwrap_or_else(|| serde_json::json!({}));
+    let task_input = crate::service::tasks::TaskInput {
+        task_metadata: metadata,
+        payload,
+    };
+
+    // ----- enqueue (idempotent via DB unique index) -----
+    let mut tx = C::Transaction::begin_write(catalog_state.clone()).await?;
+    let inserted = C::enqueue_task(queue_name_static, task_input, tx.transaction()).await?;
+    tx.commit().await?;
+
+    match inserted {
+        Some(task_id) => Ok(ScheduleTaskResponse { task_id }),
+        None => {
+            // Look up the existing active task so the 409 body carries the
+            // task_id; saves the operator a `task/list` round-trip when
+            // chaining to `task/control RunNow` / `RunAt`. Best-effort: if
+            // the lookup itself fails, log it and fall back to the generic
+            // message — a misbehaving catalog should not be invisible.
+            //
+            // Tiny race: the unique-index conflict could have cleared by
+            // the time the lookup runs (worker finished, task became
+            // terminal). In that case the lookup returns no rows and the
+            // 409 prints the generic message; the next schedule attempt
+            // would succeed.
+            let existing_task_id = match lookup_active_task_id::<C>(
+                warehouse_id,
+                project_id,
+                queue_name_static,
+                entity_id,
+                catalog_state,
+            )
+            .await
+            {
+                Ok(found) => found,
+                Err(e) => {
+                    tracing::warn!(
+                        warehouse_id = %warehouse_id,
+                        queue = %queue_name,
+                        "Failed to look up existing active task_id for 409 body: {e}"
+                    );
+                    None
+                }
+            };
+            Err(format_task_already_active_error(queue_name, existing_task_id).into())
+        }
+    }
+}
+
+/// Build the 409 conflict body for "schedule attempted but a task is
+/// already active on this `(warehouse, entity, queue)` triple". Public
+/// only so the lifecycle/unit tests can pin both shapes (with and without
+/// the looked-up `task_id`).
+fn format_task_already_active_error(
+    queue_name: &TaskQueueName,
+    existing_task_id: Option<TaskId>,
+) -> ErrorModel {
+    let msg = match existing_task_id {
+        Some(id) => format!(
+            "A task on queue '{queue_name}' is already active for this entity (task-id={id}). \
+             POST /task/control with this id to retime (run-now / run-at) or cancel it."
+        ),
+        None => format!(
+            "A task on queue '{queue_name}' is already active for this entity. \
+             Use POST /task/list to find it; POST /task/control to retime or cancel it."
+        ),
+    };
+    ErrorModel::conflict(msg, "TaskAlreadyActive", None)
+}
+
+/// Find the single active task_id for `(warehouse, entity, queue)`, used to
+/// enrich the 409 body returned by `schedule_task`. Best-effort: a lookup
+/// failure is downgraded to "task_id unknown" in the error message rather
+/// than failing the call.
+///
+/// Reads from the `task` table only, which by schema holds only active
+/// rows (status ∈ `{scheduled, running, should-stop}`; terminal rows move
+/// to `task_log` — see migration `20250523101407_tasks_store_their_state`).
+/// The explicit status filter below is therefore redundant in steady state
+/// but documents intent and protects against a future schema where
+/// `task` could hold terminal rows.
+///
+/// Tiny race: if the conflicting row transitions to terminal and is moved
+/// to `task_log` between `enqueue_task` returning `None` and this lookup
+/// running, the lookup returns `None` and the 409 falls back to the
+/// generic message. Acceptable — the next schedule attempt would succeed.
+async fn lookup_active_task_id<C: CatalogStore>(
+    warehouse_id: WarehouseId,
+    project_id: ArcProjectId,
+    queue_name: &'static TaskQueueName,
+    entity_id: WarehouseTaskEntityId,
+    catalog_state: C::State,
+) -> std::result::Result<Option<TaskId>, ErrorModel> {
+    use crate::api::management::v1::tasks::{
+        ListTasksRequest, TaskStatus, WarehouseTaskEntityFilter,
+    };
+
+    let entity_filter = match entity_id {
+        WarehouseTaskEntityId::Table { table_id } => {
+            WarehouseTaskEntityFilter::Table { table_id }
+        }
+        WarehouseTaskEntityId::View { view_id } => WarehouseTaskEntityFilter::View { view_id },
+    };
+    let query = ListTasksRequest::builder()
+        .status(Some(vec![
+            TaskStatus::Scheduled,
+            TaskStatus::Running,
+            TaskStatus::Stopping,
+        ]))
+        .queue_name(Some(vec![queue_name.clone()]))
+        .entities(Some(vec![entity_filter]))
+        .build();
+    let filter = TaskFilter::WarehouseId {
+        warehouse_id,
+        project_id,
+    };
+    let mut tx = C::Transaction::begin_read(catalog_state).await?;
+    let tasks = C::list_tasks(&filter, &query, tx.transaction()).await?;
+    tx.commit().await?;
+    Ok(tasks.tasks.into_iter().next().map(|t| t.id.task_id))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn task_already_active_error_includes_task_id_when_found() {
+        let queue: TaskQueueName = "remove_orphan_files".into();
+        let id = TaskId::from(uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap());
+
+        let err = format_task_already_active_error(&queue, Some(id));
+
+        assert_eq!(err.code, 409);
+        assert_eq!(err.r#type, "TaskAlreadyActive");
+        assert!(
+            err.message.contains("task-id=550e8400-e29b-41d4-a716-446655440000"),
+            "409 body must include the existing task-id so operators can chain to /task/control without an extra /task/list round-trip; got: {}",
+            err.message
+        );
+        assert!(err.message.contains("run-now"));
+        assert!(err.message.contains("run-at"));
+    }
+
+    #[test]
+    fn task_already_active_error_falls_back_to_generic_message_when_lookup_failed() {
+        let queue: TaskQueueName = "remove_orphan_files".into();
+
+        let err = format_task_already_active_error(&queue, None);
+
+        assert_eq!(err.code, 409);
+        assert_eq!(err.r#type, "TaskAlreadyActive");
+        // No task-id in body, but the user is still pointed at the right next step.
+        assert!(!err.message.contains("task-id="));
+        assert!(err.message.contains("POST /task/list"));
+        assert!(err.message.contains("POST /task/control"));
+    }
+
+    // Postgres-backed lifecycle coverage lives in
+    // `tasks::test::schedule_lifecycle`, which uses the
+    // `setup_and_registry` harness to register a `user_schedulable=true`
+    // test queue and exercises the full schedule → 409 → RunNow chain.
 }

--- a/crates/lakekeeper/src/api/management/v1/tasks.rs
+++ b/crates/lakekeeper/src/api/management/v1/tasks.rs
@@ -822,11 +822,14 @@ pub(crate) trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         Ok(())
     }
 
-    /// Schedule a fresh task on a queue for a specific entity (table or view).
+    /// Schedule a task on a queue for a specific entity.
     ///
-    /// Only queues that opted in via `TaskConfig::user_schedulable()` are
-    /// accepted. `AuthZ` mirrors `control_tasks`: per-entity `ControlTasks`
-    /// with a warehouse-level `ControlAllTasks` bypass.
+    /// Only queues registered with `UserScheduling::Enabled` are accepted;
+    /// others return `400 QueueNotUserSchedulable`. Per-queue eligibility
+    /// (`check_schedule_eligibility`) decides which entity types and
+    /// configurations the queue accepts. `AuthZ` mirrors `control_tasks`:
+    /// per-entity `ControlTasks` with a warehouse-level `ControlAllTasks`
+    /// bypass.
     async fn schedule_task(
         warehouse_id: WarehouseId,
         queue_name: &TaskQueueName,
@@ -842,23 +845,34 @@ pub(crate) trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // roundtrip on obviously-malformed requests.
         validate_schedule_request_static_checks(&request, chrono::Utc::now())?;
 
-        // -------------------- AUTHZ --------------------
+        // -------------------- AUTHZ + AUDIT --------------------
         let authorizer = context.v1_state.authz.clone();
         let catalog_state = context.v1_state.catalog.clone();
 
-        let (warehouse, tabular_info) = check_schedule_task_authorization::<A, C>(
+        let mut event_ctx = APIEventContext::for_warehouse(
+            Arc::new(request_metadata),
+            context.v1_state.events.clone(),
+            warehouse_id,
+            request.clone(),
+        );
+        // Path-encoded queue and the requested entity aren't part of the
+        // `schedule_task` action descriptor, so stamp them into the audit
+        // payload directly. Both authz-success and authz-failure events
+        // surface this context.
+        event_ctx.push_extra_context("queue_name", queue_name.to_string());
+        event_ctx.push_extra_context("entity_id", event_ctx.action().entity.as_uuid().to_string());
+
+        let authz_result = check_schedule_task_authorization::<A, C>(
             &authorizer,
             catalog_state.clone(),
-            &request_metadata,
+            event_ctx.request_metadata(),
             warehouse_id,
-            request.entity,
+            event_ctx.action().entity,
         )
-        .await
-        .map_err(|e| {
-            iceberg_ext::catalog::rest::IcebergErrorResponse::from(
-                crate::service::events::AuthorizationFailureSource::into_error_model(e),
-            )
-        })?;
+        .await;
+
+        let (event_ctx, (warehouse, tabular_info)) = event_ctx.emit_authz(authz_result)?;
+        let event_ctx = event_ctx.resolve(warehouse.clone());
 
         // -------------------- Business Logic --------------------
         let entity_name = tabular_info.tabular_ident().clone().into_name_parts();
@@ -871,9 +885,10 @@ pub(crate) trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             },
         };
         let entity_properties = crate::service::AuthZTabularInfo::properties(&tabular_info).clone();
+        let project_id = event_ctx.resolved().project_id.clone();
 
         crate::api::management::v1::task_queue::schedule_task::<C, A, S>(
-            warehouse.project_id.clone(),
+            project_id,
             warehouse_id,
             queue_name,
             entity_id,

--- a/crates/lakekeeper/src/api/management/v1/tasks.rs
+++ b/crates/lakekeeper/src/api/management/v1/tasks.rs
@@ -825,7 +825,7 @@ pub(crate) trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
     /// Schedule a fresh task on a queue for a specific entity (table or view).
     ///
     /// Only queues that opted in via `TaskConfig::user_schedulable()` are
-    /// accepted. AuthZ mirrors `control_tasks`: per-entity `ControlTasks`
+    /// accepted. `AuthZ` mirrors `control_tasks`: per-entity `ControlTasks`
     /// with a warehouse-level `ControlAllTasks` bypass.
     async fn schedule_task(
         warehouse_id: WarehouseId,
@@ -834,13 +834,12 @@ pub(crate) trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         context: ApiContext<State<A, C, S>>,
         request_metadata: RequestMetadata,
     ) -> Result<crate::api::management::v1::task_queue::ScheduleTaskResponse> {
-        // Pure validation runs *before* AuthZ on purpose: view-rejection
-        // and the scheduled-for clamp neither reference catalog state nor
-        // depend on caller identity. The error codes they emit
-        // (`ViewSchedulingUnsupported`, `ScheduledForTooFarInFuture`) carry
-        // no info an unauthenticated caller couldn't already infer from
-        // the published API spec, so failing fast here is safe and saves
-        // a DB roundtrip on obviously-malformed requests.
+        // Pure validation runs *before* AuthZ on purpose: the scheduled-for
+        // clamp neither references catalog state nor depends on caller
+        // identity. The error it emits (`ScheduledForTooFarInFuture`) carries
+        // no info an unauthenticated caller couldn't already infer from the
+        // published API spec, so failing fast here is safe and saves a DB
+        // roundtrip on obviously-malformed requests.
         validate_schedule_request_static_checks(&request, chrono::Utc::now())?;
 
         // -------------------- AUTHZ --------------------
@@ -871,8 +870,7 @@ pub(crate) trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 view_id: v.tabular_id,
             },
         };
-        let table_properties =
-            crate::service::AuthZTabularInfo::properties(&tabular_info).clone();
+        let entity_properties = crate::service::AuthZTabularInfo::properties(&tabular_info).clone();
 
         crate::api::management::v1::task_queue::schedule_task::<C, A, S>(
             warehouse.project_id.clone(),
@@ -880,7 +878,7 @@ pub(crate) trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             queue_name,
             entity_id,
             entity_name,
-            table_properties,
+            entity_properties,
             request,
             context,
         )
@@ -1457,12 +1455,13 @@ async fn check_control_tasks_authorization<A: Authorizer, C: CatalogStore>(
     Ok(tabular_expiration_entities)
 }
 
-/// Pure validation that runs before AuthZ on the schedule endpoint.
+/// Pure validation that runs before `AuthZ` on the schedule endpoint.
 ///
-/// Catches misuse that doesn't need a DB roundtrip:
-/// - Views aren't supported by the v1 schedulable queues; reject up-front
-///   instead of resolving the entity and then having the worker fail at
-///   pickup.
+/// Only request-shape limits live here. Entity-type rules (e.g. "this
+/// operation doesn't support views") belong in each queue's
+/// `check_schedule_eligibility` impl, since they're queue-specific.
+///
+/// What this does check:
 /// - `scheduled-for` more than `MAX_SCHEDULE_HORIZON_DAYS` in the future
 ///   would occupy the unique-index slot for `(warehouse, entity, queue)`
 ///   and silently block adaptive (hook-fired) enqueues until an admin
@@ -1473,16 +1472,6 @@ fn validate_schedule_request_static_checks(
     request: &crate::api::management::v1::task_queue::ScheduleTaskRequest,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<()> {
-    if matches!(request.entity, WarehouseTaskEntityId::View { .. }) {
-        return Err(ErrorModel::bad_request(
-            "Scheduling for views is not supported. The schedulable queues \
-             (remove_orphan_files, expire_snapshots) operate on tables only.",
-            "ViewSchedulingUnsupported",
-            None,
-        )
-        .into());
-    }
-
     if let Some(when) = request.scheduled_for {
         let max_horizon = now + chrono::Duration::days(MAX_SCHEDULE_HORIZON_DAYS);
         if when > max_horizon {
@@ -1502,7 +1491,7 @@ fn validate_schedule_request_static_checks(
     Ok(())
 }
 
-/// AuthZ + entity resolution for the schedule endpoint.
+/// `AuthZ` + entity resolution for the schedule endpoint.
 ///
 /// Resolves the warehouse and the target entity (table or view), then checks:
 /// 1. `Use` on the warehouse (must be allowed to address the warehouse at all),
@@ -1556,10 +1545,17 @@ async fn check_schedule_task_authorization<A: Authorizer, C: CatalogStore>(
     )
     .await
     .map_err(RequireTableActionError::from)?;
-    let tabular_info = tabulars.into_iter().next().ok_or_else(|| match tabular_id {
-        TabularId::Table(t) => AuthZError::from(AuthZCannotSeeTable::new_not_found(warehouse_id, t)),
-        TabularId::View(v) => AuthZError::from(AuthZCannotSeeView::new_not_found(warehouse_id, v)),
-    })?;
+    let tabular_info = tabulars
+        .into_iter()
+        .next()
+        .ok_or_else(|| match tabular_id {
+            TabularId::Table(t) => {
+                AuthZError::from(AuthZCannotSeeTable::new_not_found(warehouse_id, t))
+            }
+            TabularId::View(v) => {
+                AuthZError::from(AuthZCannotSeeView::new_not_found(warehouse_id, v))
+            }
+        })?;
 
     let namespaces =
         C::get_namespaces_by_id(warehouse_id, &[tabular_info.namespace_id()], catalog_state)
@@ -1617,17 +1613,20 @@ mod test {
     }
 
     mod schedule_static_validation {
-        use crate::api::management::v1::task_queue::ScheduleTaskRequest;
-        use crate::service::tasks::WarehouseTaskEntityId;
-        use crate::service::{TableId, ViewId};
-
         use super::super::{MAX_SCHEDULE_HORIZON_DAYS, validate_schedule_request_static_checks};
+        use crate::{
+            api::management::v1::task_queue::ScheduleTaskRequest,
+            service::{TableId, tasks::WarehouseTaskEntityId},
+        };
 
         fn now() -> chrono::DateTime<chrono::Utc> {
             "2026-05-28T00:00:00Z".parse().unwrap()
         }
 
-        fn req_with(entity: WarehouseTaskEntityId, scheduled_for: Option<chrono::DateTime<chrono::Utc>>) -> ScheduleTaskRequest {
+        fn req_with(
+            entity: WarehouseTaskEntityId,
+            scheduled_for: Option<chrono::DateTime<chrono::Utc>>,
+        ) -> ScheduleTaskRequest {
             ScheduleTaskRequest {
                 entity,
                 scheduled_for,
@@ -1647,20 +1646,6 @@ mod test {
         }
 
         #[test]
-        fn view_entity_is_rejected_with_view_scheduling_unsupported() {
-            let req = req_with(
-                WarehouseTaskEntityId::View {
-                    view_id: ViewId::new_random(),
-                },
-                None,
-            );
-            let err = validate_schedule_request_static_checks(&req, now())
-                .expect_err("view should be rejected");
-            assert_eq!(err.error.r#type, "ViewSchedulingUnsupported");
-            assert_eq!(err.error.code, 400);
-        }
-
-        #[test]
         fn far_future_scheduled_for_is_rejected() {
             let req = req_with(
                 WarehouseTaskEntityId::Table {
@@ -1674,7 +1659,9 @@ mod test {
             assert_eq!(err.error.code, 400);
             // Operator-facing message names the horizon so they know what to fix.
             assert!(
-                err.error.message.contains(&MAX_SCHEDULE_HORIZON_DAYS.to_string()),
+                err.error
+                    .message
+                    .contains(&MAX_SCHEDULE_HORIZON_DAYS.to_string()),
                 "error message should mention the horizon, got: {}",
                 err.error.message
             );
@@ -1723,26 +1710,35 @@ mod test {
     mod schedule_lifecycle {
         use std::sync::{Arc, LazyLock};
 
-        use iceberg::{spec::Schema, spec::UnboundPartitionSpec};
+        use iceberg::spec::{Schema, UnboundPartitionSpec};
         use iceberg_ext::catalog::rest::CreateTableRequest;
         use serde::{Deserialize, Serialize};
         use sqlx::PgPool;
 
-        use crate::api::iceberg::v1::tables::TablesService as _;
-        use crate::api::iceberg::v1::{DataAccess, NamespaceParameters, Prefix};
-        use crate::api::management::v1::ApiServer;
-        use crate::api::management::v1::task_queue::{ScheduleTaskRequest, ScheduleTaskResponse};
-        use crate::api::management::v1::tasks::{
-            ControlTaskAction, ControlTasksRequest, Service as _,
+        use crate::{
+            api::{
+                iceberg::v1::{
+                    DataAccess, NamespaceParameters, Prefix, tables::TablesService as _,
+                },
+                management::v1::{
+                    ApiServer,
+                    task_queue::{ScheduleTaskRequest, ScheduleTaskResponse},
+                    tasks::{ControlTaskAction, ControlTasksRequest, Service as _},
+                    warehouse::TabularDeleteProfile,
+                },
+            },
+            request_metadata::RequestMetadata,
+            server::CatalogServer,
+            service::{
+                TableId,
+                authz::AllowAllAuthorizer,
+                tasks::{
+                    QueueRegistration, QueueScope, TaskConfig, TaskData, TaskQueueName,
+                    UserScheduling, WarehouseTaskEntityId,
+                },
+            },
+            tests::{memory_io_profile, setup_with_registry},
         };
-        use crate::api::management::v1::warehouse::TabularDeleteProfile;
-        use crate::request_metadata::RequestMetadata;
-        use crate::server::CatalogServer;
-        use crate::service::authz::AllowAllAuthorizer;
-        use crate::service::tasks::{
-            QueueRegistration, QueueScope, TaskConfig, TaskQueueName, WarehouseTaskEntityId,
-        };
-        use crate::tests::{memory_io_profile, setup_with_registry};
 
         static TEST_QUEUE_NAME: LazyLock<TaskQueueName> =
             LazyLock::new(|| "test_schedulable_lifecycle".into());
@@ -1752,6 +1748,13 @@ mod test {
         /// Marker property the rejecting queue's eligibility check looks at.
         /// When set to `"reject"` on a table the queue refuses to schedule.
         const REJECTION_MARKER_PROPERTY: &str = "schedule-test.reject-me";
+
+        /// Empty payload shared by both test queues. Real queues bind their
+        /// own `TaskData`; the lifecycle test just needs the type to round-
+        /// trip through the payload validator.
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        struct TestSchedulablePayload {}
+        impl TaskData for TestSchedulablePayload {}
 
         /// Minimal user-schedulable queue for the lifecycle test. No worker
         /// is registered (`num_workers=0`) — we never want a real run, just
@@ -1766,9 +1769,6 @@ mod test {
             }
             fn max_time_since_last_heartbeat() -> chrono::Duration {
                 chrono::Duration::seconds(60)
-            }
-            fn user_schedulable() -> bool {
-                true
             }
             // `check_schedule_eligibility` uses the trait default (always Ok)
             // so the lifecycle test isn't sensitive to property setup.
@@ -1790,15 +1790,12 @@ mod test {
             fn max_time_since_last_heartbeat() -> chrono::Duration {
                 chrono::Duration::seconds(60)
             }
-            fn user_schedulable() -> bool {
-                true
-            }
             fn check_schedule_eligibility(
                 _config: &Self,
-                table_properties: &std::collections::HashMap<String, String>,
+                entity_properties: &std::collections::HashMap<String, String>,
                 _entity: WarehouseTaskEntityId,
             ) -> Result<(), iceberg_ext::catalog::rest::ErrorModel> {
-                if table_properties
+                if entity_properties
                     .get(REJECTION_MARKER_PROPERTY)
                     .map(String::as_str)
                     == Some("reject")
@@ -1815,12 +1812,16 @@ mod test {
             }
         }
 
-        async fn build_schema() -> Schema {
+        fn build_schema() -> Schema {
             use iceberg::spec::{NestedField, PrimitiveType};
             Schema::builder()
                 .with_fields(vec![
-                    NestedField::required(1, "id", iceberg::spec::Type::Primitive(PrimitiveType::Int))
-                        .into(),
+                    NestedField::required(
+                        1,
+                        "id",
+                        iceberg::spec::Type::Primitive(PrimitiveType::Int),
+                    )
+                    .into(),
                 ])
                 .build()
                 .unwrap()
@@ -1841,12 +1842,20 @@ mod test {
             .await;
 
             registry
-                .register_queue::<TestSchedulableConfig>(QueueRegistration {
-                    queue_name: &TEST_QUEUE_NAME,
-                    worker_fn: Arc::new(|_| Box::pin(async {})),
-                    num_workers: 0,
-                    scope: QueueScope::Warehouse,
-                })
+                .register_queue::<TestSchedulableConfig, TestSchedulablePayload>(
+                    QueueRegistration {
+                        queue_name: &TEST_QUEUE_NAME,
+                        worker_fn: Arc::new(|_| Box::pin(async {})),
+                        num_workers: 0,
+                        scope: QueueScope::Warehouse,
+                        #[cfg(feature = "open-api")]
+                        user_scheduling: UserScheduling::Enabled {
+                            payload_schema: None,
+                        },
+                        #[cfg(not(feature = "open-api"))]
+                        user_scheduling: UserScheduling::Enabled,
+                    },
+                )
                 .await;
 
             // ---- create namespace + table ----
@@ -1866,7 +1875,7 @@ mod test {
                 CreateTableRequest {
                     name: "tab-1".to_string(),
                     location: None,
-                    schema: build_schema().await,
+                    schema: build_schema(),
                     partition_spec: Some(UnboundPartitionSpec::builder().build()),
                     write_order: None,
                     stage_create: Some(false),
@@ -1964,12 +1973,20 @@ mod test {
             .await;
 
             registry
-                .register_queue::<RejectingSchedulableConfig>(QueueRegistration {
-                    queue_name: &REJECTING_QUEUE_NAME,
-                    worker_fn: Arc::new(|_| Box::pin(async {})),
-                    num_workers: 0,
-                    scope: QueueScope::Warehouse,
-                })
+                .register_queue::<RejectingSchedulableConfig, TestSchedulablePayload>(
+                    QueueRegistration {
+                        queue_name: &REJECTING_QUEUE_NAME,
+                        worker_fn: Arc::new(|_| Box::pin(async {})),
+                        num_workers: 0,
+                        scope: QueueScope::Warehouse,
+                        #[cfg(feature = "open-api")]
+                        user_scheduling: UserScheduling::Enabled {
+                            payload_schema: None,
+                        },
+                        #[cfg(not(feature = "open-api"))]
+                        user_scheduling: UserScheduling::Enabled,
+                    },
+                )
                 .await;
 
             let warehouse_id = warehouse.warehouse_id;
@@ -1988,7 +2005,7 @@ mod test {
                 CreateTableRequest {
                     name: "tab-reject".to_string(),
                     location: None,
-                    schema: build_schema().await,
+                    schema: build_schema(),
                     partition_spec: Some(UnboundPartitionSpec::builder().build()),
                     write_order: None,
                     stage_create: Some(false),
@@ -2034,6 +2051,316 @@ mod test {
                 "endpoint must surface the queue's error message verbatim; got: {}",
                 err.error.message
             );
+        }
+
+        /// Hitting `schedule` with a queue name that was never registered must
+        /// return `404 QueueNotFound`, not a 400 or a 500. Covers the
+        /// `resolve_schedulable_queue` `None` arm. A real table is required
+        /// because authz runs before queue resolution and would otherwise
+        /// preempt with a 404 for the entity.
+        #[sqlx::test]
+        async fn schedule_unknown_queue_returns_404(pool: PgPool) {
+            let (ctx, warehouse, _registry) = setup_with_registry(
+                pool,
+                memory_io_profile(),
+                None,
+                AllowAllAuthorizer::default(),
+                TabularDeleteProfile::Hard {},
+                None,
+                1,
+                None,
+            )
+            .await;
+            let warehouse_id = warehouse.warehouse_id;
+            let ns = crate::server::test::create_ns(
+                ctx.clone(),
+                warehouse_id.to_string(),
+                "ns1".to_string(),
+            )
+            .await;
+            let table = CatalogServer::create_table(
+                NamespaceParameters {
+                    prefix: Some(Prefix(warehouse_id.to_string())),
+                    namespace: ns.namespace.clone(),
+                },
+                CreateTableRequest {
+                    name: "t-unknown-queue".to_string(),
+                    location: None,
+                    schema: build_schema(),
+                    partition_spec: Some(UnboundPartitionSpec::builder().build()),
+                    write_order: None,
+                    stage_create: Some(false),
+                    properties: None,
+                },
+                DataAccess {
+                    vended_credentials: false,
+                    remote_signing: false,
+                },
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect("create_table should succeed");
+
+            let unknown = TaskQueueName::from("never-registered-queue");
+            let err = ApiServer::schedule_task(
+                warehouse_id,
+                &unknown,
+                ScheduleTaskRequest {
+                    entity: WarehouseTaskEntityId::Table {
+                        table_id: table.metadata.uuid().into(),
+                    },
+                    scheduled_for: None,
+                    payload: None,
+                },
+                ctx,
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect_err("unknown queue must not return 2xx");
+            assert_eq!(err.error.code, 404, "expected 404, got {err:?}");
+            assert_eq!(err.error.r#type, "QueueNotFound");
+        }
+
+        /// `tabular_purge` is registered but `user_scheduling: Disabled`.
+        /// Hitting `schedule` against it must return `400` — the destructive
+        /// purge queue must never be exposed via the schedule endpoint, even
+        /// when its name is valid.
+        #[sqlx::test]
+        async fn schedule_non_user_schedulable_queue_returns_400(pool: PgPool) {
+            use crate::service::tasks::tabular_purge_queue::QUEUE_NAME as PURGE_QUEUE_NAME;
+
+            let (ctx, warehouse, _registry) = setup_with_registry(
+                pool,
+                memory_io_profile(),
+                None,
+                AllowAllAuthorizer::default(),
+                TabularDeleteProfile::Hard {},
+                None,
+                1,
+                None,
+            )
+            .await;
+            let warehouse_id = warehouse.warehouse_id;
+            let ns = crate::server::test::create_ns(
+                ctx.clone(),
+                warehouse_id.to_string(),
+                "ns1".to_string(),
+            )
+            .await;
+            let table = CatalogServer::create_table(
+                NamespaceParameters {
+                    prefix: Some(Prefix(warehouse_id.to_string())),
+                    namespace: ns.namespace.clone(),
+                },
+                CreateTableRequest {
+                    name: "t-non-schedulable-queue".to_string(),
+                    location: None,
+                    schema: build_schema(),
+                    partition_spec: Some(UnboundPartitionSpec::builder().build()),
+                    write_order: None,
+                    stage_create: Some(false),
+                    properties: None,
+                },
+                DataAccess {
+                    vended_credentials: false,
+                    remote_signing: false,
+                },
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect("create_table should succeed");
+
+            let err = ApiServer::schedule_task(
+                warehouse_id,
+                &PURGE_QUEUE_NAME,
+                ScheduleTaskRequest {
+                    entity: WarehouseTaskEntityId::Table {
+                        table_id: table.metadata.uuid().into(),
+                    },
+                    scheduled_for: None,
+                    payload: None,
+                },
+                ctx,
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect_err("non-schedulable queue must not return 2xx");
+            assert_eq!(err.error.code, 400, "expected 400, got {err:?}");
+            assert_eq!(err.error.r#type, "QueueNotUserSchedulable");
+        }
+
+        static TYPED_PAYLOAD_QUEUE_NAME: LazyLock<TaskQueueName> =
+            LazyLock::new(|| "test_schedulable_typed_payload".into());
+
+        /// Payload type with a required field. A request that omits the field
+        /// (or passes a wrong-shape JSON) fails `serde_json::from_value::<D>`
+        /// in the registry's payload validator, which the endpoint surfaces
+        /// as `400 InvalidTaskPayload`.
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        struct RequiredFieldPayload {
+            #[allow(dead_code)]
+            must_have: String,
+        }
+        impl TaskData for RequiredFieldPayload {}
+
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+        struct TypedPayloadConfig {}
+
+        impl TaskConfig for TypedPayloadConfig {
+            fn queue_name() -> &'static TaskQueueName {
+                &TYPED_PAYLOAD_QUEUE_NAME
+            }
+            fn max_time_since_last_heartbeat() -> chrono::Duration {
+                chrono::Duration::seconds(60)
+            }
+        }
+
+        /// End-to-end pin for the payload validator: a wrong-shape JSON
+        /// payload must surface as `400 InvalidTaskPayload` from the
+        /// endpoint, not a 500 or a silently accepted task. The registry-
+        /// level unit test
+        /// (`test_payload_validator_dispatches_through_registry`) covers
+        /// the type-erased closure in isolation; this test covers the path
+        /// from `Service::schedule_task` through `validate_and_default_payload`
+        /// and back out to the caller.
+        #[sqlx::test]
+        async fn schedule_invalid_payload_returns_400(pool: PgPool) {
+            let (ctx, warehouse, registry) = setup_with_registry(
+                pool,
+                memory_io_profile(),
+                None,
+                AllowAllAuthorizer::default(),
+                TabularDeleteProfile::Hard {},
+                None,
+                1,
+                None,
+            )
+            .await;
+
+            registry
+                .register_queue::<TypedPayloadConfig, RequiredFieldPayload>(QueueRegistration {
+                    queue_name: &TYPED_PAYLOAD_QUEUE_NAME,
+                    worker_fn: Arc::new(|_| Box::pin(async {})),
+                    num_workers: 0,
+                    scope: QueueScope::Warehouse,
+                    #[cfg(feature = "open-api")]
+                    user_scheduling: UserScheduling::Enabled {
+                        payload_schema: None,
+                    },
+                    #[cfg(not(feature = "open-api"))]
+                    user_scheduling: UserScheduling::Enabled,
+                })
+                .await;
+
+            let warehouse_id = warehouse.warehouse_id;
+            let ns = crate::server::test::create_ns(
+                ctx.clone(),
+                warehouse_id.to_string(),
+                "ns1".to_string(),
+            )
+            .await;
+            let table = CatalogServer::create_table(
+                NamespaceParameters {
+                    prefix: Some(Prefix(warehouse_id.to_string())),
+                    namespace: ns.namespace.clone(),
+                },
+                CreateTableRequest {
+                    name: "t-bad-payload".to_string(),
+                    location: None,
+                    schema: build_schema(),
+                    partition_spec: Some(UnboundPartitionSpec::builder().build()),
+                    write_order: None,
+                    stage_create: Some(false),
+                    properties: None,
+                },
+                DataAccess {
+                    vended_credentials: false,
+                    remote_signing: false,
+                },
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect("create_table should succeed");
+
+            let err = ApiServer::schedule_task(
+                warehouse_id,
+                &TYPED_PAYLOAD_QUEUE_NAME,
+                ScheduleTaskRequest {
+                    entity: WarehouseTaskEntityId::Table {
+                        table_id: table.metadata.uuid().into(),
+                    },
+                    scheduled_for: None,
+                    // Wrong shape: queue expects `{ must_have: String }`,
+                    // we send a key it doesn't know about.
+                    payload: Some(serde_json::json!({"unexpected": 42})),
+                },
+                ctx,
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect_err("malformed payload must not return 2xx");
+            assert_eq!(err.error.code, 400, "expected 400, got {err:?}");
+            assert_eq!(err.error.r#type, "InvalidTaskPayload");
+        }
+
+        /// Scheduling against a non-existent `table_id` must return `404`,
+        /// not a 500 or a panic. The authz/entity-resolution step short-
+        /// circuits via `AuthZCannotSeeTable::new_not_found` before queue
+        /// resolution gets a chance to run.
+        #[sqlx::test]
+        async fn schedule_missing_table_returns_404(pool: PgPool) {
+            let (ctx, warehouse, registry) = setup_with_registry(
+                pool,
+                memory_io_profile(),
+                None,
+                AllowAllAuthorizer::default(),
+                TabularDeleteProfile::Hard {},
+                None,
+                1,
+                None,
+            )
+            .await;
+
+            // Register a schedulable queue so the failure isn't masked by
+            // queue-resolution; the table miss must still short-circuit
+            // before queue resolution runs.
+            registry
+                .register_queue::<TestSchedulableConfig, TestSchedulablePayload>(
+                    QueueRegistration {
+                        queue_name: &TEST_QUEUE_NAME,
+                        worker_fn: Arc::new(|_| Box::pin(async {})),
+                        num_workers: 0,
+                        scope: QueueScope::Warehouse,
+                        #[cfg(feature = "open-api")]
+                        user_scheduling: UserScheduling::Enabled {
+                            payload_schema: None,
+                        },
+                        #[cfg(not(feature = "open-api"))]
+                        user_scheduling: UserScheduling::Enabled,
+                    },
+                )
+                .await;
+
+            let err = ApiServer::schedule_task(
+                warehouse.warehouse_id,
+                &TEST_QUEUE_NAME,
+                ScheduleTaskRequest {
+                    entity: WarehouseTaskEntityId::Table {
+                        table_id: TableId::new_random(),
+                    },
+                    scheduled_for: None,
+                    payload: None,
+                },
+                ctx,
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect_err("missing table must not return 2xx");
+            assert_eq!(err.error.code, 404, "expected 404, got {err:?}");
         }
     }
 }

--- a/crates/lakekeeper/src/api/management/v1/tasks.rs
+++ b/crates/lakekeeper/src/api/management/v1/tasks.rs
@@ -14,9 +14,9 @@ use crate::{
     request_metadata::{ProjectIdMissing, RequestMetadata},
     service::{
         ArcProjectId, CachePolicy, CatalogNamespaceOps, CatalogStore, CatalogTabularOps,
-        CatalogTaskOps, CatalogWarehouseOps, NoWarehouseTaskError, ResolvedTask, ResolvedWarehouse,
-        Result, SecretStore, State, TableId, TabularId, TabularListFlags, TaskDetails, TaskList,
-        TaskNotFoundError, Transaction, ViewId, ViewOrTableInfo,
+        CatalogTaskOps, CatalogWarehouseOps, NamedEntity as _, NoWarehouseTaskError, ResolvedTask,
+        ResolvedWarehouse, Result, SecretStore, State, TableId, TabularId, TabularListFlags,
+        TaskDetails, TaskList, TaskNotFoundError, Transaction, ViewId, ViewOrTableInfo,
         authz::{
             AuthZCannotListAllTasks, AuthZCannotSeeTable, AuthZCannotSeeView,
             AuthZCannotUseWarehouseId, AuthZError, AuthZProjectOps, AuthZTableOps as _,
@@ -45,6 +45,25 @@ const CONTROL_TASK_PERMISSION_TABLE: CatalogTableAction = CatalogTableAction::Co
 const CONTROL_TASK_PERMISSION_VIEW: CatalogViewAction = CatalogViewAction::ControlTasks;
 const CONTROL_TASK_WAREHOUSE_PERMISSION: CatalogWarehouseAction =
     CatalogWarehouseAction::ControlAllTasks;
+// `schedule` is a form of `control` over the queue for an entity, so it
+// reuses the same per-entity / warehouse-bypass permission split.
+const SCHEDULE_TASK_PERMISSION_TABLE: CatalogTableAction = CatalogTableAction::ControlTasks;
+const SCHEDULE_TASK_PERMISSION_VIEW: CatalogViewAction = CatalogViewAction::ControlTasks;
+const SCHEDULE_TASK_WAREHOUSE_PERMISSION: CatalogWarehouseAction =
+    CatalogWarehouseAction::ControlAllTasks;
+/// Maximum number of days the `task-queue/{name}/schedule` endpoint accepts
+/// for `scheduled-for`. Bounds operator typos that would otherwise
+/// permanently occupy the active-task slot for a `(warehouse, entity, queue)`
+/// triple and silently disable adaptive (hook-fired) scheduling.
+///
+/// Independent of any queue's `maximum_interval_seconds` adaptive ceiling
+/// (e.g. ROF defaults to 90 days). An operator scheduling 200 days out is
+/// accepted here but the adaptive scheduler would never have targeted that
+/// far — the task occupies the slot until it runs or is cancelled. We
+/// don't cross-reference per-queue ceilings to keep this layer queue-agnostic;
+/// queues with shorter ceilings should document the divergence in their
+/// operator guide.
+const MAX_SCHEDULE_HORIZON_DAYS: i64 = 365;
 const CAN_GET_ALL_TASKS_DETAILS_WAREHOUSE_PERMISSION: CatalogWarehouseAction =
     CatalogWarehouseAction::GetAllTasks;
 const DEFAULT_ATTEMPTS: u16 = 5;
@@ -803,6 +822,71 @@ pub(crate) trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         Ok(())
     }
 
+    /// Schedule a fresh task on a queue for a specific entity (table or view).
+    ///
+    /// Only queues that opted in via `TaskConfig::user_schedulable()` are
+    /// accepted. AuthZ mirrors `control_tasks`: per-entity `ControlTasks`
+    /// with a warehouse-level `ControlAllTasks` bypass.
+    async fn schedule_task(
+        warehouse_id: WarehouseId,
+        queue_name: &TaskQueueName,
+        request: crate::api::management::v1::task_queue::ScheduleTaskRequest,
+        context: ApiContext<State<A, C, S>>,
+        request_metadata: RequestMetadata,
+    ) -> Result<crate::api::management::v1::task_queue::ScheduleTaskResponse> {
+        // Pure validation runs *before* AuthZ on purpose: view-rejection
+        // and the scheduled-for clamp neither reference catalog state nor
+        // depend on caller identity. The error codes they emit
+        // (`ViewSchedulingUnsupported`, `ScheduledForTooFarInFuture`) carry
+        // no info an unauthenticated caller couldn't already infer from
+        // the published API spec, so failing fast here is safe and saves
+        // a DB roundtrip on obviously-malformed requests.
+        validate_schedule_request_static_checks(&request, chrono::Utc::now())?;
+
+        // -------------------- AUTHZ --------------------
+        let authorizer = context.v1_state.authz.clone();
+        let catalog_state = context.v1_state.catalog.clone();
+
+        let (warehouse, tabular_info) = check_schedule_task_authorization::<A, C>(
+            &authorizer,
+            catalog_state.clone(),
+            &request_metadata,
+            warehouse_id,
+            request.entity,
+        )
+        .await
+        .map_err(|e| {
+            iceberg_ext::catalog::rest::IcebergErrorResponse::from(
+                crate::service::events::AuthorizationFailureSource::into_error_model(e),
+            )
+        })?;
+
+        // -------------------- Business Logic --------------------
+        let entity_name = tabular_info.tabular_ident().clone().into_name_parts();
+        let entity_id = match &tabular_info {
+            ViewOrTableInfo::Table(t) => WarehouseTaskEntityId::Table {
+                table_id: t.tabular_id,
+            },
+            ViewOrTableInfo::View(v) => WarehouseTaskEntityId::View {
+                view_id: v.tabular_id,
+            },
+        };
+        let table_properties =
+            crate::service::AuthZTabularInfo::properties(&tabular_info).clone();
+
+        crate::api::management::v1::task_queue::schedule_task::<C, A, S>(
+            warehouse.project_id.clone(),
+            warehouse_id,
+            queue_name,
+            entity_id,
+            entity_name,
+            table_properties,
+            request,
+            context,
+        )
+        .await
+    }
+
     async fn list_project_tasks(
         query: ListProjectTasksRequest,
         context: ApiContext<State<A, C, S>>,
@@ -1373,6 +1457,132 @@ async fn check_control_tasks_authorization<A: Authorizer, C: CatalogStore>(
     Ok(tabular_expiration_entities)
 }
 
+/// Pure validation that runs before AuthZ on the schedule endpoint.
+///
+/// Catches misuse that doesn't need a DB roundtrip:
+/// - Views aren't supported by the v1 schedulable queues; reject up-front
+///   instead of resolving the entity and then having the worker fail at
+///   pickup.
+/// - `scheduled-for` more than `MAX_SCHEDULE_HORIZON_DAYS` in the future
+///   would occupy the unique-index slot for `(warehouse, entity, queue)`
+///   and silently block adaptive (hook-fired) enqueues until an admin
+///   notices and cancels the row. Most often a year-typo.
+///
+/// `now` is passed in so tests get deterministic horizon checks.
+fn validate_schedule_request_static_checks(
+    request: &crate::api::management::v1::task_queue::ScheduleTaskRequest,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<()> {
+    if matches!(request.entity, WarehouseTaskEntityId::View { .. }) {
+        return Err(ErrorModel::bad_request(
+            "Scheduling for views is not supported. The schedulable queues \
+             (remove_orphan_files, expire_snapshots) operate on tables only.",
+            "ViewSchedulingUnsupported",
+            None,
+        )
+        .into());
+    }
+
+    if let Some(when) = request.scheduled_for {
+        let max_horizon = now + chrono::Duration::days(MAX_SCHEDULE_HORIZON_DAYS);
+        if when > max_horizon {
+            return Err(ErrorModel::bad_request(
+                format!(
+                    "`scheduled-for` cannot be more than {MAX_SCHEDULE_HORIZON_DAYS} days \
+                     in the future (got {when}). Use a closer timestamp or omit the field \
+                     to run on the next worker poll."
+                ),
+                "ScheduledForTooFarInFuture",
+                None,
+            )
+            .into());
+        }
+    }
+
+    Ok(())
+}
+
+/// AuthZ + entity resolution for the schedule endpoint.
+///
+/// Resolves the warehouse and the target entity (table or view), then checks:
+/// 1. `Use` on the warehouse (must be allowed to address the warehouse at all),
+/// 2. Either `ControlAllTasks` on the warehouse OR `ControlTasks` on the entity.
+///
+/// Returns `AuthZError` on any failure path; callers convert to a public
+/// response (same pattern as `check_control_tasks_authorization`).
+async fn check_schedule_task_authorization<A: Authorizer, C: CatalogStore>(
+    authorizer: &A,
+    catalog_state: C::State,
+    request_metadata: &RequestMetadata,
+    warehouse_id: WarehouseId,
+    entity: WarehouseTaskEntityId,
+) -> Result<(Arc<ResolvedWarehouse>, ViewOrTableInfo), AuthZError> {
+    let warehouse = C::get_active_warehouse_by_id(warehouse_id, catalog_state.clone()).await;
+    let warehouse = authorizer.require_warehouse_presence(warehouse_id, warehouse)?;
+
+    let [authz_can_use, authz_control_all] = authorizer
+        .are_allowed_warehouse_actions_arr(
+            request_metadata,
+            None,
+            &[
+                (&warehouse, CatalogWarehouseAction::Use),
+                (&warehouse, SCHEDULE_TASK_WAREHOUSE_PERMISSION),
+            ],
+        )
+        .await?
+        .into_inner();
+
+    if !authz_can_use {
+        return Err(AuthZCannotUseWarehouseId::new_access_denied(warehouse_id).into());
+    }
+
+    // Resolve the entity regardless of authz_control_all so we can build
+    // `entity_name` for the task metadata, and so that scheduling for a
+    // non-existent table returns 404 (via AuthZCannotSee*) instead of
+    // creating an orphaned task row.
+    let tabular_id = match entity {
+        WarehouseTaskEntityId::Table { table_id } => TabularId::Table(table_id),
+        WarehouseTaskEntityId::View { view_id } => TabularId::View(view_id),
+    };
+    // Restrict to active entities only. Soft-deleted or staged tabulars
+    // can't be a meaningful schedule target — the worker would either skip
+    // or fail at pickup. Returning "not found" here matches what the
+    // operator would expect anyway.
+    let tabulars = C::get_tabular_infos_by_id(
+        warehouse_id,
+        &[tabular_id],
+        TabularListFlags::active(),
+        catalog_state.clone(),
+    )
+    .await
+    .map_err(RequireTableActionError::from)?;
+    let tabular_info = tabulars.into_iter().next().ok_or_else(|| match tabular_id {
+        TabularId::Table(t) => AuthZError::from(AuthZCannotSeeTable::new_not_found(warehouse_id, t)),
+        TabularId::View(v) => AuthZError::from(AuthZCannotSeeView::new_not_found(warehouse_id, v)),
+    })?;
+
+    let namespaces =
+        C::get_namespaces_by_id(warehouse_id, &[tabular_info.namespace_id()], catalog_state)
+            .await
+            .map_err(RequireNamespaceActionError::from)?;
+
+    if !authz_control_all {
+        let action = (
+            require_namespace_for_tabular(&namespaces, &tabular_info)?,
+            tabular_info.as_action_request(
+                SCHEDULE_TASK_PERMISSION_VIEW,
+                SCHEDULE_TASK_PERMISSION_TABLE,
+                None,
+            ),
+        );
+        authorizer
+            .require_tabular_actions(request_metadata, &warehouse, &namespaces, &[action])
+            .await?;
+    }
+
+    Ok((warehouse, tabular_info))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1404,5 +1614,426 @@ mod test {
         let deserialized: ControlTasksRequest =
             serde_json::from_value(request_json).expect("Failed to deserialize");
         assert_eq!(deserialized, request);
+    }
+
+    mod schedule_static_validation {
+        use crate::api::management::v1::task_queue::ScheduleTaskRequest;
+        use crate::service::tasks::WarehouseTaskEntityId;
+        use crate::service::{TableId, ViewId};
+
+        use super::super::{MAX_SCHEDULE_HORIZON_DAYS, validate_schedule_request_static_checks};
+
+        fn now() -> chrono::DateTime<chrono::Utc> {
+            "2026-05-28T00:00:00Z".parse().unwrap()
+        }
+
+        fn req_with(entity: WarehouseTaskEntityId, scheduled_for: Option<chrono::DateTime<chrono::Utc>>) -> ScheduleTaskRequest {
+            ScheduleTaskRequest {
+                entity,
+                scheduled_for,
+                payload: None,
+            }
+        }
+
+        #[test]
+        fn table_with_no_scheduled_for_passes() {
+            let req = req_with(
+                WarehouseTaskEntityId::Table {
+                    table_id: TableId::new_random(),
+                },
+                None,
+            );
+            assert!(validate_schedule_request_static_checks(&req, now()).is_ok());
+        }
+
+        #[test]
+        fn view_entity_is_rejected_with_view_scheduling_unsupported() {
+            let req = req_with(
+                WarehouseTaskEntityId::View {
+                    view_id: ViewId::new_random(),
+                },
+                None,
+            );
+            let err = validate_schedule_request_static_checks(&req, now())
+                .expect_err("view should be rejected");
+            assert_eq!(err.error.r#type, "ViewSchedulingUnsupported");
+            assert_eq!(err.error.code, 400);
+        }
+
+        #[test]
+        fn far_future_scheduled_for_is_rejected() {
+            let req = req_with(
+                WarehouseTaskEntityId::Table {
+                    table_id: TableId::new_random(),
+                },
+                Some(now() + chrono::Duration::days(MAX_SCHEDULE_HORIZON_DAYS + 1)),
+            );
+            let err = validate_schedule_request_static_checks(&req, now())
+                .expect_err("year-2099-style scheduled-for should be rejected");
+            assert_eq!(err.error.r#type, "ScheduledForTooFarInFuture");
+            assert_eq!(err.error.code, 400);
+            // Operator-facing message names the horizon so they know what to fix.
+            assert!(
+                err.error.message.contains(&MAX_SCHEDULE_HORIZON_DAYS.to_string()),
+                "error message should mention the horizon, got: {}",
+                err.error.message
+            );
+        }
+
+        #[test]
+        fn scheduled_for_at_exact_horizon_is_accepted() {
+            // Boundary: == max is allowed; > max is rejected.
+            let req = req_with(
+                WarehouseTaskEntityId::Table {
+                    table_id: TableId::new_random(),
+                },
+                Some(now() + chrono::Duration::days(MAX_SCHEDULE_HORIZON_DAYS)),
+            );
+            assert!(validate_schedule_request_static_checks(&req, now()).is_ok());
+        }
+
+        #[test]
+        fn past_scheduled_for_is_accepted() {
+            // "Past" timestamps are intentionally allowed — operators sometimes
+            // pass `now - small_delta` racily; the worker picks it up on its
+            // next poll. We only bound the future side.
+            let req = req_with(
+                WarehouseTaskEntityId::Table {
+                    table_id: TableId::new_random(),
+                },
+                Some(now() - chrono::Duration::days(30)),
+            );
+            assert!(validate_schedule_request_static_checks(&req, now()).is_ok());
+        }
+    }
+
+    /// Postgres-backed lifecycle of the schedule endpoint.
+    ///
+    /// Covers the chain that the in-process unit tests can't:
+    ///   1. First schedule → `200 { task_id }`
+    ///   2. Second schedule → `409` with `task-id=<first>` in the body
+    ///      (proves the conflict-lookup path through
+    ///      `lookup_active_task_id` + `format_task_already_active_error`)
+    ///   3. `task/control RunNow` on the existing id → `204`
+    ///
+    /// Uses the `setup_and_registry` test helper to register a custom
+    /// `user_schedulable = true` test queue so the OSS endpoint has
+    /// something to dispatch to without enabling enterprise queues.
+    #[cfg(feature = "open-api")]
+    mod schedule_lifecycle {
+        use std::sync::{Arc, LazyLock};
+
+        use iceberg::{spec::Schema, spec::UnboundPartitionSpec};
+        use iceberg_ext::catalog::rest::CreateTableRequest;
+        use serde::{Deserialize, Serialize};
+        use sqlx::PgPool;
+
+        use crate::api::iceberg::v1::tables::TablesService as _;
+        use crate::api::iceberg::v1::{DataAccess, NamespaceParameters, Prefix};
+        use crate::api::management::v1::ApiServer;
+        use crate::api::management::v1::task_queue::{ScheduleTaskRequest, ScheduleTaskResponse};
+        use crate::api::management::v1::tasks::{
+            ControlTaskAction, ControlTasksRequest, Service as _,
+        };
+        use crate::api::management::v1::warehouse::TabularDeleteProfile;
+        use crate::request_metadata::RequestMetadata;
+        use crate::server::CatalogServer;
+        use crate::service::authz::AllowAllAuthorizer;
+        use crate::service::tasks::{
+            QueueRegistration, QueueScope, TaskConfig, TaskQueueName, WarehouseTaskEntityId,
+        };
+        use crate::tests::{memory_io_profile, setup_with_registry};
+
+        static TEST_QUEUE_NAME: LazyLock<TaskQueueName> =
+            LazyLock::new(|| "test_schedulable_lifecycle".into());
+        static REJECTING_QUEUE_NAME: LazyLock<TaskQueueName> =
+            LazyLock::new(|| "test_schedulable_rejecting".into());
+
+        /// Marker property the rejecting queue's eligibility check looks at.
+        /// When set to `"reject"` on a table the queue refuses to schedule.
+        const REJECTION_MARKER_PROPERTY: &str = "schedule-test.reject-me";
+
+        /// Minimal user-schedulable queue for the lifecycle test. No worker
+        /// is registered (`num_workers=0`) — we never want a real run, just
+        /// the schedule/conflict/control round-trips on the catalog row.
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+        struct TestSchedulableConfig {}
+
+        impl TaskConfig for TestSchedulableConfig {
+            fn queue_name() -> &'static TaskQueueName {
+                &TEST_QUEUE_NAME
+            }
+            fn max_time_since_last_heartbeat() -> chrono::Duration {
+                chrono::Duration::seconds(60)
+            }
+            fn user_schedulable() -> bool {
+                true
+            }
+            // `check_schedule_eligibility` uses the trait default (always Ok)
+            // so the lifecycle test isn't sensitive to property setup.
+        }
+
+        /// User-schedulable queue whose `check_schedule_eligibility` rejects
+        /// any table that carries the `REJECTION_MARKER_PROPERTY`. Used to
+        /// pin the "endpoint surfaces the eligibility-fn 400 verbatim"
+        /// contract that the registry-level unit test cannot exercise
+        /// end-to-end.
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+        struct RejectingSchedulableConfig {}
+
+        impl TaskConfig for RejectingSchedulableConfig {
+            fn queue_name() -> &'static TaskQueueName {
+                &REJECTING_QUEUE_NAME
+            }
+            fn max_time_since_last_heartbeat() -> chrono::Duration {
+                chrono::Duration::seconds(60)
+            }
+            fn user_schedulable() -> bool {
+                true
+            }
+            fn check_schedule_eligibility(
+                _config: &Self,
+                table_properties: &std::collections::HashMap<String, String>,
+                _entity: WarehouseTaskEntityId,
+            ) -> Result<(), iceberg_ext::catalog::rest::ErrorModel> {
+                if table_properties
+                    .get(REJECTION_MARKER_PROPERTY)
+                    .map(String::as_str)
+                    == Some("reject")
+                {
+                    return Err(iceberg_ext::catalog::rest::ErrorModel::bad_request(
+                        format!(
+                            "rejected by test eligibility fn: {REJECTION_MARKER_PROPERTY}=reject"
+                        ),
+                        "RejectedByTestEligibility",
+                        None,
+                    ));
+                }
+                Ok(())
+            }
+        }
+
+        async fn build_schema() -> Schema {
+            use iceberg::spec::{NestedField, PrimitiveType};
+            Schema::builder()
+                .with_fields(vec![
+                    NestedField::required(1, "id", iceberg::spec::Type::Primitive(PrimitiveType::Int))
+                        .into(),
+                ])
+                .build()
+                .unwrap()
+        }
+
+        #[sqlx::test]
+        async fn schedule_then_409_then_runnow(pool: PgPool) {
+            let (ctx, warehouse, registry) = setup_with_registry(
+                pool,
+                memory_io_profile(),
+                None,
+                AllowAllAuthorizer::default(),
+                TabularDeleteProfile::Hard {},
+                None,
+                1,
+                None,
+            )
+            .await;
+
+            registry
+                .register_queue::<TestSchedulableConfig>(QueueRegistration {
+                    queue_name: &TEST_QUEUE_NAME,
+                    worker_fn: Arc::new(|_| Box::pin(async {})),
+                    num_workers: 0,
+                    scope: QueueScope::Warehouse,
+                })
+                .await;
+
+            // ---- create namespace + table ----
+            let warehouse_id = warehouse.warehouse_id;
+            let ns = crate::server::test::create_ns(
+                ctx.clone(),
+                warehouse_id.to_string(),
+                "ns1".to_string(),
+            )
+            .await;
+            let ns_params = NamespaceParameters {
+                prefix: Some(Prefix(warehouse_id.to_string())),
+                namespace: ns.namespace.clone(),
+            };
+            let table = CatalogServer::create_table(
+                ns_params,
+                CreateTableRequest {
+                    name: "tab-1".to_string(),
+                    location: None,
+                    schema: build_schema().await,
+                    partition_spec: Some(UnboundPartitionSpec::builder().build()),
+                    write_order: None,
+                    stage_create: Some(false),
+                    properties: None,
+                },
+                DataAccess {
+                    vended_credentials: false,
+                    remote_signing: false,
+                },
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .unwrap();
+            let table_id = table.metadata.uuid();
+
+            // ---- 1) First schedule call: 200 + fresh task_id ----
+            let resp: ScheduleTaskResponse = ApiServer::schedule_task(
+                warehouse_id,
+                &TEST_QUEUE_NAME,
+                ScheduleTaskRequest {
+                    entity: WarehouseTaskEntityId::Table {
+                        table_id: table_id.into(),
+                    },
+                    scheduled_for: None,
+                    payload: None,
+                },
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect("first schedule call should succeed");
+            let first_task_id = resp.task_id;
+
+            // ---- 2) Second schedule call: 409 with the first task_id in body ----
+            let err = ApiServer::schedule_task(
+                warehouse_id,
+                &TEST_QUEUE_NAME,
+                ScheduleTaskRequest {
+                    entity: WarehouseTaskEntityId::Table {
+                        table_id: table_id.into(),
+                    },
+                    scheduled_for: None,
+                    payload: None,
+                },
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect_err("second schedule call must hit the unique index");
+            assert_eq!(err.error.code, 409, "expected 409 Conflict, got {err:?}");
+            assert_eq!(err.error.r#type, "TaskAlreadyActive");
+            let id_str = first_task_id.to_string();
+            assert!(
+                err.error.message.contains(&id_str),
+                "409 body must include the existing task-id ({id_str}); got: {}",
+                err.error.message
+            );
+
+            // ---- 3) RunNow on the existing id: succeeds, no error ----
+            ApiServer::control_tasks(
+                warehouse_id,
+                ControlTasksRequest {
+                    action: ControlTaskAction::RunNow,
+                    task_ids: vec![first_task_id],
+                },
+                ctx,
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect("control_tasks RunNow on the existing task should succeed");
+        }
+
+        /// End-to-end pin for the eligibility gate: when a queue's
+        /// `check_schedule_eligibility` returns `Err`, the schedule
+        /// endpoint must surface the same error verbatim — not the
+        /// 409 conflict path, not a generic 500, not a swallowed 200.
+        /// The registry-level dispatch test
+        /// (`test_check_schedule_eligibility_dispatches_through_registry`)
+        /// covers the type-erased closure in isolation; this test covers
+        /// the path from `Service::schedule_task` through the catalog
+        /// fetch into the eligibility fn and back out to the caller.
+        #[sqlx::test]
+        async fn schedule_eligibility_rejection_surfaces_as_400(pool: PgPool) {
+            let (ctx, warehouse, registry) = setup_with_registry(
+                pool,
+                memory_io_profile(),
+                None,
+                AllowAllAuthorizer::default(),
+                TabularDeleteProfile::Hard {},
+                None,
+                1,
+                None,
+            )
+            .await;
+
+            registry
+                .register_queue::<RejectingSchedulableConfig>(QueueRegistration {
+                    queue_name: &REJECTING_QUEUE_NAME,
+                    worker_fn: Arc::new(|_| Box::pin(async {})),
+                    num_workers: 0,
+                    scope: QueueScope::Warehouse,
+                })
+                .await;
+
+            let warehouse_id = warehouse.warehouse_id;
+            let ns = crate::server::test::create_ns(
+                ctx.clone(),
+                warehouse_id.to_string(),
+                "ns1".to_string(),
+            )
+            .await;
+            let ns_params = NamespaceParameters {
+                prefix: Some(Prefix(warehouse_id.to_string())),
+                namespace: ns.namespace.clone(),
+            };
+            let table = CatalogServer::create_table(
+                ns_params,
+                CreateTableRequest {
+                    name: "tab-reject".to_string(),
+                    location: None,
+                    schema: build_schema().await,
+                    partition_spec: Some(UnboundPartitionSpec::builder().build()),
+                    write_order: None,
+                    stage_create: Some(false),
+                    properties: Some(std::collections::HashMap::from([(
+                        REJECTION_MARKER_PROPERTY.to_string(),
+                        "reject".to_string(),
+                    )])),
+                },
+                DataAccess {
+                    vended_credentials: false,
+                    remote_signing: false,
+                },
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect("create_table should succeed");
+            let table_id = table.metadata.uuid();
+
+            let err = ApiServer::schedule_task(
+                warehouse_id,
+                &REJECTING_QUEUE_NAME,
+                ScheduleTaskRequest {
+                    entity: WarehouseTaskEntityId::Table {
+                        table_id: table_id.into(),
+                    },
+                    scheduled_for: None,
+                    payload: None,
+                },
+                ctx,
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect_err("eligibility rejection must surface as an error from the endpoint");
+
+            assert_eq!(err.error.code, 400, "expected 400, got {err:?}");
+            assert_eq!(
+                err.error.r#type, "RejectedByTestEligibility",
+                "endpoint must surface the queue's error code verbatim, got {err:?}"
+            );
+            assert!(
+                err.error.message.contains(REJECTION_MARKER_PROPERTY),
+                "endpoint must surface the queue's error message verbatim; got: {}",
+                err.error.message
+            );
+        }
     }
 }

--- a/crates/lakekeeper/src/service/events/context.rs
+++ b/crates/lakekeeper/src/service/events/context.rs
@@ -14,6 +14,7 @@ use crate::{
                 CatalogActionCheckItem, CatalogActionCheckOperation, NamespaceIdentOrUuid,
                 TabularIdentOrUuid,
             },
+            task_queue::ScheduleTaskRequest,
             tasks::{ControlTasksRequest, ListTasksRequest},
         },
     },
@@ -521,6 +522,16 @@ impl APIEventActions for ControlTasksRequest {
         vec![
             ActionDescriptor::builder()
                 .action_name("control_tasks")
+                .build(),
+        ]
+    }
+}
+
+impl APIEventActions for ScheduleTaskRequest {
+    fn event_actions(&self) -> Vec<ActionDescriptor> {
+        vec![
+            ActionDescriptor::builder()
+                .action_name("schedule_task")
                 .build(),
         ]
     }

--- a/crates/lakekeeper/src/service/tasks/mod.rs
+++ b/crates/lakekeeper/src/service/tasks/mod.rs
@@ -22,8 +22,8 @@ mod task_queues_runner;
 mod task_registry;
 pub use task_queues_runner::{TaskQueueWorkerFn, TaskQueuesRunner};
 pub use task_registry::{
-    QueueApiConfig, QueueRegistration, QueueScope, RegisteredTaskQueues, TaskQueueRegistry,
-    ValidatorFn,
+    QueueApiConfig, QueueRegistration, QueueScope, RegisteredTaskQueues, ScheduleEligibilityFn,
+    TaskQueueRegistry, ValidatorFn,
 };
 pub mod tabular_expiration_queue;
 pub mod tabular_purge_queue;
@@ -53,6 +53,39 @@ pub static BUILT_IN_PROJECT_API_CONFIGS: std::sync::LazyLock<Vec<QueueApiConfig>
 pub static BUILT_IN_DEPENDENT_SCHEMAS: std::sync::LazyLock<
     HashMap<String, utoipa::openapi::RefOr<utoipa::openapi::Schema>>,
 > = std::sync::LazyLock::new(HashMap::new);
+
+#[cfg(all(test, feature = "open-api"))]
+mod built_in_schedulable_pin_test {
+    use super::{BUILT_IN_API_CONFIGS, BUILT_IN_PROJECT_API_CONFIGS};
+
+    /// Pin the set of OSS queues that opt in to `task-queue/{name}/schedule`.
+    ///
+    /// **OSS has zero schedulable queues.** Destructive (`tabular_purge`) and
+    /// lifecycle-managed (`tabular_expiration`) queues intentionally stay
+    /// opted out so they can't be enqueued out-of-band; `task_log_cleanup` is
+    /// project-scoped and not meaningful to trigger manually.
+    ///
+    /// Enterprise has its own pin test for `expire_snapshots` and
+    /// `remove_orphan_files`. If a new OSS queue legitimately needs to be
+    /// manually schedulable, update both this list and the operator docs in
+    /// the same PR so the decision is reviewed.
+    #[test]
+    fn oss_schedulable_queues_pin() {
+        let mut names: Vec<&str> = BUILT_IN_API_CONFIGS
+            .iter()
+            .chain(BUILT_IN_PROJECT_API_CONFIGS.iter())
+            .filter(|c| c.user_schedulable)
+            .map(|c| c.queue_name.as_str())
+            .collect();
+        names.sort_unstable();
+        let expected: Vec<&str> = vec![];
+        assert_eq!(
+            names, expected,
+            "OSS schedulable-queue set changed; review the security \
+             implications and update the operator docs."
+        );
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(transparent)]
@@ -144,6 +177,42 @@ pub trait TaskConfig:
     }
 
     fn queue_name() -> &'static TaskQueueName;
+
+    /// Whether operators can directly schedule a task on this queue for a
+    /// single entity via
+    /// `POST /management/v1/warehouse/{warehouse_id}/task-queue/{queue_name}/schedule`.
+    ///
+    /// Default `false` — opt-in. Destructive or lifecycle-managed queues
+    /// (e.g. `tabular_purge`, `tabular_expiration`) must stay opted out so
+    /// they cannot be enqueued out-of-band.
+    #[must_use]
+    fn user_schedulable() -> bool {
+        false
+    }
+
+    /// Decide whether a manual schedule call is acceptable right now.
+    ///
+    /// Called by the `task-queue/{name}/schedule` endpoint after authz, with
+    /// the queue's current config and the target entity's properties already
+    /// fetched. Sync + pure: given inputs, decide.
+    ///
+    /// Return `Err(ErrorModel)` (typically `400 Bad Request`) when the
+    /// configuration is one the worker would skip at pickup — e.g.
+    /// `gc.enabled=false` on the table, per-table opt-out property set, or
+    /// the queue's master switch is off at the warehouse. Failing here
+    /// surfaces the misconfiguration to the operator instead of creating a
+    /// no-op task they have to discover via `task/list`.
+    ///
+    /// Default: always eligible. Queues whose workers have skip-at-pickup
+    /// conditions should override.
+    #[allow(unused_variables)]
+    fn check_schedule_eligibility(
+        config: &Self,
+        table_properties: &std::collections::HashMap<String, String>,
+        entity: WarehouseTaskEntityId,
+    ) -> Result<(), ErrorModel> {
+        Ok(())
+    }
 }
 
 #[cfg(not(feature = "open-api"))]
@@ -157,6 +226,22 @@ pub trait TaskConfig: Serialize + DeserializeOwned + Clone + Send + Sync {
     }
 
     fn queue_name() -> &'static TaskQueueName;
+
+    /// See the `open-api`-enabled trait for full documentation.
+    #[must_use]
+    fn user_schedulable() -> bool {
+        false
+    }
+
+    /// See the `open-api`-enabled trait for full documentation.
+    #[allow(unused_variables)]
+    fn check_schedule_eligibility(
+        config: &Self,
+        table_properties: &std::collections::HashMap<String, String>,
+        entity: WarehouseTaskEntityId,
+    ) -> Result<(), ErrorModel> {
+        Ok(())
+    }
 }
 
 /// Task Payload

--- a/crates/lakekeeper/src/service/tasks/mod.rs
+++ b/crates/lakekeeper/src/service/tasks/mod.rs
@@ -23,7 +23,7 @@ mod task_registry;
 pub use task_queues_runner::{TaskQueueWorkerFn, TaskQueuesRunner};
 pub use task_registry::{
     QueueApiConfig, QueueRegistration, QueueScope, RegisteredTaskQueues, ScheduleEligibilityFn,
-    TaskQueueRegistry, ValidatorFn,
+    TaskQueueRegistry, UserScheduling, ValidatorFn,
 };
 pub mod tabular_expiration_queue;
 pub mod tabular_purge_queue;
@@ -57,6 +57,7 @@ pub static BUILT_IN_DEPENDENT_SCHEMAS: std::sync::LazyLock<
 #[cfg(all(test, feature = "open-api"))]
 mod built_in_schedulable_pin_test {
     use super::{BUILT_IN_API_CONFIGS, BUILT_IN_PROJECT_API_CONFIGS};
+    use crate::service::tasks::{tabular_expiration_queue, tabular_purge_queue};
 
     /// Pin the set of OSS queues that opt in to `task-queue/{name}/schedule`.
     ///
@@ -74,7 +75,7 @@ mod built_in_schedulable_pin_test {
         let mut names: Vec<&str> = BUILT_IN_API_CONFIGS
             .iter()
             .chain(BUILT_IN_PROJECT_API_CONFIGS.iter())
-            .filter(|c| c.user_schedulable)
+            .filter(|c| c.user_scheduling.is_enabled())
             .map(|c| c.queue_name.as_str())
             .collect();
         names.sort_unstable();
@@ -83,6 +84,23 @@ mod built_in_schedulable_pin_test {
             names, expected,
             "OSS schedulable-queue set changed; review the security \
              implications and update the operator docs."
+        );
+    }
+
+    /// Belt-and-braces: explicitly assert the two queues we must never expose
+    /// stay `Disabled`. If a future refactor reshuffles `BUILT_IN_API_CONFIGS`
+    /// and the aggregate above goes stale, this catches the regression by name.
+    #[test]
+    fn tabular_purge_and_expiration_are_never_schedulable() {
+        assert!(
+            !tabular_purge_queue::API_CONFIG.user_scheduling.is_enabled(),
+            "tabular_purge is destructive and must never be user-schedulable"
+        );
+        assert!(
+            !tabular_expiration_queue::API_CONFIG
+                .user_scheduling
+                .is_enabled(),
+            "tabular_expiration is lifecycle-managed and must never be user-schedulable"
         );
     }
 }
@@ -178,23 +196,16 @@ pub trait TaskConfig:
 
     fn queue_name() -> &'static TaskQueueName;
 
-    /// Whether operators can directly schedule a task on this queue for a
-    /// single entity via
-    /// `POST /management/v1/warehouse/{warehouse_id}/task-queue/{queue_name}/schedule`.
-    ///
-    /// Default `false` — opt-in. Destructive or lifecycle-managed queues
-    /// (e.g. `tabular_purge`, `tabular_expiration`) must stay opted out so
-    /// they cannot be enqueued out-of-band.
-    #[must_use]
-    fn user_schedulable() -> bool {
-        false
-    }
-
     /// Decide whether a manual schedule call is acceptable right now.
     ///
     /// Called by the `task-queue/{name}/schedule` endpoint after authz, with
     /// the queue's current config and the target entity's properties already
     /// fetched. Sync + pure: given inputs, decide.
+    ///
+    /// `entity_properties` carries the properties of whichever entity the
+    /// caller targeted — table OR view. Implementors that only support one
+    /// entity kind must match on `entity` and reject the unsupported variant
+    /// explicitly; the framework no longer rejects views globally.
     ///
     /// Return `Err(ErrorModel)` (typically `400 Bad Request`) when the
     /// configuration is one the worker would skip at pickup — e.g.
@@ -208,7 +219,7 @@ pub trait TaskConfig:
     #[allow(unused_variables)]
     fn check_schedule_eligibility(
         config: &Self,
-        table_properties: &std::collections::HashMap<String, String>,
+        entity_properties: &std::collections::HashMap<String, String>,
         entity: WarehouseTaskEntityId,
     ) -> Result<(), ErrorModel> {
         Ok(())
@@ -228,23 +239,24 @@ pub trait TaskConfig: Serialize + DeserializeOwned + Clone + Send + Sync {
     fn queue_name() -> &'static TaskQueueName;
 
     /// See the `open-api`-enabled trait for full documentation.
-    #[must_use]
-    fn user_schedulable() -> bool {
-        false
-    }
-
-    /// See the `open-api`-enabled trait for full documentation.
     #[allow(unused_variables)]
     fn check_schedule_eligibility(
         config: &Self,
-        table_properties: &std::collections::HashMap<String, String>,
+        entity_properties: &std::collections::HashMap<String, String>,
         entity: WarehouseTaskEntityId,
     ) -> Result<(), ErrorModel> {
         Ok(())
     }
 }
 
-/// Task Payload
+/// Task Payload.
+///
+/// Queues whose worker depends on exact payload shape should annotate the
+/// payload type with `#[serde(deny_unknown_fields)]`. The schedule
+/// endpoint's payload validator is `serde_json::from_value::<D>`, which by
+/// default silently ignores unknown fields — fine for queues that take an
+/// empty or open-ended payload, but a silent footgun for queues with a
+/// strict contract.
 pub trait TaskData: Clone + Serialize + DeserializeOwned + Send + Sync {}
 
 pub trait TaskExecutionDetails: Clone + Serialize + DeserializeOwned + Send + Sync {}

--- a/crates/lakekeeper/src/service/tasks/tabular_expiration_queue.rs
+++ b/crates/lakekeeper/src/service/tasks/tabular_expiration_queue.rs
@@ -28,6 +28,7 @@ pub(crate) static API_CONFIG: LazyLock<super::QueueApiConfig> =
         utoipa_type_name: TabularExpirationQueueConfig::name(),
         utoipa_schema: TabularExpirationQueueConfig::schema(),
         scope: super::QueueScope::Warehouse,
+        user_schedulable: false,
     });
 
 pub type TabularExpirationTask = SpecializedTask<

--- a/crates/lakekeeper/src/service/tasks/tabular_expiration_queue.rs
+++ b/crates/lakekeeper/src/service/tasks/tabular_expiration_queue.rs
@@ -28,7 +28,7 @@ pub(crate) static API_CONFIG: LazyLock<super::QueueApiConfig> =
         utoipa_type_name: TabularExpirationQueueConfig::name(),
         utoipa_schema: TabularExpirationQueueConfig::schema(),
         scope: super::QueueScope::Warehouse,
-        user_schedulable: false,
+        user_scheduling: super::UserScheduling::Disabled,
     });
 
 pub type TabularExpirationTask = SpecializedTask<

--- a/crates/lakekeeper/src/service/tasks/tabular_purge_queue.rs
+++ b/crates/lakekeeper/src/service/tasks/tabular_purge_queue.rs
@@ -26,6 +26,7 @@ pub(crate) static API_CONFIG: LazyLock<super::QueueApiConfig> =
         utoipa_type_name: PurgeQueueConfig::name(),
         utoipa_schema: PurgeQueueConfig::schema(),
         scope: super::QueueScope::Warehouse,
+        user_schedulable: false,
     });
 
 pub type TabularPurgeTask =

--- a/crates/lakekeeper/src/service/tasks/tabular_purge_queue.rs
+++ b/crates/lakekeeper/src/service/tasks/tabular_purge_queue.rs
@@ -26,7 +26,7 @@ pub(crate) static API_CONFIG: LazyLock<super::QueueApiConfig> =
         utoipa_type_name: PurgeQueueConfig::name(),
         utoipa_schema: PurgeQueueConfig::schema(),
         scope: super::QueueScope::Warehouse,
-        user_schedulable: false,
+        user_scheduling: super::UserScheduling::Disabled,
     });
 
 pub type TabularPurgeTask =

--- a/crates/lakekeeper/src/service/tasks/task_log_cleanup_queue.rs
+++ b/crates/lakekeeper/src/service/tasks/task_log_cleanup_queue.rs
@@ -31,6 +31,7 @@ pub(crate) static API_CONFIG: LazyLock<QueueApiConfig> = LazyLock::new(|| QueueA
     utoipa_type_name: TaskLogCleanupConfig::name(),
     utoipa_schema: TaskLogCleanupConfig::schema(),
     scope: super::QueueScope::Project,
+    user_schedulable: false,
 });
 
 const DEFAULT_CLEANUP_PERIOD_DAYS: Duration = Duration::days(1);

--- a/crates/lakekeeper/src/service/tasks/task_log_cleanup_queue.rs
+++ b/crates/lakekeeper/src/service/tasks/task_log_cleanup_queue.rs
@@ -31,7 +31,7 @@ pub(crate) static API_CONFIG: LazyLock<QueueApiConfig> = LazyLock::new(|| QueueA
     utoipa_type_name: TaskLogCleanupConfig::name(),
     utoipa_schema: TaskLogCleanupConfig::schema(),
     scope: super::QueueScope::Project,
-    user_schedulable: false,
+    user_scheduling: super::UserScheduling::Disabled,
 });
 
 const DEFAULT_CLEANUP_PERIOD_DAYS: Duration = Duration::days(1);

--- a/crates/lakekeeper/src/service/tasks/task_registry.rs
+++ b/crates/lakekeeper/src/service/tasks/task_registry.rs
@@ -16,6 +16,23 @@ use crate::{
 
 pub type ValidatorFn = Arc<dyn Fn(serde_json::Value) -> serde_json::Result<()> + Send + Sync>;
 
+/// Eligibility pre-check invoked by the `task-queue/{name}/schedule`
+/// endpoint after authz. Receives the queue's current raw config JSON and
+/// the entity's table properties; returns `Err(ErrorModel)` to reject the
+/// schedule call with a clear status (typically 400) instead of creating a
+/// task the worker would immediately skip at pickup. See
+/// `TaskConfig::check_schedule_eligibility` for the typed hook each queue
+/// implements.
+pub type ScheduleEligibilityFn = Arc<
+    dyn Fn(
+            serde_json::Value,
+            std::collections::HashMap<String, String>,
+            crate::service::tasks::WarehouseTaskEntityId,
+        ) -> Result<(), iceberg_ext::catalog::rest::ErrorModel>
+        + Send
+        + Sync,
+>;
+
 #[derive(Clone)]
 struct RegisteredQueue {
     /// API configuration for this queue
@@ -23,6 +40,14 @@ struct RegisteredQueue {
     /// Schema validator function for the queue configuration
     /// This function is called to validate the configuration payload
     schema_validator_fn: ValidatorFn,
+    /// Whether this queue accepts manual scheduling via the
+    /// `task-queue/{name}/schedule` endpoint. Mirrors
+    /// `TaskConfig::user_schedulable()` captured at registration time so we
+    /// don't need the type parameter on lookup.
+    user_schedulable: bool,
+    /// Pre-check called by the schedule endpoint. Wraps
+    /// `T::check_schedule_eligibility` into a type-erased dispatch.
+    schedule_eligibility_fn: ScheduleEligibilityFn,
 }
 
 impl std::fmt::Debug for RegisteredQueue {
@@ -30,6 +55,8 @@ impl std::fmt::Debug for RegisteredQueue {
         f.debug_struct("RegisteredQueue")
             .field("api_config", &self.api_config)
             .field("schema_validator_fn", &"Fn(...)")
+            .field("user_schedulable", &self.user_schedulable)
+            .field("schedule_eligibility_fn", &"Fn(...)")
             .finish()
     }
 }
@@ -72,6 +99,62 @@ impl RegisteredTaskQueues {
     #[must_use]
     pub async fn queue_names(&self) -> Vec<&'static TaskQueueName> {
         let mut v: Vec<_> = self.queues.read().await.keys().copied().collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// Resolve a user-provided `TaskQueueName` to the `&'static` reference
+    /// the registry holds. Required by `C::enqueue_task`, which expects a
+    /// `&'static` queue name.
+    #[must_use]
+    pub async fn static_queue_name(
+        &self,
+        queue_name: &TaskQueueName,
+    ) -> Option<&'static TaskQueueName> {
+        self.queues
+            .read()
+            .await
+            .get_key_value(queue_name)
+            .map(|(k, _)| *k)
+    }
+
+    /// Eligibility pre-check for the schedule endpoint. Returns `None` if
+    /// the queue is not registered.
+    #[must_use]
+    pub async fn schedule_eligibility_fn(
+        &self,
+        queue_name: &TaskQueueName,
+    ) -> Option<ScheduleEligibilityFn> {
+        self.queues
+            .read()
+            .await
+            .get(queue_name)
+            .map(|q| Arc::clone(&q.schedule_eligibility_fn))
+    }
+
+    /// Whether a registered queue accepts manual scheduling via the
+    /// `task-queue/{name}/schedule` endpoint. Returns `None` if the queue is
+    /// not registered.
+    #[must_use]
+    pub async fn is_user_schedulable(&self, queue_name: &TaskQueueName) -> Option<bool> {
+        self.queues
+            .read()
+            .await
+            .get(queue_name)
+            .map(|q| q.user_schedulable)
+    }
+
+    /// Names of all registered queues that opted in to manual scheduling.
+    /// Sorted for stable output.
+    #[must_use]
+    pub async fn user_schedulable_queue_names(&self) -> Vec<&'static TaskQueueName> {
+        let mut v: Vec<_> = self
+            .queues
+            .read()
+            .await
+            .iter()
+            .filter_map(|(name, q)| q.user_schedulable.then_some(*name))
+            .collect();
         v.sort_unstable();
         v
     }
@@ -150,6 +233,21 @@ impl TaskQueueRegistry {
         } = task_queue;
         let schema_validator_fn = |v| serde_json::from_value::<T>(v).map(|_| ());
         let schema_validator_fn = Arc::new(schema_validator_fn) as ValidatorFn;
+        let user_schedulable = T::user_schedulable();
+        let schedule_eligibility_fn: ScheduleEligibilityFn =
+            Arc::new(|raw_config, table_props, entity| {
+                let config: T = serde_json::from_value(raw_config).map_err(|e| {
+                    iceberg_ext::catalog::rest::ErrorModel::internal(
+                        format!(
+                            "Failed to deserialize queue config for queue '{}': {e}",
+                            T::queue_name()
+                        ),
+                        "TaskConfigDeserializeError",
+                        Some(Box::new(e)),
+                    )
+                })?;
+                T::check_schedule_eligibility(&config, &table_props, entity)
+            });
         let api_config = QueueApiConfig {
             queue_name,
             #[cfg(feature = "open-api")]
@@ -163,6 +261,7 @@ impl TaskQueueRegistry {
             #[cfg(not(feature = "open-api"))]
             utoipa_schema: (),
             scope,
+            user_schedulable,
         };
 
         if let Some(_prev) = self.registered_queues.write().await.insert(
@@ -170,6 +269,8 @@ impl TaskQueueRegistry {
             RegisteredQueue {
                 api_config,
                 schema_validator_fn,
+                user_schedulable,
+                schedule_eligibility_fn,
             },
         ) {
             tracing::warn!("Overwriting registration for queue `{queue_name}`");
@@ -338,6 +439,9 @@ pub struct QueueApiConfig {
     #[cfg(not(feature = "open-api"))]
     pub utoipa_schema: (),
     pub scope: QueueScope,
+    /// Whether the queue opted in to the schedule endpoint.
+    /// Used by the OpenAPI builder to materialise per-queue schedule paths.
+    pub user_schedulable: bool,
 }
 
 impl std::fmt::Debug for QueueApiConfig {
@@ -347,6 +451,7 @@ impl std::fmt::Debug for QueueApiConfig {
             .field("utoipa_type_name", &self.utoipa_type_name)
             .field("utoipa_schema", &"<schema>")
             .field("scope", &self.scope)
+            .field("user_schedulable", &self.user_schedulable)
             .finish()
     }
 }
@@ -537,6 +642,190 @@ mod test {
         assert_eq!(
             later_queue_names,
             vec![&*SECOND_QUEUE_NAME, &*FIRST_QUEUE_NAME]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_user_schedulable_propagates_through_register_queue() {
+        static DEFAULT_QN: LazyLock<TaskQueueName> = LazyLock::new(|| "default-schedulable".into());
+        static OPTED_IN_QN: LazyLock<TaskQueueName> =
+            LazyLock::new(|| "opted-in-schedulable".into());
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+        struct DefaultCfg {}
+        impl TaskConfig for DefaultCfg {
+            fn queue_name() -> &'static TaskQueueName {
+                &DEFAULT_QN
+            }
+            fn max_time_since_last_heartbeat() -> chrono::Duration {
+                chrono::Duration::seconds(60)
+            }
+            // user_schedulable() not overridden — default false.
+        }
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+        struct OptedInCfg {}
+        impl TaskConfig for OptedInCfg {
+            fn queue_name() -> &'static TaskQueueName {
+                &OPTED_IN_QN
+            }
+            fn max_time_since_last_heartbeat() -> chrono::Duration {
+                chrono::Duration::seconds(60)
+            }
+            fn user_schedulable() -> bool {
+                true
+            }
+        }
+
+        let registry = TaskQueueRegistry::new();
+        let queues = registry.registered_task_queues();
+        for (cfg_name, queue_name) in [
+            ("default", &*DEFAULT_QN),
+            ("opted-in", &*OPTED_IN_QN),
+        ] {
+            let reg = QueueRegistration {
+                queue_name,
+                worker_fn: Arc::new(|_| Box::pin(async {})),
+                num_workers: 0,
+                scope: QueueScope::Warehouse,
+            };
+            if cfg_name == "default" {
+                registry.register_queue::<DefaultCfg>(reg).await;
+            } else {
+                registry.register_queue::<OptedInCfg>(reg).await;
+            }
+        }
+
+        assert_eq!(queues.is_user_schedulable(&DEFAULT_QN).await, Some(false));
+        assert_eq!(queues.is_user_schedulable(&OPTED_IN_QN).await, Some(true));
+        assert_eq!(
+            queues
+                .is_user_schedulable(&TaskQueueName::from("never-registered"))
+                .await,
+            None
+        );
+
+        assert_eq!(
+            queues.user_schedulable_queue_names().await,
+            vec![&*OPTED_IN_QN]
+        );
+
+        let api_configs = queues.api_config().await;
+        let default_cfg = api_configs
+            .iter()
+            .find(|c| c.queue_name == &*DEFAULT_QN)
+            .expect("default queue registered");
+        let opted_in_cfg = api_configs
+            .iter()
+            .find(|c| c.queue_name == &*OPTED_IN_QN)
+            .expect("opted-in queue registered");
+        assert!(!default_cfg.user_schedulable);
+        assert!(opted_in_cfg.user_schedulable);
+    }
+
+    #[tokio::test]
+    async fn test_check_schedule_eligibility_dispatches_through_registry() {
+        use std::collections::HashMap;
+
+        use crate::service::tasks::WarehouseTaskEntityId;
+
+        static EAGER_QN: LazyLock<TaskQueueName> = LazyLock::new(|| "eager-eligibility".into());
+        static PICKY_QN: LazyLock<TaskQueueName> = LazyLock::new(|| "picky-eligibility".into());
+
+        // Eager queue: always eligible. Picky queue: rejects when
+        // `disabled-by-table-prop` is present, so we can verify the
+        // dispatcher passes table_properties through faithfully.
+
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+        struct EagerCfg {}
+        impl TaskConfig for EagerCfg {
+            fn queue_name() -> &'static TaskQueueName {
+                &EAGER_QN
+            }
+            fn max_time_since_last_heartbeat() -> chrono::Duration {
+                chrono::Duration::seconds(60)
+            }
+        }
+
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+        struct PickyCfg {}
+        impl TaskConfig for PickyCfg {
+            fn queue_name() -> &'static TaskQueueName {
+                &PICKY_QN
+            }
+            fn max_time_since_last_heartbeat() -> chrono::Duration {
+                chrono::Duration::seconds(60)
+            }
+            fn check_schedule_eligibility(
+                _config: &Self,
+                table_properties: &HashMap<String, String>,
+                _entity: WarehouseTaskEntityId,
+            ) -> Result<(), iceberg_ext::catalog::rest::ErrorModel> {
+                if table_properties.get("disabled-by-table-prop").map(String::as_str)
+                    == Some("true")
+                {
+                    return Err(iceberg_ext::catalog::rest::ErrorModel::bad_request(
+                        "rejected",
+                        "PickyRejected",
+                        None,
+                    ));
+                }
+                Ok(())
+            }
+        }
+
+        let registry = TaskQueueRegistry::new();
+        let queues = registry.registered_task_queues();
+        registry
+            .register_queue::<EagerCfg>(QueueRegistration {
+                queue_name: &EAGER_QN,
+                worker_fn: Arc::new(|_| Box::pin(async {})),
+                num_workers: 0,
+                scope: QueueScope::Warehouse,
+            })
+            .await;
+        registry
+            .register_queue::<PickyCfg>(QueueRegistration {
+                queue_name: &PICKY_QN,
+                worker_fn: Arc::new(|_| Box::pin(async {})),
+                num_workers: 0,
+                scope: QueueScope::Warehouse,
+            })
+            .await;
+
+        let entity = WarehouseTaskEntityId::Table {
+            table_id: crate::service::TableId::new_random(),
+        };
+
+        // Eager queue: any input passes.
+        let eager_fn = queues
+            .schedule_eligibility_fn(&EAGER_QN)
+            .await
+            .expect("eager queue registered");
+        assert!(
+            eager_fn(serde_json::json!({}), HashMap::new(), entity).is_ok(),
+            "eager queue should accept empty inputs"
+        );
+
+        // Picky queue: rejects when the marker property is set, accepts otherwise.
+        let picky_fn = queues
+            .schedule_eligibility_fn(&PICKY_QN)
+            .await
+            .expect("picky queue registered");
+        let mut bad_props = HashMap::new();
+        bad_props.insert("disabled-by-table-prop".to_string(), "true".to_string());
+        let err = picky_fn(serde_json::json!({}), bad_props.clone(), entity)
+            .expect_err("picky queue should reject when marker prop is set");
+        assert_eq!(err.r#type, "PickyRejected");
+
+        // Without the marker, the same picky queue accepts.
+        assert!(
+            picky_fn(serde_json::json!({}), HashMap::new(), entity).is_ok(),
+            "picky queue should accept when the marker prop is absent"
         );
     }
 }

--- a/crates/lakekeeper/src/service/tasks/task_registry.rs
+++ b/crates/lakekeeper/src/service/tasks/task_registry.rs
@@ -16,6 +16,60 @@ use crate::{
 
 pub type ValidatorFn = Arc<dyn Fn(serde_json::Value) -> serde_json::Result<()> + Send + Sync>;
 
+/// Whether a queue is exposed via the schedule endpoint, and (under
+/// `open-api`) what payload schema its request body uses.
+///
+/// Folds two coupled fields into one decision so a reader can't end up
+/// with `Disabled` + a meaningless payload schema, or `Enabled` while
+/// silently emitting an untyped body.
+#[cfg(feature = "open-api")]
+#[derive(Clone)]
+pub enum UserScheduling {
+    /// Not exposed via the schedule endpoint. The `OpenAPI` patcher omits
+    /// the queue's path; the endpoint rejects manual scheduling for this
+    /// queue with `400 QueueNotUserSchedulable`. Destructive or
+    /// lifecycle-managed queues (e.g. `tabular_purge`, `tabular_expiration`)
+    /// must use this so they can't be enqueued out-of-band.
+    Disabled,
+    /// Exposed via the schedule endpoint. `payload_schema` shapes the
+    /// per-queue request body: `None` strips the `payload` field;
+    /// `Some(schema)` references the typed payload.
+    Enabled {
+        payload_schema: Option<utoipa::openapi::RefOr<utoipa::openapi::Schema>>,
+    },
+}
+
+#[cfg(not(feature = "open-api"))]
+#[derive(Clone, Debug)]
+pub enum UserScheduling {
+    Disabled,
+    Enabled,
+}
+
+impl UserScheduling {
+    /// Whether the queue is exposed via the schedule endpoint.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+}
+
+#[cfg(feature = "open-api")]
+impl std::fmt::Debug for UserScheduling {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled => f.write_str("Disabled"),
+            Self::Enabled { payload_schema } => f
+                .debug_struct("Enabled")
+                .field(
+                    "payload_schema",
+                    &payload_schema.as_ref().map(|_| "<schema>"),
+                )
+                .finish(),
+        }
+    }
+}
+
 /// Eligibility pre-check invoked by the `task-queue/{name}/schedule`
 /// endpoint after authz. Receives the queue's current raw config JSON and
 /// the entity's table properties; returns `Err(ErrorModel)` to reject the
@@ -40,14 +94,15 @@ struct RegisteredQueue {
     /// Schema validator function for the queue configuration
     /// This function is called to validate the configuration payload
     schema_validator_fn: ValidatorFn,
-    /// Whether this queue accepts manual scheduling via the
-    /// `task-queue/{name}/schedule` endpoint. Mirrors
-    /// `TaskConfig::user_schedulable()` captured at registration time so we
-    /// don't need the type parameter on lookup.
-    user_schedulable: bool,
     /// Pre-check called by the schedule endpoint. Wraps
     /// `T::check_schedule_eligibility` into a type-erased dispatch.
     schedule_eligibility_fn: ScheduleEligibilityFn,
+    /// Structural validator for the queue's task payload — deserialises the
+    /// caller-supplied JSON against the queue's `TaskData` type. The schedule
+    /// endpoint runs this before enqueueing so a malformed payload fails
+    /// fast with `400` instead of producing a task the worker can't decode
+    /// at pickup. Built from the `D` generic at `register_queue` time.
+    payload_validator_fn: ValidatorFn,
 }
 
 impl std::fmt::Debug for RegisteredQueue {
@@ -55,8 +110,8 @@ impl std::fmt::Debug for RegisteredQueue {
         f.debug_struct("RegisteredQueue")
             .field("api_config", &self.api_config)
             .field("schema_validator_fn", &"Fn(...)")
-            .field("user_schedulable", &self.user_schedulable)
             .field("schedule_eligibility_fn", &"Fn(...)")
+            .field("payload_validator_fn", &"Fn(...)")
             .finish()
     }
 }
@@ -118,6 +173,19 @@ impl RegisteredTaskQueues {
             .map(|(k, _)| *k)
     }
 
+    /// Structural payload validator for the schedule endpoint. Returns
+    /// `None` if the queue is not registered. Deserialises the
+    /// caller-supplied JSON against the queue's `TaskData` type; fails the
+    /// schedule request with `400` before enqueue if the shape is wrong.
+    #[must_use]
+    pub async fn payload_validator_fn(&self, queue_name: &TaskQueueName) -> Option<ValidatorFn> {
+        self.queues
+            .read()
+            .await
+            .get(queue_name)
+            .map(|q| Arc::clone(&q.payload_validator_fn))
+    }
+
     /// Eligibility pre-check for the schedule endpoint. Returns `None` if
     /// the queue is not registered.
     #[must_use]
@@ -141,7 +209,7 @@ impl RegisteredTaskQueues {
             .read()
             .await
             .get(queue_name)
-            .map(|q| q.user_schedulable)
+            .map(|q| q.api_config.user_scheduling.is_enabled())
     }
 
     /// Names of all registered queues that opted in to manual scheduling.
@@ -153,7 +221,7 @@ impl RegisteredTaskQueues {
             .read()
             .await
             .iter()
-            .filter_map(|(name, q)| q.user_schedulable.then_some(*name))
+            .filter_map(|(name, q)| q.api_config.user_scheduling.is_enabled().then_some(*name))
             .collect();
         v.sort_unstable();
         v
@@ -202,6 +270,9 @@ pub struct QueueRegistration {
     pub num_workers: usize,
     /// Scope of the queue configuration
     pub scope: QueueScope,
+    /// Whether this queue is exposed via the schedule endpoint and (under
+    /// `open-api`) the payload schema of its request body. See [`UserScheduling`].
+    pub user_scheduling: UserScheduling,
 }
 
 impl std::fmt::Debug for QueueRegistration {
@@ -211,6 +282,7 @@ impl std::fmt::Debug for QueueRegistration {
             .field("worker_fn", &"Fn(...)")
             .field("num_workers", &self.num_workers)
             .field("scope", &self.scope)
+            .field("user_scheduling", &self.user_scheduling)
             .finish()
     }
 }
@@ -224,18 +296,27 @@ impl TaskQueueRegistry {
         }
     }
 
-    pub async fn register_queue<T: TaskConfig>(&self, task_queue: QueueRegistration) -> &Self {
+    pub async fn register_queue<T: TaskConfig, D: super::TaskData>(
+        &self,
+        task_queue: QueueRegistration,
+    ) -> &Self {
         let QueueRegistration {
             queue_name,
             worker_fn,
             num_workers,
             scope,
+            user_scheduling,
         } = task_queue;
         let schema_validator_fn = |v| serde_json::from_value::<T>(v).map(|_| ());
         let schema_validator_fn = Arc::new(schema_validator_fn) as ValidatorFn;
-        let user_schedulable = T::user_schedulable();
+        // Structural payload validator: deserialises caller-supplied JSON
+        // against the queue's `TaskData` type. Fails fast at the schedule
+        // endpoint instead of letting a malformed payload land on the
+        // worker and fail at pickup.
+        let payload_validator_fn = |v| serde_json::from_value::<D>(v).map(|_| ());
+        let payload_validator_fn = Arc::new(payload_validator_fn) as ValidatorFn;
         let schedule_eligibility_fn: ScheduleEligibilityFn =
-            Arc::new(|raw_config, table_props, entity| {
+            Arc::new(|raw_config, entity_props, entity| {
                 let config: T = serde_json::from_value(raw_config).map_err(|e| {
                     iceberg_ext::catalog::rest::ErrorModel::internal(
                         format!(
@@ -246,7 +327,7 @@ impl TaskQueueRegistry {
                         Some(Box::new(e)),
                     )
                 })?;
-                T::check_schedule_eligibility(&config, &table_props, entity)
+                T::check_schedule_eligibility(&config, &entity_props, entity)
             });
         let api_config = QueueApiConfig {
             queue_name,
@@ -261,7 +342,7 @@ impl TaskQueueRegistry {
             #[cfg(not(feature = "open-api"))]
             utoipa_schema: (),
             scope,
-            user_schedulable,
+            user_scheduling,
         };
 
         if let Some(_prev) = self.registered_queues.write().await.insert(
@@ -269,8 +350,8 @@ impl TaskQueueRegistry {
             RegisteredQueue {
                 api_config,
                 schema_validator_fn,
-                user_schedulable,
                 schedule_eligibility_fn,
+                payload_validator_fn,
             },
         ) {
             tracing::warn!("Overwriting registration for queue `{queue_name}`");
@@ -296,7 +377,10 @@ impl TaskQueueRegistry {
         use super::{tabular_expiration_queue, tabular_purge_queue, task_log_cleanup_queue};
 
         let catalog_state_clone_for_tabular_expiration = catalog_state.clone();
-        self.register_queue::<tabular_expiration_queue::TabularExpirationQueueConfig>(
+        self.register_queue::<
+            tabular_expiration_queue::TabularExpirationQueueConfig,
+            tabular_expiration_queue::TabularExpirationPayload,
+        >(
             QueueRegistration {
                 queue_name: &tabular_expiration_queue::QUEUE_NAME,
                 worker_fn: Arc::new(move |cancellation_token| {
@@ -316,12 +400,16 @@ impl TaskQueueRegistry {
                 }),
                 num_workers: CONFIG.task_tabular_expiration_workers,
                 scope: QueueScope::Warehouse,
+                user_scheduling: UserScheduling::Disabled,
             },
         )
         .await;
 
         let catalog_state_clone_for_tabular_purge = catalog_state.clone();
-        self.register_queue::<tabular_purge_queue::PurgeQueueConfig>(QueueRegistration {
+        self.register_queue::<
+            tabular_purge_queue::PurgeQueueConfig,
+            tabular_purge_queue::TabularPurgePayload,
+        >(QueueRegistration {
             queue_name: &tabular_purge_queue::QUEUE_NAME,
             worker_fn: Arc::new(move |cancellation_token| {
                 let catalog_state_clone = catalog_state_clone_for_tabular_purge.clone();
@@ -338,11 +426,15 @@ impl TaskQueueRegistry {
             }),
             num_workers: CONFIG.task_tabular_purge_workers,
             scope: QueueScope::Warehouse,
+            user_scheduling: UserScheduling::Disabled,
         })
         .await;
 
         let catalog_state_for_task_log_cleanup = catalog_state.clone();
-        self.register_queue::<task_log_cleanup_queue::TaskLogCleanupConfig>(QueueRegistration {
+        self.register_queue::<
+            task_log_cleanup_queue::TaskLogCleanupConfig,
+            task_log_cleanup_queue::TaskLogCleanupPayload,
+        >(QueueRegistration {
             queue_name: &task_log_cleanup_queue::QUEUE_NAME,
             worker_fn: Arc::new(move |cancellation_token| {
                 let catalog_state_clone = catalog_state_for_task_log_cleanup.clone();
@@ -357,6 +449,7 @@ impl TaskQueueRegistry {
             }),
             num_workers: CONFIG.task_log_cleanup_workers,
             scope: QueueScope::Project,
+            user_scheduling: UserScheduling::Disabled,
         })
         .await;
 
@@ -439,9 +532,9 @@ pub struct QueueApiConfig {
     #[cfg(not(feature = "open-api"))]
     pub utoipa_schema: (),
     pub scope: QueueScope,
-    /// Whether the queue opted in to the schedule endpoint.
-    /// Used by the OpenAPI builder to materialise per-queue schedule paths.
-    pub user_schedulable: bool,
+    /// Whether this queue is exposed via the schedule endpoint and (under
+    /// `open-api`) the schema of its request payload. See [`UserScheduling`].
+    pub user_scheduling: UserScheduling,
 }
 
 impl std::fmt::Debug for QueueApiConfig {
@@ -451,7 +544,7 @@ impl std::fmt::Debug for QueueApiConfig {
             .field("utoipa_type_name", &self.utoipa_type_name)
             .field("utoipa_schema", &"<schema>")
             .field("scope", &self.scope)
-            .field("user_schedulable", &self.user_schedulable)
+            .field("user_scheduling", &self.user_scheduling)
             .finish()
     }
 }
@@ -464,7 +557,15 @@ mod test {
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::service::tasks::TaskQueueName;
+    use crate::service::tasks::{TaskData, TaskQueueName};
+
+    /// Placeholder payload used by the test queues below. Real queues bind
+    /// their actual `TaskData` via the `D` generic of `register_queue`;
+    /// these tests don't run a worker so the type just needs to be empty
+    /// and `TaskData`-conformant.
+    #[derive(Clone, Debug, Serialize, Deserialize, Default)]
+    struct TestPayload {}
+    impl TaskData for TestPayload {}
 
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
@@ -521,7 +622,7 @@ mod test {
         assert!(initial_queues.api_config().await.is_empty());
 
         registry
-            .register_queue::<TestQueueConfig>(super::QueueRegistration {
+            .register_queue::<TestQueueConfig, TestPayload>(super::QueueRegistration {
                 queue_name: &FIRST_QUEUE_NAME,
                 worker_fn: std::sync::Arc::new(move |_cancellation_token| {
                     Box::pin(async {
@@ -530,6 +631,7 @@ mod test {
                 }),
                 num_workers: 1,
                 scope: QueueScope::Warehouse,
+                user_scheduling: UserScheduling::Disabled,
             })
             .await;
 
@@ -576,7 +678,7 @@ mod test {
         );
 
         registry
-            .register_queue::<SecondTestQueueConfig>(super::QueueRegistration {
+            .register_queue::<SecondTestQueueConfig, TestPayload>(super::QueueRegistration {
                 queue_name: &SECOND_QUEUE_NAME,
                 worker_fn: std::sync::Arc::new(move |_cancellation_token| {
                     Box::pin(async {
@@ -585,6 +687,7 @@ mod test {
                 }),
                 num_workers: 2,
                 scope: QueueScope::Warehouse,
+                user_scheduling: UserScheduling::Disabled,
             })
             .await;
 
@@ -653,50 +756,41 @@ mod test {
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
         #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
-        struct DefaultCfg {}
-        impl TaskConfig for DefaultCfg {
+        struct Cfg {}
+        impl TaskConfig for Cfg {
             fn queue_name() -> &'static TaskQueueName {
                 &DEFAULT_QN
             }
             fn max_time_since_last_heartbeat() -> chrono::Duration {
                 chrono::Duration::seconds(60)
             }
-            // user_schedulable() not overridden — default false.
-        }
-
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
-        struct OptedInCfg {}
-        impl TaskConfig for OptedInCfg {
-            fn queue_name() -> &'static TaskQueueName {
-                &OPTED_IN_QN
-            }
-            fn max_time_since_last_heartbeat() -> chrono::Duration {
-                chrono::Duration::seconds(60)
-            }
-            fn user_schedulable() -> bool {
-                true
-            }
         }
 
         let registry = TaskQueueRegistry::new();
         let queues = registry.registered_task_queues();
-        for (cfg_name, queue_name) in [
-            ("default", &*DEFAULT_QN),
-            ("opted-in", &*OPTED_IN_QN),
-        ] {
-            let reg = QueueRegistration {
-                queue_name,
+        registry
+            .register_queue::<Cfg, TestPayload>(QueueRegistration {
+                queue_name: &DEFAULT_QN,
                 worker_fn: Arc::new(|_| Box::pin(async {})),
                 num_workers: 0,
                 scope: QueueScope::Warehouse,
-            };
-            if cfg_name == "default" {
-                registry.register_queue::<DefaultCfg>(reg).await;
-            } else {
-                registry.register_queue::<OptedInCfg>(reg).await;
-            }
-        }
+                user_scheduling: UserScheduling::Disabled,
+            })
+            .await;
+        registry
+            .register_queue::<Cfg, TestPayload>(QueueRegistration {
+                queue_name: &OPTED_IN_QN,
+                worker_fn: Arc::new(|_| Box::pin(async {})),
+                num_workers: 0,
+                scope: QueueScope::Warehouse,
+                #[cfg(feature = "open-api")]
+                user_scheduling: UserScheduling::Enabled {
+                    payload_schema: None,
+                },
+                #[cfg(not(feature = "open-api"))]
+                user_scheduling: UserScheduling::Enabled,
+            })
+            .await;
 
         assert_eq!(queues.is_user_schedulable(&DEFAULT_QN).await, Some(false));
         assert_eq!(queues.is_user_schedulable(&OPTED_IN_QN).await, Some(true));
@@ -721,8 +815,8 @@ mod test {
             .iter()
             .find(|c| c.queue_name == &*OPTED_IN_QN)
             .expect("opted-in queue registered");
-        assert!(!default_cfg.user_schedulable);
-        assert!(opted_in_cfg.user_schedulable);
+        assert!(!default_cfg.user_scheduling.is_enabled());
+        assert!(opted_in_cfg.user_scheduling.is_enabled());
     }
 
     #[tokio::test]
@@ -736,7 +830,7 @@ mod test {
 
         // Eager queue: always eligible. Picky queue: rejects when
         // `disabled-by-table-prop` is present, so we can verify the
-        // dispatcher passes table_properties through faithfully.
+        // dispatcher passes entity_properties through faithfully.
 
         #[derive(Clone, Debug, Default, Serialize, Deserialize)]
         #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
@@ -762,10 +856,12 @@ mod test {
             }
             fn check_schedule_eligibility(
                 _config: &Self,
-                table_properties: &HashMap<String, String>,
+                entity_properties: &HashMap<String, String>,
                 _entity: WarehouseTaskEntityId,
             ) -> Result<(), iceberg_ext::catalog::rest::ErrorModel> {
-                if table_properties.get("disabled-by-table-prop").map(String::as_str)
+                if entity_properties
+                    .get("disabled-by-table-prop")
+                    .map(String::as_str)
                     == Some("true")
                 {
                     return Err(iceberg_ext::catalog::rest::ErrorModel::bad_request(
@@ -781,19 +877,21 @@ mod test {
         let registry = TaskQueueRegistry::new();
         let queues = registry.registered_task_queues();
         registry
-            .register_queue::<EagerCfg>(QueueRegistration {
+            .register_queue::<EagerCfg, TestPayload>(QueueRegistration {
                 queue_name: &EAGER_QN,
                 worker_fn: Arc::new(|_| Box::pin(async {})),
                 num_workers: 0,
                 scope: QueueScope::Warehouse,
+                user_scheduling: UserScheduling::Disabled,
             })
             .await;
         registry
-            .register_queue::<PickyCfg>(QueueRegistration {
+            .register_queue::<PickyCfg, TestPayload>(QueueRegistration {
                 queue_name: &PICKY_QN,
                 worker_fn: Arc::new(|_| Box::pin(async {})),
                 num_workers: 0,
                 scope: QueueScope::Warehouse,
+                user_scheduling: UserScheduling::Disabled,
             })
             .await;
 
@@ -826,6 +924,94 @@ mod test {
         assert!(
             picky_fn(serde_json::json!({}), HashMap::new(), entity).is_ok(),
             "picky queue should accept when the marker prop is absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_payload_validator_dispatches_through_registry() {
+        static EMPTY_QN: LazyLock<TaskQueueName> = LazyLock::new(|| "empty-payload".into());
+        static REQUIRED_FIELD_QN: LazyLock<TaskQueueName> =
+            LazyLock::new(|| "required-field-payload".into());
+
+        // Empty-payload queue: accepts `{}` and ignores extras (default serde behavior).
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+        struct EmptyCfg {}
+        impl TaskConfig for EmptyCfg {
+            fn queue_name() -> &'static TaskQueueName {
+                &EMPTY_QN
+            }
+            fn max_time_since_last_heartbeat() -> chrono::Duration {
+                chrono::Duration::seconds(60)
+            }
+        }
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        struct EmptyPayload {}
+        impl TaskData for EmptyPayload {}
+
+        // Required-field-payload queue: rejects anything missing `must_have`.
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+        struct RequiredFieldCfg {}
+        impl TaskConfig for RequiredFieldCfg {
+            fn queue_name() -> &'static TaskQueueName {
+                &REQUIRED_FIELD_QN
+            }
+            fn max_time_since_last_heartbeat() -> chrono::Duration {
+                chrono::Duration::seconds(60)
+            }
+        }
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        struct RequiredFieldPayload {
+            #[allow(dead_code)]
+            must_have: String,
+        }
+        impl TaskData for RequiredFieldPayload {}
+
+        let registry = TaskQueueRegistry::new();
+        let queues = registry.registered_task_queues();
+        registry
+            .register_queue::<EmptyCfg, EmptyPayload>(QueueRegistration {
+                queue_name: &EMPTY_QN,
+                worker_fn: Arc::new(|_| Box::pin(async {})),
+                num_workers: 0,
+                scope: QueueScope::Warehouse,
+                user_scheduling: UserScheduling::Disabled,
+            })
+            .await;
+        registry
+            .register_queue::<RequiredFieldCfg, RequiredFieldPayload>(QueueRegistration {
+                queue_name: &REQUIRED_FIELD_QN,
+                worker_fn: Arc::new(|_| Box::pin(async {})),
+                num_workers: 0,
+                scope: QueueScope::Warehouse,
+                user_scheduling: UserScheduling::Disabled,
+            })
+            .await;
+
+        let empty_validator = queues
+            .payload_validator_fn(&EMPTY_QN)
+            .await
+            .expect("empty queue registered");
+        // Empty queue accepts the canonical `{}` the endpoint defaults to.
+        assert!(empty_validator(serde_json::json!({})).is_ok());
+
+        let required_validator = queues
+            .payload_validator_fn(&REQUIRED_FIELD_QN)
+            .await
+            .expect("required-field queue registered");
+        // Required-field queue rejects `{}` (the endpoint's default) when the
+        // payload type has a non-optional field — proving an empty-default
+        // payload doesn't silently slip past validation for queues that
+        // actually need shape.
+        assert!(
+            required_validator(serde_json::json!({})).is_err(),
+            "required-field payload must reject empty `{{}}`"
+        );
+        // Correct shape passes.
+        assert!(
+            required_validator(serde_json::json!({"must_have": "yes"})).is_ok(),
+            "valid shape must pass"
         );
     }
 }

--- a/crates/lakekeeper/src/tests/mod.rs
+++ b/crates/lakekeeper/src/tests/mod.rs
@@ -141,12 +141,47 @@ pub(crate) async fn setup<T: Authorizer>(
     ApiContext<State<T, PostgresBackend, SecretsState>>,
     TestWarehouseResponse,
 ) {
+    let (ctx, warehouse, _registry) = setup_with_registry(
+        pool,
+        storage_profile,
+        storage_credential,
+        authorizer,
+        delete_profile,
+        user_id,
+        number_of_warehouses,
+        project_id,
+    )
+    .await;
+    (ctx, warehouse)
+}
+
+/// Like [`setup`] but also returns the `TaskQueueRegistry` so tests can
+/// register additional queues (e.g. a `user_schedulable=true` fixture for
+/// scheduling-endpoint lifecycle tests). The registry shares interior-mutable
+/// state with the `RegisteredTaskQueues` inside the returned `ApiContext`,
+/// so a later `register_queue` call is visible to subsequent endpoint
+/// invocations on `ctx` — no rebuild needed.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn setup_with_registry<T: Authorizer>(
+    pool: PgPool,
+    storage_profile: StorageProfile,
+    storage_credential: Option<StorageCredential>,
+    authorizer: T,
+    delete_profile: TabularDeleteProfile,
+    user_id: Option<UserId>,
+    number_of_warehouses: usize,
+    project_id: Option<ProjectId>,
+) -> (
+    ApiContext<State<T, PostgresBackend, SecretsState>>,
+    TestWarehouseResponse,
+    TaskQueueRegistry,
+) {
     assert!(
         number_of_warehouses > 0,
         "Number of warehouses must be greater than 0",
     );
     migrate_core_only(&pool).await.unwrap();
-    let api_context = get_api_context(&pool, authorizer).await;
+    let (api_context, registry) = get_api_context_with_registry(&pool, authorizer).await;
 
     let metadata = if let Some(user_id) = user_id {
         RequestMetadata::test_user(user_id)
@@ -210,13 +245,31 @@ pub(crate) async fn setup<T: Authorizer>(
             warehouse_name,
             additional_warehouses,
         },
+        registry,
     )
 }
 
+/// Backwards-compatible wrapper for callers that don't need the registry.
+/// Prefer [`get_api_context_with_registry`] for new tests that need to
+/// register additional queues post-bootstrap.
+#[allow(dead_code)] // Some call sites are only enabled under specific feature combos.
 pub(crate) async fn get_api_context<T: Authorizer>(
     pool: &PgPool,
     auth: T,
 ) -> ApiContext<State<T, PostgresBackend, SecretsState>> {
+    get_api_context_with_registry(pool, auth).await.0
+}
+
+/// Like [`get_api_context`] but also returns the `TaskQueueRegistry`.
+/// Lets tests register additional queues into the same shared state the
+/// returned `ApiContext` reads from.
+pub(crate) async fn get_api_context_with_registry<T: Authorizer>(
+    pool: &PgPool,
+    auth: T,
+) -> (
+    ApiContext<State<T, PostgresBackend, SecretsState>>,
+    TaskQueueRegistry,
+) {
     let catalog_state = CatalogState::from_pools(pool.clone(), pool.clone());
     let secret_store = SecretsState::from_pools(pool.clone(), pool.clone());
 
@@ -230,7 +283,7 @@ pub(crate) async fn get_api_context<T: Authorizer>(
         )
         .await;
     let registered_task_queues = task_queues.registered_task_queues();
-    ApiContext {
+    let ctx = ApiContext {
         v1_state: State {
             authz: auth,
             catalog: catalog_state,
@@ -245,7 +298,8 @@ pub(crate) async fn get_api_context<T: Authorizer>(
             license_status: &APACHE_LICENSE_STATUS,
             build_info: &DEFAULT_BUILD_INFO,
         },
-    }
+    };
+    (ctx, task_queues)
 }
 
 pub(crate) fn random_request_metadata() -> RequestMetadata {

--- a/crates/lakekeeper/src/tests/tasks.rs
+++ b/crates/lakekeeper/src/tests/tasks.rs
@@ -24,7 +24,7 @@ mod test {
             tasks::{
                 QueueRegistration, QueueScope, ScheduleTaskMetadata, SpecializedTask,
                 TaskConfig as QueueConfigTrait, TaskData, TaskEntity, TaskExecutionDetails,
-                TaskInput, TaskQueueName, TaskQueueRegistry, WarehouseTaskEntityId,
+                TaskInput, TaskQueueName, TaskQueueRegistry, UserScheduling, WarehouseTaskEntityId,
             },
         },
     };
@@ -73,7 +73,7 @@ mod test {
 
         let task_queue_registry = TaskQueueRegistry::new();
         task_queue_registry
-            .register_queue::<Config>(QueueRegistration {
+            .register_queue::<Config, TestTaskData>(QueueRegistration {
                 queue_name: &QUEUE_NAME,
                 worker_fn: Arc::new(move |_| {
                     let ctx = ctx_clone.clone();
@@ -100,6 +100,7 @@ mod test {
                 }),
                 num_workers: 1,
                 scope: QueueScope::Warehouse,
+                user_scheduling: UserScheduling::Disabled,
             })
             .await;
         let mut transaction =

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -6693,37 +6693,9 @@ components:
         - path
         - virtual_host
         - auto
-    ScheduleTaskRequest:
-      type: object
-      description: |-
-        Request body for `POST .../task-queue/{queue_name}/schedule`.
-
-        Schedules a single new task on the named queue for the given entity.
-        The queue must have opted in via `TaskConfig::user_schedulable() = true`.
-      required:
-        - entity
-      properties:
-        entity:
-          $ref: '#/components/schemas/WarehouseTaskEntityId'
-          description: |-
-            The entity to schedule a task for. Today only tables and views are
-            accepted; warehouse- or project-scoped queues are not user-schedulable.
-        payload:
-          description: |-
-            Optional queue-specific payload. Defaults to `{}` when omitted.
-            Validated against the queue's payload schema.
-        scheduled-for:
-          type:
-            - string
-            - 'null'
-          format: date-time
-          description: |-
-            When the task should run. `None` means immediately (the worker picks
-            it up on its next poll). RFC 3339 / ISO 8601 format.
-          example: 2026-12-31T23:59:59Z
     ScheduleTaskResponse:
       type: object
-      description: Response from `POST .../task-queue/{queue_name}/schedule`.
+      description: Response returned on a successful schedule call.
       required:
         - task-id
       properties:

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -6693,6 +6693,44 @@ components:
         - path
         - virtual_host
         - auto
+    ScheduleTaskRequest:
+      type: object
+      description: |-
+        Request body for `POST .../task-queue/{queue_name}/schedule`.
+
+        Schedules a single new task on the named queue for the given entity.
+        The queue must have opted in via `TaskConfig::user_schedulable() = true`.
+      required:
+        - entity
+      properties:
+        entity:
+          $ref: '#/components/schemas/WarehouseTaskEntityId'
+          description: |-
+            The entity to schedule a task for. Today only tables and views are
+            accepted; warehouse- or project-scoped queues are not user-schedulable.
+        payload:
+          description: |-
+            Optional queue-specific payload. Defaults to `{}` when omitted.
+            Validated against the queue's payload schema.
+        scheduled-for:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: |-
+            When the task should run. `None` means immediately (the worker picks
+            it up on its next poll). RFC 3339 / ISO 8601 format.
+          example: 2026-12-31T23:59:59Z
+    ScheduleTaskResponse:
+      type: object
+      description: Response from `POST .../task-queue/{queue_name}/schedule`.
+      required:
+        - task-id
+      properties:
+        task-id:
+          type: string
+          format: uuid
+          description: The id of the newly scheduled task.
     SearchRoleRequest:
       type: object
       required:


### PR DESCRIPTION
Lets operators directly schedule a task for a single table without waiting for a commit hook. Primary use case: bootstrapping a cold table for `remove_orphan_files` or `expire_snapshots` (enterprise), which otherwise needed a no-op ALTER to wake the hook.

Queues opt in via `TaskConfig::user_schedulable()` (default `false`), and override `TaskConfig::check_schedule_eligibility()` to fail upfront when the worker would skip at pickup (`gc.enabled=false`, per-table veto, warehouse master off). The endpoint also enforces a 365-day `scheduled-for` cap, rejects views, and resolves entities with `TabularListFlags::active()` so soft-deleted tabulars 404 instead of producing a no-op task.

AuthZ mirrors `task/control`: per-entity `ControlTasks` with a warehouse-level `ControlAllTasks` bypass. On unique-index conflict the 409 body carries the existing `task_id` (best-effort lookup + tracing::warn on failure) so operators chain straight to `task/control` for retiming.

OpenAPI paths materialise per-queue via a placeholder patcher; OSS opts in zero queues today and ships an empty pin test. Postgres migration registers `management-v1-schedule-task` so the `endpoint_statistics` enum-mismatch test stays green. Test harness gains `setup_with_registry` / `get_api_context_with_registry` so sqlx::test cases can register custom user-schedulable queues post-bootstrap.

Tests added:
- registry: user_schedulable propagation, eligibility-fn dispatch
- unit: static validation (view, scheduled-for clamp), 409 message shape (with + without task-id)
- sqlx::test: full lifecycle (schedule → 409 → RunNow) and endpoint-level eligibility rejection (400 verbatim from the gate)
- OSS pin test: schedulable-queue set is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task scheduling for warehouse queues with optional payloads, scheduled times, eligibility checks, and enriched conflict responses.

* **API**
  * New management schedule POST endpoint per-queue; OpenAPI adds schedule response schema and generates per-queue request variants.

* **Configuration**
  * Built-in queues explicitly disable user scheduling; registry exposes user-scheduling and eligibility hooks.

* **Tests**
  * Expanded unit and integration tests for scheduling, conflicts, validation, and registry behavior.

* **Chores**
  * Database enum safely extended with new schedule-endpoint value; audit events emit schedule action.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/lakekeeper/pull/1783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->