### PR TITLE
feat(authz): surface contributing policies in authorization audit events

### DIFF
--- a/crates/authz-openfga/src/api.rs
+++ b/crates/authz-openfga/src/api.rs
@@ -3353,8 +3353,8 @@ mod tests {
 
             // Verify results match expected pattern (every other one allowed)
             assert_eq!(results.len(), num_namespaces);
-            for (i, &allowed) in results.iter().enumerate() {
-                assert_eq!(allowed, i % 2 == 0, "Namespace {i} permission mismatch");
+            for (i, allowed) in results.iter().enumerate() {
+                assert_eq!(*allowed, i % 2 == 0, "Namespace {i} permission mismatch");
             }
         }
 

--- a/crates/authz-openfga/src/authorizer.rs
+++ b/crates/authz-openfga/src/authorizer.rs
@@ -16,11 +16,12 @@ use lakekeeper::{
         TableId, UserId, ViewId,
         authz::{
             ActionOnGenericTable, ActionOnTable, ActionOnView, AddRoleAssignmentsError,
-            AuthorizationBackendUnavailable, Authorizer, AuthzBackendErrorOrBadRequest,
-            CannotInspectPermissions, CatalogProjectAction, CatalogUserAction,
-            IsAllowedActionError, ListProjectsResponse, ListRoleAssignmentsError,
-            ListRoleAssignmentsResultPage, MalformedRoleAssignment, ManagesRoleAssignments,
-            NamespaceParent, RoleAssignmentFilter, RoleAssignmentRow, UserOrRole, UserOrRoleId,
+            AuthorizationBackendUnavailable, AuthorizationDecision, Authorizer,
+            AuthzBackendErrorOrBadRequest, CannotInspectPermissions, CatalogProjectAction,
+            CatalogUserAction, IsAllowedActionError, ListProjectsResponse,
+            ListRoleAssignmentsError, ListRoleAssignmentsResultPage, MalformedRoleAssignment,
+            ManagesRoleAssignments, NamespaceParent, RoleAssignmentFilter, RoleAssignmentRow,
+            UserOrRole, UserOrRoleId,
         },
         events::context::authz_to_error_no_audit,
         health::Health,
@@ -214,7 +215,7 @@ impl Authorizer for OpenFGAAuthorizer {
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         roles_with_actions: &[(&Role, Self::RoleAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         // Every authenticated user can read role metadata.
         // This does not include assignments to the role.
         // Used for cross-project role get so that we can show role names and not just IDs.
@@ -268,13 +269,16 @@ impl Authorizer for OpenFGAAuthorizer {
                 .await?;
 
             for (batch_idx, result) in batch_results.iter().enumerate() {
-                results.push((batch_indices[batch_idx], *result));
+                results.push((batch_indices[batch_idx], result.allowed));
             }
         }
 
         // Sort by original index and extract boolean values
         results.sort_by_key(|(idx, _)| *idx);
-        Ok(results.into_iter().map(|(_, allowed)| allowed).collect())
+        Ok(results
+            .into_iter()
+            .map(|(_, allowed)| AuthorizationDecision::from(allowed))
+            .collect())
     }
 
     async fn are_allowed_user_actions_impl(
@@ -282,7 +286,7 @@ impl Authorizer for OpenFGAAuthorizer {
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         users_with_actions: &[(&UserId, Self::UserAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         let actor_principal = match metadata.actor() {
             Actor::Role {
                 principal,
@@ -377,7 +381,10 @@ impl Authorizer for OpenFGAAuthorizer {
         }
 
         results.sort_by_key(|(idx, _)| *idx);
-        Ok(results.into_iter().map(|(_, allowed)| allowed).collect())
+        Ok(results
+            .into_iter()
+            .map(|(_, allowed)| AuthorizationDecision::from(allowed))
+            .collect())
     }
 
     async fn are_allowed_server_actions_impl(
@@ -385,7 +392,7 @@ impl Authorizer for OpenFGAAuthorizer {
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         actions: &[Self::ServerAction],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         let user = for_user.map_or_else(
             || metadata.actor().to_openfga(),
             |u| u.api_user_or_role().to_openfga(),
@@ -420,7 +427,7 @@ impl Authorizer for OpenFGAAuthorizer {
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         projects_with_actions: &[(&ArcProjectId, Self::ProjectAction)],
-    ) -> std::result::Result<Vec<bool>, IsAllowedActionError> {
+    ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         let user = for_user.map_or_else(
             || metadata.actor().to_openfga(),
             |u| u.api_user_or_role().to_openfga(),
@@ -463,7 +470,7 @@ impl Authorizer for OpenFGAAuthorizer {
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         warehouses_with_actions: &[(&ResolvedWarehouse, Self::WarehouseAction)],
-    ) -> std::result::Result<Vec<bool>, IsAllowedActionError> {
+    ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         let user = for_user.map_or_else(
             || metadata.actor().to_openfga(),
             |u| u.api_user_or_role().to_openfga(),
@@ -508,7 +515,7 @@ impl Authorizer for OpenFGAAuthorizer {
         _warehouse: &ResolvedWarehouse,
         _parent_namespaces: &HashMap<NamespaceId, NamespaceWithParent>,
         actions: &[(&impl AuthZNamespaceInfo, Self::NamespaceAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         let user = for_user.map_or_else(
             || metadata.actor().to_openfga(),
             |u| u.api_user_or_role().to_openfga(),
@@ -555,7 +562,7 @@ impl Authorizer for OpenFGAAuthorizer {
             &NamespaceWithParent,
             ActionOnTable<'_, '_, impl AuthZTableInfo, A>,
         )],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         // Build check requests with per-action user handling
         let items: Vec<_> = actions
             .iter()
@@ -602,7 +609,7 @@ impl Authorizer for OpenFGAAuthorizer {
             &NamespaceWithParent,
             ActionOnView<'_, '_, impl AuthZViewInfo, A>,
         )],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         // Build check requests with per-action user handling
         let items: Vec<_> = actions
             .iter()
@@ -651,7 +658,7 @@ impl Authorizer for OpenFGAAuthorizer {
             &NamespaceWithParent,
             ActionOnGenericTable<'_, '_, impl AuthZGenericTableInfo, A>,
         )],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         // Build check requests with per-action user handling
         let items: Vec<_> = actions
             .iter()
@@ -1239,7 +1246,7 @@ impl OpenFGAAuthorizer {
         _actor: &Actor,
         mut items: Vec<CheckRequestTupleKey>,
         guard_tuples: Vec<CheckRequestTupleKey>,
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         let num_guards = guard_tuples.len();
 
         // Collect objects for error reporting if guards fail
@@ -1262,7 +1269,10 @@ impl OpenFGAAuthorizer {
             }
         }
 
-        Ok(results)
+        Ok(results
+            .into_iter()
+            .map(AuthorizationDecision::from)
+            .collect())
     }
     /// A convenience wrapper around `batch_check`.
     async fn batch_check(

--- a/crates/lakekeeper/src/api/management/v1/check.rs
+++ b/crates/lakekeeper/src/api/management/v1/check.rs
@@ -1596,16 +1596,6 @@ fn spawn_tabular_checks_by_id<A: Authorizer>(
                     &tabular_with_actions,
                 )
                 .await?;
-            // Tabular trace surfacing is deferred: tables/views/generic tables
-            // emit empty `determined_by` for now. The per-type `_impl` captures
-            // the trace, but the multi-level tabular merge drops it.
-            let allowed = MustUse::from(
-                allowed
-                    .into_inner()
-                    .into_iter()
-                    .map(AuthorizationDecision::from)
-                    .collect::<Vec<_>>(),
-            );
             Ok::<_, AuthZError>((original_indices, allowed))
         });
     }
@@ -1722,16 +1712,6 @@ fn spawn_tabular_checks_by_ident<A: Authorizer>(
                     &tabular_with_actions,
                 )
                 .await?;
-            // Tabular trace surfacing is deferred: tables/views/generic tables
-            // emit empty `determined_by` for now. The per-type `_impl` captures
-            // the trace, but the multi-level tabular merge drops it.
-            let allowed = MustUse::from(
-                allowed
-                    .into_inner()
-                    .into_iter()
-                    .map(AuthorizationDecision::from)
-                    .collect::<Vec<_>>(),
-            );
             Ok::<_, AuthZError>((original_indices, allowed))
         });
     }

--- a/crates/lakekeeper/src/api/management/v1/check.rs
+++ b/crates/lakekeeper/src/api/management/v1/check.rs
@@ -24,12 +24,12 @@ use crate::{
             ActionOnView, AuthZCannotSeeGenericTable, AuthZCannotSeeNamespace, AuthZCannotSeeTable,
             AuthZCannotSeeView, AuthZCannotUseWarehouseId, AuthZError, AuthZProjectOps,
             AuthZServerOps, AuthZTableOps, AuthorizationBackendUnavailable,
-            AuthorizationCountMismatch, Authorizer, AuthzNamespaceOps, AuthzWarehouseOps,
-            CatalogAction, CatalogGenericTableAction, CatalogNamespaceAction, CatalogProjectAction,
-            CatalogServerAction, CatalogTableAction, CatalogViewAction, CatalogWarehouseAction,
-            MustUse, RequireNamespaceActionError, RequireTableActionError,
-            RequireWarehouseActionError, RoleAssignee as AuthZRoleAssignee,
-            UserOrRole as AuthzUserOrRole, UserOrRoleId,
+            AuthorizationCountMismatch, AuthorizationDecision, Authorizer, AuthzNamespaceOps,
+            AuthzWarehouseOps, CatalogAction, CatalogGenericTableAction, CatalogNamespaceAction,
+            CatalogProjectAction, CatalogServerAction, CatalogTableAction, CatalogViewAction,
+            CatalogWarehouseAction, DeterminingFactor, MustUse, RequireNamespaceActionError,
+            RequireTableActionError, RequireWarehouseActionError,
+            RoleAssignee as AuthZRoleAssignee, UserOrRole as AuthzUserOrRole, UserOrRoleId,
         },
         events::{
             APIEventContext, Authorization,
@@ -264,6 +264,10 @@ pub struct CatalogActionsBatchCheckResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub allowed: bool,
+    /// Policies/rules that determined this decision. Internal-only: carried
+    /// to the audit event, never serialised into the API response.
+    #[serde(skip)]
+    pub determined_by: Vec<DeterminingFactor>,
 }
 
 /// Convert a request-side `UserOrRole` (which only carries identifiers) to
@@ -407,6 +411,7 @@ fn check_to_authorization(
     index: usize,
     ambient_project_id: Option<&ProjectId>,
     allowed: Option<bool>,
+    determined_by: Vec<DeterminingFactor>,
 ) -> Authorization {
     let (entity, action) = item.operation.to_audit_entity_action(ambient_project_id);
     Authorization {
@@ -415,6 +420,7 @@ fn check_to_authorization(
         action,
         entity,
         allowed,
+        determined_by,
     }
 }
 
@@ -443,7 +449,8 @@ type TabularChecksByIdentMap = HashMap<
     (WarehouseId, Option<UserOrRole>),
     HashMap<TabularIdentOwned, Vec<(usize, TabularActionPair)>>,
 >;
-type AuthzTaskJoinSet = tokio::task::JoinSet<Result<(Vec<usize>, MustUse<Vec<bool>>), AuthZError>>;
+type AuthzTaskJoinSet =
+    tokio::task::JoinSet<Result<(Vec<usize>, MustUse<Vec<AuthorizationDecision>>), AuthZError>>;
 
 /// Grouped checks by resource type
 struct GroupedChecks {
@@ -485,6 +492,7 @@ fn group_checks(
         results.push(CatalogActionsBatchCheckResult {
             id: check.id,
             allowed: false,
+            determined_by: Vec::new(),
         });
         let for_user = check.identity;
 
@@ -1588,6 +1596,16 @@ fn spawn_tabular_checks_by_id<A: Authorizer>(
                     &tabular_with_actions,
                 )
                 .await?;
+            // Tabular trace surfacing is deferred: tables/views/generic tables
+            // emit empty `determined_by` for now. The per-type `_impl` captures
+            // the trace, but the multi-level tabular merge drops it.
+            let allowed = MustUse::from(
+                allowed
+                    .into_inner()
+                    .into_iter()
+                    .map(AuthorizationDecision::from)
+                    .collect::<Vec<_>>(),
+            );
             Ok::<_, AuthZError>((original_indices, allowed))
         });
     }
@@ -1704,6 +1722,16 @@ fn spawn_tabular_checks_by_ident<A: Authorizer>(
                     &tabular_with_actions,
                 )
                 .await?;
+            // Tabular trace surfacing is deferred: tables/views/generic tables
+            // emit empty `determined_by` for now. The per-type `_impl` captures
+            // the trace, but the multi-level tabular merge drops it.
+            let allowed = MustUse::from(
+                allowed
+                    .into_inner()
+                    .into_iter()
+                    .map(AuthorizationDecision::from)
+                    .collect::<Vec<_>>(),
+            );
             Ok::<_, AuthZError>((original_indices, allowed))
         });
     }
@@ -1722,17 +1750,18 @@ async fn collect_authz_results(
                     .append_detail("Failed to join authorization check task"),
             )
         })??;
-        let allowed_vec = allowed.into_inner();
-        if original_indices.len() != allowed_vec.len() {
+        let decision_vec = allowed.into_inner();
+        if original_indices.len() != decision_vec.len() {
             return Err(AuthorizationCountMismatch::new(
                 original_indices.len(),
-                allowed_vec.len(),
+                decision_vec.len(),
                 "check endpoint",
             )
             .into());
         }
-        for (i, is_allowed) in original_indices.into_iter().zip(allowed_vec) {
-            results[i].allowed = is_allowed;
+        for (i, decision) in original_indices.into_iter().zip(decision_vec) {
+            results[i].allowed = decision.allowed;
+            results[i].determined_by = decision.determined_by;
         }
     }
     Ok(())
@@ -1803,8 +1832,10 @@ pub async fn check_internal<A: Authorizer, C: CatalogStore, S: SecretStore>(
         .iter()
         .enumerate()
         .map(|(i, c)| {
-            let allowed = audit_decisions.and_then(|r| r.get(i)).map(|r| r.allowed);
-            check_to_authorization(c, i, ambient_project_id_ref, allowed)
+            let result = audit_decisions.and_then(|r| r.get(i));
+            let allowed = result.map(|r| r.allowed);
+            let determined_by = result.map(|r| r.determined_by.clone()).unwrap_or_default();
+            check_to_authorization(c, i, ambient_project_id_ref, allowed, determined_by)
         })
         .collect();
     // For an empty batch (`POST {"checks": []}`) `set_authorizations`

--- a/crates/lakekeeper/src/api/management/v1/lakekeeper_actions.rs
+++ b/crates/lakekeeper/src/api/management/v1/lakekeeper_actions.rs
@@ -185,7 +185,7 @@ pub(super) async fn get_allowed_server_actions<C: CatalogStore, A: Authorizer, S
                 actions,
             )
             .await?
-            .into_inner())
+            .into_allowed())
     }
     .await;
     let (_event_ctx, results) = event_ctx.emit_authz(authz_result)?;
@@ -254,7 +254,7 @@ async fn authorize_get_user_actions<C: CatalogStore>(
                 .collect::<Vec<_>>(),
         )
         .await?
-        .into_inner();
+        .into_allowed();
 
     let mut can_see = false;
     let allowed_actions = results
@@ -348,7 +348,7 @@ async fn authorize_get_role_actions<C: CatalogStore>(
                 .collect::<Vec<_>>(),
         )
         .await?
-        .into_inner();
+        .into_allowed();
 
     let mut can_see = false;
     let allowed_actions = results
@@ -425,7 +425,7 @@ async fn authorize_get_project_actions<C: CatalogStore>(
                 .collect::<Vec<_>>(),
         )
         .await?
-        .into_inner();
+        .into_allowed();
 
     let mut can_see = false;
     let allowed_actions = results
@@ -515,7 +515,7 @@ async fn authorize_get_warehouse_actions<C: CatalogStore>(
                 .collect::<Vec<_>>(),
         )
         .await?
-        .into_inner();
+        .into_allowed();
 
     let mut can_see = false;
     let allowed_actions = results
@@ -617,7 +617,7 @@ async fn authorize_get_namespace_actions<C: CatalogStore>(
                 .collect::<Vec<_>>(),
         )
         .await?
-        .into_inner();
+        .into_allowed();
 
     let mut can_see = false;
     let allowed_actions = results
@@ -735,7 +735,7 @@ async fn authorize_get_table_actions<C: CatalogStore>(
                 .collect::<Vec<_>>(),
         )
         .await?
-        .into_inner();
+        .into_allowed();
 
     let mut can_see = false;
     let allowed_actions = results
@@ -851,7 +851,7 @@ async fn authorize_get_view_actions<C: CatalogStore>(
                 .collect::<Vec<_>>(),
         )
         .await?
-        .into_inner();
+        .into_allowed();
 
     let mut can_see = false;
     let allowed_actions = results
@@ -970,7 +970,7 @@ async fn authorize_get_generic_table_actions<C: CatalogStore>(
                 .collect::<Vec<_>>(),
         )
         .await?
-        .into_inner();
+        .into_allowed();
 
     let mut can_see = false;
     let allowed_actions = results

--- a/crates/lakekeeper/src/api/management/v1/project.rs
+++ b/crates/lakekeeper/src/api/management/v1/project.rs
@@ -330,7 +330,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 .map_err(authz_to_error_no_audit)?;
             projects
                 .into_iter()
-                .zip(decisions.into_inner())
+                .zip(decisions.into_allowed())
                 .filter_map(
                     |(project, is_allowed)| {
                         if is_allowed { Some(project) } else { None }

--- a/crates/lakekeeper/src/api/management/v1/tabular.rs
+++ b/crates/lakekeeper/src/api/management/v1/tabular.rs
@@ -109,7 +109,7 @@ where
                 )
                 .await
                 .map_err(authz_to_error_no_audit)?
-                .into_inner()
+                .into_allowed()
         };
 
         // Merge authorized tables and views and show best matches first.

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -1566,7 +1566,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                             )
                             .await
                             .map_err(authz_to_error_no_audit)?
-                            .into_inner()
+                            .into_allowed()
                     };
 
                     let (next_idents, next_uuids, next_page_tokens, mask): (

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -567,7 +567,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             )
             .await
             .map_err(authz_to_error_no_audit)?
-            .into_inner()
+            .into_allowed()
             .into_iter()
             .zip(warehouses)
             .filter_map(|(allowed, warehouse)| if allowed { Some(warehouse) } else { None })

--- a/crates/lakekeeper/src/server/generic_tables/credentials.rs
+++ b/crates/lakekeeper/src/server/generic_tables/credentials.rs
@@ -223,7 +223,7 @@ pub(super) async fn authorize_load_generic_table<C: CatalogStore, A: Authorizer 
     let authz_results = authorizer
         .are_allowed_tabular_actions_vec(request_metadata, &warehouse, &namespaces, &actions)
         .await?
-        .into_inner();
+        .into_allowed();
 
     // 10. Interpret results.
     let target_ns = sorted_tabulars_with_full_info

--- a/crates/lakekeeper/src/server/generic_tables/list.rs
+++ b/crates/lakekeeper/src/server/generic_tables/list.rs
@@ -119,7 +119,7 @@ pub(super) async fn list_generic_tables<C: CatalogStore, A: Authorizer + Clone, 
             )
             .await
             .map_err(AuthorizationFailureSource::into_error_model)?
-            .into_inner()
+            .into_allowed()
     };
 
     let identifiers = entries

