### PR TITLE
feat(metrics): add client-side Postgres connection metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4001,6 +4001,7 @@ dependencies = [
  "lakekeeper",
  "lakekeeper-io",
  "lakekeeper-storage-postgres",
+ "metrics",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ limes = { git = "https://github.com/vakamo-labs/limes-rs.git", rev = "a88da41", 
 ] }
 maplit = "1.0.2"
 md5 = "0.8.0"
+metrics = "0.24"
 middle = { version = "0.4", features = ["tonic"] }
 mockall = "0.14.0"
 moka = { version = "^0.12", features = ["future"] }

--- a/crates/lakekeeper-bin/src/serve.rs
+++ b/crates/lakekeeper-bin/src/serve.rs
@@ -152,6 +152,7 @@ async fn get_default_catalog_from_config() -> anyhow::Result<(
     .await?;
 
     let catalog_state = CatalogState::from_pools(read_pool.clone(), write_pool.clone());
+    catalog_state.spawn_pool_metrics();
 
     let secrets_state: SecretsEnum = match lakekeeper::CONFIG.secret_backend {
         SecretBackend::KV2 => lakekeeper_secrets_kv2::SecretsState::from_config(

--- a/crates/lakekeeper-storage-postgres/Cargo.toml
+++ b/crates/lakekeeper-storage-postgres/Cargo.toml
@@ -43,6 +43,7 @@ lakekeeper-io = { path = "../io", features = [
     "storage-adls",
     "storage-gcs",
 ] }
+metrics = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 sqlx = { workspace = true, features = [

--- a/crates/lakekeeper-storage-postgres/src/lib.rs
+++ b/crates/lakekeeper-storage-postgres/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod idempotency;
 pub mod migrations;
 pub mod namespace;
 mod pagination;
+pub(crate) mod pool_metrics;
 pub mod role;
 pub(crate) mod role_assignment;
 pub(crate) mod secrets;
@@ -88,21 +89,23 @@ impl Transaction<CatalogState> for PostgresTransaction {
     type Transaction<'a> = PostgresTransactionType<'a>;
 
     async fn begin_write(db_state: CatalogState) -> Result<Self> {
-        let transaction = db_state
-            .write_pool()
-            .begin()
-            .await
-            .map_err(|e| e.into_error_model("Error starting transaction".to_string()))?;
+        let transaction = db_state.write_pool().begin().await.map_err(|e| {
+            if crate::pool_metrics::is_pool_timeout(&e) {
+                crate::pool_metrics::record_acquire_timeout("write");
+            }
+            e.into_error_model("Error starting transaction".to_string())
+        })?;
 
         Ok(Self { transaction })
     }
 
     async fn begin_read(db_state: CatalogState) -> Result<Self> {
-        let mut transaction = db_state
-            .read_pool()
-            .begin()
-            .await
-            .map_err(|e| e.into_error_model("Error starting transaction".to_string()))?;
+        let mut transaction = db_state.read_pool().begin().await.map_err(|e| {
+            if crate::pool_metrics::is_pool_timeout(&e) {
+                crate::pool_metrics::record_acquire_timeout("read");
+            }
+            e.into_error_model("Error starting transaction".to_string())
+        })?;
 
         transaction
             .execute("SET TRANSACTION READ ONLY")
@@ -223,6 +226,24 @@ impl CatalogState {
     #[must_use]
     pub fn write_pool(&self) -> PgPool {
         self.read_write.write_pool.clone()
+    }
+
+    /// Spawn a detached background task that samples both pools' connection
+    /// stats into Prometheus gauges every [`pool_metrics::SAMPLE_INTERVAL`].
+    ///
+    /// Detached on purpose: sampling is stateless and needs no graceful
+    /// shutdown — the task is dropped when the runtime stops. Any ticks before
+    /// the global metrics recorder is installed are harmless no-ops.
+    pub fn spawn_pool_metrics(&self) {
+        let read_pool = self.read_pool();
+        let write_pool = self.write_pool();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(pool_metrics::SAMPLE_INTERVAL);
+            loop {
+                ticker.tick().await;
+                pool_metrics::record(&read_pool, &write_pool);
+            }
+        });
     }
 }
 

--- a/crates/lakekeeper-storage-postgres/src/pool_metrics.rs
+++ b/crates/lakekeeper-storage-postgres/src/pool_metrics.rs
@@ -1,0 +1,130 @@
+//! Prometheus metrics for the Postgres connection pools.
+//!
+//! Exposes Lakekeeper's *client-side* pool saturation, which is distinct from
+//! the Postgres *server's* connection slots (covered by `postgres_exporter`).
+//! The read and write pools are reported separately via the `pool` label.
+
+use std::{sync::LazyLock, time::Duration};
+
+use metrics::{counter, describe_counter, describe_gauge, gauge};
+use sqlx::PgPool;
+
+pub(crate) const METRIC_POOL_CONNECTIONS: &str = "lakekeeper_catalog_pg_pool_connections";
+pub(crate) const METRIC_POOL_MAX_CONNECTIONS: &str = "lakekeeper_catalog_pg_pool_max_connections";
+pub(crate) const METRIC_POOL_ACQUIRE_TIMEOUTS: &str =
+    "lakekeeper_catalog_pg_pool_acquire_timeouts_total";
+
+/// Sample interval for the pool gauges. Saturation *events* are caught
+/// per-occurrence by the timeout counter; the gauges only need to surface
+/// *sustained* pressure.
+pub(crate) const SAMPLE_INTERVAL: Duration = Duration::from_secs(15);
+
+static METRICS_INITIALIZED: LazyLock<()> = LazyLock::new(|| {
+    describe_gauge!(
+        METRIC_POOL_CONNECTIONS,
+        "Live Postgres pool connections, by pool (read/write) and state (in_use/idle)"
+    );
+    describe_gauge!(
+        METRIC_POOL_MAX_CONNECTIONS,
+        "Configured maximum connections per Postgres pool"
+    );
+    describe_counter!(
+        METRIC_POOL_ACQUIRE_TIMEOUTS,
+        "Total Postgres connection acquisitions that timed out (client-side pool saturation)"
+    );
+});
+
+#[derive(Debug, PartialEq, Eq)]
+struct PoolGaugeValues {
+    in_use: u32,
+    idle: u32,
+    max: u32,
+}
+
+/// Pure derivation of gauge values from raw sqlx pool stats.
+/// `size` = total connections in the pool (idle + in_use); `num_idle` = idle.
+fn pool_gauge_values(size: u32, num_idle: usize, max: u32) -> PoolGaugeValues {
+    let idle = u32::try_from(num_idle).unwrap_or(u32::MAX);
+    PoolGaugeValues {
+        in_use: size.saturating_sub(idle),
+        idle,
+        max,
+    }
+}
+
+/// True if the error is a connection-pool acquire timeout.
+pub(crate) fn is_pool_timeout(e: &sqlx::Error) -> bool {
+    matches!(e, sqlx::Error::PoolTimedOut)
+}
+
+fn record_one(pool: &PgPool, pool_label: &'static str) {
+    let v = pool_gauge_values(
+        pool.size(),
+        pool.num_idle(),
+        pool.options().get_max_connections(),
+    );
+    gauge!(METRIC_POOL_CONNECTIONS, "pool" => pool_label, "state" => "in_use")
+        .set(f64::from(v.in_use));
+    gauge!(METRIC_POOL_CONNECTIONS, "pool" => pool_label, "state" => "idle").set(f64::from(v.idle));
+    gauge!(METRIC_POOL_MAX_CONNECTIONS, "pool" => pool_label).set(f64::from(v.max));
+}
+
+/// Sample both pools once and set their gauges.
+pub(crate) fn record(read_pool: &PgPool, write_pool: &PgPool) {
+    let () = *METRICS_INITIALIZED;
+    record_one(read_pool, "read");
+    record_one(write_pool, "write");
+}
+
+/// Increment the acquire-timeout counter for `pool_label` (`"read"` | `"write"`).
+pub(crate) fn record_acquire_timeout(pool_label: &'static str) {
+    let () = *METRICS_INITIALIZED;
+    counter!(METRIC_POOL_ACQUIRE_TIMEOUTS, "pool" => pool_label).increment(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PoolGaugeValues, is_pool_timeout, pool_gauge_values};
+
+    #[test]
+    fn computes_in_use_from_size_and_idle() {
+        assert_eq!(
+            pool_gauge_values(10, 3, 10),
+            PoolGaugeValues {
+                in_use: 7,
+                idle: 3,
+                max: 10
+            }
+        );
+    }
+
+    #[test]
+    fn empty_pool_is_all_zero_with_configured_max() {
+        assert_eq!(
+            pool_gauge_values(0, 0, 5),
+            PoolGaugeValues {
+                in_use: 0,
+                idle: 0,
+                max: 5
+            }
+        );
+    }
+
+    #[test]
+    fn idle_exceeding_size_clamps_in_use_to_zero() {
+        assert_eq!(
+            pool_gauge_values(2, 5, 10),
+            PoolGaugeValues {
+                in_use: 0,
+                idle: 5,
+                max: 10
+            }
+        );
+    }
+
+    #[test]
+    fn pool_timeout_is_detected_others_are_not() {
+        assert!(is_pool_timeout(&sqlx::Error::PoolTimedOut));
+        assert!(!is_pool_timeout(&sqlx::Error::RowNotFound));
+    }
+}

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -99,6 +99,19 @@ Postgres is Lakekeeper's primary backend. Use [postgres_exporter](https://github
 
 If you run Postgres via the [CloudNativePG](https://cloudnative-pg.io/) operator, its built-in per-instance exporter (port `9187`, metrics prefixed `cnpg_collector_*`) covers WAL file counts and size, archive status, sync replica state, and basic liveness — complementing `postgres_exporter` for those signals. Connection pool slots, query latency, and replication lag are available as [user-defined custom queries](https://cloudnative-pg.io/documentation/current/monitoring/#user-defined-metrics) in CloudNativePG; disk and IOPS still require `node_exporter` or cloud provider metrics.
 
+### Connection Pool (client-side)
+
+`postgres_exporter` reports the Postgres *server's* connection slots. Lakekeeper additionally exposes its own *client-side* pools — the separate read and write pools each replica holds, sized by `LAKEKEEPER__PG_READ_POOL_CONNECTIONS` and `LAKEKEEPER__PG_WRITE_POOL_CONNECTIONS`. A client pool can saturate even when the server has free slots, so monitor both. The read and write pools are reported separately via the `pool` label.
+
+| Metric                                                                          | Type    | Labels                                            | Description |
+|---------------------------------------------------------------------------------|---------|---------------------------------------------------|-----|
+| <code class="selectable">lakekeeper_catalog_pg_<wbr>pool_connections</code>             | Gauge   | `pool` (`read`/`write`), `state` (`in_use`/`idle`) | Live connections held by the pool |
+| <code class="selectable">lakekeeper_catalog_pg_<wbr>pool_max_connections</code>         | Gauge   | `pool`                                            | Configured pool ceiling |
+| <code class="selectable">lakekeeper_catalog_pg_<wbr>pool_acquire_timeouts_total</code>  | Counter | `pool`                                            | Connection acquisitions that timed out — direct evidence of pool exhaustion |
+
+!!! tip "Alerting on pool saturation"
+    Utilization `lakekeeper_catalog_pg_pool_connections{state="in_use"} / lakekeeper_catalog_pg_pool_max_connections` approaching `1` is the leading edge of exhaustion. Any nonzero rate on `lakekeeper_catalog_pg_pool_acquire_timeouts_total` means requests are already being delayed or failing — alert on it. The gauges are sampled every 15s, so brief spikes may be smoothed; the timeout counter captures every occurrence. The counter covers transaction acquisition (the path catalog reads and writes use), not ad-hoc direct-pool queries.
+
 !!! warning
     Lakekeeper's `/health` endpoint checks the database connection. If Postgres becomes unreachable or runs out of connections, `/health` returns `503 Service Unavailable`, so standard Kubernetes HTTP probes fail and the pod is marked unhealthy or unready.
 


### PR DESCRIPTION
Expose Lakekeeper's own read/write connection pools so client-side pool saturation — previously invisible — can be monitored and alerted on. postgres_exporter only sees the database server's connection slots; a client pool can saturate while the server still has free slots.

New Prometheus metrics (read vs write separated by the `pool` label):
- lakekeeper_catalog_pg_pool_connections{pool,state=in_use|idle} (gauge)
- lakekeeper_catalog_pg_pool_max_connections{pool} (gauge)
- lakekeeper_catalog_pg_pool_acquire_timeouts_total{pool} (counter)

Gauges are sampled every 15s by a detached background task; the acquire-timeout counter increments in begin_read/begin_write when sqlx returns PoolTimedOut (covers transaction acquisition — the path catalog reads/writes use — not ad-hoc direct-pool queries).

Documented under "Connection Pool (client-side)" in monitoring.md.