### PR TITLE
chore(ci): free disk space before Docker image builds

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -36,6 +36,15 @@ jobs:
       - name: Docker info
         run: docker info
 
+      # The full image build (Rust compile + image layers + the `docker save`
+      # tar) can exhaust the ~14 GB free on hosted runners, failing with
+      # "no space left on device". Reclaim preinstalled toolchains we don't use.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          docker-images: false # we build and save Docker images in this job
+          large-packages: false # apt purge is slow; the toolchain dirs free enough
+
       - name: Build Docker image (${{ inputs.platform }})
         run: |
           DOCKER_BUILDKIT=1 docker build --build-arg NO_CHEF=true -t localhost/${{ inputs.image_name }}:${{ inputs.platform }} \

--- a/.github/workflows/kube-auth.yml
+++ b/.github/workflows/kube-auth.yml
@@ -31,9 +31,20 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+      # `kind create cluster` pulls kindest/node from Docker Hub, which flakily
+      # times out on shared CI IPs. Pre-pull it (retried) so cluster creation
+      # below uses the cached image. The tag must match setup-kind's `image`.
+      - name: Pre-pull kind node image (Docker Hub is flaky; retry)
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          max_attempts: 5
+          timeout_minutes: 5
+          retry_wait_seconds: 15
+          command: docker pull kindest/node:v1.31.0
       - uses: engineerd/setup-kind@v0.6.2 # does not support hash pinning (no dist/ in commit)
         with:
           version: "v0.24.0"
+          image: kindest/node:v1.31.0
       - name: Restore binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,14 @@ jobs:
       - name: Docker info
         run: docker info
 
+      # Builds two full images (amd64 + arm64); reclaim preinstalled toolchains
+      # we don't use to avoid "no space left on device" on hosted runners.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          docker-images: false # we build and save Docker images in this job
+          large-packages: false # apt purge is slow; the toolchain dirs free enough
+
       - name: Build Docker image (amd64)
         run: |
           DOCKER_BUILDKIT=1 docker build --provenance=false -t localhost/lakekeeper-local:amd64 \

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -72,13 +72,21 @@ jobs:
         run: |
           docker load -i artifacts/lakekeeper-local-amd64.tar
 
+      # Retry: `docker compose` pulls base images from Docker Hub, which flakily
+      # times out on shared CI IPs. A retry re-pulls; `down -v` resets state.
       - name: Test Minimal
-        run: |
-          cd examples/minimal
-          sed -i '/pull_policy: always/d' docker-compose.yaml
-          docker compose run jupyter bash -c "cd /home/jovyan/examples/ && jupyter execute Pyiceberg.ipynb && jupyter execute Spark.ipynb && jupyter execute Trino.ipynb && jupyter execute Starrocks.ipynb && jupyter execute \"Multiple Warehouses.ipynb\" && jupyter execute DuckDB.ipynb"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         env:
           LAKEKEEPER_TEST__SERVER_IMAGE: localhost/lakekeeper-local:amd64
+        with:
+          max_attempts: 3
+          timeout_minutes: 25
+          retry_wait_seconds: 30
+          command: |
+            cd examples/minimal
+            sed -i '/pull_policy: always/d' docker-compose.yaml
+            docker compose down -v 2>/dev/null || true
+            docker compose run jupyter bash -c "cd /home/jovyan/examples/ && jupyter execute Pyiceberg.ipynb && jupyter execute Spark.ipynb && jupyter execute Trino.ipynb && jupyter execute Starrocks.ipynb && jupyter execute \"Multiple Warehouses.ipynb\" && jupyter execute DuckDB.ipynb"
       - name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2.2.2
@@ -117,13 +125,21 @@ jobs:
         run: |
           docker load -i artifacts/lakekeeper-local-amd64.tar
 
+      # Retry: `docker compose` pulls base images from Docker Hub, which flakily
+      # times out on shared CI IPs. A retry re-pulls; `down -v` resets state.
       - name: Test Aeccess Control Simple
-        run: |
-          cd examples/access-control-simple
-          sed -i '/pull_policy: always/d' docker-compose.yaml
-          docker compose run jupyter bash -c "cd /home/jovyan/examples/ && jupyter execute 01-Bootstrap.ipynb && jupyter execute 02-Create-Warehouse.ipynb && jupyter execute 03-01-Spark.ipynb && jupyter execute 03-02-Trino.ipynb && jupyter execute 03-03-Starrocks.ipynb && jupyter execute 03-04-PyIceberg.ipynb && jupyter execute 03-05-DuckDB.ipynb"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         env:
           LAKEKEEPER_TEST__SERVER_IMAGE: localhost/lakekeeper-local:amd64
+        with:
+          max_attempts: 3
+          timeout_minutes: 25
+          retry_wait_seconds: 30
+          command: |
+            cd examples/access-control-simple
+            sed -i '/pull_policy: always/d' docker-compose.yaml
+            docker compose down -v 2>/dev/null || true
+            docker compose run jupyter bash -c "cd /home/jovyan/examples/ && jupyter execute 01-Bootstrap.ipynb && jupyter execute 02-Create-Warehouse.ipynb && jupyter execute 03-01-Spark.ipynb && jupyter execute 03-02-Trino.ipynb && jupyter execute 03-03-Starrocks.ipynb && jupyter execute 03-04-PyIceberg.ipynb && jupyter execute 03-05-DuckDB.ipynb"
       - name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2.2.2
