### PR TITLE
chore(authz-openfga): refactor / decouple reconcile from Postgres/sqlx

### DIFF
--- a/crates/authz-openfga/src/lib.rs
+++ b/crates/authz-openfga/src/lib.rs
@@ -34,8 +34,8 @@ mod tuples;
 pub use config::CONFIG;
 pub use migration::migrate;
 pub use reconcile::{
-    RebuildReport, ReconcileMode, ReconcileReport, rebuild_hierarchy_tuples_from_catalog,
-    reconcile_hierarchy_tuples_from_catalog,
+    RECONCILE_LOCK_KEY, RebuildReport, ReconcileMode, ReconcileReport,
+    rebuild_hierarchy_tuples_from_catalog, reconcile_hierarchy_tuples_from_catalog,
 };
 
 const MAX_TUPLES_PER_WRITE: i32 = 100;

--- a/crates/authz-openfga/src/reconcile.rs
+++ b/crates/authz-openfga/src/reconcile.rs
@@ -1,15 +1,15 @@
-//! Reconcile structural OpenFGA tuples against the Postgres catalog.
+//! Reconcile structural OpenFGA tuples against the catalog.
 //!
-//! Two public entry points:
+//! Two public entry points, both generic over the [`CatalogStore`] backend:
 //!
 //! * [`rebuild_hierarchy_tuples_from_catalog`] — additive only. Reads the
 //!   catalog, idempotently writes any hierarchy tuple the catalog implies.
-//!   Never deletes. Generic over the [`CatalogStore`] backend. Safe under
-//!   concurrent writes (no lock acquired).
+//!   Never deletes. Safe under concurrent writes (no lock required).
 //! * [`reconcile_hierarchy_tuples_from_catalog`] — additive **plus** drift
-//!   deletion. Acquires a Postgres advisory lock to prevent concurrent
-//!   reconciles. Postgres-only by signature because the lock and per-delete
-//!   revalidation use sqlx directly.
+//!   deletion. The caller passes a lock guard to serialize concurrent
+//!   reconciles; this module is agnostic to which lock primitive backs it.
+//!   For Postgres deployments use [`lakekeeper::implementations::postgres::PostgresAdvisoryLock`]
+//!   with [`RECONCILE_LOCK_KEY`]; single-replica deployments may pass `()`.
 //!
 //! The shape of every emitted tuple comes from the `hierarchy_tuples_for_*`
 //! helpers in [`crate::tuples`] — the same helpers the authorizer's
