### PR TITLE
feat(authz): add load_and_authorize_generic_table_operation

### DIFF
--- a/crates/lakekeeper/src/api/management/v1/generic_table.rs
+++ b/crates/lakekeeper/src/api/management/v1/generic_table.rs
@@ -7,11 +7,8 @@ use crate::{
     service::{
         CatalogStore, CatalogTabularOps, GenericTableId, SecretStore, State, TabularId,
         TabularListFlags, Transaction,
-        authz::{
-            AuthZGenericTableOps, Authorizer, CatalogGenericTableAction,
-            RequireGenericTableActionError, fetch_warehouse_namespace_generic_table_by_id,
-        },
-        events::APIEventContext,
+        authz::{AuthZGenericTableOps, Authorizer, CatalogGenericTableAction},
+        events::{APIEventContext, context::UserProvidedGenericTable},
     },
 };
 
@@ -118,24 +115,15 @@ where
     C: CatalogStore,
     A: Authorizer + Clone,
 {
-    let (warehouse, namespace, info) = fetch_warehouse_namespace_generic_table_by_id::<C, A>(
-        authorizer,
-        warehouse_id,
-        generic_table_id,
-        TabularListFlags::all(),
-        catalog_state,
-    )
-    .await?;
-
-    authorizer
-        .require_generic_table_action(
+    let (_warehouse, _namespace, info) = authorizer
+        .load_and_authorize_generic_table_operation::<C>(
             request_metadata,
-            &warehouse,
-            &namespace,
-            generic_table_id,
-            Ok::<_, RequireGenericTableActionError>(Some(info)),
+            &UserProvidedGenericTable::new(warehouse_id, generic_table_id),
+            TabularListFlags::all(),
             action,
+            catalog_state,
         )
-        .await
-        .map_err(Into::into)
+        .await?;
+
+    Ok(info)
 }

--- a/crates/lakekeeper/src/service/authz/generic_table.rs
+++ b/crates/lakekeeper/src/service/authz/generic_table.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         events::{
             AuthorizationFailureReason, AuthorizationFailureSource,
-            delegate_authorization_failure_source,
+            context::UserProvidedGenericTable, delegate_authorization_failure_source,
         },
     },
 };
@@ -456,6 +456,107 @@ pub trait AuthZGenericTableOps: Authorizer {
             Ok(final_decisions)
         }
         .map(MustUse::from)
