### PR TITLE
chore(docker): migrate base images from Debian bookworm to trixie

### DIFF
--- a/docker/bin.Dockerfile
+++ b/docker/bin.Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH
 
-FROM gcr.io/distroless/cc-debian12:nonroot-${ARCH} AS base
+FROM gcr.io/distroless/cc-debian13:nonroot-${ARCH} AS base
 
 FROM busybox:1.37.0 AS cleaner
 # small diversion through busybox to remove some files

--- a/docker/bin.Dockerfile
+++ b/docker/bin.Dockerfile
@@ -7,7 +7,7 @@ FROM busybox:1.37.0 AS cleaner
 
 COPY --from=base / /clean
 
-RUN rm -r /clean/usr/lib/*-linux-gnu/libgomp*  \
+RUN rm -rf /clean/usr/lib/*-linux-gnu/libgomp*  \
        /clean/usr/lib/*-linux-gnu/libssl*  \
        /clean/usr/lib/*-linux-gnu/libstdc++* \
        /clean/usr/lib/*-linux-gnu/engines-3 \

--- a/docker/bin.Dockerfile
+++ b/docker/bin.Dockerfile
@@ -7,17 +7,16 @@ FROM busybox:1.37.0 AS cleaner
 
 COPY --from=base / /clean
 
-RUN rm -rf /clean/usr/lib/*-linux-gnu/libgomp*  \
+RUN rm -r /clean/usr/lib/*-linux-gnu/libgomp*  \
        /clean/usr/lib/*-linux-gnu/libssl*  \
        /clean/usr/lib/*-linux-gnu/libstdc++* \
        /clean/usr/lib/*-linux-gnu/engines-3 \
-       /clean/usr/lib/*-linux-gnu/ossl-modules \
        /clean/usr/lib/*-linux-gnu/libcrypto.so.3 \
        /clean/usr/lib/*-linux-gnu/gconv \
        /clean/var/lib/dpkg/status.d/libgomp1*  \
        /clean/var/lib/dpkg/status.d/libssl3*  \
        /clean/var/lib/dpkg/status.d/libstdc++6* \
-       /clean/usr/share/doc/libssl3 \
+       /clean/usr/share/doc/libssl3* \
        /clean/usr/share/doc/libstdc++6 \
        /clean/usr/share/doc/libgomp1
 

--- a/docker/full-debug.Dockerfile
+++ b/docker/full-debug.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.95-slim-bookworm AS chef
+FROM rust:1.95-slim-trixie AS chef
 
 ARG NO_CHEF=false
 ENV NO_CHEF=${NO_CHEF}
@@ -38,7 +38,7 @@ ENV SQLX_OFFLINE=true
 RUN cargo build --all-features --locked --bin lakekeeper
 
 # our final base
-FROM gcr.io/distroless/cc-debian12:nonroot AS base
+FROM gcr.io/distroless/cc-debian13:nonroot AS base
 
 
 FROM busybox:1.37.0 AS cleaner

--- a/docker/full-debug.Dockerfile
+++ b/docker/full-debug.Dockerfile
@@ -47,7 +47,7 @@ FROM busybox:1.37.0 AS cleaner
 
 COPY --from=base / /clean
 
-RUN rm -r /clean/usr/lib/*-linux-gnu/libgomp*  \
+RUN rm -rf /clean/usr/lib/*-linux-gnu/libgomp*  \
   /clean/usr/lib/*-linux-gnu/libssl*  \
   /clean/usr/lib/*-linux-gnu/libstdc++* \
   /clean/usr/lib/*-linux-gnu/engines-3 \

--- a/docker/full-debug.Dockerfile
+++ b/docker/full-debug.Dockerfile
@@ -47,17 +47,16 @@ FROM busybox:1.37.0 AS cleaner
 
 COPY --from=base / /clean
 
-RUN rm -rf /clean/usr/lib/*-linux-gnu/libgomp*  \
+RUN rm -r /clean/usr/lib/*-linux-gnu/libgomp*  \
   /clean/usr/lib/*-linux-gnu/libssl*  \
   /clean/usr/lib/*-linux-gnu/libstdc++* \
   /clean/usr/lib/*-linux-gnu/engines-3 \
-  /clean/usr/lib/*-linux-gnu/ossl-modules \
   /clean/usr/lib/*-linux-gnu/libcrypto.so.3 \
   /clean/usr/lib/*-linux-gnu/gconv \
   /clean/var/lib/dpkg/status.d/libgomp1*  \
   /clean/var/lib/dpkg/status.d/libssl3*  \
   /clean/var/lib/dpkg/status.d/libstdc++6* \
-  /clean/usr/share/doc/libssl3 \
+  /clean/usr/share/doc/libssl3* \
   /clean/usr/share/doc/libstdc++6 \
   /clean/usr/share/doc/libgomp1
 

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.95-slim-bookworm AS chef
+FROM rust:1.95-slim-trixie AS chef
 
 ARG NO_CHEF=false
 ENV NO_CHEF=${NO_CHEF}
@@ -38,7 +38,7 @@ ENV SQLX_OFFLINE=true
 RUN cargo build --release --all-features --locked --bin lakekeeper
 
 # our final base
-FROM gcr.io/distroless/cc-debian12:nonroot AS base
+FROM gcr.io/distroless/cc-debian13:nonroot AS base
 
 
 FROM busybox:1.37.0 AS cleaner

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -47,7 +47,7 @@ FROM busybox:1.37.0 AS cleaner
 
 COPY --from=base / /clean
 
-RUN rm -r /clean/usr/lib/*-linux-gnu/libgomp*  \
+RUN rm -rf /clean/usr/lib/*-linux-gnu/libgomp*  \
   /clean/usr/lib/*-linux-gnu/libssl*  \
   /clean/usr/lib/*-linux-gnu/libstdc++* \
   /clean/usr/lib/*-linux-gnu/engines-3 \

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -47,17 +47,16 @@ FROM busybox:1.37.0 AS cleaner
 
 COPY --from=base / /clean
 
-RUN rm -rf /clean/usr/lib/*-linux-gnu/libgomp*  \
+RUN rm -r /clean/usr/lib/*-linux-gnu/libgomp*  \
   /clean/usr/lib/*-linux-gnu/libssl*  \
   /clean/usr/lib/*-linux-gnu/libstdc++* \
   /clean/usr/lib/*-linux-gnu/engines-3 \
-  /clean/usr/lib/*-linux-gnu/ossl-modules \
   /clean/usr/lib/*-linux-gnu/libcrypto.so.3 \
   /clean/usr/lib/*-linux-gnu/gconv \
   /clean/var/lib/dpkg/status.d/libgomp1*  \
   /clean/var/lib/dpkg/status.d/libssl3*  \
   /clean/var/lib/dpkg/status.d/libstdc++6* \
-  /clean/usr/share/doc/libssl3 \
+  /clean/usr/share/doc/libssl3* \
   /clean/usr/share/doc/libstdc++6 \
   /clean/usr/share/doc/libgomp1
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated base container images from Debian 12 to Debian 13 for production and debug builds.
  * Switched Rust build environment to the Debian 13 (trixie) variant.
  * Adjusted image cleanup patterns to match Debian 13 runtime file layout; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->