@@ -66,7 +66,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use lakekeeper::{
     ProjectId, WarehouseId,
     api::iceberg::v1::{ListNamespacesQuery, NamespaceIdent, PageToken, PaginationQuery},
-    implementations::postgres::CatalogState,
     service::{
         ArcProjectId, CatalogListRolesByIdFilter, CatalogNamespaceOps, CatalogRoleOps,
         CatalogStore, CatalogTabularOps, CatalogWarehouseOps, GenericTableId, NamespaceId,
@@ -92,9 +91,12 @@ use crate::{
 const WRITE_BATCH_SIZE: usize = 100;
 /// OpenFGA hard-caps Read page size at 100 (proto-level).
 const READ_PAGE_SIZE: i32 = 100;
-/// Postgres advisory lock key. Stable arbitrary value; the lock is scoped
-/// to "reconcile-with-deletion".
-const RECONCILE_LOCK_KEY: i64 = 0x5f8e_2d63_a4b1_00ff;
+/// Lock scope for OpenFGA reconcile-with-deletion. Pass this to the
+/// backend's lock primitive (e.g.
+/// `lakekeeper::implementations::postgres::PostgresAdvisoryLock::try_acquire`)
+/// when calling [`reconcile_hierarchy_tuples_from_catalog`] in
+/// `AddMissingAndDeleteDrift` mode.
+pub const RECONCILE_LOCK_KEY: i64 = 0x5f8e_2d63_a4b1_00ff;
 
 // ============================================================================
 // Public types
@@ -185,41 +187,43 @@ where
 }
 
 // ============================================================================
-// Public entry: additive + delete drift (Postgres-specific)
+// Public entry: additive + delete drift
 // ============================================================================
 
 /// Reconcile structural tuples against the catalog, with optional drift
-/// deletion. Postgres-only because of the advisory lock and per-delete
-/// revalidation.
+/// deletion. Generic over the catalog backend.
+///
+/// The caller passes a `lock_guard` that it owns for the duration of the
+/// call; this module never inspects it and drops it when the function
+/// returns. Use it to serialize concurrent reconciles — e.g. acquire a
+/// Postgres advisory lock with
+/// `lakekeeper::implementations::postgres::PostgresAdvisoryLock::try_acquire(
+/// state, RECONCILE_LOCK_KEY)` and pass the guard in. Single-replica
+/// deployments without a meaningful concurrency story may pass `()`.
 ///
 /// When `dry_run` is true, no OpenFGA writes or deletes occur — the report
-/// counts what *would* have been changed. The advisory lock is still
-/// acquired so a dry-run reads a stable snapshot relative to other
-/// reconciles.
+/// counts what *would* have been changed.
 ///
 /// # Errors
 /// * Catalog or OpenFGA call fails.
-/// * Advisory lock is already held by another reconcile.
-pub async fn reconcile_hierarchy_tuples_from_catalog(
-    catalog_state: CatalogState,
+pub async fn reconcile_hierarchy_tuples_from_catalog<C>(
+    catalog_state: C::State,
+    lock_guard: impl Send + 'static,
     sink: &BasicOpenFgaClient,
     server_id: ServerId,
     mode: ReconcileMode,
     dry_run: bool,
-) -> anyhow::Result<ReconcileReport> {
+) -> anyhow::Result<ReconcileReport>
+where
+    C: CatalogStore,
+{
     tracing::info!("reconcile: starting (mode={mode:?}, server_id={server_id}, dry_run={dry_run})");
     let mut report = ReconcileReport {
         dry_run,
         ..ReconcileReport::default()
     };
 
-    let _lock = AdvisoryLock::acquire(&catalog_state).await?;
-
-    let idx = CatalogIndex::build::<lakekeeper::implementations::postgres::PostgresBackend>(
-        &catalog_state,
-        server_id,
-    )
-    .await?;
+    let idx = CatalogIndex::build::<C>(&catalog_state, server_id).await?;
     log_index(&idx);
 
     if matches!(mode, ReconcileMode::AddMissingAndDeleteDrift) {
@@ -231,6 +235,7 @@ pub async fn reconcile_hierarchy_tuples_from_catalog(
     write_missing_from_index(&idx, sink, &mut report, dry_run).await?;
 
     log_done(&report, "reconcile");
+    drop(lock_guard);
     Ok(report)
 }
 
@@ -744,37 +749,6 @@ async fn flush_deletes(
 }
 
 // ============================================================================
-// Postgres advisory lock
-// ============================================================================
-
-/// Holds an exclusive Postgres session-level advisory lock for the duration
-/// of a reconcile run. Released when the held connection is dropped.
-struct AdvisoryLock {
-    /// Keep the connection alive — release happens on drop.
-    _conn: sqlx::pool::PoolConnection<sqlx::Postgres>,
-}
-
-impl AdvisoryLock {
-    async fn acquire(state: &CatalogState) -> anyhow::Result<Self> {
-        let mut conn =
-            state.write_pool().acquire().await.map_err(|e| {
-                anyhow::anyhow!("reconcile: failed to acquire pool conn for lock: {e}")
-            })?;
-        let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
-            .bind(RECONCILE_LOCK_KEY)
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(|e| anyhow::anyhow!("reconcile: pg_try_advisory_lock failed: {e}"))?;
-        if !acquired {
-            anyhow::bail!(
-                "reconcile: another reconcile is already running (advisory lock {RECONCILE_LOCK_KEY:#x} held)"
-            );
-        }
-        Ok(Self { _conn: conn })
-    }
-}
-
-// ============================================================================
 // Internal write helper
 // ============================================================================
 
@@ -874,7 +848,7 @@ mod openfga_integration_tests {
                 role::{CreateRoleRequest, Service as RoleService},
             },
         },
-        implementations::postgres::PostgresBackend,
+        implementations::postgres::{CatalogState, PostgresAdvisoryLock, PostgresBackend},
         server::{CatalogServer, NAMESPACE_ID_PROPERTY},
         service::{
             NamespaceIdent, RoleId,
@@ -1237,8 +1211,14 @@ mod openfga_integration_tests {
         assert!(state_before.contains(&ident(&stale_forward)));
         assert!(state_before.contains(&ident(&stale_inverse)));
 
-        let report = reconcile_hierarchy_tuples_from_catalog(
-            pg_state(&pool),
+        let state = pg_state(&pool);
+        let lock = PostgresAdvisoryLock::try_acquire(&state, RECONCILE_LOCK_KEY)
+            .await
+            .expect("acquire lock")
+            .expect("lock free");
+        let report = reconcile_hierarchy_tuples_from_catalog::<PostgresBackend>(
+            state,
+            lock,
             &authorizer.client,
             server_id,
             ReconcileMode::AddMissingAndDeleteDrift,
@@ -1299,8 +1279,14 @@ mod openfga_integration_tests {
             .await
             .unwrap();
 
-        reconcile_hierarchy_tuples_from_catalog(
-            pg_state(&pool),
+        let state = pg_state(&pool);
+        let lock = PostgresAdvisoryLock::try_acquire(&state, RECONCILE_LOCK_KEY)
+            .await
+            .expect("acquire lock")
+            .expect("lock free");
+        reconcile_hierarchy_tuples_from_catalog::<PostgresBackend>(
+            state,
+            lock,
             &authorizer.client,
             server_id,
             ReconcileMode::AddMissingAndDeleteDrift,
@@ -1318,46 +1304,6 @@ mod openfga_integration_tests {
             state_after.contains(&ident(&both_orphan)),
             "both-endpoints-unknown tuple must be preserved (no anchor)"
         );
-    }
-
-    #[sqlx::test]
-    async fn test_reconcile_advisory_lock_is_exclusive(pool: sqlx::PgPool) {
-        let operator_id = UserId::new_unchecked("oidc", &Uuid::now_v7().to_string());
-        let (_svc_client, authorizer) = authorizer_for_empty_store().await;
-        let server_id = authorizer.server_id();
-        let _ = populate(&authorizer, &pool, &operator_id).await;
-        let state = pg_state(&pool);
-
-        // Hold the lock manually using a dedicated session connection.
-        let mut conn = state.write_pool().acquire().await.unwrap();
-        let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
-            .bind(RECONCILE_LOCK_KEY)
-            .fetch_one(&mut *conn)
-            .await
-            .unwrap();
-        assert!(acquired, "test setup: must acquire lock");
-
-        let result = reconcile_hierarchy_tuples_from_catalog(
-            state.clone(),
-            &authorizer.client,
-            server_id,
-            ReconcileMode::AddMissingAndDeleteDrift,
-            false,
-        )
-        .await;
-
-        assert!(
-            result.is_err(),
-            "must error when lock is held by another session"
-        );
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("another reconcile is already running"),
-            "expected lock-contention error message; got: {err}"
-        );
-
-        // Release: drop conn (advisory_lock is session-scoped so it's released on close).
-        drop(conn);
     }
 
     #[sqlx::test]
@@ -1385,8 +1331,14 @@ mod openfga_integration_tests {
 
         let state_before = read_all_tuples(&authorizer.client).await;
 
-        let report = reconcile_hierarchy_tuples_from_catalog(
-            pg_state(&pool),
+        let state = pg_state(&pool);
+        let lock = PostgresAdvisoryLock::try_acquire(&state, RECONCILE_LOCK_KEY)
+            .await
+            .expect("acquire lock")
+            .expect("lock free");
+        let report = reconcile_hierarchy_tuples_from_catalog::<PostgresBackend>(
+            state,
+            lock,
             &authorizer.client,
             server_id,
             ReconcileMode::AddMissingAndDeleteDrift,
@@ -1575,8 +1527,14 @@ mod openfga_integration_tests {
         assert!(state_before.contains(&ident(&stale_forward)));
         assert!(state_before.contains(&ident(&stale_inverse)));
 
-        let report = reconcile_hierarchy_tuples_from_catalog(
-            pg_state(&pool),
+        let state = pg_state(&pool);
+        let lock = PostgresAdvisoryLock::try_acquire(&state, RECONCILE_LOCK_KEY)
+            .await
+            .expect("acquire lock")
+            .expect("lock free");
+        let report = reconcile_hierarchy_tuples_from_catalog::<PostgresBackend>(
+            state,
+            lock,
             &authorizer.client,
             server_id,
             ReconcileMode::AddMissingAndDeleteDrift,

--- a/crates/authz-openfga/src/reconcile.rs
+++ b/crates/authz-openfga/src/reconcile.rs
@@ -34,8 +34,9 @@
 //!
 //! # Operational notes (deletion mode)
 //!
-//! * The advisory lock blocks concurrent reconciles. It does **not** block
-//!   API writes — operators should run during low-traffic windows.
+//! * The caller-provided lock guard serializes concurrent reconciles for
+//!   the chosen backend. It does **not** block API writes — operators
+//!   should run during low-traffic windows.
 //! * Total runtime scales with OpenFGA store size at ~80k tuples/sec for
 //!   the global Read scan, plus catalog read time.
 //!
@@ -70,7 +71,7 @@ use lakekeeper::{
         ArcProjectId, CatalogListRolesByIdFilter, CatalogNamespaceOps, CatalogRoleOps,
         CatalogStore, CatalogTabularOps, CatalogWarehouseOps, GenericTableId, NamespaceId,
         ServerId, TableId, TabularId, TabularListFlags, Transaction, ViewId,
-        authz::NamespaceParent,
+        authz::NamespaceParent, maintenance::MaintenanceLockGuard,
     },
 };
 use openfga_client::client::{
@@ -96,6 +97,11 @@ const READ_PAGE_SIZE: i32 = 100;
 /// `lakekeeper::implementations::postgres::PostgresAdvisoryLock::try_acquire`)
 /// when calling [`reconcile_hierarchy_tuples_from_catalog`] in
 /// `AddMissingAndDeleteDrift` mode.
+///
+/// **Contract identifier only.** This key is the agreed-upon namespace
+/// between callers of `reconcile_hierarchy_tuples_from_catalog` and the
+/// lock backend; do not reuse it for unrelated locks. New maintenance
+/// flows should pick their own distinct `i64`.
 pub const RECONCILE_LOCK_KEY: i64 = 0x5f8e_2d63_a4b1_00ff;
 
 // ============================================================================
@@ -194,12 +200,13 @@ where
 /// deletion. Generic over the catalog backend.
 ///
 /// The caller passes a `lock_guard` that it owns for the duration of the
-/// call; this module never inspects it and drops it when the function
-/// returns. Use it to serialize concurrent reconciles — e.g. acquire a
+/// call; this module never inspects it and the guard drops at function
+/// exit. Use it to serialize concurrent reconciles — e.g. acquire a
 /// Postgres advisory lock with
 /// `lakekeeper::implementations::postgres::PostgresAdvisoryLock::try_acquire(
 /// state, RECONCILE_LOCK_KEY)` and pass the guard in. Single-replica
-/// deployments without a meaningful concurrency story may pass `()`.
+/// deployments may pass [`lakekeeper::service::maintenance::NoMaintenanceLock`]
+/// as an explicit opt-out.
 ///
 /// When `dry_run` is true, no OpenFGA writes or deletes occur — the report
 /// counts what *would* have been changed.
@@ -208,7 +215,7 @@ where
 /// * Catalog or OpenFGA call fails.
 pub async fn reconcile_hierarchy_tuples_from_catalog<C>(
     catalog_state: C::State,
-    lock_guard: impl Send + 'static,
+    lock_guard: impl MaintenanceLockGuard,
     sink: &BasicOpenFgaClient,
     server_id: ServerId,
     mode: ReconcileMode,
@@ -217,6 +224,7 @@ pub async fn reconcile_hierarchy_tuples_from_catalog<C>(
 where
     C: CatalogStore,
 {
+    let _lock_guard = lock_guard;
     tracing::info!("reconcile: starting (mode={mode:?}, server_id={server_id}, dry_run={dry_run})");
     let mut report = ReconcileReport {
         dry_run,
@@ -235,7 +243,6 @@ where
     write_missing_from_index(&idx, sink, &mut report, dry_run).await?;
 
     log_done(&report, "reconcile");
-    drop(lock_guard);
     Ok(report)
 }
 

--- a/crates/lakekeeper-bin/src/main.rs
+++ b/crates/lakekeeper-bin/src/main.rs
@@ -352,7 +352,6 @@ async fn openfga_reconcile(
     let authorizer =
         lakekeeper_authz_openfga::new_authorizer_from_default_config(server_id).await?;
 
-    tracing::info!("openfga reconcile: starting (mode={mode:?}, dry_run={dry_run})");
     let lock = lakekeeper::implementations::postgres::PostgresAdvisoryLock::try_acquire(
         &catalog_state,
         lakekeeper_authz_openfga::RECONCILE_LOCK_KEY,
@@ -364,15 +363,16 @@ async fn openfga_reconcile(
             lakekeeper_authz_openfga::RECONCILE_LOCK_KEY
         )
     })?;
-    let report = lakekeeper_authz_openfga::reconcile_hierarchy_tuples_from_catalog::<PostgresBackend>(
-        catalog_state,
-        lock,
-        authorizer.client(),
-        server_id,
-        mode,
-        dry_run,
-    )
-    .await?;
+    let report =
+        lakekeeper_authz_openfga::reconcile_hierarchy_tuples_from_catalog::<PostgresBackend>(
+            catalog_state,
+            lock,
+            authorizer.client(),
+            server_id,
+            mode,
+            dry_run,
+        )
+        .await?;
 
     let action = if report.dry_run { "would" } else { "did" };
     println!();

--- a/crates/lakekeeper-bin/src/main.rs
+++ b/crates/lakekeeper-bin/src/main.rs
@@ -353,8 +353,20 @@ async fn openfga_reconcile(
         lakekeeper_authz_openfga::new_authorizer_from_default_config(server_id).await?;
 
     tracing::info!("openfga reconcile: starting (mode={mode:?}, dry_run={dry_run})");
-    let report = lakekeeper_authz_openfga::reconcile_hierarchy_tuples_from_catalog(
+    let lock = lakekeeper::implementations::postgres::PostgresAdvisoryLock::try_acquire(
+        &catalog_state,
+        lakekeeper_authz_openfga::RECONCILE_LOCK_KEY,
+    )
+    .await?
+    .ok_or_else(|| {
+        anyhow::anyhow!(
+            "openfga reconcile: another reconcile is already running (advisory lock {:#x} held)",
+            lakekeeper_authz_openfga::RECONCILE_LOCK_KEY
+        )
+    })?;
+    let report = lakekeeper_authz_openfga::reconcile_hierarchy_tuples_from_catalog::<PostgresBackend>(
         catalog_state,
+        lock,
         authorizer.client(),
         server_id,
         mode,

--- a/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
+++ b/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
@@ -1,8 +1,21 @@
 //! Postgres session-level advisory lock as a generic mutex primitive.
 //!
 //! Used by maintenance flows (currently: OpenFGA reconcile-with-deletion)
-//! to prevent two long-running mutation passes from racing. The lock is
-//! session-scoped: it is released when the held `PoolConnection` drops.
+//! to prevent two long-running mutation passes from racing.
+//!
+//! The lock is session-scoped (`pg_try_advisory_lock`) and stays held
+//! for the lifetime of the postgres backend session. To release on
+//! `Drop`, the held [`sqlx::pool::PoolConnection`] is marked
+//! `close_on_drop` at acquire time — when the guard goes out of scope,
+//! sqlx spawns a task to terminate the connection, the server detects
+//! the closed socket, and `PostgreSQL` releases every advisory lock the
+//! session held. (Returning the connection to the pool would leave the
+//! lock held and let a re-entrant acquire on the same recycled
+//! connection silently succeed.)
+//!
+//! Release is async-deferred — bounded by the time it takes the close
+//! task to run and the server to notice — but for a maintenance flow
+//! that already runs at human cadence, the window is irrelevant.
 //!
 //! The lock key namespace is the caller's responsibility — pick a stable
 //! arbitrary `i64` and document its scope at the call site.
@@ -48,6 +61,11 @@ impl PostgresAdvisoryLock {
             .await
             .map_err(|e| anyhow::anyhow!("advisory lock: pg_try_advisory_lock failed: {e}"))?;
         if acquired {
+            // Terminate the postgres session when the guard drops, so the
+            // session-level advisory lock is released. Otherwise the
+            // connection would be returned to the pool with the lock
+            // still held (and re-entrant on subsequent acquires).
+            conn.close_on_drop();
             Ok(Some(Self { _conn: conn }))
         } else {
             Ok(None)
@@ -108,12 +126,22 @@ mod tests {
             assert!(lock.is_some());
         }
 
-        let reacquire = PostgresAdvisoryLock::try_acquire(&state, TEST_KEY)
-            .await
-            .expect("query ok");
-        assert!(
-            reacquire.is_some(),
-            "lock must be re-acquirable after previous guard dropped"
-        );
+        // Release is async-deferred: the dropped PoolConnection spawns a
+        // close task, and `PostgreSQL` releases the lock once it sees the
+        // socket close. Poll up to a few seconds before failing.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let attempt = PostgresAdvisoryLock::try_acquire(&state, TEST_KEY)
+                .await
+                .expect("query ok");
+            if attempt.is_some() {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "lock not released within 5s after guard drop"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
     }
 }

--- a/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
+++ b/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
@@ -7,7 +7,10 @@
 //! The lock key namespace is the caller's responsibility — pick a stable
 //! arbitrary `i64` and document its scope at the call site.
 
-use crate::implementations::postgres::CatalogState;
+use crate::{
+    implementations::postgres::CatalogState,
+    service::maintenance::{MaintenanceLockGuard, MaintenanceLockGuardSealed},
+};
 
 /// Holds an exclusive Postgres session-level advisory lock for the lifetime
 /// of the value. Release happens on `Drop`.
@@ -20,6 +23,9 @@ use crate::implementations::postgres::CatalogState;
 pub struct PostgresAdvisoryLock {
     _conn: sqlx::pool::PoolConnection<sqlx::Postgres>,
 }
+
+impl MaintenanceLockGuardSealed for PostgresAdvisoryLock {}
+impl MaintenanceLockGuard for PostgresAdvisoryLock {}
 
 impl PostgresAdvisoryLock {
     /// Try to acquire the advisory lock identified by `key`.

--- a/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
+++ b/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
@@ -1,0 +1,113 @@
+//! Postgres session-level advisory lock as a generic mutex primitive.
+//!
+//! Used by maintenance flows (currently: OpenFGA reconcile-with-deletion)
+//! to prevent two long-running mutation passes from racing. The lock is
+//! session-scoped: it is released when the held `PoolConnection` drops.
+//!
+//! The lock key namespace is the caller's responsibility — pick a stable
+//! arbitrary `i64` and document its scope at the call site.
+
+use crate::implementations::postgres::CatalogState;
+
+/// Holds an exclusive Postgres session-level advisory lock for the lifetime
+/// of the value. Release happens on `Drop`.
+///
+/// Hold across the operation you want to serialize, and let the guard drop
+/// when you're done. Do not move the guard into a `'static` task unless you
+/// intend the lock to outlive the awaiting flow.
+#[must_use = "lock is released when guard is dropped"]
+#[derive(Debug)]
+pub struct PostgresAdvisoryLock {
+    _conn: sqlx::pool::PoolConnection<sqlx::Postgres>,
+}
+
+impl PostgresAdvisoryLock {
+    /// Try to acquire the advisory lock identified by `key`.
+    ///
+    /// Returns `Ok(Some(guard))` when the lock was acquired, `Ok(None)`
+    /// when another session already holds it, and `Err` on database
+    /// failure.
+    ///
+    /// # Errors
+    /// Database connection acquisition or query failure.
+    pub async fn try_acquire(state: &CatalogState, key: i64) -> anyhow::Result<Option<Self>> {
+        let mut conn = state
+            .write_pool()
+            .acquire()
+            .await
+            .map_err(|e| anyhow::anyhow!("advisory lock: failed to acquire pool conn: {e}"))?;
+        let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
+            .bind(key)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(|e| anyhow::anyhow!("advisory lock: pg_try_advisory_lock failed: {e}"))?;
+        if acquired {
+            Ok(Some(Self { _conn: conn }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::PgPool;
+
+    use super::*;
+
+    const TEST_KEY: i64 = 0x5f8e_2d63_a4b1_dead;
+
+    #[sqlx::test]
+    async fn try_acquire_succeeds_when_free(pool: PgPool) {
+        let state = CatalogState::from_pools(pool.clone(), pool);
+        let lock = PostgresAdvisoryLock::try_acquire(&state, TEST_KEY)
+            .await
+            .expect("query ok");
+        assert!(lock.is_some(), "lock must be acquired when key is free");
+    }
+
+    #[sqlx::test]
+    async fn try_acquire_returns_none_when_held(pool: PgPool) {
+        let state = CatalogState::from_pools(pool.clone(), pool);
+
+        // Hold the lock manually on a separate session.
+        let mut holder = state.write_pool().acquire().await.unwrap();
+        let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
+            .bind(TEST_KEY)
+            .fetch_one(&mut *holder)
+            .await
+            .unwrap();
+        assert!(acquired, "test setup: holder must acquire");
+
+        let attempt = PostgresAdvisoryLock::try_acquire(&state, TEST_KEY)
+            .await
+            .expect("query ok");
+        assert!(
+            attempt.is_none(),
+            "second acquire must fail while another session holds the lock"
+        );
+
+        // Releasing the holder's session frees the lock.
+        drop(holder);
+    }
+
+    #[sqlx::test]
+    async fn lock_released_on_drop(pool: PgPool) {
+        let state = CatalogState::from_pools(pool.clone(), pool);
+
+        {
+            let lock = PostgresAdvisoryLock::try_acquire(&state, TEST_KEY)
+                .await
+                .expect("query ok");
+            assert!(lock.is_some());
+        }
+
+        let reacquire = PostgresAdvisoryLock::try_acquire(&state, TEST_KEY)
+            .await
+            .expect("query ok");
+        assert!(
+            reacquire.is_some(),
+            "lock must be re-acquirable after previous guard dropped"
+        );
+    }
+}

--- a/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
+++ b/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     implementations::postgres::CatalogState,
-    service::maintenance::{MaintenanceLockGuard, MaintenanceLockGuardSealed},
+    service::maintenance::{MaintenanceLockGuard, sealed::Sealed as MaintenanceLockGuardSealed},
 };
 
 /// Holds an exclusive Postgres session-level advisory lock for the lifetime

--- a/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
+++ b/crates/lakekeeper/src/implementations/postgres/advisory_lock.rs
@@ -17,6 +17,15 @@
 //! task to run and the server to notice — but for a maintenance flow
 //! that already runs at human cadence, the window is irrelevant.
 //!
+//! ## Pool footprint
+//!
+//! The guard holds one pool connection for its entire lifetime. The
+//! protected operation typically needs at least one additional
+//! connection (catalog reads, transactions). Ensure the pool's
+//! `max_connections` is at least 2 — small or single-connection pools
+//! will self-deadlock when the operation tries to acquire its second
+//! connection while the lock conn is held.
+//!
 //! The lock key namespace is the caller's responsibility — pick a stable
 //! arbitrary `i64` and document its scope at the call site.
 

--- a/crates/lakekeeper/src/implementations/postgres/mod.rs
+++ b/crates/lakekeeper/src/implementations/postgres/mod.rs
@@ -1,3 +1,4 @@
+mod advisory_lock;
 mod bootstrap;
 mod catalog;
 pub(crate) mod dbutils;
@@ -16,6 +17,7 @@ pub(crate) mod warehouse;
 
 use std::{str::FromStr, sync::Arc};
 
+pub use advisory_lock::PostgresAdvisoryLock;
 use anyhow::anyhow;
 use async_trait::async_trait;
 pub use endpoint_statistics::sink::PostgresStatisticsSink;

--- a/crates/lakekeeper/src/service/maintenance.rs
+++ b/crates/lakekeeper/src/service/maintenance.rs
@@ -8,7 +8,13 @@
 //! disable concurrency control) a compile error at the function
 //! boundary.
 
-mod sealed {
+/// Sealing module for [`MaintenanceLockGuard`]. The trait `Sealed` is
+/// `pub` so other modules in the lakekeeper crate can implement it for
+/// their lock primitives (e.g.
+/// [`crate::implementations::postgres::PostgresAdvisoryLock`]), but the
+/// `sealed` module is `pub(crate)` — downstream crates cannot reach it
+/// and therefore cannot satisfy the supertrait of `MaintenanceLockGuard`.
+pub(crate) mod sealed {
     pub trait Sealed {}
 }
 
@@ -29,8 +35,3 @@ pub struct NoMaintenanceLock;
 
 impl sealed::Sealed for NoMaintenanceLock {}
 impl MaintenanceLockGuard for NoMaintenanceLock {}
-
-// Crate-internal re-export so other modules in the lakekeeper crate
-// (e.g. `implementations::postgres::advisory_lock`) can opt their lock
-// types into the sealed marker without needing a public seal API.
-pub(crate) use sealed::Sealed as MaintenanceLockGuardSealed;

--- a/crates/lakekeeper/src/service/maintenance.rs
+++ b/crates/lakekeeper/src/service/maintenance.rs
@@ -1,0 +1,36 @@
+//! Cross-cutting primitives for long-running maintenance flows that must
+//! serialize across replicas (catalog reconciliation, schema-migration
+//! coordination, etc.).
+//!
+//! [`MaintenanceLockGuard`] is a sealed marker trait. The defining crate
+//! is the only place that can grant the marker to a type, which makes
+//! `impl Send + 'static` foot-shots (e.g. passing `()` to silently
+//! disable concurrency control) a compile error at the function
+//! boundary.
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// RAII guard for a maintenance operation that must not run concurrently
+/// across replicas. The trait carries no methods; implementations are
+/// owned values whose `Drop` releases whatever distributed-mutex
+/// primitive backs them (Postgres advisory lock, etc.). The maintenance
+/// function holds the guard for the operation's lifetime and never
+/// inspects it.
+pub trait MaintenanceLockGuard: sealed::Sealed + Send + 'static {}
+
+/// Sentinel guard for deployments where concurrency control is not
+/// needed (single-replica, single-writer). Passing this is an explicit
+/// opt-out — the named token forces the caller to think about whether
+/// their deployment actually needs serialization.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoMaintenanceLock;
+
+impl sealed::Sealed for NoMaintenanceLock {}
+impl MaintenanceLockGuard for NoMaintenanceLock {}
+
+// Crate-internal re-export so other modules in the lakekeeper crate
+// (e.g. `implementations::postgres::advisory_lock`) can opt their lock
+// types into the sealed marker without needing a public seal API.
+pub(crate) use sealed::Sealed as MaintenanceLockGuardSealed;

--- a/crates/lakekeeper/src/service/mod.rs
+++ b/crates/lakekeeper/src/service/mod.rs
@@ -7,6 +7,7 @@ pub mod endpoint_statistics;
 pub mod events;
 pub mod health;
 pub mod idempotency;
+pub mod maintenance;
 pub mod secrets;
 pub mod storage;
 pub mod task_configs;

--- a/docs/docs/authorization-openfga.md
+++ b/docs/docs/authorization-openfga.md
@@ -119,7 +119,7 @@ Reconcile only operates on the **structural** parts of the OpenFGA store: the pa
 ### Operational notes
 
 - Run during a low-traffic window. Reconcile does **not** stop API writes; concurrent renames/creates/deletes can produce transient inconsistencies that self-heal on the next run.
-- A Postgres advisory lock prevents two reconciles from running at once. A held lock causes the second invocation to fail fast.
+- A Postgres advisory lock prevents two reconciles from running at once. The second invocation fails fast with the lock key in the error message; you can confirm a held lock with `SELECT * FROM pg_locks WHERE locktype = 'advisory'`.
 - Use `--dry-run` first when you intend to delete drift.
 
 ## Switching to OpenFGA or replacing the store


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconcile now requires an external maintenance lock; Postgres advisory locking is supported and the reconcile command fails fast if another reconcile holds the lock (error includes held lock key).
  * Added a pluggable maintenance-lock abstraction with a no-lock opt-out for single-replica setups.
  * Postgres advisory lock acquisition is available for the reconcile command.

* **Documentation**
  * Updated operational guidance for reconcile, including examples to inspect held advisory locks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->