### PR TITLE
feat(cache): jitter cache TTLs and add role-membership fan-out metric

### DIFF
--- a/crates/lakekeeper/src/service/cache_metrics.rs
+++ b/crates/lakekeeper/src/service/cache_metrics.rs
@@ -13,9 +13,21 @@ pub(crate) const METRIC_CACHE_SIZE: &str = "lakekeeper_cache_size";
 pub(crate) const METRIC_CACHE_HITS_TOTAL: &str = "lakekeeper_cache_hits_total";
 pub(crate) const METRIC_CACHE_MISSES_TOTAL: &str = "lakekeeper_cache_misses_total";
 
+/// Histogram of how many users' cached role assignments are invalidated by a
+/// single role→role membership edge change, labelled by `operation`
+/// (`"add"`/`"remove"`). `USER_ASSIGNMENTS_CACHE` stores a fully-expanded
+/// transitive closure, so one edge change fans out to every affected user; this
+/// measures that fan-out distribution.
+pub(crate) const METRIC_ROLE_MEMBERSHIP_EDGE_FANOUT_USERS: &str =
+    "lakekeeper_role_membership_edge_fanout_users";
+
 /// Registers metric descriptions exactly once for the shared cache metrics.
 pub(crate) static METRICS_INITIALIZED: LazyLock<()> = LazyLock::new(|| {
     metrics::describe_gauge!(METRIC_CACHE_SIZE, "Current number of entries in the cache");
     metrics::describe_counter!(METRIC_CACHE_HITS_TOTAL, "Total number of cache hits");
     metrics::describe_counter!(METRIC_CACHE_MISSES_TOTAL, "Total number of cache misses");
+    metrics::describe_histogram!(
+        METRIC_ROLE_MEMBERSHIP_EDGE_FANOUT_USERS,
+        "Number of users whose cached role assignments were invalidated by a single role-membership edge change"
+    );
 });

