### PR TITLE
fix(cache): serialize invalidation with the read-through loader (by-id resurrection race)

### DIFF
--- a/crates/lakekeeper/src/service/catalog_store.rs
+++ b/crates/lakekeeper/src/service/catalog_store.rs
@@ -170,6 +170,18 @@ where
             let id = id_of(&loaded);
             // Prime the primary cache (+ this index) so coalesced callers resolve
             // the full entity without another backend round-trip.
+            //
+            // RESURRECTION RESIDUAL (by-name/by-ident → primary caches): `prime`
+            // writes the primary cache by id via a plain `*_cache_insert` — a
+            // different lock domain than the by-id `*_cache_invalidate` (`Op::Remove`).
+            // The authoritative read above ran under THIS (secondary) key's lock, not
+            // the primary id's, so a delete that invalidates during this load isn't
+            // serialized against the prime: the stale prime can land after the
+            // invalidate and resurrect the deleted entity until TTL. (The by-id
+            // read-through is safe because it holds the id lock across its own load;
+            // this path structurally cannot.) A full fix needs the prime to revalidate
+            // under the id lock — per-key tombstone, or re-resolve via the by-id
+            // loader — tracked as follow-up; TTL bounds the window for now.
             prime(loaded).await;
             Ok(Op::Put(id))
         })

--- a/crates/lakekeeper/src/service/catalog_store/namespace_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/namespace_cache.rs
@@ -112,7 +112,18 @@ pub static IDENT_TO_ID_CACHE: LazyLock<Cache<NamespaceCacheKey, NamespaceId>> =
 async fn namespace_cache_invalidate(namespace_id: NamespaceId) {
     if CONFIG.cache.namespace.enabled {
         tracing::debug!("Invalidating namespace id {namespace_id} from cache");
-        NAMESPACE_CACHE.invalidate(&namespace_id).await;
+        // Remove via the loader's per-key compute lock (`Op::Remove`), not a bare
+        // `invalidate()`: the version-gate fences stale *updates* but not *deletes*
+        // (a delete leaves no entry to compare), so a bare invalidate racing an
+        // in-flight by-id load lets the loader re-`Put` the deleted namespace until
+        // TTL. `Op::Remove` shares the loader's lock and still fires the eviction
+        // listener (Explicit), preserving the IDENT_TO_ID_CACHE cascade. Closes the
+        // by-id path only; the by-ident prime path keeps the residual — see
+        // `secondary_index_get_or_load`.
+        NAMESPACE_CACHE
+            .entry(namespace_id)
+            .and_compute_with(|_| async { Op::Remove })
+            .await;
         update_cache_size_metric();
     }
 }

--- a/crates/lakekeeper/src/service/catalog_store/role_assignments_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/role_assignments_cache.rs
@@ -76,7 +76,15 @@ pub(crate) async fn user_assignments_cache_get(
 pub(crate) async fn user_assignments_cache_invalidate(user_id: &UserId) {
     if CONFIG.cache.user_assignments.enabled {
         tracing::debug!("Invalidating user assignments for {user_id} from cache");
-        USER_ASSIGNMENTS_CACHE.invalidate(user_id).await;
+        // Remove via the loader's per-key compute lock (`Op::Remove`), not a bare
+        // `invalidate()`: a bare invalidate is a different moka lock domain, so one
+        // landing mid-load is a no-op and the loader's later insert resurrects the
+        // revoked entry until TTL. `Op::Remove` orders this post-commit removal after
+        // any in-flight load's insert. See `user_assignments_cache_get_or_load`.
+        USER_ASSIGNMENTS_CACHE
+            .entry(user_id.clone())
+            .and_compute_with(|_| async { Op::Remove })
+            .await;
         update_ua_size_metric();
     }
 }
@@ -92,7 +100,12 @@ pub(crate) async fn user_assignments_cache_invalidate_many(user_ids: &[UserId]) 
     }
     for user_id in user_ids {
         tracing::debug!("Invalidating user assignments for {user_id} from cache");
-        USER_ASSIGNMENTS_CACHE.invalidate(user_id).await;
+        // Compute-based removal — serializes with the loader. See
+        // `user_assignments_cache_invalidate`.
+        USER_ASSIGNMENTS_CACHE
+            .entry(user_id.clone())
+            .and_compute_with(|_| async { Op::Remove })
+            .await;
     }
     update_ua_size_metric();
 }