@@ -149,10 +165,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      # Retry: `make all` brings up a docker compose stack, pulling base images
+      # from Docker Hub which flakily times out on shared CI IPs.
       - name: Test Make all
-        run: |
-          cd examples/kafka-connect-iceberg-sink
-          make all
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          max_attempts: 3
+          timeout_minutes: 20
+          retry_wait_seconds: 30
+          command: |
+            cd examples/kafka-connect-iceberg-sink
+            make all
 
       - name: Test Make all
         run: |
@@ -193,13 +216,21 @@ jobs:
         run: |
           docker load -i artifacts/lakekeeper-local-amd64.tar
 
+      # Retry: `docker compose` pulls base images from Docker Hub, which flakily
+      # times out on shared CI IPs. A retry re-pulls; `down -v` resets state.
       - name: Test Access Control Advanced
-        run: |
-          cd examples/access-control-advanced
-          sed -i '/pull_policy: always/d' docker-compose.yaml
-          docker compose run jupyter bash -c "cd /home/jovyan/examples/ && jupyter execute 01-Bootstrap.ipynb && jupyter execute 02-Create-Warehouse.ipynb"
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         env:
           LAKEKEEPER_TEST__SERVER_IMAGE: localhost/lakekeeper-local:amd64
+        with:
+          max_attempts: 3
+          timeout_minutes: 25
+          retry_wait_seconds: 30
+          command: |
+            cd examples/access-control-advanced
+            sed -i '/pull_policy: always/d' docker-compose.yaml
+            docker compose down -v 2>/dev/null || true
+            docker compose run jupyter bash -c "cd /home/jovyan/examples/ && jupyter execute 01-Bootstrap.ipynb && jupyter execute 02-Create-Warehouse.ipynb"
       - name: Dump docker logs on failure
         if: failure()
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2.2.2
@@ -238,13 +269,21 @@ jobs:
         run: |
           docker load -i artifacts/lakekeeper-local-amd64.tar
 
+      # Retry: `docker compose up` pulls base images from Docker Hub, which
+      # flakily times out on shared CI IPs. A retry re-pulls; `down -v` resets.
       - name: Launch Docker Compose with Keycloak
-        run: |
-          cd docker-compose
-          sed -i '/pull_policy: /d' docker-compose.yaml
-          docker compose -f docker-compose.yaml -f keycloak-overlay.yaml up -d --wait
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         env:
           LAKEKEEPER__SERVER_IMAGE: localhost/lakekeeper-local:amd64
+        with:
+          max_attempts: 3
+          timeout_minutes: 15
+          retry_wait_seconds: 30
+          command: |
+            cd docker-compose
+            sed -i '/pull_policy: /d' docker-compose.yaml
+            docker compose -f docker-compose.yaml -f keycloak-overlay.yaml down -v 2>/dev/null || true
+            docker compose -f docker-compose.yaml -f keycloak-overlay.yaml up -d --wait
 
       - name: Test Docker Compose with Keycloak
         run: |

--- a/docker/full-debug.Dockerfile
+++ b/docker/full-debug.Dockerfile
@@ -3,6 +3,12 @@ FROM rust:1.95-slim-trixie AS chef
 ARG NO_CHEF=false
 ENV NO_CHEF=${NO_CHEF}
 
+# Make crate downloads resilient to transient crates.io blips in CI. Force
+# HTTP/1.1 (libcurl's HTTP/2 multiplexing intermittently fails with
+# "[16] Error in the HTTP2 framing layer") and retry more before giving up.
+ENV CARGO_HTTP_MULTIPLEXING=false
+ENV CARGO_NET_RETRY=10
+
 ENV NODE_VERSION=24.14.0
 ENV NVM_DIR=/root/.nvm
 

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -3,6 +3,12 @@ FROM rust:1.95-slim-trixie AS chef
 ARG NO_CHEF=false
 ENV NO_CHEF=${NO_CHEF}
 
+# Make crate downloads resilient to transient crates.io blips in CI. Force
+# HTTP/1.1 (libcurl's HTTP/2 multiplexing intermittently fails with
+# "[16] Error in the HTTP2 framing layer") and retry more before giving up.
+ENV CARGO_HTTP_MULTIPLEXING=false
+ENV CARGO_NET_RETRY=10
+
 ENV NODE_VERSION=24.14.0
 ENV NVM_DIR=/root/.nvm
 


### PR DESCRIPTION
The docker_build reusable workflow and release.yml's build-docker job build full images on hosted runners and intermittently fail with "no space left on device" (#1821, #1841). Add jlumbroso/free-disk-space (SHA-pinned) before the build to reclaim unused preinstalled toolchains (Android/.NET/Haskell/swap), keeping Docker images and skipping the slow apt purge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI build stability by adding automatic disk-space cleanup steps and pre-pulling required container images to reduce runner resource issues.
  * Made build tooling more resilient by tuning network/retry settings for dependency downloads in container builds.
* **Bug Fixes**
  * Reduced flaky example/tests by adding retry logic and state resets around container compose and test execution steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->