### PR TITLE
fix(io): retry transient failures when acquiring storage OAuth tokens

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,10 @@
+# Cloud storage integration tests open many concurrent connections (e.g. the
+# 100-way delete_batch fanout). Running too many of them at once exhausts
+# ephemeral ports / SNAT against the cloud endpoints, causing connect timeouts
+# (os error 110) that exhaust the SDK retry budget. Cap how many run together.
+[test-groups]
+cloud-io = { max-threads = 4 }
+
 # Tests that can run without secrets and external services.
 [profile.default]
 default-filter = """
@@ -23,6 +30,16 @@ default-filter = "all()"
 failure-output = "immediate-final"
 fail-fast = false
 retries = 0
+
+# The io integration tests hit live cloud backends (ADLS/GCS/S3/R2) and are
+# inherently prone to transient network blips under concurrency. Cap their
+# combined concurrency and retry transient failures: a retried test runs in
+# isolation under less load, so genuine flakes pass on re-run while real
+# failures (which fail every attempt) still fail.
+[[profile.ci.overrides]]
+filter = 'package(lakekeeper-io) and binary(integration_tests)'
+test-group = 'cloud-io'
+retries = { backoff = "exponential", count = 2, delay = "2s", jitter = true }
 
 [profile.ci.junit] # this can be some other profile, too
 path = "junit.xml"

--- a/crates/io/src/adls.rs
+++ b/crates/io/src/adls.rs
@@ -3,7 +3,10 @@ use std::{
     time::Duration,
 };
 
-use azure_core::{FixedRetryOptions, RetryOptions, TransportOptions};
+use azure_core::{
+    FixedRetryOptions, RetryOptions, TransportOptions,
+    auth::{AccessToken, TokenCredential},
+};
 use azure_identity::{
     DefaultAzureCredential, DefaultAzureCredentialBuilder, TokenCredentialOptions,
 };
@@ -25,6 +28,37 @@ pub use adls_location::{
 pub use adls_storage::AdlsStorage;
 
 use crate::InitializeClientError;
+
+/// Wraps a [`TokenCredential`] to retry transient failures when acquiring a
+/// bearer token. The Azure storage data-plane retry policy ([`RetryOptions`])
+/// does not cover the credential/token endpoint, so a single transient connect
+/// timeout to the OAuth endpoint (e.g. SNAT/ephemeral-port exhaustion under
+/// high concurrency) would otherwise fail the operation, unretried.
+#[derive(Debug)]
+struct RetryingTokenCredential {
+    inner: Arc<dyn TokenCredential>,
+}
+
+impl RetryingTokenCredential {
+    fn new(inner: Arc<dyn TokenCredential>) -> Arc<Self> {
+        Arc::new(Self { inner })
+    }
+}
+
+#[async_trait::async_trait]
+impl TokenCredential for RetryingTokenCredential {
+    async fn get_token(&self, scopes: &[&str]) -> azure_core::Result<AccessToken> {
+        tryhard::retry_fn(|| self.inner.get_token(scopes))
+            .retries(3)
+            .exponential_backoff(Duration::from_millis(200))
+            .max_delay(Duration::from_secs(10))
+            .await
+    }
+
+    async fn clear_cache(&self) -> azure_core::Result<()> {
+        self.inner.clear_cache().await
+    }
+}
 
 const DEFAULT_HOST: &str = "dfs.core.windows.net";
 static DEFAULT_AUTHORITY_HOST: LazyLock<Url> = LazyLock::new(|| {
@@ -154,14 +188,16 @@ impl AzureSettings {
                     client_secret.clone(),
                 );
 
-                StorageCredentials::token_credential(Arc::new(azure_auth))
+                StorageCredentials::token_credential(RetryingTokenCredential::new(Arc::new(
+                    azure_auth,
+                )))
             }
             AzureAuth::SharedAccessKey(AzureSharedAccessKeyAuth { key }) => {
                 StorageCredentials::access_key(account_name, key.clone())
             }
             AzureAuth::AzureSystemIdentity => {
                 let identity: Arc<DefaultAzureCredential> = self.get_system_identity().await?;
-                StorageCredentials::token_credential(identity)
+                StorageCredentials::token_credential(RetryingTokenCredential::new(identity))
             }
             AzureAuth::Sas(AzureSasAuth { sas_token }) => StorageCredentials::sas_token(sas_token)
                 .map_err(|e| InitializeClientError {

--- a/crates/io/src/gcs.rs
+++ b/crates/io/src/gcs.rs
@@ -2,7 +2,10 @@ mod gcs_error;
 mod gcs_location;
 mod gcs_storage;
 
-use std::sync::{Arc, LazyLock};
+use std::{
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 pub use gcs_location::{GcsLocation, InvalidGCSBucketName, validate_bucket_name};
@@ -125,41 +128,53 @@ impl GCSSettings {
             .with(RetryTransientMiddleware::new_with_policy(retry_policy))
             .build();
 
-        let config = ClientConfig {
-            http: Some(mid_client),
-            ..ClientConfig::default()
-        };
+        // Acquiring the OAuth token during client init (with_auth /
+        // with_credentials) hits the token endpoint directly and is NOT covered
+        // by the data-plane retry middleware above. A single transient connect
+        // timeout to the token endpoint (e.g. SNAT/ephemeral-port exhaustion
+        // under high concurrency) would otherwise fail init, unretried — so
+        // retry the whole construction on transient failures.
+        let config = tryhard::retry_fn(|| async {
+            let config = ClientConfig {
+                http: Some(mid_client.clone()),
+                ..ClientConfig::default()
+            };
 
-        let config = match auth {
-            GcsAuth::GcpSystemIdentity {} => {
-                config
-                    .with_auth()
-                    .await
-                    .map_err(|e| InitializeClientError {
+            match auth {
+                GcsAuth::GcpSystemIdentity {} => config.with_auth().await.map_err(|e| {
+                    InitializeClientError {
                         reason: format!(
                             "Failed to initialize GCS client with system identity: {e}"
                         ),
                         source: Some(e.into()),
-                    })?
+                    }
+                }),
+                GcsAuth::CredentialsFile { file } => {
+                    config.with_credentials(file.clone()).await.map_err(|e| {
+                        InitializeClientError {
+                            reason: format!(
+                                "Failed to initialize GCS client with credentials file: {e}"
+                            ),
+                            source: Some(e.into()),
+                        }
+                    })
+                }
+                GcsAuth::BearerToken(GcsBearerTokenAuth { access_token }) => {
+                    let mut config = config;
+                    let provider = StaticTokenSourceProvider {
+                        source: Arc::new(StaticTokenSource {
+                            bearer: format!("Bearer {access_token}"),
+                        }),
+                    };
+                    config.token_source_provider = Some(Box::new(provider));
+                    Ok(config)
+                }
             }
-            GcsAuth::CredentialsFile { file } => config
-                .with_credentials(file.clone())
-                .await
-                .map_err(|e| InitializeClientError {
-                    reason: format!("Failed to initialize GCS client with credentials file: {e}"),
-                    source: Some(e.into()),
-                })?,
-            GcsAuth::BearerToken(GcsBearerTokenAuth { access_token }) => {
-                let mut config = config;
-                let provider = StaticTokenSourceProvider {
-                    source: Arc::new(StaticTokenSource {
-                        bearer: format!("Bearer {access_token}"),
-                    }),
-                };
-                config.token_source_provider = Some(Box::new(provider));
-                config
-            }
-        };
+        })
+        .retries(3)
+        .exponential_backoff(Duration::from_millis(200))
+        .max_delay(Duration::from_secs(10))
+        .await?;
 
         Ok(Client::new(config))
     }

--- a/crates/io/src/gcs.rs
+++ b/crates/io/src/gcs.rs
@@ -141,24 +141,23 @@ impl GCSSettings {
             };
 
             match auth {
-                GcsAuth::GcpSystemIdentity {} => config.with_auth().await.map_err(|e| {
-                    InitializeClientError {
+                GcsAuth::GcpSystemIdentity {} => {
+                    config.with_auth().await.map_err(|e| InitializeClientError {
                         reason: format!(
                             "Failed to initialize GCS client with system identity: {e}"
                         ),
                         source: Some(e.into()),
-                    }
-                }),
-                GcsAuth::CredentialsFile { file } => {
-                    config.with_credentials(file.clone()).await.map_err(|e| {
-                        InitializeClientError {
-                            reason: format!(
-                                "Failed to initialize GCS client with credentials file: {e}"
-                            ),
-                            source: Some(e.into()),
-                        }
                     })
                 }
+                GcsAuth::CredentialsFile { file } => config
+                    .with_credentials(file.clone())
+                    .await
+                    .map_err(|e| InitializeClientError {
+                        reason: format!(
+                            "Failed to initialize GCS client with credentials file: {e}"
+                        ),
+                        source: Some(e.into()),
+                    }),
                 GcsAuth::BearerToken(GcsBearerTokenAuth { access_token }) => {
                     let mut config = config;
                     let provider = StaticTokenSourceProvider {


### PR DESCRIPTION
ADLS and GCS fetch a bearer token from the provider's OAuth endpoint (login.microsoftonline.com / oauth2.googleapis.com) during credential and client setup. That token-fetch path is not covered by the data-plane retry policy (ADLS FixedRetryOptions) or retry middleware (GCS reqwest-retry), so a single transient connect timeout to the token endpoint — e.g. SNAT / ephemeral-port exhaustion under high concurrency — failed the whole operation, unretried. This surfaced as flaky integration-test failures ("operation timed out" / "failed to get bearer token ... which will not be retried") when many clients authenticate at once.

Wrap token acquisition in a 3x exponential-backoff retry, matching the existing S3 tryhard pattern:
- ADLS: a RetryingTokenCredential wrapper around the TokenCredential, applied to both the client-credentials and system-identity paths.
- GCS: retry client construction (with_auth / with_credentials), where the token exchange happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of cloud storage authentication (Azure and GCS) by adding automatic retry behavior for transient token acquisition failures, reducing intermittent authentication errors.

* **Tests**
  * Reduced concurrency and added targeted retry/backoff for cloud IO integration tests in CI to lower flakiness and transient test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->