--- a/crates/lakekeeper/src/service/cache_ttl.rs
+++ b/crates/lakekeeper/src/service/cache_ttl.rs
@@ -1,0 +1,147 @@
+//! Shared per-entry TTL jitter for the in-process caches.
+//!
+//! Every catalog cache uses a fixed `time_to_live`. Many replicas that warm the
+//! same hot key around the same wall-clock instant then expire it on the same
+//! TTL boundary and re-derive it simultaneously — a fleet-wide stampede that
+//! per-replica single-flight cannot see. [`JitteredTtl`] desynchronizes those
+//! boundaries by shortening each entry's lifetime by a small random fraction.
+//!
+//! The jitter is **downward-only**: an entry lives `base * f` for a random
+//! `f ∈ (1 - JITTER, 1]`, so a cache's configured `time_to_live` stays an
+//! unchanged upper bound on any single entry's life — the staleness window can
+//! only shrink, never grow.
+//!
+//! **Cross-cache caveat.** The startup invariant `user_assignments.ttl ≤
+//! role.ttl` (see `config.rs`) requires a `USER_ASSIGNMENTS_CACHE` entry to never
+//! outlive the role-cache entry it references. With equal default TTLs, jittering
+//! *both* downward could let a co-warmed UA entry outlive its role entry by up to
+//! the jitter fraction. So `ROLE_CACHE` is deliberately **excluded** from jitter
+//! (held at its exact base TTL); a UA entry then lives `≤ ua_base ≤ role_base =`
+//! the role entry's life and never outlives it. Every other cache is jittered.
+//!
+//! Jittered caches keep their `.time_to_live(base)` builder call as that upper
+//! bound and add `.expire_after(JitteredTtl::new(base, ..))`; moka evicts at the
+//! *earliest* of the two, which is always the jittered value (it never exceeds
+//! `base`).
+
+use std::time::{Duration, Instant};
+
+use moka::Expiry;
+
+/// Default downward jitter fraction (10%): entries live 90–100% of their base TTL.
+pub(crate) const DEFAULT_TTL_JITTER: f64 = 0.10;
+
+/// Per-entry [`Expiry`] that returns a base TTL shortened by a small random
+/// fraction, desynchronizing cross-replica expiry. Reused by every catalog cache
+/// (it ignores key and value).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct JitteredTtl {
+    base: Duration,
+    /// Fraction in `[0.0, 1.0)`: sampled lifetime is `base * (1 - rand[0, jitter))`.
+    jitter: f64,
+}
+
+impl JitteredTtl {
+    pub(crate) fn new(base: Duration, jitter: f64) -> Self {
+        debug_assert!(
+            (0.0..1.0).contains(&jitter),
+            "jitter must be in [0.0, 1.0) to stay downward-only"
+        );
+        Self { base, jitter }
+    }
+
+    /// [`JitteredTtl`] over `base` using the [`DEFAULT_TTL_JITTER`] fraction —
+    /// the form every catalog cache uses.
+    pub(crate) fn with_default_jitter(base: Duration) -> Self {
+        Self::new(base, DEFAULT_TTL_JITTER)
+    }
+
+    /// Sample a jittered lifetime in `(base * (1 - jitter), base]`. Random per
+    /// call (NOT derived from the key): deterministic jitter would give the same
+    /// key the same lifetime on every replica and re-synchronize the expiry,
+    /// defeating the purpose.
+    fn sample(&self) -> Duration {
+        // `fastrand::f64()` ∈ [0, 1) ⇒ factor ∈ (1 - jitter, 1] ⇒ result ≤ base.
+        let factor = 1.0 - fastrand::f64() * self.jitter;
+        self.base.mul_f64(factor)
+    }
+}
+
+impl<K, V> Expiry<K, V> for JitteredTtl {
+    fn expire_after_create(&self, _key: &K, _value: &V, _created_at: Instant) -> Option<Duration> {
+        Some(self.sample())
+    }
+
+    /// MUST be implemented alongside `expire_after_create`. `time_to_live` resets
+    /// the clock on every write, and the cache writers *replace* entries
+    /// (version-gated re-inserts). The default `expire_after_update` returns
+    /// `duration_until_expiry` ("no change"), so without this a hot,
+    /// frequently-rewritten key would pin its first jittered TTL and never
+    /// re-jitter. Sample fresh on every update too.
+    fn expire_after_update(
+        &self,
+        _key: &K,
+        _value: &V,
+        _updated_at: Instant,
+        _duration_until_expiry: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(self.sample())
+    }
+
+    // `expire_after_read`: left at the default (no change) — these TTLs are
+    // write-based, not access-based.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every sample stays within `(base·(1−J), base]`, and across many samples
+    /// the value actually varies (jitter is applied, not a constant).
+    #[test]
+    fn sample_is_in_downward_only_bounds_and_varies() {
+        let base = Duration::from_secs(100);
+        let jitter = JitteredTtl::new(base, DEFAULT_TTL_JITTER);
+        let lower = base.mul_f64(1.0 - DEFAULT_TTL_JITTER); // 90s
+
+        let mut min = base;
+        let mut max = Duration::ZERO;
+        for _ in 0..1000 {
+            let d = jitter.sample();
+            assert!(d >= lower, "sample {d:?} below lower bound {lower:?}");
+            assert!(
+                d <= base,
+                "sample {d:?} above base {base:?} (must be downward-only)"
+            );
+            min = min.min(d);
+            max = max.max(d);
+        }
+        assert!(
+            min < max,
+            "jitter must produce a spread of values, got constant {min:?}"
+        );
+    }
+
+    /// Both write-path expiry hooks return a value (never `None`, which would
+    /// clear expiry) within the downward-only bounds.
+    #[test]
+    fn expire_after_create_and_update_return_in_range() {
+        let base = Duration::from_mins(2);
+        let jitter = JitteredTtl::new(base, DEFAULT_TTL_JITTER);
+        let lower = base.mul_f64(1.0 - DEFAULT_TTL_JITTER);
+        let now = Instant::now();
+
+        for _ in 0..1000 {
+            let on_create =
+                Expiry::<(), ()>::expire_after_create(&jitter, &(), &(), now).expect("create");
+            let on_update = Expiry::<(), ()>::expire_after_update(&jitter, &(), &(), now, None)
+                .expect("update");
+            for d in [on_create, on_update] {
+                assert!(
+                    d >= lower && d <= base,
+                    "expiry {d:?} out of [{lower:?}, {base:?}]"
+                );
+            }
+        }
+    }
+}

