### PR TITLE
feat(storage): emit Iceberg 1.11 signer.uri/signer.endpoint properties

### DIFF
--- a/crates/iceberg-ext/src/configs/table.rs
+++ b/crates/iceberg-ext/src/configs/table.rs
@@ -25,6 +25,9 @@ impl TableProperties {
             } else if key.starts_with("gcs") {
                 gcs::validate(&key, &value)?;
                 config.props.insert(key, value);
+            } else if key.starts_with("signer") {
+                signer::validate(&key, &value)?;
+                config.props.insert(key, value);
             } else if key.starts_with("adls") {
                 adls::validate(&key, &value)?;
             } else if [creds::ExpirationTimeMs::KEY].contains(&key.as_str()) {
@@ -73,6 +76,26 @@ pub mod s3 {
             SignerEndpoint, String, "s3.signer.endpoint", "s3_signer_endpoint";
             SesionTokenExpiresAtMs, i64, "s3.session-token-expires-at-ms", "s3_session_token_expires_at_ms";
          }
+    );
+}
+
+/// Remote-signing properties introduced in Iceberg 1.11.0. These supersede the
+/// S3-namespaced `s3.signer.uri` / `s3.signer.endpoint` (deprecated, removed in Iceberg 1.12.0).
+/// Lakekeeper emits both the old and new keys with identical values: new clients (>=1.11) read
+/// these and avoid the deprecation warning, while older clients keep using the `s3.signer.*` keys.
+pub mod signer {
+    use super::{
+        super::ConfigProperty, ConfigParseError, NotCustomProp, ParseFromStr, TableProperties,
+        TableProperty,
+    };
+    use crate::configs::impl_config_values;
+
+    impl_config_values!(
+        Table,
+        {
+            Uri, String, "signer.uri", "signer_uri";
+            Endpoint, String, "signer.endpoint", "signer_endpoint";
+        }
     );
 }
 
@@ -158,5 +181,30 @@ mod tests {
         assert_eq!(iceberg::io::S3_ACCESS_KEY_ID, s3::AccessKeyId::KEY);
         assert_eq!(iceberg::io::S3_SECRET_ACCESS_KEY, s3::SecretAccessKey::KEY);
         assert_eq!(iceberg::io::S3_SESSION_TOKEN, s3::SessionToken::KEY);
+    }
+
+    #[test]
+    fn test_signer_keys_match_iceberg_1_11() {
+        // Property names introduced in Iceberg 1.11.0 (org.apache.iceberg.rest.RESTCatalogProperties).
+        assert_eq!(signer::Uri::KEY, "signer.uri");
+        assert_eq!(signer::Endpoint::KEY, "signer.endpoint");
+    }
+
+    #[test]
+    fn test_signer_props_round_trip_through_validate() {
+        // `signer.*` keys must be dispatched to `signer::validate` and retained, not dropped as custom.
+        let config = TableProperties::try_from_props([
+            (
+                "signer.uri".to_string(),
+                "https://example.com/catalog/".to_string(),
+            ),
+            ("signer.endpoint".to_string(), "v1/aws/s3/sign".to_string()),
+        ])
+        .unwrap();
+        assert_eq!(
+            config.signer_uri().as_deref(),
+            Some("https://example.com/catalog/")
+        );
+        assert_eq!(config.signer_endpoint().as_deref(), Some("v1/aws/s3/sign"));
     }
 }

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -12,7 +12,7 @@ use aws_sdk_sts::{config::ProvideCredentials as _, types::Tag};
 use aws_smithy_runtime_api::client::identity::Identity;
 use iceberg_ext::{
     catalog::rest::ErrorModel,
-    configs::table::{TableProperties, client, creds, custom, s3},
+    configs::table::{TableProperties, client, creds, custom, s3, signer},
 };
 use lakekeeper_io::{
     InvalidLocationError, Location,
@@ -560,10 +560,15 @@ impl S3Profile {
             let tabular_id = stc_request.tabular_id;
             push_fsspec_fileio_with_s3v4restsigner(&mut config);
             config.insert(&s3::RemoteSigningEnabled(true));
-            config.insert(&s3::SignerUri(request_metadata.s3_signer_uri(warehouse_id)));
-            config.insert(&s3::SignerEndpoint(
-                request_metadata.s3_signer_endpoint_for_table(warehouse_id, tabular_id),
-            ));
+            let signer_uri = request_metadata.s3_signer_uri(warehouse_id);
+            let signer_endpoint =
+                request_metadata.s3_signer_endpoint_for_table(warehouse_id, tabular_id);
+            // Iceberg 1.11.0 renamed `s3.signer.*` to `signer.*`. Emit both so clients >=1.11 read
+            // the new keys (no deprecation warning) and older clients keep using the old ones.
+            config.insert(&signer::Uri(signer_uri.clone()));
+            config.insert(&signer::Endpoint(signer_endpoint.clone()));
+            config.insert(&s3::SignerUri(signer_uri));
+            config.insert(&s3::SignerEndpoint(signer_endpoint));
         }
 
         Ok(TableConfig { creds, config })


### PR DESCRIPTION
Iceberg 1.11.0 renamed the S3 remote-signing config keys from the S3-namespaced s3.signer.uri/s3.signer.endpoint (S3V4RestSignerClient) to the generic signer.uri/signer.endpoint (RESTCatalogProperties). The old keys are deprecated and removed in 1.12.0; clients >=1.11 log a deprecation warning when only the old keys are present.

Emit both the new and old keys with identical values when remote signing is enabled. Clients >=1.11 read the new keys (no warning), while older clients keep using s3.signer.*. The sign endpoint and protocol are unchanged — this is purely a config-property rename.

Closes #1762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for remote-signing table configuration properties (`signer.uri` and `signer.endpoint`) aligned with Iceberg 1.11.0.
  * Configuration now maintains backward compatibility by emitting both legacy and new remote-signing property formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->