### PR TITLE
chore(docs): add a per-PR docs link-check gate

### DIFF
--- a/.github/workflows/docs_linkcheck.yml
+++ b/.github/workflows/docs_linkcheck.yml
@@ -1,0 +1,32 @@
+name: Docs Link Check
+
+on:
+  push:
+    branches:
+      - main
+      - "manual-release-*"
+      - "rel-*"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read # Needed to checkout code
+
+jobs:
+  linkcheck:
+    name: Link Check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: 3.x
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+        with:
+          just-version: 1.x
+      - uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2
+        with:
+          tool: lychee
+      - name: Link check (nightly anchors + assembled-site files)
+        run: just linkcheck
+        working-directory: ./site

--- a/.github/workflows/docs_linkcheck.yml
+++ b/.github/workflows/docs_linkcheck.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.x

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,11 @@
   ],
   "packageRules": [
     {
+      "description": "Don't auto-bump CI service/runner versions. postgres (the catalog DB) and the ubuntu runner OS define the test environment, not the dependency tree — major bumps should be a deliberate, reviewed choice (does CI still reflect the versions we support?), not an automatic PR.",
+      "matchDepNames": ["postgres", "ubuntu"],
+      "enabled": false
+    },
+    {
       "description": "Group all GitHub Actions updates (digest, minor, major) into one PR",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",

--- a/site/justfile
+++ b/site/justfile
@@ -16,8 +16,30 @@ deploy:
   dev/deploy.sh
 
 # Clean and build the docs site locally.
-build: 
+build:
   dev/build.sh
+
+# Build the docs and link-check the live content (nightly + top-level pages).
+# Two layers, both scoped to what's editable here:
+#   1. Anchors — mkdocs validates these per-page; we fail only on the `nightly`
+#      source version (released versions are frozen snapshots and may carry old links).
+#   2. File/asset existence — lychee resolves the cross-unit/shared-asset paths that
+#      mkdocs' per-unit validation can't. Fragments are skipped (lychee mis-resolves
+#      mkdocs' pretty `page/` URLs), and the doubled `nightly/docs` orphan is excluded.
+# Needs lychee: `cargo install lychee` (CI installs it via taiki-e/install-action).
+linkcheck:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  command -v lychee >/dev/null || { echo "lychee not found — run: cargo install lychee"; exit 127; }
+  ./dev/build.sh 2>&1 | tee /tmp/lk-build.log
+  if grep -qE "Doc file 'docs/nightly/.*does not contain an anchor" /tmp/lk-build.log; then
+    echo "::error:: broken anchor link(s) in nightly docs:"
+    grep -E "docs/nightly/.*does not contain an anchor" /tmp/lk-build.log || true
+    exit 1
+  fi
+  lychee --offline --root-dir "$PWD/site" --no-progress \
+    --exclude-path site/docs/nightly/docs \
+    site/index.html site/getting-started site/support site/about site/docs/nightly
 
 # Clean the local docs site.
 clean:

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -4,6 +4,17 @@ site_description: Lakekeeper is a rust native Iceberg REST Catalog
 site_author: Lakekeeper Team
 edit_uri: blob/main/docs/
 
+# Link validation. The monorepo plugin builds each version as a separate unit, so
+# cross-unit / shared-asset links (../../assets, ../../about, ../../getting-started)
+# can't be resolved here — they only resolve in the assembled site — so keep them at
+# `info`. Anchors are per-page, so broken anchors ARE real — keep them as warnings.
+# `just linkcheck` validates the assembled site (lychee) as the real gate.
+validation:
+  links:
+    not_found: info
+    anchors: warn
+    absolute_links: info
+
 theme:
   custom_dir: overrides
   name: material


### PR DESCRIPTION
New "Docs Link Check" workflow runs on every PR: fail on broken anchors in the nightly docs (mkdocs validates anchors per-page; released versions are frozen snapshots and are skipped) and run lychee over the assembled site for file/asset existence — resolving the cross-unit and shared-asset paths that mkdocs' per-unit validation can't see.

- site/justfile: `just linkcheck` recipe (build, gate nightly anchors, lychee with --root-dir, no --include-fragments, excluding the doubled nightly/docs orphan)
- site/mkdocs.yml: tune link validation (anchors warn; cross-unit not_found / absolute_links info)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated documentation link-check workflow to CI (runs on pushes, PRs, and manual trigger).
  * Added a local build-and-linkcheck recipe to docs tooling to build the site and validate links before publishing.
  * Updated dependency automation rules to disable automatic updates for runner/CI platform packages.

* **Documentation**
  * Adjusted link-validation settings to treat missing links as informational and anchor issues as warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->