--- a/crates/lakekeeper/src/server/namespace.rs
+++ b/crates/lakekeeper/src/server/namespace.rs
@@ -153,7 +153,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
                             )
                             .await
                             .map_err(authz_to_error_no_audit)?
-                            .into_inner()
+                            .into_allowed()
                     };
 
                     let (next_namespaces, next_ids, next_page_tokens, mask): (

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -1062,7 +1062,7 @@ async fn authorize_load_table<C: CatalogStore, A: Authorizer + Clone>(
     let authz_results = authorizer
         .are_allowed_tabular_actions_vec(request_metadata, &warehouse, &namespaces, &actions)
         .await?
-        .into_inner();
+        .into_allowed();
 
     // 10. Interpret authorization results.
     let (table_info, storage_permissions) =

--- a/crates/lakekeeper/src/server/tabular.rs
+++ b/crates/lakekeeper/src/server/tabular.rs
@@ -148,7 +148,7 @@ macro_rules! list_entities {
                             .map_err(authz_to_error_no_audit)?,
                         ).await
                         .map_err(authz_to_error_no_audit)?
-                        .into_inner()
+                        .into_allowed()
                     }
                 };
 

--- a/crates/lakekeeper/src/server/views/load.rs
+++ b/crates/lakekeeper/src/server/views/load.rs
@@ -223,7 +223,7 @@ async fn authorize_load_view<C: CatalogStore, A: Authorizer + Clone>(
     let authz_results = authorizer
         .are_allowed_tabular_actions_vec(request_metadata, &warehouse, &namespaces, &actions)
         .await?
-        .into_inner();
+        .into_allowed();
 
     // 10. Interpret authorization results
     let (view_info, storage_permissions) =

--- a/crates/lakekeeper/src/service/authz/decision.rs
+++ b/crates/lakekeeper/src/service/authz/decision.rs
@@ -1,0 +1,100 @@
+//! Per-decision authorization results and their contributing diagnostics.
+//!
+//! These types are authorizer-agnostic and contain no authorizer-specific
+//! types, so they can live in the audit-event payload while each authorizer
+//! maps its own diagnostics down to them.
+
+/// One authorization verdict together with the diagnostics that explain it.
+///
+/// Returned per checked `(resource, action)` tuple by the batch authorizer
+/// methods. `allowed` is the decision; `determined_by` lists the policies or
+/// rules that determined it. `determined_by` is empty when the authorizer
+/// produces no per-decision diagnostics (`AllowAll`, OpenFGA) or for a
+/// default-deny where no policy matched.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthorizationDecision {
+    pub allowed: bool,
+    pub determined_by: Vec<DeterminingFactor>,
+}
+
+impl AuthorizationDecision {
+    /// An allow carrying no diagnostics.
+    #[must_use]
+    pub fn allow() -> Self {
+        Self {
+            allowed: true,
+            determined_by: Vec::new(),
+        }
+    }
+
+    /// A deny carrying no diagnostics.
+    #[must_use]
+    pub fn deny() -> Self {
+        Self {
+            allowed: false,
+            determined_by: Vec::new(),
+        }
+    }
+
+    /// A decision carrying the factors that determined it.
+    #[must_use]
+    pub fn new(allowed: bool, determined_by: Vec<DeterminingFactor>) -> Self {
+        Self {
+            allowed,
+            determined_by,
+        }
+    }
+}
+
+impl PartialEq<bool> for AuthorizationDecision {
+    /// A decision compares equal to a `bool` by its verdict (`allowed`),
+    /// ignoring diagnostics. Convenient for asserting allow/deny outcomes,
+    /// including `Vec<AuthorizationDecision> == Vec<bool>` via the standard
+    /// library's cross-type `Vec` equality.
+    fn eq(&self, other: &bool) -> bool {
+        self.allowed == *other
+    }
+}
+
+impl From<bool> for AuthorizationDecision {
+    /// A verdict with no diagnostics — for authorizers that produce only a
+    /// boolean (`AllowAll`, OpenFGA) or call sites that have no trace.
+    fn from(allowed: bool) -> Self {
+        Self {
+            allowed,
+            determined_by: Vec::new(),
+        }
+    }
+}
+
+/// A single factor that contributed to an authorization decision.
+///
+/// Enum-tagged so new producers (restriction-profile matched rules, native
+/// OSS-authorizer diagnostics) add a variant without breaking existing audit
+/// consumers.
+#[derive(Clone, Debug, PartialEq, Eq, valuable::Valuable)]
+pub enum DeterminingFactor {
+    /// A policy that determined the decision, surfaced by a policy-based
+    /// authorizer.
+    Policy {
+        /// Stable, human-meaningful policy identifier where the authorizer
+        /// provides one, or a fallback identifier otherwise (see
+        /// `id_is_fallback`).
+        id: String,
+        /// `true` when `id` is a fallback because no stable identifier was
+        /// available from the authorizer.
+        id_is_fallback: bool,
+        /// Whether the policy permits or forbids.
+        effect: PolicyEffect,
+        /// Opaque origin of the policy (e.g. a policy-source identifier). `None`
+        /// when the producer cannot attribute a source.
+        source: Option<String>,
+    },
+}
+
+/// Whether a determining policy permits or forbids.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, valuable::Valuable)]
+pub enum PolicyEffect {
+    Permit,
+    Forbid,
+}