--- a/crates/lakekeeper/src/service/catalog_store/namespace_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/namespace_cache.rs
@@ -1,4 +1,7 @@
-use std::{sync::LazyLock, time::Duration};
+use std::{
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use axum_prometheus::metrics;
 use iceberg::NamespaceIdent;
@@ -20,6 +23,7 @@ use crate::{
             METRIC_CACHE_MISSES_TOTAL as METRIC_NAMESPACE_CACHE_MISSES,
             METRIC_CACHE_SIZE as METRIC_NAMESPACE_CACHE_SIZE, METRICS_INITIALIZED,
         },
+        cache_ttl::JitteredTtl,
         catalog_store::namespace::NamespaceHierarchy,
     },
 };
@@ -33,6 +37,9 @@ pub static NAMESPACE_CACHE: LazyLock<Cache<NamespaceId, NamespaceWithParent>> =
             .time_to_live(Duration::from_secs(
                 CONFIG.cache.namespace.time_to_live_secs,
             ))
+            .expire_after(JitteredTtl::with_default_jitter(Duration::from_secs(
+                CONFIG.cache.namespace.time_to_live_secs,
+            )))
             .async_eviction_listener(|key, value: NamespaceWithParent, cause| {
                 Box::pin(async move {
                     // On Replaced: invalidate the old secondary index mapping immediately,
@@ -95,6 +102,9 @@ pub static IDENT_TO_ID_CACHE: LazyLock<Cache<NamespaceCacheKey, NamespaceId>> =
             .time_to_live(Duration::from_secs(
                 CONFIG.cache.namespace.time_to_live_secs,
             ))
+            .expire_after(JitteredTtl::with_default_jitter(Duration::from_secs(
+                CONFIG.cache.namespace.time_to_live_secs,
+            )))
             .build()
     });
 
@@ -312,6 +322,14 @@ where
         return Ok(true);
     }
 
+    // The compute always returns `Op::Nop` (the authoritative write is the
+    // version-gated `insert_multiple`, not a raw `Op::Put`), so existence is
+    // normally surfaced by re-reading the cache below. That re-read alone can
+    // race a (microsecond, capacity-driven) eviction of the just-primed entry and
+    // spuriously report not-found, so we also record whether the load itself found
+    // the namespace — making `found` independent of the entry still being resident.
+    let found_in_load = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let found_signal = Arc::clone(&found_in_load);
     let outcome = NAMESPACE_CACHE
         .entry(namespace_id)
         .and_try_compute_with(|maybe_entry| async move {
@@ -323,13 +341,13 @@ where
                 // Namespace not found — never negative-cached.
                 return Ok(Op::Nop);
             }
+            found_signal.store(true, std::sync::atomic::Ordering::Relaxed);
             // `namespace_cache_insert_multiple` is the authoritative write: it is
             // version-gated (keeps a concurrently-cached newer version) and stores
             // *canonical* entries (the invariant `build_hierarchy_from_cache` relies
             // on). We deliberately return `Op::Nop` rather than `Op::Put(leaf)` — a
             // raw, possibly-stale, non-canonical leaf — which would clobber a newer
-            // concurrent insert and break the canonical invariant. `found` is
-            // resolved by the re-read below.
+            // concurrent insert and break the canonical invariant.
             namespace_cache_insert_multiple(chain).await;
             Ok(Op::Nop)
         })
@@ -340,10 +358,14 @@ where
         CompResult::Inserted(_) | CompResult::ReplacedWith(_) | CompResult::Unchanged(_) => true,
         // We always return `Op::Nop`, so a found namespace lands here: our gated
         // `insert_multiple` wrote it via a different lock domain that moka's
-        // snapshot-based `Op::Nop` result cannot surface. Re-read to decide `found`
-        // (also covers the genuine not-found case → `false`).
+        // snapshot-based `Op::Nop` result cannot surface. The load's own result is
+        // authoritative for existence; the cache re-read additionally covers the
+        // case where a concurrent caller populated the entry. Without the
+        // `found_in_load` term, an eviction between our insert and this read would
+        // spuriously report not-found for a namespace that exists.
         CompResult::StillNone(_) | CompResult::Removed(_) => {
-            NAMESPACE_CACHE.get(&namespace_id).await.is_some()
+            found_in_load.load(std::sync::atomic::Ordering::Relaxed)
+                || NAMESPACE_CACHE.get(&namespace_id).await.is_some()
         }
     })
 }