+    }
+
+    /// Fetches the warehouse, namespace hierarchy, and generic table, then
+    /// authorizes `action` against the resolved generic table in one call.
+    ///
+    /// Mirrors `AuthZTableOps::load_and_authorize_table_operation`:
+    /// supports addressing the generic table either by id or by identifier,
+    /// performs TOCTOU-safe warehouse/namespace version refresh, and runs the
+    /// authorization check.
+    ///
+    /// # Returns
+    /// A tuple of `(warehouse, namespace, generic_table)` if all checks pass.
+    ///
+    /// # Errors
+    /// Returns `AuthZError` if the warehouse, namespace, or generic table is not
+    /// found, identifiers are inconsistent, the user is not authorized, or a
+    /// catalog/authorization backend error occurs.
+    async fn load_and_authorize_generic_table_operation<C: CatalogStore>(
+        &self,
+        request_metadata: &RequestMetadata,
+        user_provided: &UserProvidedGenericTable,
+        table_flags: TabularListFlags,
+        action: impl Into<Self::GenericTableAction> + Send,
+        catalog_state: C::State,
+    ) -> Result<
+        (
+            Arc<ResolvedWarehouse>,
+            NamespaceHierarchy,
+            GenericTabularInfo,
+        ),
+        AuthZError,
+    > {
+        let warehouse_id = user_provided.warehouse_id;
+        let action = action.into();
+
+        // Determine the fetch strategy based on whether we have an id or an ident.
+        let (warehouse, namespace, info) = match &user_provided.generic_table {
+            GenericTableIdentOrId::Id(generic_table_id) => {
+                fetch_warehouse_namespace_generic_table_by_id::<C, _>(
+                    self,
+                    warehouse_id,
+                    *generic_table_id,
+                    table_flags,
+                    catalog_state.clone(),
+                )
+                .await?
+            }
+            GenericTableIdentOrId::Ident(ident) => {
+                // For an identifier: fetch warehouse, namespace, and table in parallel.
+                let (warehouse_result, namespace_result, info_result) = tokio::join!(
+                    C::get_active_warehouse_by_id(warehouse_id, catalog_state.clone()),
+                    C::get_namespace(warehouse_id, ident.namespace.clone(), catalog_state.clone()),
+                    C::get_generic_table_info(
+                        warehouse_id,
+                        ident.clone(),
+                        table_flags,
+                        catalog_state.clone()
+                    )
+                );
+
+                let warehouse = self.require_warehouse_presence(warehouse_id, warehouse_result)?;
+                let namespace = self.require_namespace_presence(
+                    warehouse_id,
+                    ident.namespace.clone(),
+                    namespace_result,
+                )?;
+                let info =
+                    self.require_generic_table_presence(warehouse_id, ident.clone(), info_result)?;
+
+                (warehouse, namespace, info)
+            }
+        };
+
+        // Validate warehouse and namespace id/version consistency (with TOCTOU protection).
+        let (warehouse, namespace) =
+            super::table::refresh_warehouse_and_namespace_if_needed::<C, _, _>(
+                &warehouse,
+                namespace,
+                &info,
+                AuthZCannotSeeGenericTable::new_not_found(
+                    warehouse_id,
+                    user_provided.generic_table.clone(),
+                ),
+                self,
+                catalog_state,
+            )
+            .await?;
+
+        // Perform the authorization check.
+        let info = self
+            .require_generic_table_action(
+                request_metadata,
+                &warehouse,
+                &namespace,
+                user_provided.generic_table.clone(),
+                Ok::<_, RequireGenericTableActionError>(Some(info)),
+                action,
+            )
+            .await?;
+
+        Ok((warehouse, namespace, info))
     }
 }
 


### PR DESCRIPTION
## What

Adds `load_and_authorize_generic_table_operation` to `AuthZGenericTableOps`, mirroring the existing `load_and_authorize_table_operation` / `load_and_authorize_view_operation` on the table/view ops traits.

It resolves warehouse + namespace hierarchy + generic table (addressable **by id or by identifier**), performs the TOCTOU-safe warehouse/namespace version refresh, and runs the authorization check — all in one call.

## Why

Generic tables had runtime authz primitives (`require_generic_table_action`, `are_allowed_generic_table_actions_*`) but no single load-and-authorize entry point like tables/views. Downstream consumers (e.g. the Cedar `/resolve` introspection endpoint in enterprise) need this to reach parity with tables/views without re-implementing the fetch + refresh + authorize sequence.

## Changes

- **New trait method** `AuthZGenericTableOps::load_and_authorize_generic_table_operation` (id path reuses `fetch_warehouse_namespace_generic_table_by_id`; ident path does the parallel warehouse/namespace/table fetch like the table version).
- **Consolidated** the management by-id authorize path (`authorize_set_or_get`) onto the new method, removing the duplicated fetch + `require_generic_table_action` sequence.

## Intentionally left as-is

- The server-layer **by-name drop loader** keeps using `load_generic_table`: its `ResolvedGenericTable` event payload needs the richer `GenericTableInfo`, not the lightweight `GenericTabularInfo` the authz path returns.
- The **multi-action introspection** path (`authorize_get_generic_table_actions`) keeps the lower-level primitives (`fetch_... + are_allowed_generic_table_actions_vec`), matching the table equivalent (`authorize_get_table_actions`).

## Testing

`cargo test -p lakekeeper --lib generic_table` — 62 passed (incl. protection round-trip exercising the refactored path). Clippy clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authorization checks for generic table operations with enhanced consistency and safety across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->