### PR TITLE
fix(config): resolve GET /config warehouse directly, drop project-level authz

### DIFF
--- a/crates/lakekeeper/src/server/config.rs
+++ b/crates/lakekeeper/src/server/config.rs
@@ -16,8 +16,7 @@ use crate::{
         CatalogStore, CatalogWarehouseOps, ProjectId, SecretStore, State, Transaction,
         WarehouseNameNotFound, WarehouseStatus,
         authz::{
-            AuthZProjectOps, Authorizer, AuthzWarehouseOps, CatalogProjectAction,
-            CatalogWarehouseAction,
+            Authorizer, AuthzWarehouseOps, CatalogWarehouseAction, RequireWarehouseActionError,
         },
         events::APIEventContext,
     },
@@ -47,32 +46,30 @@ impl<A: Authorizer + Clone, C: CatalogStore, S: SecretStore>
         let request_metadata_arc = Arc::new(request_metadata);
 
         // Arg takes precedence over auth
-        let warehouse = if let Some(query_warehouse) = query.warehouse {
-            let (project_from_arg, warehouse_from_arg) = parse_warehouse_arg(&query_warehouse);
-            let project_id = request_metadata_arc.require_project_id(project_from_arg)?;
-
-            let action = CatalogProjectAction::ListWarehouses;
-            let event_ctx = APIEventContext::for_project_arc(
-                request_metadata_arc.clone(),
-                api_context.v1_state.events.clone(),
-                project_id.clone(),
-                Arc::new(action.clone()),
-            );
-
-            let authz_result = authorizer
-                .require_project_action(&request_metadata_arc, &project_id, action)
-                .await;
-            event_ctx.emit_authz(authz_result)?;
-            C::get_warehouse_by_name(
-                &warehouse_from_arg,
-                &project_id,
-                WarehouseStatus::active(),
-                api_context.v1_state.catalog.clone(),
-            )
-            .await?
-            .ok_or_else(|| ErrorModel::from(WarehouseNameNotFound::new(warehouse_from_arg)))?
-        } else {
+        let Some(query_warehouse) = query.warehouse else {
             return Err(ErrorModel::bad_request("No warehouse specified. Please specify the 'warehouse' parameter in the GET /config request.".to_string(), "GetConfigNoWarehouseProvided", None).into());
+        };
+        let (project_from_arg, warehouse_from_arg) = parse_warehouse_arg(&query_warehouse);
+        let project_id = request_metadata_arc.require_project_id(project_from_arg)?;
+
+        // Authorize the single warehouse (get-config), not the project: a project-level
+        // "list warehouses" check considers every warehouse and times out on large
+        // projects (issue #1780). With no project gate, the caller-supplied project_id
+        // is unchecked, so a missing name and a warehouse the caller can't see both
+        // return the same name-keyed `NoSuchWarehouseException` — otherwise name->id
+        // resolution leaks existence/UUID. (Audit log keeps the truth; response timing
+        // still differs.)
+        let not_found = || ErrorModel::from(WarehouseNameNotFound::new(warehouse_from_arg.clone()));
+
+        let Some(warehouse) = C::get_warehouse_by_name(
+            &warehouse_from_arg,
+            &project_id,
+            WarehouseStatus::active(),
+            api_context.v1_state.catalog.clone(),
+        )
+        .await?
+        else {
+            return Err(not_found().into());
         };
 
         let action = CatalogWarehouseAction::GetConfig;
@@ -91,7 +88,24 @@ impl<A: Authorizer + Clone, C: CatalogStore, S: SecretStore>
                 action,
             )
             .await;