@@ -476,8 +498,7 @@ impl EventListener for NamespaceCacheEventListener {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
+    use Arc;
     use chrono::Utc;
     use iceberg::NamespaceIdent;
 

--- a/crates/lakekeeper/src/service/catalog_store/namespace_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/namespace_cache.rs
@@ -498,7 +498,6 @@ impl EventListener for NamespaceCacheEventListener {
 
 #[cfg(test)]
 mod tests {
-    use Arc;
     use chrono::Utc;
     use iceberg::NamespaceIdent;
 

--- a/crates/lakekeeper/src/service/catalog_store/role_assignment.rs
+++ b/crates/lakekeeper/src/service/catalog_store/role_assignment.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::HashSet, sync::Arc};
 
+use axum_prometheus::metrics;
 use http::StatusCode;
 use iceberg_ext::catalog::rest::ErrorModel;
 
@@ -10,7 +11,7 @@ use crate::{
         ArcProjectId, CatalogBackendError, CatalogStore, DatabaseIntegrityError, RoleId,
         RoleIdNotFoundInProject, RoleIdent, RoleNameAlreadyExists, RoleProviderId, Transaction,
         authn::{UserId, UserIdRef},
-        define_transparent_error,
+        cache_metrics, define_transparent_error,
         events::{EventDispatcher, RoleMembersSyncedEvent, UserRoleAssignmentsSyncedEvent},
         identifier::role::ArcRoleIdent,
         impl_error_stack_methods, impl_from_with_detail, role_assignments_cache, role_cache,
@@ -1161,6 +1162,7 @@ where
         // commit→evict window leaves affected entries stale until the
         // `USER_ASSIGNMENTS_CACHE` TTL — stale-permissive for removes, but bounded
         // and acceptable for this cache.
+        record_membership_edge_fanout("add", parent_role_id, &affected);
         role_assignments_cache::user_assignments_cache_invalidate_many(&affected).await;
         Ok(result)
     }
@@ -1185,6 +1187,7 @@ where
         t.commit().await?;
 
         // Infallible post-commit eviction; see `add_role_members_and_invalidate`.
+        record_membership_edge_fanout("remove", parent_role_id, &affected);
         role_assignments_cache::user_assignments_cache_invalidate_many(&affected).await;
         Ok(result)
     }
@@ -1387,6 +1390,39 @@ where
 
 impl<T> CatalogRoleAssignmentOps for T where T: CatalogStore {}
 
+/// Above this many users invalidated by one role-membership edge change, emit a
+/// `warn`: the materialized per-user closure fanned out unusually wide, which may
+/// signal a pathological role graph. Operational signal only — not an error.
+const ROLE_MEMBERSHIP_FANOUT_WARN_THRESHOLD: usize = 1000;
+
+/// Record the role-membership edge fan-out histogram for one edge mutation and
+/// `warn` when the fan-out is large. Called at the edge-mutation sites (where the
+/// `add`/`remove` op label is known), never inside the shared
+/// `user_assignments_cache_invalidate_many` — that helper is also used by direct
+/// user deletion, which is not an edge fan-out and would conflate the two events.
+#[allow(clippy::cast_precision_loss)]
+fn record_membership_edge_fanout(
+    operation: &'static str,
+    parent_role_id: RoleId,
+    affected: &[UserId],
+) {
+    let () = &*cache_metrics::METRICS_INITIALIZED;
+    let count = affected.len();
+    metrics::histogram!(
+        cache_metrics::METRIC_ROLE_MEMBERSHIP_EDGE_FANOUT_USERS,
+        "operation" => operation
+    )
+    .record(count as f64);
+    if count > ROLE_MEMBERSHIP_FANOUT_WARN_THRESHOLD {
+        tracing::warn!(
+            count,
+            %parent_role_id,
+            operation,
+            "large role-membership edge fan-out invalidated many user-assignment caches"
+        );
+    }
+}
+
 /// Users whose effective roles a `role_membership` edge change on `member_role_ids`
 /// makes stale: those assigned to a member or any role in its descendant closure.
 ///
@@ -1404,4 +1440,44 @@ async fn membership_edge_affected_users<S: CatalogStore>(
         affected.extend(users);
     }
     Ok(affected.into_iter().collect())
+}
+
+#[cfg(test)]
+mod fanout_metric_tests {
+    use super::*;
+
+    fn users(n: usize) -> Vec<UserId> {
+        (0..n)
+            .map(|i| UserId::new_unchecked("test", &format!("u{i}")))
+            .collect()
+    }
+
+    /// A fan-out above the warn threshold logs the operational `warn`. The
+    /// histogram `.record()` also runs (with no recorder installed in the test it
+    /// is a no-op), so this guards the threshold/warn logic — the part worth
+    /// asserting. Capturing the exact recorded histogram value would require a
+    /// metrics test recorder, which is not worth a new dev-dependency for one
+    /// `.record()` call.
+    #[test]
+    #[tracing_test::traced_test]
+    fn warns_above_threshold() {
+        let many = users(ROLE_MEMBERSHIP_FANOUT_WARN_THRESHOLD + 1);
+        record_membership_edge_fanout("add", RoleId::new_random(), &many);
+        assert!(logs_contain(
+            "large role-membership edge fan-out invalidated many user-assignment caches"
+        ));
+    }
+
+    /// At the threshold, and for a zero fan-out, no `warn` is emitted.
+    #[test]
+    #[tracing_test::traced_test]
+    fn silent_at_or_below_threshold() {
+        record_membership_edge_fanout(
+            "remove",
+            RoleId::new_random(),
+            &users(ROLE_MEMBERSHIP_FANOUT_WARN_THRESHOLD),
+        );
+        record_membership_edge_fanout("add", RoleId::new_random(), &[]);
+        assert!(!logs_contain("large role-membership edge fan-out"));
+    }
 }

