### PR TITLE
chore(docs): Sync documentation from lakekeeper plus

### DIFF
--- a/docs/docs/api/lakekeeper.cedarschema
+++ b/docs/docs/api/lakekeeper.cedarschema
@@ -94,9 +94,11 @@ namespace Lakekeeper {
   entity User in [Role, Server] {
     // Email of the user, extracted from the authentication token.
     // Not available for all token types.
-    // Lakekeeper does not enforce email uniqueness. Two distinct
-    // users may share an email (e.g. service principals using a
-    // shared mailbox, or default emails issued by an IDP).
+    // NOT UNIQUE: Lakekeeper does not enforce email uniqueness. Two distinct
+    // users may legitimately share an email (e.g. service principals using a
+    // shared mailbox, or default emails issued by an IDP). Do not use `email`
+    // as an identity discriminator in policies — use the entity UID
+    // (`Lakekeeper::User::"<provider>~<source>"`) or `provider_id`/`source_id`.
     email?: String,
     // Provider-resolved role memberships as Cedar Role entity UIDs.
     // The user entity is a Cedar parent of every role in this set, so
@@ -226,6 +228,21 @@ namespace Lakekeeper {
     properties: ResourceProperties,
   };
 
+  // GenericTable entity for non-Iceberg ("generic") tables.
+  // ID: "<warehouse-UUID>/<generic-table-UUID>"
+  //     e.g. "01943e3d-43c5-7a4e-b6dd-a44b6685c8c9/01943e3d-43c5-7a4e-b6dd-a88faa29gcad"
+  entity GenericTable in [Namespace] {
+    project: Project,
+    warehouse: Warehouse,
+    // Direct parent namespace.
+    namespace: Namespace,
+    // Name of the generic table within its namespace.
+    name: String,
+    protected: Bool,
+    // Current properties of this generic table.
+    properties: ResourceProperties,
+  };
+
   // ---------- Resource Properties ----------
 
   // ResourceProperties is modeled as a Cedar entity with `tags` to represent
@@ -347,7 +364,8 @@ namespace Lakekeeper {
   action IntrospectWarehouseAuthorization, DeleteWarehouse, UpdateStorage, UpdateStorageCredential,
          DeactivateWarehouse, ActivateWarehouse,
          RenameWarehouse, ModifySoftDeletion,
-         ModifyTaskQueueConfig, ControlAllTasks, SetWarehouseProtection in ["WarehouseModifyActions"]
+         ModifyTaskQueueConfig, ControlAllTasks, SetWarehouseProtection,
+         SetWarehouseFormatVersionPolicy in ["WarehouseModifyActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Warehouse]
@@ -371,7 +389,7 @@ namespace Lakekeeper {
   action "NamespaceModifyActions" in ["NamespaceActions"];
 
   action ListEverythingInNamespace, GetNamespaceMetadata, IncludeNamespaceInList,
-         ListTables, ListViews,
+         ListTables, ListViews, ListGenericTables,
          ListNamespacesInNamespace in ["NamespaceDescribeActions"]
     appliesTo {
       principal: [User, Role],
@@ -408,6 +426,27 @@ namespace Lakekeeper {
         view_name?: String,
         // Initial property values for the view being created.
         initial_view_properties: ResourceProperties,
+      }
+    };
+  action CreateGenericTableInNamespace in ["NamespaceModifyActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Namespace],
+      context: {
+        // Name of the generic table being created. Absent when listing allowed
+        // actions or when not specified via the check API.
+        generic_table_name?: String,
+        // Externally provided generic table ID. Absent when listing allowed
+        // actions or when not specified via the check API.
+        generic_table_id?: String,
+        // Generic table format (e.g. "lance", "delta"). Absent when listing
+        // allowed actions or when not specified via the check API.
+        format?: String,
+        // User-supplied base location override. Absent when listing allowed
+        // actions or when not specified via the check API.
+        base_location?: String,
+        // Initial property values for the generic table being created.
+        initial_generic_table_properties: ResourceProperties,
       }
     };
   action CreateNamespaceInNamespace in ["NamespaceModifyActions"]
@@ -499,5 +538,29 @@ namespace Lakekeeper {
         // Property keys to be removed from this view.
         view_properties_removal: Set<String>,
       }
+    };
+
+  // ---------- Generic Table Actions ----------
+  action "GenericTableActions";
+  action "GenericTableDescribeActions" in ["GenericTableActions", "GenericTableSelectActions", "GenericTableModifyActions"];
+  action "GenericTableSelectActions" in ["GenericTableActions", "GenericTableModifyActions"];
+  action "GenericTableModifyActions" in ["GenericTableActions"];
+  action GetGenericTableMetadata, IncludeGenericTableInList,
+         GetGenericTableTasks in ["GenericTableDescribeActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [GenericTable]
+    };
+  action ReadGenericTableData in ["GenericTableSelectActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [GenericTable]
+    };
+  action IntrospectGenericTableAuthorization, DropGenericTable, WriteGenericTableData,
+         RenameGenericTable, UndropGenericTable, ControlGenericTableTasks,
+         SetGenericTableProtection in ["GenericTableModifyActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [GenericTable]
     };
 }

--- a/docs/docs/api/management-open-api-plus.yaml
+++ b/docs/docs/api/management-open-api-plus.yaml
@@ -1052,6 +1052,119 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetOpenFGAWarehouseActionsResponse'
+  /management/v1/permissions/warehouse/{warehouse_id}/generic-table/{generic_table_id}/assignments:
+    get:
+      tags:
+        - permissions-openfga
+      summary: Get user and role assignments for a generic table
+      operationId: get_generic_table_assignments_by_id
+      parameters:
+        - name: relations
+          in: query
+          description: Relations to be loaded. If not specified, all relations are returned.
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/GenericTableRelation'
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: generic_table_id
+          in: path
+          description: Generic Table ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetGenericTableAssignmentsResponse'
+    post:
+      tags:
+        - permissions-openfga
+      summary: Update permissions for a generic table
+      operationId: update_generic_table_assignments_by_id
+      parameters:
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: generic_table_id
+          in: path
+          description: Generic Table ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGenericTableAssignmentsRequest'
+        required: true
+      responses:
+        '204':
+          description: Permissions updated successfully
+  /management/v1/permissions/warehouse/{warehouse_id}/generic-table/{generic_table_id}/authorizer-actions:
+    get:
+      tags:
+        - permissions-openfga
+      summary: Get allowed Authorizer actions on a generic table
+      description: |-
+        Returns Authorizer permissions (OpenFGA relations) for the specified generic table.
+        For Catalog permissions, use `/management/v1/warehouse/{warehouse_id}/generic-table/{generic_table_id}/actions` instead.
+      operationId: get_authorizer_generic_table_actions
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            The user to show actions for.
+            If neither user nor role is specified, shows actions for the current user.
+          required: false
+          schema:
+            type: string
+        - name: principalRole
+          in: query
+          description: |-
+            The role to show actions for.
+            If neither user nor role is specified, shows actions for the current user.
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: generic_table_id
+          in: path
+          description: Generic Table ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Generic Table Authorizer Actions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOpenFGAGenericTableActionsResponse'
   /management/v1/permissions/warehouse/{warehouse_id}/managed-access:
     post:
       tags:
@@ -2805,6 +2918,162 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/format-version-policy:
+    post:
+      tags:
+        - warehouse
+      summary: Update Format Version Policy
+      description: |-
+        Configures which Iceberg table format versions may be created in, or
+        upgraded to, within a warehouse, and the default version applied when a
+        create-table request does not specify one.
+      operationId: update_warehouse_format_version_policy
+      parameters:
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateWarehouseFormatVersionPolicyRequest'
+        required: true
+      responses:
+        '200':
+          description: Format version policy updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetWarehouseResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/generic-table/{generic_table_id}/actions:
+    get:
+      tags:
+        - warehouse
+      summary: Get allowed actions for a generic table
+      operationId: get_generic_table_actions
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            The user to show actions for.
+            If neither user nor role is specified, shows actions for the current user.
+          required: false
+          schema:
+            type: string
+        - name: principalRole
+          in: query
+          description: |-
+            The role to show actions for.
+            If neither user nor role is specified, shows actions for the current user.
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: generic_table_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetLakekeeperGenericTableActionsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/generic-table/{generic_table_id}/protection:
+    get:
+      tags:
+        - warehouse
+      summary: Get Generic Table Protection
+      description: Retrieves whether a generic table is protected from deletion.
+      operationId: get_generic_table_protection
+      parameters:
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: generic_table_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProtectionResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+    post:
+      tags:
+        - warehouse
+      summary: Set Generic Table Protection
+      description: Configures whether a generic table should be protected from deletion.
+      operationId: set_generic_table_protection
+      parameters:
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: generic_table_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetProtectionRequest'
+        required: true
+      responses:
+        '200':
+          description: Generic table protection set successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProtectionResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/warehouse/{warehouse_id}/namespace/{namespace_id}/actions:
     get:
       tags:
@@ -3336,6 +3605,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/task-queue/expire_snapshots/schedule:
+    post:
+      tags:
+        - tasks
+      summary: Schedule a task for an entity.
+      description: |-
+        Pre-checks run against the warehouse config and target entity
+        properties before the task is enqueued. A failure surfaces as `400`
+        with a specific error code (see the operator guide for the full set
+        of pre-check codes).
+
+        When a task is already active for the same (warehouse, entity,
+        queue) triple, the call returns `409 TaskAlreadyActive` with the
+        existing `task-id` in the body — chain to `POST /task/control`
+        with `run-now` or `run-at` to retime it without an extra
+        `task/list` round-trip.
+      operationId: schedule_task_expire_snapshots
+      parameters:
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleExpireSnapshotsTaskRequest'
+        required: true
+      responses:
+        '200':
+          description: Task scheduled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleTaskResponse'
+        '400':
+          description: Pre-check failed (e.g. scheduling disabled at the warehouse, entity opted out, unsupported entity type) or the request violates a shape limit (e.g. scheduled-for too far in the future).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        '404':
+          description: Target entity not found in this warehouse.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        '409':
+          description: A task is already active for this (warehouse, entity, queue). The error message includes the existing task-id; retime or cancel via POST /task/control.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/warehouse/{warehouse_id}/task-queue/remove_orphan_files/config:
     get:
       tags:
@@ -3391,6 +3721,67 @@ paths:
       responses:
         '204':
           description: Task queue config set successfully
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/task-queue/remove_orphan_files/schedule:
+    post:
+      tags:
+        - tasks
+      summary: Schedule a task for an entity.
+      description: |-
+        Pre-checks run against the warehouse config and target entity
+        properties before the task is enqueued. A failure surfaces as `400`
+        with a specific error code (see the operator guide for the full set
+        of pre-check codes).
+
+        When a task is already active for the same (warehouse, entity,
+        queue) triple, the call returns `409 TaskAlreadyActive` with the
+        existing `task-id` in the body — chain to `POST /task/control`
+        with `run-now` or `run-at` to retime it without an extra
+        `task/list` round-trip.
+      operationId: schedule_task_remove_orphan_files
+      parameters:
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleRemoveOrphanFilesTaskRequest'
+        required: true
+      responses:
+        '200':
+          description: Task scheduled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleTaskResponse'
+        '400':
+          description: Pre-check failed (e.g. scheduling disabled at the warehouse, entity opted out, unsupported entity type) or the request violates a shape limit (e.g. scheduled-for too far in the future).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        '404':
+          description: Target entity not found in this warehouse.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        '409':
+          description: A task is already active for this (warehouse, entity, queue). The error message includes the existing task-id; retime or cancel via POST /task/control.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
         4XX:
           description: ''
           content:
@@ -4006,6 +4397,19 @@ components:
                   properties:
                     action:
                       $ref: '#/components/schemas/LakekeeperViewAction'
+        - type: object
+          required:
+            - generic-table
+          properties:
+            generic-table:
+              allOf:
+                - $ref: '#/components/schemas/TabularIdentOrUuid'
+                - type: object
+                  required:
+                    - action
+                  properties:
+                    action:
+                      $ref: '#/components/schemas/LakekeeperGenericTableAction'
       description: Represents an action on an object
     CatalogActionsBatchCheckRequest:
       type: object
@@ -4199,6 +4603,13 @@ components:
             view:
               allOf:
                 - $ref: '#/components/schemas/TabularIdentOrUuid'
+        - type: object
+          required:
+            - generic-table
+          properties:
+            generic-table:
+              allOf:
+                - $ref: '#/components/schemas/TabularIdentOrUuid'
       description: |-
         Identifies the resource whose Cedar entity hierarchy should be resolved.
 
@@ -4239,6 +4650,14 @@ components:
           type: boolean
           description: Include policies where `resource` is unconstrained (applies to all resources)
           default: false
+        generic-table:
+          oneOf:
+            - $ref: '#/components/schemas/CedarResourceConstraintPattern'
+              description: Constraint patterns for `Lakekeeper::GenericTable` resources
+          default:
+            eq: false
+            in: false
+            is: false
         namespace:
           oneOf:
             - $ref: '#/components/schemas/CedarResourceConstraintPattern'
@@ -4408,6 +4827,19 @@ components:
                   properties:
                     action:
                       $ref: '#/components/schemas/ViewAction'
+        - type: object
+          required:
+            - generic-table
+          properties:
+            generic-table:
+              allOf:
+                - $ref: '#/components/schemas/TabularIdentOrUuid'
+                - type: object
+                  required:
+                    - action
+                  properties:
+                    action:
+                      $ref: '#/components/schemas/GenericTableAction'
       description: Represents an action on an object
     CheckRequest:
       type: object
@@ -4618,6 +5050,26 @@ components:
         - warehouse-name
         - storage-profile
       properties:
+        allowed-format-versions:
+          type:
+            - array
+            - 'null'
+          items:
+            type: integer
+            format: int32
+          description: |-
+            Iceberg table format versions that may be created in, or upgraded to,
+            within this warehouse. Must be a non-empty subset of `[1, 2, 3]`.
+            Defaults to all supported versions when omitted.
+        default-format-version:
+          type:
+            - integer
+            - 'null'
+          format: int32
+          description: |-
+            Default Iceberg table format version applied when a create-table request
+            does not specify one. Must be a member of `allowed-format-versions`. When
+            omitted, resolves to v2 if allowed, otherwise the highest allowed version.
         delete-profile:
           $ref: '#/components/schemas/TabularDeleteProfile'
           description: 'Profile to determine behavior upon dropping of tabulars. Default: hard deletion.'
@@ -4992,6 +5444,103 @@ components:
           type: string
         universe_domain:
           type: string
+    GenericTableAction:
+      type: string
+      enum:
+        - drop
+        - undrop
+        - write_data
+        - read_data
+        - get_metadata
+        - rename
+        - include_in_list
+        - get_tasks
+        - control_tasks
+        - set_protection
+        - read_assignments
+        - grant_pass_grants
+        - grant_manage_grants
+        - grant_describe
+        - grant_select
+        - grant_modify
+        - change_ownership
+    GenericTableAssignment:
+      oneOf:
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - ownership
+          title: GenericTableAssignmentOwnership
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - pass_grants
+          title: GenericTableAssignmentPassGrants
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - manage_grants
+          title: GenericTableAssignmentManageGrants
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - describe
+          title: GenericTableAssignmentDescribe
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - select
+          title: GenericTableAssignmentSelect
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - modify
+          title: GenericTableAssignmentModify
+    GenericTableRelation:
+      type: string
+      enum:
+        - ownership
+        - pass_grants
+        - manage_grants
+        - describe
+        - select
+        - modify
     GetCedarPoliciesResponse:
       type: object
       required:
@@ -5070,6 +5619,24 @@ components:
           format: int64
         queue-config:
           $ref: '#/components/schemas/ExpireSnapshotsQueueConfig'
+    GetGenericTableAssignmentsResponse:
+      type: object
+      required:
+        - assignments
+      properties:
+        assignments:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericTableAssignment'
+    GetLakekeeperGenericTableActionsResponse:
+      type: object
+      required:
+        - allowed-actions
+      properties:
+        allowed-actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/LakekeeperGenericTableAction'
     GetLakekeeperNamespaceActionsResponse:
       type: object
       required:
@@ -5170,6 +5737,15 @@ components:
           type: boolean
         managed-access-inherited:
           type: boolean
+    GetOpenFGAGenericTableActionsResponse:
+      type: object
+      required:
+        - allowed-actions
+      properties:
+        allowed-actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenFGAGenericTableAction'
     GetOpenFGANamespaceActionsResponse:
       type: object
       required:
@@ -5467,7 +6043,25 @@ components:
         - delete-profile
         - status
         - protected
+        - allowed-format-versions
       properties:
+        allowed-format-versions:
+          type: array
+          items:
+            type: integer
+            format: int32
+          description: |-
+            Iceberg table format versions that may be created in, or upgraded to,
+            within this warehouse.
+        default-format-version:
+          type:
+            - integer
+            - 'null'
+          format: int32
+          description: |-
+            Default Iceberg table format version applied when a create-table request
+            does not specify one. When absent, resolves to v2 if allowed, otherwise
+            the highest allowed version.
         delete-profile:
           $ref: '#/components/schemas/TabularDeleteProfile'
           description: Delete profile used for the warehouse.
@@ -5518,6 +6112,88 @@ components:
       properties:
         error:
           $ref: '#/components/schemas/ErrorModel'
+    LakekeeperGenericTableAction:
+      oneOf:
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - drop
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - read_data
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - write_data
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_metadata
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - rename
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - include_in_list
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - undrop
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_tasks
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - control_tasks
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - set_protection
     LakekeeperNamespaceAction:
       oneOf:
         - type: object
@@ -5665,6 +6341,53 @@ components:
               type: string
               enum:
                 - include_in_list
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - create_generic_table
+            base_location:
+              type:
+                - string
+                - 'null'
+              description: |-
+                User-supplied base location override — primary lever for
+                path-based authorization policy.
+            format:
+              type:
+                - string
+                - 'null'
+              description: |-
+                Generic table format (e.g. "lance", "delta") — primary lever for
+                format-based authorization policy.
+            generic_table_id:
+              type:
+                - string
+                - 'null'
+              format: uuid
+              description: Generic table ID, if externally provided.
+            name:
+              type:
+                - string
+                - 'null'
+              description: Name of the generic table to create.
+            properties:
+              type: object
+              additionalProperties:
+                type: string
+              propertyNames:
+                type: string
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_generic_tables
     LakekeeperProjectAction:
       oneOf:
         - type: object
@@ -6278,6 +7001,14 @@ components:
             action:
               type: string
               enum:
+                - set_format_version_policy
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
                 - get_endpoint_statistics
     LicenseStatus:
       type: object
@@ -6590,6 +7321,7 @@ components:
       enum:
         - create_table
         - create_view
+        - create_generic_table
         - create_namespace
         - delete
         - update_properties
@@ -6717,6 +7449,16 @@ components:
         - select
         - create
         - modify
+    OpenFGAGenericTableAction:
+      type: string
+      enum:
+        - read_assignments
+        - grant_pass_grants
+        - grant_manage_grants
+        - grant_describe
+        - grant_select
+        - grant_modify
+        - change_ownership
     OpenFGANamespaceAction:
       type: string
       enum:
@@ -7497,6 +8239,60 @@ components:
         - path
         - virtual_host
         - auto
+    ScheduleExpireSnapshotsTaskRequest:
+      type: object
+      description: Request body for scheduling a task.
+      required:
+        - entity
+      properties:
+        entity:
+          $ref: '#/components/schemas/WarehouseTaskEntityId'
+          description: |-
+            Entity to schedule the task for. Unsupported entity types return
+            `400` from the pre-check.
+        scheduled-for:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: |-
+            When the task should run. Omit (or pass `null`) to run on the next
+            worker poll. RFC 3339 / ISO 8601 format. Must be within roughly one
+            year of now; further-out values return
+            `400 ScheduledForTooFarInFuture`.
+          example: 2026-12-31T23:59:59Z
+    ScheduleRemoveOrphanFilesTaskRequest:
+      type: object
+      description: Request body for scheduling a task.
+      required:
+        - entity
+      properties:
+        entity:
+          $ref: '#/components/schemas/WarehouseTaskEntityId'
+          description: |-
+            Entity to schedule the task for. Unsupported entity types return
+            `400` from the pre-check.
+        scheduled-for:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: |-
+            When the task should run. Omit (or pass `null`) to run on the next
+            worker poll. RFC 3339 / ISO 8601 format. Must be within roughly one
+            year of now; further-out values return
+            `400 ScheduledForTooFarInFuture`.
+          example: 2026-12-31T23:59:59Z
+    ScheduleTaskResponse:
+      type: object
+      description: Response returned on a successful schedule call.
+      required:
+        - task-id
+      properties:
+        task-id:
+          type: string
+          format: uuid
+          description: The id of the newly scheduled task.
     SearchRoleRequest:
       type: object
       required:
@@ -8272,11 +9068,15 @@ components:
                 type: string
             table:
               type: string
-              description: Name of the table or view
+              description: Name of the table, view, or generic table.
             warehouse-id:
               type: string
               format: uuid
-      description: Identifier for a table or view, either a UUID or its name and namespace
+      description: |-
+        Identifier for a tabular (table, view, or generic table) — either a UUID
+        or its name and namespace. Wire format primary names are `table-id` and
+        `table`; `view_id` / `view` and `generic_table_id` / `generic_table` are
+        accepted as input aliases for client ergonomics.
     TabularIdentUuid:
       oneOf:
         - type: object
@@ -8303,12 +9103,25 @@ components:
               type: string
               enum:
                 - view
+        - type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              type: string
+              format: uuid
+            type:
+              type: string
+              enum:
+                - generic-table
     TabularType:
       type: string
       description: Type of tabular
       enum:
         - table
         - view
+        - generic-table
     TaskAttempt:
       type: object
       required:
@@ -8444,6 +9257,17 @@ components:
           items:
             $ref: '#/components/schemas/TabularIdentUuid'
           description: Tabulars to undrop
+    UpdateGenericTableAssignmentsRequest:
+      type: object
+      properties:
+        deletes:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericTableAssignment'
+        writes:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericTableAssignment'
     UpdateNamespaceAssignmentsRequest:
       type: object
       properties:
@@ -8577,6 +9401,28 @@ components:
       properties:
         delete-profile:
           $ref: '#/components/schemas/TabularDeleteProfile'
+    UpdateWarehouseFormatVersionPolicyRequest:
+      type: object
+      required:
+        - allowed-format-versions
+      properties:
+        allowed-format-versions:
+          type: array
+          items:
+            type: integer
+            format: int32
+          description: |-
+            Iceberg table format versions that may be created in, or upgraded to,
+            within this warehouse. Must be a non-empty subset of `[1, 2, 3]`.
+        default-format-version:
+          type:
+            - integer
+            - 'null'
+          format: int32
+          description: |-
+            Default Iceberg table format version applied when a create-table request
+            does not specify one. Must be a member of `allowed-format-versions`. When
+            omitted, resolves to v2 if allowed, otherwise the highest allowed version.
     UpdateWarehouseStorageRequest:
       type: object
       required:
@@ -8793,6 +9639,7 @@ components:
         - get_all_tasks
         - control_all_tasks
         - set_protection
+        - set_format_version_policy
         - get_endpoint_statistics
     WarehouseAssignment:
       oneOf:
@@ -9000,6 +9847,19 @@ components:
               type: string
               format: uuid
         - type: object
+          description: Get tasks for a specific generic table
+          required:
+            - generic-table-id
+            - type
+          properties:
+            generic-table-id:
+              type: string
+              format: uuid
+            type:
+              type: string
+              enum:
+                - generic-table
+        - type: object
           description: |-
             Get Warehouse-level tasks which are not associated with a specific entity
             inside the warehouse
@@ -9036,6 +9896,18 @@ components:
             view-id:
               type: string
               format: uuid
+        - type: object
+          required:
+            - generic-table-id
+            - type
+          properties:
+            generic-table-id:
+              type: string
+              format: uuid
+            type:
+              type: string
+              enum:
+                - generic-table
     WarehouseTaskInfo:
       type: object
       required:

--- a/site/docs/about/enterprise-release-notes.md
+++ b/site/docs/about/enterprise-release-notes.md
@@ -1,0 +1,83 @@
+# Lakekeeper Enterprise Release Notes
+
+## v0.12.2 (2026-05-26)
+
+### Highlights
+- Orphan-file cleanup now schedules itself adaptively per table — running more often where files accumulate and backing off where they don't — with a new dry-run mode.
+- The LDAP role provider can resolve groups via subtree **Search** and conditional **Branching**, not just the `memberOf` attribute.
+
+### Features
+- **Adaptive orphan-file scheduling.** The remove-orphan-files worker now self-tunes its cadence based on how fast reclaimable data builds up, and adds a dry-run mode that reports what it *would* delete. Orphan removal is now opt-in via `enable-remove-orphan-files`; default retention raised from 3 to 7 days. See the Table Maintenance docs for full config.
+- **LDAP group resolution modes.** Resolve group memberships via `Search` (paged subtree) or `Branching` (per-user-DN rules) in addition to the `memberOf` attribute; the resolution mode is recorded in audit logs.
+- **Build metadata in Server Info.** Server Info now reports Lakekeeper, Enterprise, and Console versions and commit SHAs, so deployed builds are easy to identify.
+
+### Breaking Changes
+- The orphan-files task-queue API was renamed `remove_orphaned_files` → `remove_orphan_files` (paths, config schemas, and worker/enable fields).
+
+### Upgrade Notes
+- Update any automation/IaC to the new `remove_orphan_files` task-queue path and schema names.
+- Orphan removal is now **opt-in** (it ran by default in 0.12.1): set `enable-remove-orphan-files=true` to keep it active. Default retention is now 7 days.
+
+### Upstream Lakekeeper changes (bump to v0.12.3)
+- Core and extension database migrations now apply atomically — no partial-migration state ([lakekeeper#1768](https://github.com/lakekeeper/lakekeeper/pull/1768)).
+- Fixed table property removal being lost when no properties remained ([lakekeeper#1767](https://github.com/lakekeeper/lakekeeper/pull/1767)).
+- New read-only maintenance mode for the server ([lakekeeper#1765](https://github.com/lakekeeper/lakekeeper/pull/1765)).
+- Users may now share an email address — the unique-email constraint was dropped ([lakekeeper#1755](https://github.com/lakekeeper/lakekeeper/pull/1755)).
+- New `LAKEKEEPER__UI__ENABLE_SURVEYS` flag to opt out of in-console surveys ([lakekeeper#1750](https://github.com/lakekeeper/lakekeeper/pull/1750)).
+
+## v0.12.1 (2026-05-10)
+
+### Features
+- **Remove Orphan Files.** New maintenance capability that reclaims storage by deleting data, manifest, and metadata files no longer referenced by any snapshot — available as a server background worker and as a `remove-orphan-files` subcommand (with dry-run). Enabled by default; set `LAKEKEEPER__TASK_REMOVE_ORPHANED_FILES_WORKERS=0` to disable. Respects `gc.enabled` and per-table opt-out properties. See the Table Maintenance docs for full config.
+- **Bounded orphan-files runtime.** Cap how long a single orphan-files run may take with a configurable max run time.
+
+### Bug Fixes
+- Warehouse rename no longer leaves a stale name in the UI table preview (bundled UI 0.7.12).
+
+### Upgrade Notes
+- The orphan-files worker is **enabled by default** (2 workers); set `LAKEKEEPER__TASK_REMOVE_ORPHANED_FILES_WORKERS=0` to disable. By default it only deletes files older than 3 days and honors `gc.enabled` / per-table opt-out.
+
+### Upstream Lakekeeper changes (bump to v0.12.2)
+- OpenFGA: rebuild/reconcile authorization tuples from the catalog, and support switching an existing server to OpenFGA ([lakekeeper#1731](https://github.com/lakekeeper/lakekeeper/pull/1731), [lakekeeper#1733](https://github.com/lakekeeper/lakekeeper/pull/1733)).
+- OPA Trino batch authorization gains a broad-access fast path for warehouses/namespaces ([lakekeeper#1727](https://github.com/lakekeeper/lakekeeper/pull/1727)).
+- Storage: dropped the opendal dependency and now validates vended credentials via `lakekeeper_io` ([lakekeeper#1737](https://github.com/lakekeeper/lakekeeper/pull/1737)).
+- ADLS fixes: correct SAS-token key removal and `%`-encoding in blob names ([lakekeeper#1746](https://github.com/lakekeeper/lakekeeper/pull/1746)).
+
+## v0.12.0 (2026-04-21)
+
+### Highlights
+- **Cedar authorization matured** into a configurable, inspectable system: derive user attributes from identity fields, reference roles by global ID, and use a new resolve-entities API + Console tabs to see exactly what drives a decision.
+- **Role providers** resolve user roles from external sources — including LDAP groups and table properties — with caching, metrics, and audit.
+- **Console**: a visual Cedar Policy Builder (beta) with a Cedar-aware editor, authorization-inspection tabs, and new statistics dashboards.
+- **Container images now default to `ubi10`** (breaking — see below).
+
+### Features
+- **Cedar user identity derivations.** Extract attributes from identity fields with named-capture regex rules (optional `lowercase`/`uppercase` transform) and match policies on the derived values.
+- **Global role IDs in policies.** Reference provider-scoped global role IDs as Cedar property values, and use short-form roles without a default provider.
+- **Resolve-entities API.** `POST /management/v1/permissions/cedar/resolve-entities` returns the Cedar entities for any resource — for debugging why a decision was reached.
+- **SelectView action.** Adds `select` / `SelectView` (and `grant_select`) for views, aligning with the upstream data-plane authorization split.
+- **Role-provider subsystem.** LDAP Group Provider + token-provider chain, roles parsed from table properties, caching with stale-fallback and metrics, and an opt-in audit event for resolved roles — wired into the Cedar authorizer. Configure via `ROLE_PROVIDER_FILE` (TOML), overridable per-field by env vars.
+- **Richer permission-introspection audit.** `introspect_permissions` logs now include the inner check tuples and their individual decisions.
+- **Console: Cedar Policy Builder (beta).** Visual editor/builder with a CodeMirror Cedar editor (highlighting, autocomplete, inline diagnostics, format/validate via cedar-wasm) and live Evaluate.
+- **Console: authorization inspection + dashboards.** Tabs for entity/policy sources, schema, and resolve-entities; new Home and Warehouse statistics dashboards; storage-layout configuration.
+
+### Bug Fixes
+- Cedar: correctness fixes around short-form role tags, per-request provider-ID derivation, Role subjects, and resolve-entities server gating.
+- Maintenance: expire-snapshots now removes statistics / partition-statistics from metadata, avoiding dangling references to deleted files.
+- TLS: added webpki and native root certs to the S3 client and UBI images, fixing handshake failures in some environments.
+- Console: correct handling of sub-namespaces containing dots; per-tab 403 keeps the navigation rail visible.
+
+### Breaking Changes
+- Container images now default to **`ubi10`**; the `ubi9`-based image remains available under a separate tag.
+
+### Upgrade Notes
+- If you pin the `ubi9` base image (e.g. FIPS/compliance), switch to the dedicated `ubi9` tag — the default is now `ubi10`.
+- Role-provider config can be supplied via `ROLE_PROVIDER_FILE` (TOML), with env vars overriding per field — review precedence if you set both.
+
+### Upstream Lakekeeper changes
+- **Instance Admins** — server-wide admin role independent of project membership ([lakekeeper#1716](https://github.com/lakekeeper/lakekeeper/pull/1716)).
+- **Idempotency keys** for safely retrying mutating requests ([lakekeeper#1671](https://github.com/lakekeeper/lakekeeper/pull/1671)).
+- **`referenced-by`** to discover views referencing a table/view ([lakekeeper#1627](https://github.com/lakekeeper/lakekeeper/pull/1627)).
+- Configurable **trusted engines** in request metadata for authorization ([lakekeeper#1629](https://github.com/lakekeeper/lakekeeper/pull/1629)).
+- **Protect immutable table properties** (e.g. `encryption.key-id`) during commits ([lakekeeper#1700](https://github.com/lakekeeper/lakekeeper/pull/1700)).
+- Faster list namespaces/tables/views ([lakekeeper#1618](https://github.com/lakekeeper/lakekeeper/pull/1618)).


### PR DESCRIPTION
This PR automatically syncs documentation files from the lakekeeper plus repository.

## Changes
- management-open-api-plus.yaml: ✓ Updated
- lakekeeper.cedarschema: ✓ Updated
- enterprise-release-notes.md: ✓ Updated

Source commit: `94d6bd23705fb2b75ecaba207963102d8ae2c99f`
Generated by [workflow run](https://github.com/vakamo-labs/lakekeeper-enterprise/actions/runs/27016237423)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for generic (non‑Iceberg) tables with full namespace management and actions
  * Warehouse format‑version policy management (set/update)
  * API endpoints for generic‑table assignments, actions, protection, and listing
  * Task scheduling endpoints for snapshot expiration and orphan‑file removal

* **Documentation**
  * Clarified that user email is not a unique identity discriminator
  * Added enterprise release notes for recent versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->