-        let (_event_ctx, warehouse) = event_ctx.emit_authz(authz_result)?;
+        // Mask "can't see it" as not-found (see above); a forbidden on a warehouse the
+        // caller *can* see keeps its native 403, which leaks nothing new.
+        let warehouse_hidden = authz_result
+            .as_ref()
+            .err()
+            .is_some_and(RequireWarehouseActionError::is_warehouse_hidden);
+        let (_event_ctx, warehouse) = match event_ctx.emit_authz(authz_result) {
+            Ok(checked) => checked,
+            // emit_authz has already written the full-detail audit event.
+            Err(masked) => {
+                return Err(if warehouse_hidden {
+                    not_found()
+                } else {
+                    masked
+                }
+                .into());
+            }
+        };
 
         let mut config = warehouse.storage_profile.generate_catalog_config(
             warehouse.warehouse_id,
@@ -190,4 +204,113 @@ async fn maybe_register_user<D: CatalogStore>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::PgPool;
+
+    use super::CatalogServer;
+    use crate::{
+        api::iceberg::v1::config::{GetConfigQueryParams, Service as _},
+        request_metadata::RequestMetadata,
+        server::test::{memory_io_profile, setup},
+        service::authz::tests::HidingAuthorizer,
+    };
+
+    fn config_query(project: &crate::ProjectId, warehouse_name: &str) -> GetConfigQueryParams {
+        GetConfigQueryParams {
+            warehouse: Some(format!("{project}/{warehouse_name}")),
+        }
+    }
+
+    #[sqlx::test]
+    async fn test_get_config_visible_warehouse(pool: PgPool) {
+        let (ctx, warehouse) = setup(
+            pool,
+            memory_io_profile(),
+            None,
+            HidingAuthorizer::new(),
+            crate::api::management::v1::warehouse::TabularDeleteProfile::Hard {},
+            None,
+        )
+        .await;
+
+        let config = CatalogServer::get_config(
+            config_query(&warehouse.project_id, &warehouse.warehouse_name),
+            ctx,
+            RequestMetadata::new_unauthenticated(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            config.overrides.get("uri"),
+            Some(&RequestMetadata::new_unauthenticated().base_uri_catalog())
+        );
+    }
+
+    /// A warehouse the caller cannot see must produce the *same* error as a
+    /// warehouse name that does not exist — otherwise the config endpoint leaks
+    /// warehouse-name existence (and the resolved UUID) to unauthorized callers.
+    /// See issue #1780: the project-level `list_warehouses` gate that previously
+    /// blocked this was removed because it forced an OpenFGA fan-out across every
+    /// warehouse in the project.
+    #[sqlx::test]
+    async fn test_get_config_hidden_warehouse_indistinguishable_from_missing(pool: PgPool) {
+        let authz = HidingAuthorizer::new();
+        let (ctx, warehouse) = setup(
+            pool,
+            memory_io_profile(),
+            None,
+            authz.clone(),
+            crate::api::management::v1::warehouse::TabularDeleteProfile::Hard {},
+            None,
+        )
+        .await;
+
+        // Hide the (existing) warehouse from the authorizer.
+        authz.hide(&format!("warehouse:{}", warehouse.warehouse_id));
+
+        // Probe the existing-but-hidden warehouse by its real name.
+        let hidden_err = CatalogServer::get_config(
+            config_query(&warehouse.project_id, &warehouse.warehouse_name),
+            ctx.clone(),
+            RequestMetadata::new_unauthenticated(),
+        )
+        .await
+        .expect_err("hidden warehouse must not be readable")
+        .error;
+
+        // The response for a hidden warehouse must be byte-identical (modulo the
+        // random `error_id`) to the canonical "name does not exist" error for the
+        // *same* name — i.e. the response is a pure function of the client-supplied
+        // input, never of whether the warehouse actually exists or its UUID.
+        let canonical_missing = crate::api::iceberg::v1::ErrorModel::from(
+            crate::service::WarehouseNameNotFound::new(warehouse.warehouse_name.clone()),
+        );
+        assert_eq!(hidden_err.code, 404);
+        assert_eq!(hidden_err.r#type, canonical_missing.r#type);
+        assert_eq!(hidden_err.message, canonical_missing.message);
+        // The resolved warehouse UUID must never appear in the masked response.
+        assert!(
+            !hidden_err
+                .message
+                .contains(&warehouse.warehouse_id.to_string()),
+            "masked error leaked the warehouse UUID: {}",
+            hidden_err.message
+        );
+
+        // Sanity-check the other branch: a name that genuinely does not exist
+        // produces the same error shape (type + code), echoing only its own input.
+        let missing_err = CatalogServer::get_config(
+            config_query(&warehouse.project_id, "does-not-exist"),
+            ctx,
+            RequestMetadata::new_unauthenticated(),
+        )
+        .await
+        .expect_err("missing warehouse must error")
+        .error;
+        assert_eq!(missing_err.code, 404);
+        assert_eq!(missing_err.r#type, hidden_err.r#type);
+    }
 }

--- a/crates/lakekeeper/src/service/authz/warehouse.rs
+++ b/crates/lakekeeper/src/service/authz/warehouse.rs
@@ -162,6 +162,18 @@ pub enum RequireWarehouseActionError {
     DatabaseIntegrityError(DatabaseIntegrityError),
 }
 
+impl RequireWarehouseActionError {
+    /// `true` if the failure is "the caller cannot see this warehouse" (existent or
+    /// not), as opposed to a forbidden action on a warehouse the caller *can* see.
+    /// Name-keyed endpoints use this to mask the failure as a generic not-found so a
+    /// name lookup can't become an existence/UUID oracle. Kept next to the variants so
+    /// the predicate can't drift if the enum changes.
+    #[must_use]
+    pub fn is_warehouse_hidden(&self) -> bool {
+        matches!(self, Self::AuthZCannotUseWarehouseId(_))
+    }
+}
+
 impl From<BackendUnavailableOrCountMismatch> for RequireWarehouseActionError {
     fn from(err: BackendUnavailableOrCountMismatch) -> Self {
         match err {


### PR DESCRIPTION

The project-level "list warehouses" check considers every warehouse and times out on large projects (#1780). Authorize the single warehouse via the get-config permission instead.

Without the project gate, mask "warehouse hidden" and "name not found" to an identical name-keyed NoSuchWarehouseException so name->id resolution can't leak warehouse existence or its UUID. Audit log keeps full detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization enforcement for warehouse configuration access.
  * Enhanced error handling to provide consistent responses for hidden or unauthorized warehouses.

* **Tests**
  * Added tests to verify warehouse visibility and authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->