--- a/crates/lakekeeper/src/service/catalog_store/role_assignments_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/role_assignments_cache.rs
@@ -12,6 +12,7 @@ use crate::{
         CatalogBackendError, RoleId,
         authn::UserId,
         cache_metrics,
+        cache_ttl::JitteredTtl,
         catalog_store::role_assignment::{ListRoleMembersResult, ListUserRoleAssignmentsResult},
     },
 };
@@ -35,6 +36,9 @@ pub(crate) static USER_ASSIGNMENTS_CACHE: std::sync::LazyLock<
         .time_to_live(Duration::from_secs(
             CONFIG.cache.user_assignments.time_to_live_secs,
         ))
+        .expire_after(JitteredTtl::with_default_jitter(Duration::from_secs(
+            CONFIG.cache.user_assignments.time_to_live_secs,
+        )))
         .build()
 });
 
@@ -171,6 +175,9 @@ pub(crate) static ROLE_MEMBERS_CACHE: std::sync::LazyLock<
         .time_to_live(Duration::from_secs(
             CONFIG.cache.role_members.time_to_live_secs,
         ))
+        .expire_after(JitteredTtl::with_default_jitter(Duration::from_secs(
+            CONFIG.cache.role_members.time_to_live_secs,
+        )))
         .build()
 });
 

--- a/crates/lakekeeper/src/service/catalog_store/role_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/role_cache.rs
@@ -19,6 +19,7 @@ use crate::{
             METRIC_CACHE_MISSES_TOTAL as METRIC_ROLE_CACHE_MISSES,
             METRIC_CACHE_SIZE as METRIC_ROLE_CACHE_SIZE, METRICS_INITIALIZED,
         },
+        cache_ttl::JitteredTtl,
     },
 };
 
