### PR TITLE
fix(roles): evict membership caches on role source-system rebind

### DIFF
--- a/crates/lakekeeper-integration-tests/tests/role_membership_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/role_membership_ops.rs
@@ -997,3 +997,109 @@ async fn transitive_role_member_of(pool: PgPool) {
         ["A".to_string(), "B".to_string()].into_iter().collect()
     );
 }
+
+// ==================== source-system rebind invalidates closures ====================
+
+/// Rebinding a role's source system changes its `RoleIdent`, which is cached per
+/// row in every assignee's USER_ASSIGNMENTS closure and in the role's ROLE_MEMBERS
+/// entry. The handler must evict both (mirroring `delete_role`), or external
+/// authorizers evaluate the stale ident until TTL. Behavioral assertion: after the
+/// rebind, the cached reads reflect the NEW ident (and return a fresh `Arc`),
+/// proving eviction. The eviction is synchronous (post-commit in the handler), so
+/// no sleep is needed.
+#[sqlx::test]
+async fn source_system_rebind_evicts_user_assignment_and_member_closures(pool: PgPool) {
+    use lakekeeper::{
+        api::management::v1::role::{Service as _, UpdateRoleSourceSystemRequest},
+        service::CatalogRoleAssignmentOps as _,
+    };
+
+    let (ctx, project_id) = setup(pool).await;
+    let role = make_role(&ctx, &project_id, "rebind-role", "old-src").await;
+    let alice = UserId::new_unchecked("oidc", "alice");
+    provision_user(&ctx, &alice, "Alice").await;
+
+    // Alice is a direct member of the role → she effectively holds it.
+    ApiServer::add_role_members(
+        ctx.clone(),
+        metadata(&project_id),
+        role,
+        AddRoleMembersRequest {
+            members: vec![user_member(&alice)],
+        },
+    )
+    .await
+    .unwrap();
+
+    // Warm both closures so they cache the OLD ident ("old-src").
+    let warmed_user =
+        PostgresBackend::list_role_assignments_for_user(&alice, ctx.v1_state.catalog.clone())
+            .await
+            .unwrap();
+    assert_eq!(
+        warmed_user
+            .roles
+            .iter()
+            .find(|r| r.role_id == role)
+            .expect("alice has the role")
+            .role_ident
+            .source_id(),
+        &RoleSourceId::try_new("old-src").unwrap(),
+    );
+    let warmed_members =
+        PostgresBackend::list_role_assignments_for_role(role, ctx.v1_state.catalog.clone())
+            .await
+            .unwrap()
+            .expect("role has a member list");
+    assert_eq!(
+        warmed_members.role_ident.source_id(),
+        &RoleSourceId::try_new("old-src").unwrap(),
+    );
+
+    // Rebind the role's source system (changes its RoleIdent's source_id).
+    ApiServer::update_role_source_system(
+        ctx.clone(),
+        metadata(&project_id),
+        role,
+        UpdateRoleSourceSystemRequest {
+            provider_id: RoleProviderId::try_new("lakekeeper").unwrap(),
+            source_id: RoleSourceId::try_new("new-src").unwrap(),
+        },
+    )
+    .await
+    .unwrap();
+
+    // USER_ASSIGNMENTS closure must reflect the rebound ident, not the stale one,
+    // and be a fresh Arc (i.e. it was evicted and reloaded).
+    let after_user =
+        PostgresBackend::list_role_assignments_for_user(&alice, ctx.v1_state.catalog.clone())
+            .await
+            .unwrap();
+    assert_eq!(
+        after_user
+            .roles
+            .iter()
+            .find(|r| r.role_id == role)
+            .expect("alice still has the role")
+            .role_ident
+            .source_id(),
+        &RoleSourceId::try_new("new-src").unwrap(),
+        "user-assignments closure served the stale ident after a source-system rebind",
+    );
+    assert!(
+        !std::sync::Arc::ptr_eq(&warmed_user, &after_user),
+        "user-assignments entry was not evicted by the rebind",
+    );
+
+    // ROLE_MEMBERS entry must likewise reflect the rebound ident.
+    let after_members =
+        PostgresBackend::list_role_assignments_for_role(role, ctx.v1_state.catalog.clone())
+            .await
+            .unwrap()
+            .expect("role still has a member list");
+    assert_eq!(
+        after_members.role_ident.source_id(),
+        &RoleSourceId::try_new("new-src").unwrap(),
+        "role-members entry served the stale ident after a source-system rebind",
+    );
+}

--- a/crates/lakekeeper/src/api/management/v1/role.rs
+++ b/crates/lakekeeper/src/api/management/v1/role.rs
@@ -821,9 +821,24 @@ async fn authorize_update_role_source_system<A: Authorizer, C: CatalogStore>(
     let mut t = C::Transaction::begin_write(catalog_state)
         .await
         .map_err::<UpdateRoleError, _>(|e| CatalogBackendError::new_unexpected(e.error).into())?;
+    // A source-system rebind changes the role's `RoleIdent` (provider_id/source_id),
+    // which is cached per row in every assignee's USER_ASSIGNMENTS closure
+    // (`AssignedRole.role_ident`) and in this role's ROLE_MEMBERS entry. External
+    // authorizers key on the ident, so without eviction those closures evaluate the
+    // stale binding until TTL. Mirror `authorized_delete_role`: read the affected-user
+    // closure pre-commit on the txn (so a failed read rolls the rebind back), evict
+    // post-commit. Unlike delete, the assignment/membership rows are updated (not
+    // cascade-deleted), so the set is identical pre- and post-commit. ROLE_CACHE is
+    // refreshed separately by the `role_updated` event the handler emits.
+    let affected_users = C::affected_users_for_membership_edges_impl(&[role_id], t.transaction())
+        .await
+        .map_err::<UpdateRoleError, _>(Into::into)?;
     let role = C::set_role_source_system(&project_id, role_id, &request, t.transaction()).await?;
     t.commit()
         .await
         .map_err::<UpdateRoleError, _>(|e| CatalogBackendError::new_unexpected(e.error).into())?;
+
+    role_assignments_cache::user_assignments_cache_invalidate_many(&affected_users).await;
+    role_assignments_cache::role_members_cache_invalidate(role_id).await;
     Ok(role)
 }


### PR DESCRIPTION
Re-pointing a role's source system (`PUT /role/{id}/source-system`) changes its `RoleIdent` (provider_id/source_id) but left the in-process caches untouched. That ident is cached per row in every assignee's USER_ASSIGNMENTS closure (`AssignedRole.role_ident`) and in the role's ROLE_MEMBERS entry. External authorizers (e.g. Cedar) key on the ident, so until those entries expired (up to the cache TTL) they evaluated the stale binding — a correctness/security gap on the rebind path.

The handler now mirrors `delete_role`: read the affected-user closure pre-commit on the rebind transaction (so a failed read rolls the rebind back), then evict the user-assignment closures and the role's member entry immediately after commit. Unlike delete, the rows are updated rather than cascade-deleted, so the affected set is identical pre- and post-commit. ROLE_CACHE is refreshed separately by the `role_updated` event the handler already emits.

Local-replica eviction only; cross-replica freshness stays bounded by TTL as before.

Adds `source_system_rebind_evicts_user_assignment_and_member_closures`, asserting both closures reflect the new ident (and return fresh `Arc`s) after a rebind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for cache invalidation when role source systems are updated.

* **Bug Fixes**
  * Fixed cache invalidation to ensure user assignments and role membership data are properly refreshed when a role's source system is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->