### PR TITLE
chore(deps): batch GitHub Actions updates

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Docker info
         run: docker info
@@ -43,7 +43,7 @@ jobs:
           docker save -o /tmp/${{ inputs.image_name }}-${{ inputs.platform }}.tar localhost/${{ inputs.image_name }}:${{ inputs.platform }}
 
       - name: Save Docker
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: lakekeeper-image
           path: /tmp/*.tar

--- a/.github/workflows/integration_test_formats.yml
+++ b/.github/workflows/integration_test_formats.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Restore binary
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lakekeeper-image
           path: artifacts

--- a/.github/workflows/integration_test_workflow.yml
+++ b/.github/workflows/integration_test_workflow.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Restore binary
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lakekeeper-image
           path: artifacts
@@ -71,7 +71,7 @@ jobs:
         run: cat dump.sql | gzip -9 > dump.sql.gz
       - name: Upload dump
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: db-dump-${{ inputs.test_name }}
           path: dump.sql.gz

--- a/.github/workflows/kube-auth.yml
+++ b/.github/workflows/kube-auth.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           version: "v0.24.0"
       - name: Restore binary
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lakekeeper-image
           path: artifacts

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Restore binary
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lakekeeper-image
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "Repository name: $GITHUB_REPOSITORY"
           echo "Branch name: $GITHUB_REF"
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -135,7 +135,7 @@ jobs:
           cd -
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bin-${{ matrix.name }}
           path: ${{ matrix.name }}
@@ -167,7 +167,7 @@ jobs:
           persist-credentials: false
 
       - name: Download Artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: List Artifacts
         run: ls -lh
@@ -182,7 +182,7 @@ jobs:
           ls -Rlh
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Docker info
         run: docker info
@@ -207,7 +207,7 @@ jobs:
           docker save -o /tmp/docker-lakekeeper-arm64.tar localhost/lakekeeper-local:arm64
 
       - name: Save Docker
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docker-lakekeeper
           path: /tmp/docker-lakekeeper-*.tar
@@ -233,10 +233,10 @@ jobs:
           persist-credentials: false
 
       - name: Download Artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Docker info
         run: docker info
@@ -273,7 +273,7 @@ jobs:
       - release_please
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: List Artifacts
         run: ls -Rlh
@@ -312,7 +312,7 @@ jobs:
       - test-docker
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: Login to Quay.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
@@ -365,7 +365,7 @@ jobs:
     if: ${{ needs.release_please.outputs.releases_created == 'true' }}
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: Publish Release
         run: gh release edit ${{ needs.release_please.outputs.tag_name }} --draft=false --repo=lakekeeper/lakekeeper
@@ -389,7 +389,7 @@ jobs:
     if: ${{ needs.release_please.outputs.releases_created == 'true' }}
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: Login to Quay.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: Restore binary
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lakekeeper-image
           path: artifacts
@@ -79,7 +79,7 @@ jobs:
           persist-credentials: false
 
       - name: Restore binary
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lakekeeper-image
           path: artifacts
@@ -129,7 +129,7 @@ jobs:
           persist-credentials: false
 
       - name: Restore binary
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lakekeeper-image
           path: artifacts
@@ -161,7 +161,7 @@ jobs:
           persist-credentials: false
 
       - name: Restore binary
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: lakekeeper-image
           path: artifacts

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Install cargo-machete
-        uses: taiki-e/install-action@eea29cff9a2b68892c0845ae3e4f45fc47ee9354 # v2
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2
         with:
           tool: cargo-machete
       - name: Check unused dependencies
@@ -289,7 +289,7 @@ jobs:
           RUST_CACHE_KEY_OS: rust-${{ env.RUST_TOOLCHAIN }}-cache-ubuntu-24.04
 
       - name: Setup cargo nextest
-        uses: taiki-e/install-action@eea29cff9a2b68892c0845ae3e4f45fc47ee9354 # v2
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2
         with:
           tool: cargo-nextest
 
@@ -388,7 +388,7 @@ jobs:
           LAKEKEEPER_TEST__GCS_HNS_BUCKET: ${{ secrets.GCS_HNS_BUCKET }}
           LAKEKEEPER_TEST__GCS_CREDENTIAL: ${{ secrets.GCS_CREDENTIAL }}
       - name: Upload junit
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: junit-pg${{ matrix.postgres-version }}
           path: target/nextest/${{ env.NEXTEST_PROFILE }}/junit.xml

--- a/renovate.json
+++ b/renovate.json
@@ -17,16 +17,26 @@
   ],
   "packageRules": [
     {
-      "description": "Group minor and patch dependency updates",
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch"
+      "description": "Group all GitHub Actions updates (digest, minor, major) into one PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Group non-major Rust crate updates (1.x crates)",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": ">=1.0.0",
+      "groupName": "rust crates (non-major, 1.x+)",
+      "groupSlug": "cargo-stable-minor-patch"
+    },
+    {
+      "description": "Group pre-1.0 Rust crate bumps separately — Cargo treats 0.x→0.y as breaking even though Renovate calls it minor",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "<1.0.0",
+      "groupName": "rust crates (pre-1.0)",
+      "groupSlug": "cargo-pre1-minor-patch"
     }
   ]
 }


### PR DESCRIPTION
- docker/setup-qemu-action digest → 06116385 (#1796)
- taiki-e/install-action digest → e49978b7 (#1798)
- googleapis/release-please-action v4 → v5 (#1800, supersedes #1797)
- actions/upload-artifact v5 → v7 (#1538)
- actions/download-artifact v6 → v8 (#1538)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment pipeline tooling to newer versions to improve build, test, and artifact handling reliability and performance.
  * Refined automated dependency update configuration to better organize and categorize Rust crate and GitHub Actions updates based on version stability levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->