@@ -107,17 +120,16 @@ fn update_ua_size_metric() {
 
 /// Single-flight read-through for the user-assignments cache.
 ///
-/// On a miss, concurrent requests for the same `user_id` are **coalesced**: the
-/// (relatively expensive) effective-roles loader runs once per key, not once per
-/// caller, and every waiter receives a clone of the same `Arc`. This replaces the
-/// previous get-then-load-then-insert path, where N concurrent misses each ran
-/// the loader (a per-replica thundering herd). Hit/miss metrics and the `enabled`
-/// flag are preserved; when caching is disabled the loader runs directly with no
-/// caching or coalescing. Errors are never cached, so a transient load failure
-/// does not poison the entry.
+/// Concurrent misses for the same `user_id` coalesce onto one loader run; hit/miss
+/// metrics and the `enabled` flag are preserved; errors are never cached (returned
+/// by value, never poisoning the entry).
 ///
-/// Uses moka `try_get_with` (hence the `Fut: 'static` bound); the
-/// `and_try_compute_with`-based helpers for the other caches do not require it.
+/// Uses `and_try_compute_with`, not `try_get_with`, deliberately: moka holds the
+/// per-key compute lock across the `load` await, and `user_assignments_cache_invalidate`
+/// removes through that *same* lock (`Op::Remove`). So a revocation racing an
+/// in-flight load can't be lost — it is serialized after this loader's insert
+/// (cleaning it up) or before it starts. `try_get_with` removed in a different lock
+/// domain, so the loader's insert resurrected the revoked grant until TTL.
 pub(super) async fn user_assignments_cache_get_or_load<Fut>(
     user_id: &UserId,
     load: Fut,
@@ -125,8 +137,7 @@ pub(super) async fn user_assignments_cache_get_or_load<Fut>(
 where
     Fut: std::future::Future<
             Output = Result<Arc<ListUserRoleAssignmentsResult>, CatalogBackendError>,
-        > + Send
-        + 'static,
+        > + Send,
 {
     if !CONFIG.cache.user_assignments.enabled {
         return load.await;
@@ -139,21 +150,34 @@ where
     }
 
     // Miss (already counted by the get above): coalesce concurrent loaders for this
-    // key (moka shares one in-flight init across all waiters).
-    let result = USER_ASSIGNMENTS_CACHE
-        .try_get_with(user_id.clone(), load)
-        .await
-        .map_err(|e: Arc<CatalogBackendError>| {
-            // Move the original error out when we are the sole owner (the common,
-            // uncontended case). Only when waiters genuinely shared one failed load
-            // can we not move it — and a read-only loader yields `Unexpected`
-            // anyway, so wrapping does not change the surfaced status.
-            Arc::try_unwrap(e).unwrap_or_else(|shared| {
-                CatalogBackendError::new_unexpected(std::io::Error::other(shared.to_string()))
-            })
-        })?;
+    // key and hold the per-key compute lock across the load, so a racing invalidate
+    // is serialized against us rather than lost (see the doc comment).
+    let outcome = USER_ASSIGNMENTS_CACHE
+        .entry(user_id.clone())
+        .and_try_compute_with(|maybe_entry| async move {
+            if maybe_entry.is_some() {
+                // Populated by another caller while we waited on the key lock.
+                return Ok::<_, CatalogBackendError>(Op::Nop);
+            }
+            Ok(Op::Put(load.await?))
+        })
+        .await?;
     update_ua_size_metric();
-    Ok(result)
+
+    Ok(match outcome {
+        CompResult::Inserted(entry)
+        | CompResult::ReplacedWith(entry)
+        | CompResult::Unchanged(entry) => entry.into_value(),
+        // Unreachable: the closure only emits `Put` (→ Inserted) or `Nop` with an
+        // existing entry (→ Unchanged). Re-read defensively rather than panic.
+        CompResult::StillNone(_) | CompResult::Removed(_) => {
+            user_assignments_cache_get(user_id).await.ok_or_else(|| {
+                CatalogBackendError::new_unexpected(std::io::Error::other(
+                    "user-assignments cache compute returned no entry",
+                ))
+            })?
+        }
+    })
 }
 
 // ============================================================================
@@ -316,7 +340,13 @@ pub(crate) async fn role_members_cache_get(role_id: RoleId) -> Option<Arc<ListRo
 pub(crate) async fn role_members_cache_invalidate(role_id: RoleId) {
     if CONFIG.cache.role_members.enabled {
         tracing::debug!("Invalidating role members for {role_id} from cache");
-        ROLE_MEMBERS_CACHE.invalidate(&role_id).await;
+        // Compute-based removal — serializes with the loader's per-key lock so a
+        // racing in-flight load can't resurrect the entry. See
+        // `user_assignments_cache_invalidate`.
+        ROLE_MEMBERS_CACHE
+            .entry(role_id)
+            .and_compute_with(|_| async { Op::Remove })
+            .await;
         update_rm_size_metric();
     }
 }
@@ -499,6 +529,105 @@ mod tests {
 
         user_assignments_cache_invalidate(&user_id).await;
         assert!(user_assignments_cache_get(&user_id).await.is_none());
+    }
+
+    /// Regression: a revocation racing an in-flight loader must win — no resurrecting
+    /// the revoked entry. Deterministic: the loader holds the key's compute lock
+    /// across its `await`, so the invalidate's `Op::Remove` is ordered after the
+    /// loader's insert and removes it. (Before the fix the loader used `try_get_with`
+    /// and the invalidate a bare, different-lock-domain `invalidate()` — a no-op
+    /// mid-load, and the insert resurrected the grant until TTL.)
+    #[tokio::test]
+    async fn invalidate_wins_over_in_flight_user_assignments_loader() {
+        use tokio::sync::oneshot;
+
+        let user_id = test_user_id("race-invalidate-vs-loader");
+        // Clean slate — the cache is a process-global static shared across tests.
+        user_assignments_cache_invalidate(&user_id).await;
+
+        let (started_tx, started_rx) = oneshot::channel::<()>();
+        let (release_tx, release_rx) = oneshot::channel::<()>();
+
+        let stale = user_result_with_role(
+            RoleId::new_random(),
+            Arc::new(ProjectId::new_random()),
+            test_role_ident("lakekeeper", "stale-grant"),
+        );
+        let stale_for_loader = Arc::clone(&stale);
+
+        // The loader runs inside the compute closure (holding the key lock). It
+        // signals once mid-flight, then blocks until the test releases it before
+        // returning the now-stale snapshot.
+        let uid = user_id.clone();
+        let loader = tokio::spawn(async move {
+            let load = async move {
+                started_tx.send(()).unwrap();
+                release_rx.await.unwrap();
+                Ok(stale_for_loader)
+            };
+            user_assignments_cache_get_or_load(&uid, load).await
+        });
+
+        // Once the loader holds the key lock, fire the revocation. Its `Op::Remove`
+        // queues behind the loader on the same key lock.
+        started_rx.await.unwrap();
+        let inv_uid = user_id.clone();
+        let invalidate = tokio::spawn(async move {
+            user_assignments_cache_invalidate(&inv_uid).await;
+        });
+
+        release_tx.send(()).unwrap();
+        let returned = loader.await.unwrap().expect("loader succeeds");
+        invalidate.await.unwrap();
+
+        // The loader still returns its snapshot to *its* caller (a read that raced a
+        // write — acceptable) ...
+        assert_eq!(returned.roles.len(), 1);
+        // ... but the cache must NOT retain the revoked grant: the invalidate won.
+        assert!(
+            user_assignments_cache_get(&user_id).await.is_none(),
+            "revoked grant was resurrected by the racing loader"
+        );
+    }
+
+    /// Same race, for `ROLE_MEMBERS`: its loader was already compute-based, so this
+    /// guards that the invalidate change (`Op::Remove`) serializes with it.
+    #[tokio::test]
+    async fn invalidate_wins_over_in_flight_role_members_loader() {
+        use tokio::sync::oneshot;
+
+        let role_id = RoleId::new_random();
+        role_members_cache_invalidate(role_id).await;
+
+        let (started_tx, started_rx) = oneshot::channel::<()>();
+        let (release_tx, release_rx) = oneshot::channel::<()>();
+
+        let stale = role_result_with_members(role_id, vec![test_user_id("stale-member")]);
+        let stale_for_loader = Arc::clone(&stale);
+
+        let loader = tokio::spawn(async move {
+            let load = async move {
+                started_tx.send(()).unwrap();
+                release_rx.await.unwrap();
+                Ok(Some(stale_for_loader))
+            };
+            role_members_cache_get_or_load(role_id, load).await
+        });
+
+        started_rx.await.unwrap();
+        let invalidate = tokio::spawn(async move {
+            role_members_cache_invalidate(role_id).await;
+        });
+
+        release_tx.send(()).unwrap();
+        let returned = loader.await.unwrap().expect("loader succeeds");
+        invalidate.await.unwrap();
+
+        assert_eq!(returned.unwrap().members.len(), 1);
+        assert!(
+            role_members_cache_get(role_id).await.is_none(),
+            "removed role-members entry was resurrected by the racing loader"
+        );
     }
 
     #[tokio::test]
@@ -718,22 +847,26 @@ mod tests {
         user_assignments_cache_invalidate(&user_id).await;
     }
 
-    /// A failed load (`Err`) coalesces like a success but **must not poison** the
-    /// entry: concurrent callers share one failing load and all observe an error,
-    /// and a subsequent successful load still populates the cache (errors are
-    /// never cached).
+    /// A failed load must not poison the entry: every caller observes the error and
+    /// nothing is cached, so a later success still populates. Errors are NOT
+    /// coalesced — `and_try_compute_with` inserts nothing on `Err`, so each
+    /// serialized caller re-runs the load (consistent with every compute-based cache;
+    /// the old `try_get_with` shared one failing load — traded away to serialize the
+    /// loader against invalidation).
     #[tokio::test]
     async fn user_assignments_get_or_load_does_not_cache_errors() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
+        const CALLERS: usize = 16;
         let user_id = test_user_id("single-flight-error");
         user_assignments_cache_invalidate(&user_id).await;
 
         let loads = Arc::new(AtomicUsize::new(0));
 
-        // Concurrent callers whose loader fails — coalesced onto one failing load.
+        // Concurrent callers whose loader fails. They serialize on the key's compute
+        // lock; since `Err` caches nothing, each one re-runs the failing load.
         let mut handles = Vec::new();
-        for _ in 0..16 {
+        for _ in 0..CALLERS {
             let loads = Arc::clone(&loads);
             let uid = user_id.clone();
             handles.push(tokio::spawn(async move {
@@ -753,13 +886,13 @@ mod tests {
         for h in handles {
             assert!(
                 h.await.unwrap().is_err(),
-                "every coalesced caller observes the failure"
+                "every caller observes the failure"
             );
         }
         assert_eq!(
             loads.load(Ordering::SeqCst),
-            1,
-            "concurrent callers coalesce onto a single failing load"
+            CALLERS,
+            "errors are not negative-cached, so each serialized caller re-runs the failing load"
         );
         assert!(
             user_assignments_cache_get(&user_id).await.is_none(),

--- a/crates/lakekeeper/src/service/catalog_store/role_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/role_cache.rs
@@ -89,8 +89,18 @@ static IDENT_TO_ID_CACHE: LazyLock<Cache<(ArcProjectId, ArcRoleIdent), RoleId>> 
 pub async fn role_cache_invalidate(role_id: RoleId) {
     if CONFIG.cache.role.enabled {
         tracing::debug!("Invalidating role id {role_id} from cache");
-        ROLE_CACHE.invalidate(&role_id).await;
-        // The eviction listener on ROLE_CACHE cascades the invalidation to IDENT_TO_ID_CACHE.
+        // Remove via the loader's per-key compute lock (`Op::Remove`), not a bare
+        // `invalidate()`: the version-gate fences stale *updates* but not *deletes*
+        // (a delete leaves no entry to compare), so a bare invalidate racing an
+        // in-flight by-id load lets the loader re-`Put` the deleted role until TTL.
+        // `Op::Remove` shares the loader's lock and still fires the eviction listener
+        // (Explicit), preserving the IDENT_TO_ID_CACHE cascade. Closes the by-id path
+        // only; the by-ident prime path keeps the residual — see
+        // `secondary_index_get_or_load`.
+        ROLE_CACHE
+            .entry(role_id)
+            .and_compute_with(|_| async { Op::Remove })
+            .await;
         update_cache_size_metric();
     }
 }

--- a/crates/lakekeeper/src/service/catalog_store/warehouse_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/warehouse_cache.rs
@@ -109,7 +109,18 @@ pub struct CachedWarehouse {
 async fn warehouse_cache_invalidate(warehouse_id: WarehouseId) {
     if CONFIG.cache.warehouse.enabled {
         tracing::debug!("Invalidating warehouse id {warehouse_id} from cache");
-        WAREHOUSE_CACHE.invalidate(&warehouse_id).await;
+        // Remove via the loader's per-key compute lock (`Op::Remove`), not a bare
+        // `invalidate()`: the version-gate fences stale *updates* but not *deletes*
+        // (a delete leaves no entry to compare), so a bare invalidate racing an
+        // in-flight by-id load lets the loader re-`Put` the deleted warehouse until
+        // TTL. `Op::Remove` shares the loader's lock and still fires the eviction
+        // listener (Explicit), preserving the NAME_TO_ID_CACHE cascade. Closes the
+        // by-id path only; the by-name prime path keeps the residual — see
+        // `secondary_index_get_or_load`.
+        WAREHOUSE_CACHE
+            .entry(warehouse_id)
+            .and_compute_with(|_| async { Op::Remove })
+            .await;
         update_cache_size_metric();
     }
 }

--- a/crates/lakekeeper/src/service/secrets.rs
+++ b/crates/lakekeeper/src/service/secrets.rs
@@ -194,7 +194,15 @@ fn update_cache_size_metric() {
 async fn secrets_cache_invalidate(secret_id: SecretId) {
     if CONFIG.cache.secrets.enabled {
         tracing::debug!("Invalidating secret id {secret_id} from cache");
-        SECRETS_CACHE.invalidate(&secret_id).await;
+        // Remove via the loader's per-key compute lock (`Op::Remove`), not a bare
+        // `invalidate()`: otherwise a delete racing an in-flight load lets the loader
+        // re-`Put` the removed secret until TTL (up to 600s of a decryptable stale
+        // credential). Secrets are by-id only, so this fully closes the race. See
+        // `user_assignments_cache_invalidate`.
+        SECRETS_CACHE
+            .entry(secret_id)
+            .and_compute_with(|_| async { Op::Remove })
+            .await;
         update_cache_size_metric();
     }
 }
@@ -276,4 +284,71 @@ where
         // here — the closure only returns `Nop`/`Put`, never `Remove`.
         CompResult::StillNone(_) | CompResult::Removed(_) => None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+    use crate::service::storage::StorageCredential;
+
+    fn test_cached_secret(secret_id: SecretId) -> CachedSecret {
+        // Construct a minimal credential via the documented serde shape — the
+        // concrete contents are irrelevant, we only need *some* CachedSecret.
+        let cred: StorageCredential = serde_json::from_str(
+            r#"{
+                "type": "s3",
+                "credential-type": "access-key",
+                "access-key-id": "minio-root-user",
+                "secret-access-key": "minio-root-password"
+            }"#,
+        )
+        .unwrap();
+        CachedSecret::StorageCredential(Secret {
+            secret_id,
+            secret: Arc::new(cred),
+            created_at: chrono::Utc::now(),
+            updated_at: None,
+        })
+    }
+
+    /// Regression: a `delete_secret` racing an in-flight load must win — no
+    /// resurrecting the removed (still-decryptable) credential. Same mechanism as the
+    /// user-assignments test; secrets are by-id only, so the race is fully closed here.
+    #[tokio::test]
+    async fn invalidate_wins_over_in_flight_secret_loader() {
+        let secret_id = SecretId::from(uuid::Uuid::new_v4());
+        secrets_cache_invalidate(secret_id).await; // clean slate
+
+        let (started_tx, started_rx) = oneshot::channel::<()>();
+        let (release_tx, release_rx) = oneshot::channel::<()>();
+
+        let stale = test_cached_secret(secret_id);
+        let loader = tokio::spawn(async move {
+            let load = async move {
+                started_tx.send(()).unwrap();
+                release_rx.await.unwrap();
+                Ok(Some(stale))
+            };
+            secrets_cache_get_or_load(secret_id, load).await
+        });
+
+        started_rx.await.unwrap();
+        let invalidate = tokio::spawn(async move {
+            secrets_cache_invalidate(secret_id).await;
+        });
+
+        release_tx.send(()).unwrap();
+        let returned = loader.await.unwrap().expect("loader succeeds");
+        invalidate.await.unwrap();
+
+        assert!(returned.is_some());
+        assert!(
+            secrets_cache_get(secret_id).await.is_none(),
+            "deleted secret was resurrected by the racing loader"
+        );
+    }
 }


### PR DESCRIPTION
Every in-process cache invalidated entries with a bare moka `invalidate()`, which runs in a different lock domain than the single-flight read-through loader. A loader that read the DB just before a delete/revocation committed could re-insert its stale snapshot *after* the invalidation landed, resurrecting the removed entry until TTL (<=120s for the role caches, <=600s for secrets). On the authz path a committed role revocation/deletion could be silently reverted for up to a TTL on the writing replica. Verified against the moka 0.12 source: the loader inserts its value unconditionally and never observes a concurrent `invalidate()` (a separate waiter / lock domain).

Route invalidation through moka's per-key compute lock (`Op::Remove`) — the same lock the by-id loader holds across its DB read — so the post-commit removal is ordered after any in-flight load's insert (and cleans it up) or before it starts (so it reloads fresh).

- USER_ASSIGNMENTS: move the loader off `try_get_with` onto `and_try_compute_with` (same waiter as the removal), and route `invalidate` / `invalidate_many` through `Op::Remove`.
- ROLE_MEMBERS, ROLE, WAREHOUSE, NAMESPACE, SECRETS: loaders were already compute-based; route their `invalidate` through `Op::Remove`. The version-gate fenced stale *updates* but not *deletes* — this closes the delete-resurrection gap for the by-id path. `Op::Remove` still fires the eviction listener, so the secondary-index cascades are preserved.

Scope / known residual: this fully closes the race for SECRETS, USER_ASSIGNMENTS and ROLE_MEMBERS (by-id only). For ROLE / WAREHOUSE / NAMESPACE it closes the by-id read-through, but NOT the by-name/by-ident resolution path: that primes the primary cache via the plain version-gated `*_cache_insert` from a different lock domain (the authoritative read happens under the secondary key's lock, not the primary id's), so a delete racing an in-flight by-name/by-ident load can still resurrect the entity until TTL. Documented in `secondary_index_get_or_load`; a full fix (per-key tombstone/generation, or re-resolving via the by-id loader) is tracked as follow-up.

Trade-off: USER_ASSIGNMENTS no longer coalesces *failing* loads — errors are never cached, so each serialized caller re-runs the load (now consistent with every other compute-based cache). The role provider is unaffected: it is called outside the cache loader, gated by its own `db_ttl` with stale-fallback. Closes the local single-replica race only; cross-replica revocation lag (<=TTL) is unchanged.

Adds deterministic race regression tests (a revocation racing an in-flight loader must win) for user-assignments, role-members and secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions in cache invalidation that could allow deleted items to temporarily reappear until cache expiration.
  * Improved serialization of cache removal operations with concurrent loader updates to ensure consistent data deletion.
  * Enhanced multiple cache systems to prevent data resurrection scenarios.

* **Tests**
  * Added regression tests to verify cache invalidation correctly handles concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->