### PR TITLE
chore(deny): ignore unreachable http-types advisory; drop stale rsa ignore

### DIFF
--- a/.cargo/deny.toml
+++ b/.cargo/deny.toml
@@ -70,10 +70,10 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    "RUSTSEC-2023-0071", # https://github.com/RustCrypto/RSA/issues/19#issuecomment-1822995643
     "RUSTSEC-2024-0384", # instant unmaintained but no direct harm, resolved eventually by azure library updates to the new official SDK once SAS is supported.
     "RUSTSEC-2024-0436", # paste is unmaintained but has no direct harm. We already removed direct dependencies.
     "RUSTSEC-2025-0134", # https://github.com/nats-io/nats.rs/issues/1502, will be fixed in v0.47
+    "RUSTSEC-2026-0174", # http-types unsound auth ASCII-invariant. Not affected: only transitive path is azure_core 0.21 (ADLS), which uses http-types solely for Method/StatusCode and never the vulnerable Authorization/WwwAuthenticate types, so that code is never reached. Unmaintained crate, no upgrade available.
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/.github/workflows/integration_test_workflow.yml
+++ b/.github/workflows/integration_test_workflow.yml
@@ -18,11 +18,23 @@ jobs:
     name: ${{ inputs.test_name }}
     env:
       current_test: ${{ inputs.test_name }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      # Authenticated Docker Hub pulls avoid anonymous per-IP rate limits on
+      # shared CI runners, which otherwise surface as image-pull connect
+      # timeouts (registry-1.docker.io). Skipped when the secret is absent
+      # (e.g. fork PRs) so those still run with anonymous pulls.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Restore binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -41,10 +41,23 @@ jobs:
   test-example-minimal:
     needs: docker
     runs-on: ubuntu-24.04
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      # Authenticated Docker Hub pulls avoid anonymous per-IP rate limits on
+      # shared CI runners, which otherwise surface as image-pull connect
+      # timeouts (registry-1.docker.io). Skipped when the secret is absent
+      # (e.g. fork PRs) so those still run with anonymous pulls.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Restore binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -73,10 +86,23 @@ jobs:
   test-example-access-control-simple:
     needs: docker
     runs-on: ubuntu-24.04
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      # Authenticated Docker Hub pulls avoid anonymous per-IP rate limits on
+      # shared CI runners, which otherwise surface as image-pull connect
+      # timeouts (registry-1.docker.io). Skipped when the secret is absent
+      # (e.g. fork PRs) so those still run with anonymous pulls.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Restore binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -105,10 +131,23 @@ jobs:
   test-example-access-control-advanced:
     needs: docker
     runs-on: ubuntu-24.04
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      # Authenticated Docker Hub pulls avoid anonymous per-IP rate limits on
+      # shared CI runners, which otherwise surface as image-pull connect
+      # timeouts (registry-1.docker.io). Skipped when the secret is absent
+      # (e.g. fork PRs) so those still run with anonymous pulls.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Test Make all
         run: |
@@ -123,10 +162,23 @@ jobs:
   test-example-kafka-connect-iceberg-sink:
     needs: docker
     runs-on: ubuntu-24.04
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      # Authenticated Docker Hub pulls avoid anonymous per-IP rate limits on
+      # shared CI runners, which otherwise surface as image-pull connect
+      # timeouts (registry-1.docker.io). Skipped when the secret is absent
+      # (e.g. fork PRs) so those still run with anonymous pulls.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Restore binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -155,10 +207,23 @@ jobs:
   test-docker-compose-with-keycloak:
     needs: docker
     runs-on: ubuntu-24.04
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      # Authenticated Docker Hub pulls avoid anonymous per-IP rate limits on
+      # shared CI runners, which otherwise surface as image-pull connect
+      # timeouts (registry-1.docker.io). Skipped when the secret is absent
+      # (e.g. fork PRs) so those still run with anonymous pulls.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Restore binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
RUSTSEC-2026-0174 flags unsound ASCII handling in http-types' typed auth::Authorization/WwwAuthenticate. We are not affected: the only path to http-types is azure_core 0.21 (ADLS), which uses it solely for Method/StatusCode and never those auth types, so the code is unreachable. Ignore it with that justification (unmaintained crate, no upgrade available).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency security advisory scanning list
  * Enhanced CI/CD pipeline for improved build reliability by addressing Docker image pull rate limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->