### PR TITLE
feat!: flat ({uuid}-only) layout is the new default storage layout

### DIFF
--- a/crates/lakekeeper/src/service/storage/az/mod.rs
+++ b/crates/lakekeeper/src/service/storage/az/mod.rs
@@ -1038,11 +1038,10 @@ pub(crate) mod test {
         let namespace_location = sp.default_namespace_location(&namespace_path).unwrap();
 
         let location = sp.default_tabular_location(&namespace_location, &tabular_name_context);
+        // Default layout is flat: no namespace directory under the base location.
         assert_eq!(
             location.to_string(),
-            format!(
-                "abfss://filesystem@account.dfs.core.windows.net/test_prefix/{namespace_uuid}/{tabular_uuid}"
-            )
+            format!("abfss://filesystem@account.dfs.core.windows.net/test_prefix/{tabular_uuid}")
         );
 
         let mut profile = profile.clone();
@@ -1054,7 +1053,7 @@ pub(crate) mod test {
         let location = sp.default_tabular_location(&namespace_location, &tabular_name_context);
         assert_eq!(
             location.to_string(),
-            format!("abfss://filesystem@account.blob.com/{namespace_uuid}/{tabular_uuid}")
+            format!("abfss://filesystem@account.blob.com/{tabular_uuid}")
         );
     }
 

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -1250,7 +1250,8 @@ mod tests {
             uuid: tabular_uuid,
         };
 
-        let target_location = format!("s3://my-bucket/subfolder/{ns_uuid}/{tabular_uuid}");
+        // Default layout is flat: no namespace directory under the base location.
+        let target_location = format!("s3://my-bucket/subfolder/{tabular_uuid}");
 
         let namespace_location = profile.default_namespace_location(&namespace_path).unwrap();
         let tabular_location =

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -1607,9 +1607,10 @@ pub(crate) mod test {
         let namespace_location = sp.default_namespace_location(&namespace_path).unwrap();
 
         let location = sp.default_tabular_location(&namespace_location, &tabular_name_context);
+        // Default layout is flat: no namespace directory under the base location.
         assert_eq!(
             location.to_string(),
-            format!("s3://test-bucket/test_prefix/{namespace_uuid}/{tabular_uuid}")
+            format!("s3://test-bucket/test_prefix/{tabular_uuid}")
         );
 
         let mut profile = profile.clone();
@@ -1620,7 +1621,7 @@ pub(crate) mod test {
         let location = sp.default_tabular_location(&namespace_location, &tabular_name_context);
         assert_eq!(
             location.to_string(),
-            format!("s3://test-bucket/{namespace_uuid}/{tabular_uuid}")
+            format!("s3://test-bucket/{tabular_uuid}")
         );
     }
 

--- a/crates/lakekeeper/src/service/storage/storage_layout.rs
+++ b/crates/lakekeeper/src/service/storage/storage_layout.rs
@@ -42,9 +42,6 @@ pub static DEFAULT_LAYOUT: LazyLock<StorageLayout> = LazyLock::new(StorageLayout
 pub static DEFAULT_TABULAR_TEMPLATE: LazyLock<StorageLayoutTabularTemplate> =
     LazyLock::new(StorageLayoutTabularTemplate::default);
 
-pub static DEFAULT_NAMESPACE_TEMPLATE: LazyLock<StorageLayoutNamespaceTemplate> =
-    LazyLock::new(StorageLayoutNamespaceTemplate::default);
-
 /// One directory per direct-parent namespace, one per tabular.
 ///
 /// For a tabular `my_tabular` (uuid `…002`) in namespace `my_ns` (uuid `…001`) the path is:
@@ -206,9 +203,14 @@ fn has_template_parameter(template: &str) -> bool {
 
 /// Controls how namespace and tabular paths are constructed under the warehouse base location.
 ///
-/// - `default` / omitted: one directory per direct-parent namespace, one per tabular, both with `"{uuid}"` segments.
+/// - `default` / omitted: flat — no namespace directories; all tabulars are placed directly under
+///   the base location with a fixed `"{uuid}"` segment. (Changed in 0.13; before 0.13 the default
+///   emitted a `"{uuid}"` directory for the direct-parent namespace. Existing namespaces created
+///   before 0.13 keep their persisted location, so only namespaces created on/after 0.13 use the
+///   flat default.)
 /// - `full-hierarchy`: one directory per namespace level, one per tabular.
-/// - `tabular-only`: no namespace directories; all tabulars are placed directly under the base location.
+/// - `tabular-only`: no namespace directories; all tabulars are placed directly under the base
+///   location, with a configurable tabular template (which must contain `{uuid}`).
 ///
 /// Segment templates may use `{uuid}` and `{name}` as placeholders.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default, derive_more::From)]
@@ -266,7 +268,9 @@ impl StorageLayout {
     #[must_use]
     pub fn render_namespace_path(&self, path_context: &NamespacePath) -> Vec<String> {
         match self {
-            StorageLayout::Flat(_) => vec![],
+            // Flat layouts — including the default since 0.13 — place tabulars
+            // directly under the base location, so no namespace directories are emitted.
+            StorageLayout::Flat(_) | StorageLayout::Default => vec![],
             StorageLayout::Parent(layout) => {
                 render_parent_namespace_path(path_context, &layout.namespace)
             }
@@ -274,9 +278,6 @@ impl StorageLayout {
                 .into_iter()
                 .map(|path| layout.namespace.render(path))
                 .collect(),
-            StorageLayout::Default => {
-                render_parent_namespace_path(path_context, &DEFAULT_NAMESPACE_TEMPLATE)
-            }
         }
     }
 }
@@ -550,8 +551,7 @@ mod tests {
     }
 
     #[test]
-    fn test_storage_layout_render_tabular_segment_in_default_layout_uses_parent_layout_with_uuid_only()
-     {
+    fn test_storage_layout_render_tabular_segment_in_default_layout_renders_uuid_only() {
         let layout = StorageLayout::Default;
         let context = TabularNameContext {
             name: "my_tabular".to_string(),
@@ -727,7 +727,10 @@ mod tests {
     }
 
     #[test]
-    fn test_storage_layout_render_namespace_segment_in_default_layout_should_render_only_parent() {
+    fn test_storage_layout_render_namespace_segment_in_default_layout_renders_no_namespace_directories()
+     {
+        // The default layout is flat: tabulars live directly under the base
+        // location, so no namespace path segments are emitted.
         let layout = StorageLayout::Default;
         let grand_parent_namespace = NamespaceNameContext {
             name: "grand_parent_namespace".to_string(),
@@ -742,10 +745,7 @@ mod tests {
             parent_namespace.clone(),
         ]);
 
-        assert_eq!(
-            *layout.render_namespace_path(&path),
-            vec![format!("{}", parent_namespace.uuid),]
-        );
+        assert!(layout.render_namespace_path(&path).is_empty());
     }
 
     #[test]
@@ -881,10 +881,8 @@ mod tests {
 
         let namespace_path_rendered = layout.render_namespace_path(&namespace_path);
 
-        assert_eq!(
-            namespace_path_rendered,
-            vec![format!("{}", parent_namespace.uuid),]
-        );
+        // Default is flat — no namespace directories.
+        assert!(namespace_path_rendered.is_empty());
 
         let tabular_name_rendered = layout.render_tabular_segment(&tabular);
         assert_eq!(tabular_name_rendered, format!("{}", tabular.uuid));

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -8734,9 +8734,14 @@ components:
       description: |-
         Controls how namespace and tabular paths are constructed under the warehouse base location.
 
-        - `default` / omitted: one directory per direct-parent namespace, one per tabular, both with `"{uuid}"` segments.
+        - `default` / omitted: flat — no namespace directories; all tabulars are placed directly under
+          the base location with a fixed `"{uuid}"` segment. (Changed in 0.13; before 0.13 the default
+          emitted a `"{uuid}"` directory for the direct-parent namespace. Existing namespaces created
+          before 0.13 keep their persisted location, so only namespaces created on/after 0.13 use the
+          flat default.)
         - `full-hierarchy`: one directory per namespace level, one per tabular.
-        - `tabular-only`: no namespace directories; all tabulars are placed directly under the base location.
+        - `tabular-only`: no namespace directories; all tabulars are placed directly under the base
+          location, with a configurable tabular template (which must contain `{uuid}`).
 
         Segment templates may use `{uuid}` and `{name}` as placeholders.
       example:

--- a/docs/docs/storage.md
+++ b/docs/docs/storage.md
@@ -42,7 +42,7 @@ The storage layout controls how namespace and tabular directories are structured
 
 | Type                       | JSON `"type"` value            | Description    |
 |----------------------------|--------------------------------|----------------|
-| Default                    | `"default"`                    | One directory for the direct parent namespace, one for the tabular, both with `{uuid}` templates. Used when `storage-layout` is omitted. |
+| Default                    | `"default"`                    | Flat: no namespace directories; all tabulars are placed directly under the base location with a `{uuid}` segment. Used when `storage-layout` is omitted. **Changed in 0.13** — see [Default](#default). |
 | Full hierarchy             | `"full-hierarchy"`             | One directory per namespace level in the full ancestry, one for the tabular. |
 | Tabular-only (flat)          | `"tabular-only"`                 | No namespace directories; all tabulars are placed directly under the base location. |
 
@@ -51,18 +51,18 @@ The storage layout controls how namespace and tabular directories are structured
 
 ### Default
 
-The default layout emits one directory for the **direct parent namespace** and one for the tabular. Ancestor namespaces beyond the immediate parent are not reflected in the path.
+The default layout is **flat**: tabulars are placed directly under the warehouse base location with no namespace directories, using a `{uuid}` segment.
 
-For a tabular `orders` in namespace `europe` / `production` the path is:
+For a tabular `orders` in any namespace the path is:
 
 ```text
-<base>/<production-namespace>/<orders-tabular>
+<base>/<orders-tabular>
 ```
 
-With the default `{uuid}`-only templates this looks like:
+With the default `{uuid}` template this looks like:
 
 ```text
-s3://my-bucket/warehouse/<uuid-of-production-namespace>/<uuid-of-tabular>/
+s3://my-bucket/warehouse/<uuid-of-tabular>/
 ```
 
 To use the default layout explicitly:
@@ -77,6 +77,17 @@ To use the default layout explicitly:
   }
 }
 ```
+
+!!! warning "The default layout changed in 0.13"
+    Before 0.13, the default layout emitted a directory for the **direct parent namespace** (`<base>/<parent-namespace-uuid>/<tabular-uuid>`). As of 0.13 the default is flat (`<base>/<tabular-uuid>`).
+
+    The change is **not retroactive** — storage paths are assigned once, at creation time, and are never recomputed:
+
+    - **Existing tabulars** keep their current locations.
+    - **Existing namespaces** keep their persisted `location` property, so new tabulars created in them remain nested under the old `<parent-namespace-uuid>/` directory (see [Namespace Location Property](#namespace-location-property)).
+    - Only **namespaces created on or after 0.13** use the flat default.
+
+    A warehouse spanning the upgrade can therefore hold a mix of nested (pre-0.13 namespaces) and flat (new namespaces) tabular paths. If you want namespace directories in new tabular paths, set `storage-layout` to [`full-hierarchy`](#full-hierarchy) — note that this nests *every* ancestor level, whereas the pre-0.13 default nested only the direct parent.
 
 ### Full Hierarchy
 
@@ -731,6 +742,8 @@ Use `regional` when data residency requires the request to stay within a specifi
 
 !!! warning "Only the `default` storage layout is supported"
     The OneLake profile currently rejects `tabular-only` and `full-hierarchy` storage layouts at warehouse-creation time. These layouts can embed namespace and table **names** into the storage path via `{name}` templates, and Lakekeeper URL-percent-encodes those segments — but OneLake silently decodes `%XX` sequences server-side (see the percent-encoding warning above), so two distinct names whose encoded form differs only by a `%XX` would land at the same blob and overwrite each other. Until we land a layout that side-steps this encoding mismatch, only the default `{uuid}`-only layout is supported. Set `storage-layout` to `{"type": "default"}` or omit it.
+
+    Since 0.13 the default layout is **flat** — it has no `{name}` segments to percent-decode, so it is OneLake-safe. OneLake warehouses therefore place new tabulars directly under the base location (`<base>/<tabular-uuid>`); see [Default](#default), including the note on how this affects namespaces created before 0.13.
 
 ### Credentials
 

--- a/tests/python/tests/test_spark.py
+++ b/tests/python/tests/test_spark.py
@@ -752,7 +752,8 @@ def test_drop_with_shared_prefix(spark, namespace, warehouse: conftest.Warehouse
     # the shared (session-scoped) warehouse root — a constant segment would
     # collide across namespaces.
     custom_location = (
-        default_location.rsplit("/", 1)[0] + f"/{namespace.name[-1]}-custom-location"
+        default_location.rstrip("/").rsplit("/", 1)[0]
+        + f"/{namespace.name[-1]}-custom-location"
     )
 
     # Create a table with a custom location
@@ -803,7 +804,8 @@ def test_custom_location(spark, namespace, warehouse: conftest.Warehouse):
     # the shared (session-scoped) warehouse root — a constant segment would
     # collide across namespaces.
     custom_location = (
-        default_location.rsplit("/", 1)[0] + f"/{namespace.name[-1]}-custom-location"
+        default_location.rstrip("/").rsplit("/", 1)[0]
+        + f"/{namespace.name[-1]}-custom-location"
     )
 
     # Create a table with a custom location
@@ -843,7 +845,8 @@ def test_cannot_create_table_at_same_location(
     # the shared (session-scoped) warehouse root — a constant segment would
     # collide across namespaces.
     custom_location = (
-        default_location.rsplit("/", 1)[0] + f"/{namespace.name[-1]}-custom-location"
+        default_location.rstrip("/").rsplit("/", 1)[0]
+        + f"/{namespace.name[-1]}-custom-location"
     )
 
     # Create a table with a custom location
@@ -892,7 +895,8 @@ def test_cannot_create_table_at_sub_location(
     # the shared (session-scoped) warehouse root — a constant segment would
     # collide across namespaces.
     custom_location = (
-        default_location.rsplit("/", 1)[0] + f"/{namespace.name[-1]}-custom-location"
+        default_location.rstrip("/").rsplit("/", 1)[0]
+        + f"/{namespace.name[-1]}-custom-location"
     )
 
     # Create a table with a custom location

--- a/tests/python/tests/test_spark.py
+++ b/tests/python/tests/test_spark.py
@@ -747,8 +747,13 @@ def test_drop_with_shared_prefix(spark, namespace, warehouse: conftest.Warehouse
         (*namespace.name, str(table_id))
     ).location()
 
-    # Replace element behind the last slash with "custom_location"
-    custom_location = default_location.rsplit("/", 1)[0] + "/custom_location"
+    # Sibling of the default table location, kept unique per test namespace.
+    # The default layout is flat (no per-namespace directory), so the parent is
+    # the shared (session-scoped) warehouse root — a constant segment would
+    # collide across namespaces.
+    custom_location = (
+        default_location.rsplit("/", 1)[0] + f"/{namespace.name[-1]}-custom-location"
+    )
 
     # Create a table with a custom location
     first_table_id = str(uuid.uuid4()).replace("-", "_")
@@ -793,8 +798,13 @@ def test_custom_location(spark, namespace, warehouse: conftest.Warehouse):
         (*namespace.name, "my_table")
     ).location()
 
-    # Replace element behind the last slash with "custom_location"
-    custom_location = default_location.rsplit("/", 1)[0] + "/custom_location"
+    # Sibling of the default table location, kept unique per test namespace.
+    # The default layout is flat (no per-namespace directory), so the parent is
+    # the shared (session-scoped) warehouse root — a constant segment would
+    # collide across namespaces.
+    custom_location = (
+        default_location.rsplit("/", 1)[0] + f"/{namespace.name[-1]}-custom-location"
+    )
 
     # Create a table with a custom location
     spark.sql(
@@ -828,8 +838,13 @@ def test_cannot_create_table_at_same_location(
         (*namespace.name, "my_table")
     ).location()
 
-    # Replace element behind the last slash with "custom_location"
-    custom_location = default_location.rsplit("/", 1)[0] + "/custom_location"
+    # Sibling of the default table location, kept unique per test namespace.
+    # The default layout is flat (no per-namespace directory), so the parent is
+    # the shared (session-scoped) warehouse root — a constant segment would
+    # collide across namespaces.
+    custom_location = (
+        default_location.rsplit("/", 1)[0] + f"/{namespace.name[-1]}-custom-location"
+    )
 
     # Create a table with a custom location
     spark.sql(
@@ -872,8 +887,13 @@ def test_cannot_create_table_at_sub_location(
         (*namespace.name, "my_table")
     ).location()
 
-    # Replace element behind the last slash with "custom_location"
-    custom_location = default_location.rsplit("/", 1)[0] + "/custom_location"
+    # Sibling of the default table location, kept unique per test namespace.
+    # The default layout is flat (no per-namespace directory), so the parent is
+    # the shared (session-scoped) warehouse root — a constant segment would
+    # collide across namespaces.
+    custom_location = (
+        default_location.rsplit("/", 1)[0] + f"/{namespace.name[-1]}-custom-location"
+    )
 
     # Create a table with a custom location
     spark.sql(


### PR DESCRIPTION
The `default` storage layout now places tabulars directly under the warehouse base location (`<base>/<tabular-uuid>`) instead of nesting them under the direct-parent namespace (`<base>/<parent-ns-uuid>/<tabular-uuid>`).

Storage paths are assigned once at creation time and never recomputed, so the change is not retroactive: existing tabulars and existing namespaces keep their persisted locations. Only namespaces created on/after 0.13 use the flat default, so a warehouse spanning the upgrade can hold a mix of nested and flat tabular paths.

OneLake (which only permits the `default` layout) inherits the flat layout; it is {uuid}-only, so the percent-decode aliasing the OneLake guard protects against cannot occur.

BREAKING CHANGE: the default storage layout for newly created namespaces changed from <base>/<parent-namespace-uuid>/<tabular-uuid> to <base>/<tabular-uuid>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Change**
  * Default storage layout is now **flat** starting in **0.13**. New namespaces use paths of the form `<base>/<tabular-uuid>` without namespace-UUID directories; existing namespace locations remain unchanged.

* **Documentation**
  * Updated API schema and storage layout docs to clearly describe **default vs tabular-only vs full-hierarchy**, including migration and OneLake-safe behavior notes.

* **Tests**
  * Adjusted storage and Spark SQL location expectations to match the new flat default layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->