@@ -27,6 +28,14 @@ pub static ROLE_CACHE: LazyLock<Cache<RoleId, ArcRole>> = LazyLock::new(|| {
     Cache::builder()
         .max_capacity(CONFIG.cache.role.capacity)
         .initial_capacity(100)
+        // Deliberately NOT jittered (unlike the other caches). `USER_ASSIGNMENTS_CACHE`
+        // entries reference roles resolved through this cache, and the startup
+        // invariant `user_assignments.ttl <= role.ttl` (see `config.rs`) requires a
+        // UA entry to never outlive its role entry. Holding this cache at its exact
+        // base TTL keeps that invariant airtight: a UA entry lives `<= ua_base <=
+        // role_base` = this entry's life. Downward jitter here could let a co-warmed
+        // UA entry outlive the role entry by up to the jitter fraction. See
+        // `crate::service::cache_ttl`.
         .time_to_live(Duration::from_secs(CONFIG.cache.role.time_to_live_secs))
         .async_eviction_listener(|key, value: ArcRole, cause| {
             Box::pin(async move {
@@ -70,6 +79,9 @@ static IDENT_TO_ID_CACHE: LazyLock<Cache<(ArcProjectId, ArcRoleIdent), RoleId>> 
             .max_capacity(CONFIG.cache.role.capacity)
             .initial_capacity(100)
             .time_to_live(Duration::from_secs(CONFIG.cache.role.time_to_live_secs))
+            .expire_after(JitteredTtl::with_default_jitter(Duration::from_secs(
+                CONFIG.cache.role.time_to_live_secs,
+            )))
             .build()
     });
 

--- a/crates/lakekeeper/src/service/catalog_store/warehouse_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/warehouse_cache.rs
@@ -23,6 +23,7 @@ use crate::{
             METRIC_CACHE_MISSES_TOTAL as METRIC_WAREHOUSE_CACHE_MISSES,
             METRIC_CACHE_SIZE as METRIC_WAREHOUSE_CACHE_SIZE, METRICS_INITIALIZED,
         },
+        cache_ttl::JitteredTtl,
     },
 };
 
@@ -34,6 +35,9 @@ pub static WAREHOUSE_CACHE: LazyLock<Cache<WarehouseId, CachedWarehouse>> = Lazy
         .time_to_live(Duration::from_secs(
             CONFIG.cache.warehouse.time_to_live_secs,
         ))
+        .expire_after(JitteredTtl::with_default_jitter(Duration::from_secs(
+            CONFIG.cache.warehouse.time_to_live_secs,
+        )))
         .async_eviction_listener(|key, value: CachedWarehouse, cause| {
             Box::pin(async move {
                 // On Replaced: invalidate the old secondary index mapping immediately,
@@ -90,6 +94,9 @@ static NAME_TO_ID_CACHE: LazyLock<Cache<(ArcProjectId, UniCase<String>), Warehou
             .time_to_live(Duration::from_secs(
                 CONFIG.cache.warehouse.time_to_live_secs,
             ))
+            .expire_after(JitteredTtl::with_default_jitter(Duration::from_secs(
+                CONFIG.cache.warehouse.time_to_live_secs,
+            )))
             .build()
     });
 

--- a/crates/lakekeeper/src/service/mod.rs
+++ b/crates/lakekeeper/src/service/mod.rs
@@ -1,6 +1,7 @@
 pub mod authn;
 pub mod authz;
 pub(crate) mod cache_metrics;
+pub(crate) mod cache_ttl;
 mod catalog_store;
 pub mod contract_verification;
 pub mod endpoint_statistics;

--- a/crates/lakekeeper/src/service/secrets.rs
+++ b/crates/lakekeeper/src/service/secrets.rs
@@ -22,6 +22,7 @@ use crate::{
             METRIC_CACHE_MISSES_TOTAL as METRIC_SECRETS_CACHE_MISSES,
             METRIC_CACHE_SIZE as METRIC_SECRETS_CACHE_SIZE, METRICS_INITIALIZED,
         },
+        cache_ttl::JitteredTtl,
         health::HealthExt,
         storage::StorageCredential,
     },
@@ -32,6 +33,9 @@ pub(crate) static SECRETS_CACHE: LazyLock<Cache<SecretId, CachedSecret>> = LazyL
         .max_capacity(CONFIG.cache.secrets.capacity)
         .initial_capacity(50)
         .time_to_live(Duration::from_secs(CONFIG.cache.secrets.time_to_live_secs))
+        .expire_after(JitteredTtl::with_default_jitter(Duration::from_secs(
+            CONFIG.cache.secrets.time_to_live_secs,
+        )))
         .build()
 });
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -348,6 +348,8 @@ When using the built-in UI which is hosted as part of the Lakekeeper binary, mos
 ### Caching
 Lakekeeper uses in-memory caches to speed up certain operations.
 
+Most cache entries' time-to-live is jittered downward by a small random fraction (up to 10%), so an entry lives 90–100% of the configured TTL. This desynchronizes expiry across replicas that warmed the same key at the same time, preventing a fleet-wide refresh stampede on the TTL boundary. The configured `..._TIME_TO_LIVE_SECS` remains the upper bound — jitter only ever shortens an entry's life, never extends it.
+
 **Short-Term Credentials (STC) Cache**
 
 When Lakekeeper vends short-term credentials for cloud storage access (S3 STS, Azure SAS tokens, or GCP access tokens), these credentials can be cached to reduce load on cloud identity services and improve response times.

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -33,6 +33,14 @@ Lakekeeper maintains in-memory caches for Short-Term Credentials, Warehouses, Na
 
 `cache_type` values: `stc`, `warehouse`, `namespace`, `secrets`, `role`, `user_assignments`, `role_members`. A persistently low hit rate signals the cache capacity should be increased. See [Configuration > Caching](./configuration.md#caching) for details.
 
+Role-membership cache invalidation emits one additional metric:
+
+| Metric                                                                                | Type      | Labels      | Description |
+|---------------------------------------------------------------------------------------|-----------|-------------|-----|
+| <code class="selectable">lakekeeper_role_<wbr>membership_edge_<wbr>fanout_users</code> | Histogram | `operation` | Users whose cached role assignments were invalidated by a single role-to-role membership edge change (`operation`: `add` / `remove`) |
+
+The user-assignments cache stores a fully-expanded transitive closure, so one role-membership edge change can invalidate many users at once. A high p99 means a single edit fans out widely; Lakekeeper also logs a `warn` when one change invalidates more than 500 users.
+
 ### Role Provider Metrics <span class="lkp"></span>
 
 When a Role Provider (e.g. LDAP) is configured, Lakekeeper emits the following metrics, each labelled by `provider_id`:

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -39,7 +39,7 @@ Role-membership cache invalidation emits one additional metric:
 |---------------------------------------------------------------------------------------|-----------|-------------|-----|
 | <code class="selectable">lakekeeper_role_<wbr>membership_edge_<wbr>fanout_users</code> | Histogram | `operation` | Users whose cached role assignments were invalidated by a single role-to-role membership edge change (`operation`: `add` / `remove`) |
 
-The user-assignments cache stores a fully-expanded transitive closure, so one role-membership edge change can invalidate many users at once. A high p99 means a single edit fans out widely; Lakekeeper also logs a `warn` when one change invalidates more than 500 users.
+The user-assignments cache stores a fully-expanded transitive closure, so one role-membership edge change can invalidate many users at once. A high p99 means a single edit fans out widely; Lakekeeper also logs a `warn` when one change invalidates more than 1000 users.
 
 ### Role Provider Metrics <span class="lkp"></span>
 


### PR DESCRIPTION
W4 — TTL jitter: each catalog cache entry now expires after a small downward-only random fraction of its configured TTL (90-100%, via a shared `JitteredTtl` expiry), desynchronizing cross-replica expiry so replicas that warmed the same hot key don't re-derive it on the same TTL boundary (a fleet-wide stampede per-replica single-flight can't see). The configured `time_to_live` stays an unchanged upper bound (moka evicts at the earliest of the two). `ROLE_CACHE` is deliberately excluded from jitter so the `user_assignments.ttl <= role.ttl` startup invariant stays exact: a UA entry must never outlive the role entry it references.

W5 — role-membership edge fan-out metric: histogram `lakekeeper_role_membership_edge_fanout_users{operation}` records how many users' cached role assignments a single role->role membership edge change invalidates, plus a `warn` above 500. The user-assignments cache stores a fully-expanded transitive closure, so one edge change can fan out widely; this measures that distribution and flags pathological edits.

Also: fix a latent spurious not-found in the namespace by-id read-through — existence now comes from the load itself, not solely a post-insert cache re-read, so an eviction racing the insert can't report not-found for a namespace that exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache TTL jittering: entry lifetimes now vary ≈90–100% of configured TTL (default 10% downward jitter).
  * Prometheus histogram for role‑membership invalidation fan‑out; records affected user counts and logs a warn when invalidations exceed 1000 users.

* **Bug Fixes**
  * Namespace cache made more resilient to races between eviction and concurrent insertion.

* **Documentation**
  * Updated caching and monitoring docs for TTL jitter and the new fan‑out metric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->