--- a/crates/lakekeeper/src/service/authz/decision.rs
+++ b/crates/lakekeeper/src/service/authz/decision.rs
@@ -77,13 +77,13 @@ pub enum DeterminingFactor {
     /// A policy that determined the decision, surfaced by a policy-based
     /// authorizer.
     Policy {
-        /// Stable, human-meaningful policy identifier where the authorizer
-        /// provides one, or a fallback identifier otherwise (see
-        /// `id_is_fallback`).
-        id: String,
-        /// `true` when `id` is a fallback because no stable identifier was
-        /// available from the authorizer.
-        id_is_fallback: bool,
+        /// Stable, authorizer-assigned identifier of the policy (e.g. the Cedar
+        /// `PolicyId`). Always present.
+        policy_id: String,
+        /// Optional human-facing name the author gave the policy (e.g. a `@name`
+        /// or `@id` annotation). Neither required nor guaranteed unique; `None`
+        /// when the author provided none.
+        name: Option<String>,
         /// Whether the policy permits or forbids.
         effect: PolicyEffect,
         /// Opaque origin of the policy (e.g. a policy-source identifier). `None`

--- a/crates/lakekeeper/src/service/authz/generic_table.rs
+++ b/crates/lakekeeper/src/service/authz/generic_table.rs
@@ -14,9 +14,10 @@ use crate::{
         UnexpectedTabularInResponse, ViewOrTableInfo,
         authz::{
             ActionOnGenericTable, AuthZError, AuthorizationBackendUnavailable,
-            AuthorizationCountMismatch, Authorizer, AuthzBadRequest, AuthzNamespaceOps,
-            AuthzWarehouseOps, BackendUnavailableOrCountMismatch, CannotInspectPermissions,
-            CatalogAction, CatalogGenericTableAction, IsAllowedActionError, MustUse, UserOrRole,
+            AuthorizationCountMismatch, AuthorizationDecision, Authorizer, AuthzBadRequest,
+            AuthzNamespaceOps, AuthzWarehouseOps, BackendUnavailableOrCountMismatch,
+            CannotInspectPermissions, CatalogAction, CatalogGenericTableAction,
+            IsAllowedActionError, MustUse, UserOrRole,
         },
         events::{
             AuthorizationFailureReason, AuthorizationFailureSource,
@@ -362,7 +363,7 @@ pub trait AuthZGenericTableOps: Authorizer {
                 &wrapped,
             )
             .await?
-            .into_inner();
+            .into_allowed();
         let n_returned = result.len();
         let arr: [bool; N] = result
             .try_into()
@@ -381,7 +382,7 @@ pub trait AuthZGenericTableOps: Authorizer {
             &NamespaceWithParent,
             ActionOnGenericTable<'_, '_, impl AuthZGenericTableInfo, A>,
         )],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         #[cfg(debug_assertions)]
         {
             let namespaces: Vec<&NamespaceWithParent> = actions.iter().map(|(ns, _)| *ns).collect();
@@ -427,7 +428,10 @@ pub trait AuthZGenericTableOps: Authorizer {
         }
 
         if actions_to_check.is_empty() {
-            Ok(auto_approved.into_iter().map(|v| v.unwrap()).collect())
+            Ok(auto_approved
+                .into_iter()
+                .map(|v| AuthorizationDecision::from(v.unwrap()))
+                .collect())
         } else {
             let decisions = self
                 .are_allowed_generic_table_actions_impl(
@@ -447,10 +451,17 @@ pub trait AuthZGenericTableOps: Authorizer {
                 .into());
             }
 
+            // Merge auto-approved decisions (warehouse-mismatch / bypass) with the
+            // authorizer's checked decisions, preserving each one's `determined_by`.
             let mut decision_iter = decisions.into_iter();
-            let final_decisions: Vec<bool> = auto_approved
+            let final_decisions: Vec<AuthorizationDecision> = auto_approved
                 .into_iter()
-                .map(|auto| auto.unwrap_or_else(|| decision_iter.next().unwrap().allowed))
+                .map(|auto| {
+                    auto.map_or_else(
+                        || decision_iter.next().unwrap(),
+                        AuthorizationDecision::from,
+                    )
+                })
                 .collect();
 
             Ok(final_decisions)

--- a/crates/lakekeeper/src/service/authz/generic_table.rs
+++ b/crates/lakekeeper/src/service/authz/generic_table.rs
@@ -450,7 +450,7 @@ pub trait AuthZGenericTableOps: Authorizer {
             let mut decision_iter = decisions.into_iter();
             let final_decisions: Vec<bool> = auto_approved
                 .into_iter()
-                .map(|auto| auto.unwrap_or_else(|| decision_iter.next().unwrap()))
+                .map(|auto| auto.unwrap_or_else(|| decision_iter.next().unwrap().allowed))
                 .collect();
 
             Ok(final_decisions)

--- a/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
+++ b/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
@@ -17,7 +17,7 @@ use crate::{
         WarehouseId,
         authn::UserId,
         authz::{
-            ActionOnGenericTable, ActionOnTable, ActionOnView, Authorizer,
+            ActionOnGenericTable, ActionOnTable, ActionOnView, AuthorizationDecision, Authorizer,
             AuthzBackendErrorOrBadRequest, CatalogGenericTableAction, CatalogNamespaceAction,
             CatalogProjectAction, CatalogRoleAction, CatalogServerAction, CatalogTableAction,
             CatalogUserAction, CatalogViewAction, CatalogWarehouseAction, IsAllowedActionError,
@@ -121,8 +121,11 @@ impl Authorizer for AllowAllAuthorizer {
         _metadata: &RequestMetadata,
         _for_user: Option<&UserOrRole>,
         users_with_actions: &[(&UserId, Self::UserAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
-        Ok(vec![true; users_with_actions.len()])
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+        Ok(vec![
+            AuthorizationDecision::allow();
+            users_with_actions.len()
+        ])
     }
 
     async fn are_allowed_role_actions_impl(
@@ -130,8 +133,11 @@ impl Authorizer for AllowAllAuthorizer {
         _metadata: &RequestMetadata,
         _for_user: Option<&UserOrRole>,
         roles_with_actions: &[(&Role, Self::RoleAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
-        Ok(vec![true; roles_with_actions.len()])
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+        Ok(vec![
+            AuthorizationDecision::allow();
+            roles_with_actions.len()
+        ])
     }
 
     async fn are_allowed_server_actions_impl(
@@ -139,8 +145,8 @@ impl Authorizer for AllowAllAuthorizer {
         _metadata: &RequestMetadata,
         _for_user: Option<&UserOrRole>,
         actions: &[Self::ServerAction],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
-        Ok(vec![true; actions.len()])
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+        Ok(vec![AuthorizationDecision::allow(); actions.len()])
     }
 
     async fn are_allowed_project_actions_impl(
@@ -148,8 +154,11 @@ impl Authorizer for AllowAllAuthorizer {
         _metadata: &RequestMetadata,
         _for_user: Option<&UserOrRole>,
         projects_with_actions: &[(&ArcProjectId, Self::ProjectAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
-        Ok(vec![true; projects_with_actions.len()])
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+        Ok(vec![
+            AuthorizationDecision::allow();
+            projects_with_actions.len()
+        ])
     }
 
     async fn are_allowed_warehouse_actions_impl(
@@ -157,8 +166,11 @@ impl Authorizer for AllowAllAuthorizer {
         _metadata: &RequestMetadata,
         _for_user: Option<&UserOrRole>,
         warehouses_with_actions: &[(&ResolvedWarehouse, Self::WarehouseAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
-        Ok(vec![true; warehouses_with_actions.len()])
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+        Ok(vec![
+            AuthorizationDecision::allow();
+            warehouses_with_actions.len()
+        ])
     }
 
     async fn are_allowed_namespace_actions_impl(
@@ -168,8 +180,8 @@ impl Authorizer for AllowAllAuthorizer {
         _warehouse: &ResolvedWarehouse,
         _parent_namespaces: &HashMap<NamespaceId, NamespaceWithParent>,
         actions: &[(&impl AuthZNamespaceInfo, Self::NamespaceAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
-        Ok(vec![true; actions.len()])
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+        Ok(vec![AuthorizationDecision::allow(); actions.len()])
     }
 
     async fn are_allowed_table_actions_impl<A: Into<Self::TableAction> + Send + Clone + Sync>(
@@ -181,8 +193,8 @@ impl Authorizer for AllowAllAuthorizer {
             &NamespaceWithParent,
             ActionOnTable<'_, '_, impl AuthZTableInfo, A>,
         )],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
-        Ok(vec![true; actions.len()])
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+        Ok(vec![AuthorizationDecision::allow(); actions.len()])
     }
 
     async fn are_allowed_view_actions_impl<A: Into<Self::ViewAction> + Send + Clone + Sync>(
@@ -194,8 +206,8 @@ impl Authorizer for AllowAllAuthorizer {
             &NamespaceWithParent,
             ActionOnView<'_, '_, impl AuthZViewInfo, A>,
         )],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
-        Ok(vec![true; actions.len()])
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+        Ok(vec![AuthorizationDecision::allow(); actions.len()])
     }
 
     async fn are_allowed_generic_table_actions_impl<
@@ -209,8 +221,8 @@ impl Authorizer for AllowAllAuthorizer {
             &NamespaceWithParent,
             ActionOnGenericTable<'_, '_, impl AuthZGenericTableInfo, A>,
         )],
-    ) -> Result<Vec<bool>, IsAllowedActionError> {
-        Ok(vec![true; actions.len()])
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+        Ok(vec![AuthorizationDecision::allow(); actions.len()])
     }
 
     async fn delete_user(&self, _metadata: &RequestMetadata, _user_id: UserId) -> Result<()> {

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -1123,15 +1123,6 @@ impl MustUse<Vec<AuthorizationDecision>> {
     }
 }
 
-impl MustUse<Vec<bool>> {
-    /// The allow/deny flags. Mirrors the same method on the
-    /// `Vec<AuthorizationDecision>` variant so callers that only need the
-    /// boolean outcome read uniformly regardless of which the wrapper holds.
-    #[must_use]
-    pub fn into_allowed(self) -> Vec<bool> {
-        self.0
-    }
-}
 #[async_trait::async_trait]
 /// Interface to provide Authorization functions to the catalog.
 /// For metadata passed into all methods except `check_actor`, the `actor()` in `RequestMetadata`

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -24,6 +24,8 @@ use crate::{
     },
 };
 
+mod decision;
+pub use decision::*;
 mod error;
 pub mod implementations;
 pub use error::*;
@@ -1111,6 +1113,25 @@ impl<T> MustUse<T> {
         self.0
     }
 }
+
+impl MustUse<Vec<AuthorizationDecision>> {
+    /// Extract just the allow/deny flags, discarding the per-decision
+    /// diagnostics. For call sites that only need the boolean outcome.
+    #[must_use]
+    pub fn into_allowed(self) -> Vec<bool> {
+        self.0.into_iter().map(|d| d.allowed).collect()
+    }
+}
+
+impl MustUse<Vec<bool>> {
+    /// The allow/deny flags. Mirrors the same method on the
+    /// `Vec<AuthorizationDecision>` variant so callers that only need the
+    /// boolean outcome read uniformly regardless of which the wrapper holds.
+    #[must_use]
+    pub fn into_allowed(self) -> Vec<bool> {
+        self.0
+    }
+}
 #[async_trait::async_trait]
 /// Interface to provide Authorization functions to the catalog.
 /// For metadata passed into all methods except `check_actor`, the `actor()` in `RequestMetadata`
@@ -1199,35 +1220,35 @@ where
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         users_with_actions: &[(&UserId, Self::UserAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError>;
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError>;
 
     async fn are_allowed_role_actions_impl(
         &self,
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         roles_with_actions: &[(&Role, Self::RoleAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError>;
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError>;
 
     async fn are_allowed_server_actions_impl(
         &self,
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         actions: &[Self::ServerAction],
-    ) -> Result<Vec<bool>, IsAllowedActionError>;
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError>;
 
     async fn are_allowed_project_actions_impl(
         &self,
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         projects_with_actions: &[(&ArcProjectId, Self::ProjectAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError>;
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError>;
 
     async fn are_allowed_warehouse_actions_impl(
         &self,
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         warehouses_with_actions: &[(&ResolvedWarehouse, Self::WarehouseAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError>;
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError>;
 
     async fn are_allowed_namespace_actions_impl(
         &self,
@@ -1236,7 +1257,7 @@ where
         warehouse: &ResolvedWarehouse,
         parent_namespaces: &HashMap<NamespaceId, NamespaceWithParent>,
         actions: &[(&impl AuthZNamespaceInfo, Self::NamespaceAction)],
-    ) -> Result<Vec<bool>, IsAllowedActionError>;
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError>;
 
     /// Checks if actions are allowed on tables. If supported by the concrete implementation, these
     /// checks may happen in batches to avoid sending a separate request for each tuple.
@@ -1255,7 +1276,7 @@ where
             &NamespaceWithParent,
             ActionOnTable<'_, '_, impl AuthZTableInfo, A>,
         )],
-    ) -> Result<Vec<bool>, IsAllowedActionError>;
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError>;
 
     /// Checks if actions are allowed on views. If supported by the concrete implementation, these
     /// checks may happen in batches to avoid sending a separate request for each tuple.
@@ -1274,7 +1295,7 @@ where
             &NamespaceWithParent,
             ActionOnView<'_, '_, impl AuthZViewInfo, A>,
         )],
-    ) -> Result<Vec<bool>, IsAllowedActionError>;
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError>;
 
     /// Checks if actions are allowed on generic tables.
     async fn are_allowed_generic_table_actions_impl<
@@ -1288,7 +1309,7 @@ where
             &NamespaceWithParent,
             ActionOnGenericTable<'_, '_, impl AuthZGenericTableInfo, A>,
         )],
-    ) -> Result<Vec<bool>, IsAllowedActionError>;
+    ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError>;
 
     /// Hook that is called when a user is deleted.
     async fn delete_user(&self, metadata: &RequestMetadata, user_id: UserId) -> Result<()>;
@@ -2130,8 +2151,11 @@ pub mod tests {
             _metadata: &RequestMetadata,
             _for_user: Option<&UserOrRole>,
             users_with_actions: &[(&UserId, Self::UserAction)],
-        ) -> Result<Vec<bool>, IsAllowedActionError> {
-            Ok(vec![true; users_with_actions.len()])
+        ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+            Ok(vec![
+                AuthorizationDecision::allow();
+                users_with_actions.len()
+            ])
         }
 
         async fn are_allowed_role_actions_impl(
@@ -2139,7 +2163,7 @@ pub mod tests {
             _metadata: &RequestMetadata,
             _for_user: Option<&UserOrRole>,
             roles_with_actions: &[(&Role, Self::RoleAction)],
-        ) -> Result<Vec<bool>, IsAllowedActionError> {
+        ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
             let results: Vec<bool> = roles_with_actions
                 .iter()
                 .map(|(role, action)| {
@@ -2149,7 +2173,10 @@ pub mod tests {
                     self.check_available(format!("role:{}", role.id).as_str())
                 })
                 .collect();
-            Ok(results)
+            Ok(results
+                .into_iter()
+                .map(AuthorizationDecision::from)
+                .collect())
         }
 
         async fn are_allowed_server_actions_impl(
@@ -2157,8 +2184,8 @@ pub mod tests {
             _metadata: &RequestMetadata,
             _for_user: Option<&UserOrRole>,
             actions: &[Self::ServerAction],
-        ) -> Result<Vec<bool>, IsAllowedActionError> {
-            Ok(vec![true; actions.len()])
+        ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+            Ok(vec![AuthorizationDecision::allow(); actions.len()])
         }
 
         async fn are_allowed_project_actions_impl(
@@ -2166,7 +2193,7 @@ pub mod tests {
             _metadata: &RequestMetadata,
             _for_user: Option<&UserOrRole>,
             projects_with_actions: &[(&ArcProjectId, Self::ProjectAction)],
-        ) -> Result<Vec<bool>, IsAllowedActionError> {
+        ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
             let results: Vec<bool> = projects_with_actions
                 .iter()
                 .map(|(project_id, action)| {
@@ -2176,7 +2203,10 @@ pub mod tests {
                     self.check_available(format!("project:{project_id}").as_str())
                 })
                 .collect();
-            Ok(results)
+            Ok(results
+                .into_iter()
+                .map(AuthorizationDecision::from)
+                .collect())
         }
 
         async fn are_allowed_warehouse_actions_impl(
@@ -2184,7 +2214,7 @@ pub mod tests {
             _metadata: &RequestMetadata,
             _for_user: Option<&UserOrRole>,
             warehouses_with_actions: &[(&ResolvedWarehouse, Self::WarehouseAction)],
-        ) -> Result<Vec<bool>, IsAllowedActionError> {
+        ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
             let results: Vec<bool> = warehouses_with_actions
                 .iter()
                 .map(|(warehouse, action)| {
@@ -2195,7 +2225,10 @@ pub mod tests {
                     self.check_available(format!("warehouse:{warehouse_id}").as_str())
                 })
                 .collect();
-            Ok(results)
+            Ok(results
+                .into_iter()
+                .map(AuthorizationDecision::from)
+                .collect())
         }
 
         async fn are_allowed_namespace_actions_impl(
@@ -2205,7 +2238,7 @@ pub mod tests {
             _warehouse: &ResolvedWarehouse,
             _parent_namespaces: &HashMap<NamespaceId, NamespaceWithParent>,
             actions: &[(&impl AuthZNamespaceInfo, Self::NamespaceAction)],
-        ) -> Result<Vec<bool>, IsAllowedActionError> {
+        ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
             let results: Vec<bool> = actions
                 .iter()
                 .map(|(namespace, action)| {
@@ -2216,7 +2249,10 @@ pub mod tests {
                     self.check_available(format!("namespace:{namespace_id}").as_str())
                 })
                 .collect();
-            Ok(results)
+            Ok(results
+                .into_iter()
+                .map(AuthorizationDecision::from)
+                .collect())
         }
 
         async fn are_allowed_table_actions_impl<
@@ -2230,7 +2266,7 @@ pub mod tests {
                 &NamespaceWithParent,
                 ActionOnTable<'_, '_, impl AuthZTableInfo, A>,
             )],
-        ) -> Result<Vec<bool>, IsAllowedActionError> {
+        ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
             // `action.user == None` means "acting as self" (subject = actor),
             // so per-user hiding for the actor must still apply.
             let actor_identity = metadata.actor().to_user_or_role();
@@ -2249,7 +2285,10 @@ pub mod tests {
                     self.check_available_for_user(&object, subject)
                 })
                 .collect();
-            Ok(results)
+            Ok(results
+                .into_iter()
+                .map(AuthorizationDecision::from)
+                .collect())
         }
 
         async fn are_allowed_view_actions_impl<A: Into<Self::ViewAction> + Send + Clone + Sync>(
@@ -2261,7 +2300,7 @@ pub mod tests {
                 &NamespaceWithParent,
                 ActionOnView<'_, '_, impl AuthZViewInfo, A>,
             )],
-        ) -> Result<Vec<bool>, IsAllowedActionError> {
+        ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
             // See the table impl above for why we fall back to the actor.
             let actor_identity = metadata.actor().to_user_or_role();
             let results: Vec<bool> = actions
@@ -2279,7 +2318,10 @@ pub mod tests {
                     self.check_available_for_user(&object, subject)
                 })
                 .collect();
-            Ok(results)
+            Ok(results
+                .into_iter()
+                .map(AuthorizationDecision::from)
+                .collect())
         }
 
         async fn are_allowed_generic_table_actions_impl<
@@ -2293,7 +2335,7 @@ pub mod tests {
                 &NamespaceWithParent,
                 ActionOnGenericTable<'_, '_, impl AuthZGenericTableInfo, A>,
             )],
-        ) -> Result<Vec<bool>, IsAllowedActionError> {
+        ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
             // See the table impl above for why we fall back to the actor.
             let actor_identity = metadata.actor().to_user_or_role();
             let results: Vec<bool> = actions
@@ -2310,7 +2352,10 @@ pub mod tests {
                     self.check_available_for_user(&object, subject)
                 })
                 .collect();
-            Ok(results)
+            Ok(results
+                .into_iter()
+                .map(AuthorizationDecision::from)
+                .collect())
         }
 
         async fn delete_user(&self, _metadata: &RequestMetadata, _user_id: UserId) -> Result<()> {

--- a/crates/lakekeeper/src/service/authz/namespace.rs
+++ b/crates/lakekeeper/src/service/authz/namespace.rs
@@ -12,10 +12,11 @@ use crate::{
         NamespaceHierarchy, NamespaceId, NamespaceIdentOrId, NamespaceNotFound,
         NamespaceWithParent, ResolvedWarehouse, SerializationError,
         authz::{
-            AuthZError, AuthorizationBackendUnavailable, AuthorizationCountMismatch, Authorizer,
-            AuthzBadRequest, AuthzWarehouseOps as _, BackendUnavailableOrCountMismatch,
-            CannotInspectPermissions, CatalogAction, CatalogNamespaceAction, IsAllowedActionError,
-            MustUse, RequireWarehouseActionError, UserOrRole,
+            AuthZError, AuthorizationBackendUnavailable, AuthorizationCountMismatch,
+            AuthorizationDecision, Authorizer, AuthzBadRequest, AuthzWarehouseOps as _,
+            BackendUnavailableOrCountMismatch, CannotInspectPermissions, CatalogAction,
+            CatalogNamespaceAction, IsAllowedActionError, MustUse, RequireWarehouseActionError,
+            UserOrRole,
         },
         events::{
             AuthorizationFailureReason, AuthorizationFailureSource, context::UserProvidedNamespace,
@@ -485,7 +486,7 @@ pub trait AuthzNamespaceOps: Authorizer {
                 actions,
             )
             .await?
-            .into_inner();
+            .into_allowed();
         let n_returned = result.len();
         let arr: [bool; N] = result
             .try_into()
@@ -502,7 +503,7 @@ pub trait AuthzNamespaceOps: Authorizer {
         warehouse: &ResolvedWarehouse,
         parent_namespaces: &HashMap<NamespaceId, NamespaceWithParent>,
         actions: &[(&impl AuthZNamespaceInfo, A)],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         if metadata.actor().to_user_or_role().as_ref() == for_user {
             for_user = None;
         }
@@ -523,7 +524,10 @@ pub trait AuthzNamespaceOps: Authorizer {
             .collect();
 
         if metadata.bypasses_control_plane_authz(for_user) {
-            Ok(warehouse_matches)
+            Ok(warehouse_matches
+                .into_iter()
+                .map(AuthorizationDecision::from)
+                .collect())
         } else {
             let converted = actions
                 .iter()
@@ -548,11 +552,17 @@ pub trait AuthzNamespaceOps: Authorizer {
                 .into());
             }
 
-            // Combine warehouse check with authorization check (both must be true)
+            // Combine warehouse check with authorization check (both must be true),
+            // preserving the per-decision diagnostics from the authorizer.
             let results = warehouse_matches
                 .iter()
-                .zip(authz_results.iter())
-                .map(|(warehouse_match, authz_allowed)| *warehouse_match && *authz_allowed)
+                .zip(authz_results)
+                .map(|(warehouse_match, authz)| {
+                    AuthorizationDecision::new(
+                        *warehouse_match && authz.allowed,
+                        authz.determined_by,
+                    )
+                })
                 .collect::<Vec<_>>();
 
             Ok(results)

--- a/crates/lakekeeper/src/service/authz/namespace.rs
+++ b/crates/lakekeeper/src/service/authz/namespace.rs
@@ -543,25 +543,32 @@ pub trait AuthzNamespaceOps: Authorizer {
                 )
                 .await?;
 
-            if warehouse_matches.len() != actions.len() {
+            // `warehouse_matches` is built from `actions` so it always matches in
+            // length; the authorizer's result is what could be truncated, so guard
+            // its length before zipping (a short `zip` would silently drop tuples).
+            if authz_results.len() != actions.len() {
                 return Err(AuthorizationCountMismatch::new(
                     actions.len(),
-                    warehouse_matches.len(),
+                    authz_results.len(),
                     "namespace",
                 )
                 .into());
             }
 
-            // Combine warehouse check with authorization check (both must be true),
-            // preserving the per-decision diagnostics from the authorizer.
+            // Combine the local warehouse precheck with the authorizer's verdict.
+            // A warehouse mismatch is a *local* denial, so it carries no
+            // `determined_by` — attributing it to the authorizer's policies would
+            // be wrong. When the warehouse matches, the authorizer's decision
+            // (verdict and diagnostics) stands as-is.
             let results = warehouse_matches
                 .iter()
                 .zip(authz_results)
                 .map(|(warehouse_match, authz)| {
-                    AuthorizationDecision::new(
-                        *warehouse_match && authz.allowed,
-                        authz.determined_by,
-                    )
+                    if *warehouse_match {
+                        authz
+                    } else {
+                        AuthorizationDecision::deny()
+                    }
                 })
                 .collect::<Vec<_>>();
 

--- a/crates/lakekeeper/src/service/authz/project.rs
+++ b/crates/lakekeeper/src/service/authz/project.rs
@@ -8,10 +8,10 @@ use crate::{
     service::{
         ArcProjectId,
         authz::{
-            AuthorizationBackendUnavailable, AuthorizationCountMismatch, Authorizer,
-            AuthzBackendErrorOrBadRequest, AuthzBadRequest, BackendUnavailableOrCountMismatch,
-            CannotInspectPermissions, CatalogAction, CatalogProjectAction, IsAllowedActionError,
-            MustUse, UserOrRole,
+            AuthorizationBackendUnavailable, AuthorizationCountMismatch, AuthorizationDecision,
+            Authorizer, AuthzBackendErrorOrBadRequest, AuthzBadRequest,
+            BackendUnavailableOrCountMismatch, CannotInspectPermissions, CatalogAction,
+            CatalogProjectAction, IsAllowedActionError, MustUse, UserOrRole,
         },
         events::{
             AuthorizationFailureReason, AuthorizationFailureSource,
@@ -119,14 +119,14 @@ pub trait AuthZProjectOps: Authorizer {
         metadata: &RequestMetadata,
         mut for_user: Option<&UserOrRole>,
         projects_with_actions: &[(&ArcProjectId, A)],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         if metadata.actor().to_user_or_role().as_ref() == for_user {
             for_user = None;
         }
 
         Ok(MustUse::from(
             if metadata.bypasses_control_plane_authz(for_user) {
-                vec![true; projects_with_actions.len()]
+                vec![AuthorizationDecision::allow(); projects_with_actions.len()]
             } else {
                 let converted: Vec<(&ArcProjectId, Self::ProjectAction)> = projects_with_actions
                     .iter()
@@ -162,7 +162,7 @@ pub trait AuthZProjectOps: Authorizer {
         let result = self
             .are_allowed_project_actions_vec(metadata, for_user, projects_with_actions)
             .await?
-            .into_inner();
+            .into_allowed();
         let n_returned = result.len();
         let arr: [bool; N] = result
             .try_into()

--- a/crates/lakekeeper/src/service/authz/role.rs
+++ b/crates/lakekeeper/src/service/authz/role.rs
@@ -8,9 +8,9 @@ use crate::{
         ArcProjectId, CatalogBackendError, GetRoleInProjectError, InvalidPaginationToken, Role,
         RoleId, RoleIdNotFoundInProject,
         authz::{
-            AuthorizationBackendUnavailable, AuthorizationCountMismatch, Authorizer,
-            AuthzBadRequest, BackendUnavailableOrCountMismatch, CannotInspectPermissions,
-            CatalogRoleAction, IsAllowedActionError, MustUse, UserOrRole,
+            AuthorizationBackendUnavailable, AuthorizationCountMismatch, AuthorizationDecision,
+            Authorizer, AuthzBadRequest, BackendUnavailableOrCountMismatch,
+            CannotInspectPermissions, CatalogRoleAction, IsAllowedActionError, MustUse, UserOrRole,
         },
         events::{
             AuthorizationFailureReason, AuthorizationFailureSource,
@@ -200,12 +200,15 @@ pub trait AuthZRoleOps: Authorizer {
         metadata: &RequestMetadata,
         mut for_user: Option<&UserOrRole>,
         roles_with_actions: &[(&Role, A)],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         if metadata.actor().to_user_or_role().as_ref() == for_user {
             for_user = None;
         }
         if metadata.bypasses_control_plane_authz(for_user) {
-            Ok(vec![true; roles_with_actions.len()])
+            Ok(vec![
+                AuthorizationDecision::allow();
+                roles_with_actions.len()
+            ])
         } else {
             let converted = roles_with_actions
                 .iter()
@@ -237,7 +240,7 @@ pub trait AuthZRoleOps: Authorizer {
         let result = self
             .are_allowed_role_actions_vec(metadata, for_user, roles_with_actions)
             .await?
-            .into_inner();
+            .into_allowed();
         let n_returned = result.len();
         let arr: [bool; N] = result
             .try_into()

--- a/crates/lakekeeper/src/service/authz/role.rs
+++ b/crates/lakekeeper/src/service/authz/role.rs
@@ -218,10 +218,14 @@ pub trait AuthZRoleOps: Authorizer {
                 .are_allowed_role_actions_impl(metadata, for_user, &converted)
                 .await?;
 
-            debug_assert!(
-                decisions.len() == roles_with_actions.len(),
-                "Mismatched role decision lengths",
-            );
+            if decisions.len() != roles_with_actions.len() {
+                return Err(AuthorizationCountMismatch::new(
+                    roles_with_actions.len(),
+                    decisions.len(),
+                    "role",
+                )
+                .into());
+            }
 
             Ok(decisions)
         }

--- a/crates/lakekeeper/src/service/authz/server.rs
+++ b/crates/lakekeeper/src/service/authz/server.rs
@@ -5,10 +5,10 @@ use crate::{
     service::{
         Actor, ServerId,
         authz::{
-            AuthorizationBackendUnavailable, AuthorizationCountMismatch, Authorizer,
-            AuthzBackendErrorOrBadRequest, AuthzBadRequest, BackendUnavailableOrCountMismatch,
-            CannotInspectPermissions, CatalogAction, CatalogServerAction, IsAllowedActionError,
-            MustUse, UserOrRole,
+            AuthorizationBackendUnavailable, AuthorizationCountMismatch, AuthorizationDecision,
+            Authorizer, AuthzBackendErrorOrBadRequest, AuthzBadRequest,
+            BackendUnavailableOrCountMismatch, CannotInspectPermissions, CatalogAction,
+            CatalogServerAction, IsAllowedActionError, MustUse, UserOrRole,
         },
         events::{
             AuthorizationFailureReason, AuthorizationFailureSource, context::UserProvidedRole,
@@ -167,13 +167,13 @@ pub trait AuthZServerOps: Authorizer {
         metadata: &RequestMetadata,
         mut for_user: Option<&UserOrRole>,
         actions: &[A],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         if metadata.actor().to_user_or_role().as_ref() == for_user {
             for_user = None;
         }
 
         if metadata.bypasses_control_plane_authz(for_user) {
-            Ok(vec![true; actions.len()])
+            Ok(vec![AuthorizationDecision::allow(); actions.len()])
         } else {
             let converted = actions.iter().map(|a| a.clone().into()).collect::<Vec<_>>();
             let decisions = self
@@ -206,7 +206,7 @@ pub trait AuthZServerOps: Authorizer {
         let result = self
             .are_allowed_server_actions_vec(metadata, for_user, actions)
             .await?
-            .into_inner();
+            .into_allowed();
         let n_returned = result.len();
         let arr: [bool; N] = result
             .try_into()

--- a/crates/lakekeeper/src/service/authz/table.rs
+++ b/crates/lakekeeper/src/service/authz/table.rs
@@ -20,9 +20,10 @@ use crate::{
         authz::{
             AuthZError, AuthZGenericTableActionForbidden, AuthZGenericTableOps,
             AuthZViewActionForbidden, AuthZViewOps, AuthorizationBackendUnavailable,
-            AuthorizationCountMismatch, Authorizer, AuthzBadRequest, AuthzNamespaceOps,
-            AuthzWarehouseOps, BackendUnavailableOrCountMismatch, CannotInspectPermissions,
-            CatalogAction, CatalogTableAction, IsAllowedActionError, MustUse, UserOrRole,
+            AuthorizationCountMismatch, AuthorizationDecision, Authorizer, AuthzBadRequest,
+            AuthzNamespaceOps, AuthzWarehouseOps, BackendUnavailableOrCountMismatch,
+            CannotInspectPermissions, CatalogAction, CatalogTableAction, IsAllowedActionError,
+            MustUse, UserOrRole,
         },
         catalog_store::{
             BasicTabularInfo, CachePolicy, CatalogNamespaceOps, CatalogStore, CatalogTabularOps,
@@ -829,7 +830,7 @@ pub trait AuthZTableOps: Authorizer {
         let decisions = self
             .are_allowed_table_actions_vec(metadata, warehouse, parent_namespaces, &batch_requests)
             .await?
-            .into_inner();
+            .into_allowed();
 
         // Check authorization results.
         // Due to ordering above, CAN_SEE_PERMISSION is always first for each table.
@@ -908,7 +909,7 @@ pub trait AuthZTableOps: Authorizer {
         let result = self
             .are_allowed_table_actions_vec(metadata, warehouse, parent_namespaces, &actions_vec)
             .await?
-            .into_inner();
+            .into_allowed();
         let n_returned = result.len();
         let arr: [bool; N] = result
             .try_into()
@@ -927,7 +928,7 @@ pub trait AuthZTableOps: Authorizer {
             &NamespaceWithParent,
             ActionOnTable<'_, '_, impl AuthZTableInfo, A>,
         )],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         #[cfg(debug_assertions)]
         {
             let namespaces: Vec<&NamespaceWithParent> = actions.iter().map(|(ns, _)| *ns).collect();
@@ -980,7 +981,10 @@ pub trait AuthZTableOps: Authorizer {
 
         // If all actions are auto-decided, return early
         if actions_to_check.is_empty() {
-            Ok(auto_approved.into_iter().map(|v| v.unwrap()).collect())
+            Ok(auto_approved
+                .into_iter()
+                .map(|v| AuthorizationDecision::from(v.unwrap()))
+                .collect())
         } else {
             let decisions = self
                 .are_allowed_table_actions_impl(
@@ -1000,11 +1004,17 @@ pub trait AuthZTableOps: Authorizer {
                 .into());
             }
 
-            // Merge auto-approved decisions with checked decisions
+            // Merge auto-approved decisions (warehouse-mismatch / bypass) with the
+            // authorizer's checked decisions, preserving each one's `determined_by`.
             let mut decision_iter = decisions.into_iter();
-            let final_decisions: Vec<bool> = auto_approved
+            let final_decisions: Vec<AuthorizationDecision> = auto_approved
                 .into_iter()
-                .map(|auto| auto.unwrap_or_else(|| decision_iter.next().unwrap().allowed))
+                .map(|auto| {
+                    auto.map_or_else(
+                        || decision_iter.next().unwrap(),
+                        AuthorizationDecision::from,
+                    )
+                })
                 .collect();
 
             Ok(final_decisions)
@@ -1038,7 +1048,7 @@ pub trait AuthZTableOps: Authorizer {
                 AG,
             >,
         )],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         let mut tables = Vec::new();
         let mut views = Vec::new();
         let mut generic_tables = Vec::new();
@@ -1107,28 +1117,18 @@ pub trait AuthZTableOps: Authorizer {
             .into());
         }
 
-        // Reorder results to match the original order of actions
-        let mut table_idx = 0;
-        let mut view_idx = 0;
-        let mut gt_idx = 0;
-        let ordered_results: Vec<bool> = actions
+        // Reorder results to match the original order of actions. Each per-type
+        // result is consumed in order (lengths validated above), carrying its
+        // `determined_by` through unchanged.
+        let mut table_results = table_results.into_iter();
+        let mut view_results = view_results.into_iter();
+        let mut generic_table_results = generic_table_results.into_iter();
+        let ordered_results: Vec<AuthorizationDecision> = actions
             .iter()
             .map(|(_ns, action)| match action {
-                ActionOnTableOrView::Table(_) => {
-                    let result = table_results[table_idx];
-                    table_idx += 1;
-                    result
-                }
-                ActionOnTableOrView::View(_) => {
-                    let result = view_results[view_idx];
-                    view_idx += 1;
-                    result
-                }
-                ActionOnTableOrView::GenericTable(_) => {
-                    let result = generic_table_results[gt_idx];
-                    gt_idx += 1;
-                    result
-                }
+                ActionOnTableOrView::Table(_) => table_results.next().unwrap(),
+                ActionOnTableOrView::View(_) => view_results.next().unwrap(),
+                ActionOnTableOrView::GenericTable(_) => generic_table_results.next().unwrap(),
             })
             .collect();
 
@@ -1176,7 +1176,7 @@ pub trait AuthZTableOps: Authorizer {
         let decisions = self
             .are_allowed_tabular_actions_vec(metadata, warehouse, parent_namespaces, tabulars)
             .await?
-            .into_inner();
+            .into_allowed();
 
         for ((_ns, t), &allowed) in tabulars.iter().zip(decisions.iter()) {
             if !allowed {

--- a/crates/lakekeeper/src/service/authz/table.rs
+++ b/crates/lakekeeper/src/service/authz/table.rs
@@ -1004,7 +1004,7 @@ pub trait AuthZTableOps: Authorizer {
             let mut decision_iter = decisions.into_iter();
             let final_decisions: Vec<bool> = auto_approved
                 .into_iter()
-                .map(|auto| auto.unwrap_or_else(|| decision_iter.next().unwrap()))
+                .map(|auto| auto.unwrap_or_else(|| decision_iter.next().unwrap().allowed))
                 .collect();
 
             Ok(final_decisions)

--- a/crates/lakekeeper/src/service/authz/user.rs
+++ b/crates/lakekeeper/src/service/authz/user.rs
@@ -5,9 +5,9 @@ use crate::{
     service::{
         UserId,
         authz::{
-            AuthorizationBackendUnavailable, AuthorizationCountMismatch, Authorizer,
-            AuthzBadRequest, BackendUnavailableOrCountMismatch, CannotInspectPermissions,
-            CatalogUserAction, IsAllowedActionError, MustUse, UserOrRole,
+            AuthorizationBackendUnavailable, AuthorizationCountMismatch, AuthorizationDecision,
+            Authorizer, AuthzBadRequest, BackendUnavailableOrCountMismatch,
+            CannotInspectPermissions, CatalogUserAction, IsAllowedActionError, MustUse, UserOrRole,
         },
         events::{
             AuthorizationFailureReason, AuthorizationFailureSource,
@@ -109,13 +109,16 @@ pub trait AuthZUserOps: Authorizer {
         metadata: &RequestMetadata,
         mut for_user: Option<&UserOrRole>,
         users_with_actions: &[(&UserId, A)],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         if metadata.actor().to_user_or_role().as_ref() == for_user {
             for_user = None;
         }
 
         if metadata.bypasses_control_plane_authz(for_user) {
-            Ok(vec![true; users_with_actions.len()])
+            Ok(vec![
+                AuthorizationDecision::allow();
+                users_with_actions.len()
+            ])
         } else {
             let converted = users_with_actions
                 .iter()
@@ -147,7 +150,7 @@ pub trait AuthZUserOps: Authorizer {
         let result = self
             .are_allowed_user_actions_vec(metadata, for_user, users_with_actions)
             .await?
-            .into_inner();
+            .into_allowed();
         let n_returned = result.len();
         let arr: [bool; N] = result
             .try_into()

--- a/crates/lakekeeper/src/service/authz/user.rs
+++ b/crates/lakekeeper/src/service/authz/user.rs
@@ -128,10 +128,14 @@ pub trait AuthZUserOps: Authorizer {
                 .are_allowed_user_actions_impl(metadata, for_user, &converted)
                 .await?;
 
-            debug_assert!(
-                decisions.len() == users_with_actions.len(),
-                "Mismatched user decision lengths",
-            );
+            if decisions.len() != users_with_actions.len() {
+                return Err(AuthorizationCountMismatch::new(
+                    users_with_actions.len(),
+                    decisions.len(),
+                    "user",
+                )
+                .into());
+            }
 
             Ok(decisions)
         }

--- a/crates/lakekeeper/src/service/authz/view.rs
+++ b/crates/lakekeeper/src/service/authz/view.rs
@@ -577,7 +577,7 @@ pub trait AuthZViewOps: Authorizer {
             let mut decision_iter = decisions.into_iter();
             let final_decisions: Vec<bool> = auto_approved
                 .into_iter()
-                .map(|auto| auto.unwrap_or_else(|| decision_iter.next().unwrap()))
+                .map(|auto| auto.unwrap_or_else(|| decision_iter.next().unwrap().allowed))
                 .collect();
 
             Ok(final_decisions)

--- a/crates/lakekeeper/src/service/authz/view.rs
+++ b/crates/lakekeeper/src/service/authz/view.rs
@@ -12,9 +12,9 @@ use crate::{
         ViewId, ViewIdentOrId, ViewInfo,
         authz::{
             ActionOnView, AuthZError, AuthorizationBackendUnavailable, AuthorizationCountMismatch,
-            Authorizer, AuthzBadRequest, AuthzNamespaceOps, AuthzWarehouseOps,
-            BackendUnavailableOrCountMismatch, CannotInspectPermissions, CatalogAction,
-            CatalogViewAction, IsAllowedActionError, MustUse, UserOrRole,
+            AuthorizationDecision, Authorizer, AuthzBadRequest, AuthzNamespaceOps,
+            AuthzWarehouseOps, BackendUnavailableOrCountMismatch, CannotInspectPermissions,
+            CatalogAction, CatalogViewAction, IsAllowedActionError, MustUse, UserOrRole,
             refresh_warehouse_and_namespace_if_needed,
         },
         catalog_store::{
@@ -486,7 +486,7 @@ pub trait AuthZViewOps: Authorizer {
         let result = self
             .are_allowed_view_actions_vec(metadata, warehouse, parent_namespaces, &actions_vec)
             .await?
-            .into_inner();
+            .into_allowed();
         let n_returned = result.len();
         let arr: [bool; N] = result
             .try_into()
@@ -503,7 +503,7 @@ pub trait AuthZViewOps: Authorizer {
             &NamespaceWithParent,
             ActionOnView<'_, '_, impl AuthZViewInfo, A>,
         )],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         #[cfg(debug_assertions)]
         {
             let namespaces: Vec<&NamespaceWithParent> = actions.iter().map(|(ns, _)| *ns).collect();
@@ -553,7 +553,10 @@ pub trait AuthZViewOps: Authorizer {
 
         // If all actions are auto-decided, return early
         if actions_to_check.is_empty() {
-            Ok(auto_approved.into_iter().map(|v| v.unwrap()).collect())
+            Ok(auto_approved
+                .into_iter()
+                .map(|v| AuthorizationDecision::from(v.unwrap()))
+                .collect())
         } else {
             let decisions = self
                 .are_allowed_view_actions_impl(
@@ -573,11 +576,17 @@ pub trait AuthZViewOps: Authorizer {
                 .into());
             }
 
-            // Merge auto-approved decisions with checked decisions
+            // Merge auto-approved decisions (warehouse-mismatch / bypass) with the
+            // authorizer's checked decisions, preserving each one's `determined_by`.
             let mut decision_iter = decisions.into_iter();
-            let final_decisions: Vec<bool> = auto_approved
+            let final_decisions: Vec<AuthorizationDecision> = auto_approved
                 .into_iter()
-                .map(|auto| auto.unwrap_or_else(|| decision_iter.next().unwrap().allowed))
+                .map(|auto| {
+                    auto.map_or_else(
+                        || decision_iter.next().unwrap(),
+                        AuthorizationDecision::from,
+                    )
+                })
                 .collect();
 
             Ok(final_decisions)

--- a/crates/lakekeeper/src/service/authz/warehouse.rs
+++ b/crates/lakekeeper/src/service/authz/warehouse.rs
@@ -9,9 +9,10 @@ use crate::{
         CatalogBackendError, CatalogGetWarehouseByIdError, DatabaseIntegrityError,
         ResolvedWarehouse, WarehouseIdNotFound,
         authz::{
-            AuthorizationBackendUnavailable, AuthorizationCountMismatch, Authorizer,
-            AuthzBadRequest, BackendUnavailableOrCountMismatch, CannotInspectPermissions,
-            CatalogAction, CatalogWarehouseAction, IsAllowedActionError, MustUse, UserOrRole,
+            AuthorizationBackendUnavailable, AuthorizationCountMismatch, AuthorizationDecision,
+            Authorizer, AuthzBadRequest, BackendUnavailableOrCountMismatch,
+            CannotInspectPermissions, CatalogAction, CatalogWarehouseAction, IsAllowedActionError,
+            MustUse, UserOrRole,
         },
         events::{
             AuthorizationFailureReason, AuthorizationFailureSource,
@@ -295,7 +296,7 @@ pub trait AuthzWarehouseOps: Authorizer {
         let result = self
             .are_allowed_warehouse_actions_vec(metadata, for_user, warehouses_with_actions)
             .await?
-            .into_inner();
+            .into_allowed();
         let n_returned = result.len();
         let arr: [bool; N] = result
             .try_into()
@@ -310,13 +311,16 @@ pub trait AuthzWarehouseOps: Authorizer {
         metadata: &RequestMetadata,
         mut for_user: Option<&UserOrRole>,
         warehouses_with_actions: &[(&ResolvedWarehouse, A)],
-    ) -> Result<MustUse<Vec<bool>>, IsAllowedActionError> {
+    ) -> Result<MustUse<Vec<AuthorizationDecision>>, IsAllowedActionError> {
         if metadata.actor().to_user_or_role().as_ref() == for_user {
             for_user = None;
         }
 
         if metadata.bypasses_control_plane_authz(for_user) {
-            Ok(vec![true; warehouses_with_actions.len()])
+            Ok(vec![
+                AuthorizationDecision::allow();
+                warehouses_with_actions.len()
+            ])
         } else {
             let converted: Vec<(&ResolvedWarehouse, Self::WarehouseAction)> =
                 warehouses_with_actions

--- a/crates/lakekeeper/src/service/events/backends/audit.rs
+++ b/crates/lakekeeper/src/service/events/backends/audit.rs
@@ -4,7 +4,7 @@ use valuable::{Listable, Mappable, Valuable, Value, Visit};
 
 use crate::service::{
     authn::{Actor, InternalActor},
-    authz::{ActionDescriptor, ContextValue, UserOrRoleId},
+    authz::{ActionDescriptor, ContextValue, DeterminingFactor, UserOrRoleId},
     events::{
         Authorization, AuthorizationFailedEvent, AuthorizationSucceededEvent, EventListener,
         context::EntityDescriptor,
@@ -52,6 +52,10 @@ impl Valuable for Authorization {
         if let Some(allowed) = self.allowed {
             visit.visit_entry(Value::String("allowed"), Value::Bool(allowed));
         }
+        if !self.determined_by.is_empty() {
+            let determined_by = DeterminingFactorsList(&self.determined_by);
+            visit.visit_entry(Value::String("determined_by"), determined_by.as_value());
+        }
     }
 }
 
@@ -60,8 +64,32 @@ impl Mappable for Authorization {
         let len = 2
             + usize::from(self.id.is_some())
             + usize::from(self.for_principal.is_some())
-            + usize::from(self.allowed.is_some());
+            + usize::from(self.allowed.is_some())
+            + usize::from(!self.determined_by.is_empty());
         (len, Some(len))
+    }
+}
+
+/// Newtype around `[DeterminingFactor]` so we can implement `Valuable` /
+/// `Listable` for it without an orphan-rule violation, mirroring
+/// [`AuthorizationsList`].
+struct DeterminingFactorsList<'a>(&'a [DeterminingFactor]);
+
+impl Valuable for DeterminingFactorsList<'_> {
+    fn as_value(&self) -> Value<'_> {
+        Value::Listable(self)
+    }
+
+    fn visit(&self, visit: &mut dyn Visit) {
+        for entry in self.0 {
+            visit.visit_value(entry.as_value());
+        }
+    }
+}
+
+impl Listable for DeterminingFactorsList<'_> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.0.len(), Some(self.0.len()))
     }
 }
 
@@ -487,4 +515,67 @@ macro_rules! audit_operation {
             $msg
         )
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use valuable::{Valuable, Value, Visit};
+
+    use super::*;
+    use crate::service::authz::{ActionDescriptor, DeterminingFactor, PolicyEffect};
+
+    /// Records the top-level map keys an `Authorization` emits when visited.
+    #[derive(Default)]
+    struct KeyCollector {
+        keys: Vec<String>,
+    }
+
+    impl Visit for KeyCollector {
+        fn visit_value(&mut self, _value: Value<'_>) {}
+        fn visit_entry(&mut self, key: Value<'_>, _value: Value<'_>) {
+            if let Value::String(k) = key {
+                self.keys.push(k.to_string());
+            }
+        }
+    }
+
+    fn sample(determined_by: Vec<DeterminingFactor>) -> Authorization {
+        Authorization {
+            id: None,
+            for_principal: None,
+            action: ActionDescriptor {
+                action_name: "read",
+                context: Vec::new(),
+            },
+            entity: EntityDescriptor::new("table"),
+            allowed: Some(true),
+            determined_by,
+        }
+    }
+
+    #[test]
+    fn determined_by_emitted_when_present() {
+        let auth = sample(vec![DeterminingFactor::Policy {
+            id: "allow-read".to_string(),
+            id_is_fallback: false,
+            effect: PolicyEffect::Permit,
+            source: None,
+        }]);
+        let mut collector = KeyCollector::default();
+        auth.visit(&mut collector);
+        assert_eq!(
+            collector.keys,
+            vec!["action", "entity", "allowed", "determined_by"],
+        );
+        assert_eq!(auth.size_hint().0, collector.keys.len());
+    }
+
+    #[test]
+    fn determined_by_absent_when_empty() {
+        let auth = sample(Vec::new());
+        let mut collector = KeyCollector::default();
+        auth.visit(&mut collector);
+        assert_eq!(collector.keys, vec!["action", "entity", "allowed"]);
+        assert_eq!(auth.size_hint().0, collector.keys.len());
+    }
 }

--- a/crates/lakekeeper/src/service/events/backends/audit.rs
+++ b/crates/lakekeeper/src/service/events/backends/audit.rs
@@ -556,8 +556,8 @@ mod tests {
     #[test]
     fn determined_by_emitted_when_present() {
         let auth = sample(vec![DeterminingFactor::Policy {
-            id: "allow-read".to_string(),
-            id_is_fallback: false,
+            policy_id: "policy0".to_string(),
+            name: Some("allow-read".to_string()),
             effect: PolicyEffect::Permit,
             source: None,
         }]);

--- a/crates/lakekeeper/src/service/events/context.rs
+++ b/crates/lakekeeper/src/service/events/context.rs
@@ -1293,6 +1293,7 @@ fn synthesise_authorizations(
                 action: action.clone(),
                 entity: entity.clone(),
                 allowed,
+                determined_by: Vec::new(),
             });
         }
     }
@@ -1316,6 +1317,7 @@ fn synthesise_authorizations(
                 .cloned()
                 .unwrap_or_else(|| EntityDescriptor::new("unknown")),
             allowed,
+            determined_by: Vec::new(),
         });
     }
     out

--- a/crates/lakekeeper/src/service/events/types/authorization.rs
+++ b/crates/lakekeeper/src/service/events/types/authorization.rs
@@ -5,7 +5,7 @@ use iceberg_ext::catalog::rest::ErrorModel;
 use crate::{
     api::RequestMetadata,
     service::{
-        authz::{ActionDescriptor, UserOrRoleId},
+        authz::{ActionDescriptor, DeterminingFactor, UserOrRoleId},
         events::context::{EntityDescriptor, EventEntities},
     },
 };
@@ -34,6 +34,11 @@ pub struct Authorization {
     /// upstream error prevented this entry from producing a decision (e.g. a
     /// batch failed before the inner tuples were evaluated).
     pub allowed: Option<bool>,
+    /// Policies or rules that determined this decision. Empty when the
+    /// authorizer produces no per-decision diagnostics (`AllowAll`, OpenFGA),
+    /// for a default-deny where no policy matched, or for synthesised entries
+    /// whose call site did not capture a trace.
+    pub determined_by: Vec<DeterminingFactor>,
 }
 
 /// Trait for extracting failure reason from authorization errors


### PR DESCRIPTION
Widen the authorizer batch API to return per-decision diagnostics so audit events can record *which* policies determined an authorization outcome, not just allow/deny.

- Add authorizer-agnostic `AuthorizationDecision { allowed, determined_by }` with `DeterminingFactor::Policy { id, id_is_fallback, effect, source }` and `PolicyEffect { Permit, Forbid }` (service/authz/decision.rs). No backend-specific types — each authorizer maps its own diagnostics down.
- `are_allowed_*_actions_impl` now return `Vec<AuthorizationDecision>` instead of `Vec<bool>`. The `_arr`/`is_allowed_*`/`require_*` wrappers keep returning `bool` via `MustUse::into_allowed()`, so enforce-style call sites are unchanged.
- `Authorization` audit entries gain `determined_by`, emitted (valuable) only when non-empty.
- introspect / batch-check surfaces the contributing policies per checked tuple via `set_authorizations`.
- AllowAll and the test authorizer build decisions; OpenFGA wraps its boolean results with empty diagnostics (no native contributing tuples).

Tables/views/generic tables and the single-check `require_*` path capture decisions but do not yet surface them; tracked as follow-ups.

BREAKING CHANGE: `Authorizer::are_allowed_*_actions_impl` return `Result<Vec<AuthorizationDecision>, _>` instead of `Result<Vec<bool>, _>`. Implementors map their per-decision diagnostics into `AuthorizationDecision` (or `vec![AuthorizationDecision::allow(); n]` / `.map(AuthorizationDecision::from)` for backends without diagnostics).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization decisions can now carry diagnostic details (“determined by” with policy id, effect, and optional source).
  * Audit authorization events now include these diagnostics when available.
* **Refactor**
  * Bulk authorization flows now propagate full decision objects (verdict + diagnostics) end-to-end.
  * Permission filtering consistently derives allow/deny from the decision verdict.
* **Bug Fixes**
  * Added runtime validation to detect mismatched batch decision counts.
* **Tests**
  * Updated coverage for conditional `determined_by` audit serialization and decision handling in bulk checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->