### PR TITLE
feat(ui): bump console to v0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,8 +3844,8 @@ dependencies = [
 
 [[package]]
 name = "lakekeeper-console"
-version = "0.14.3"
-source = "git+https://github.com/lakekeeper/console?rev=v0.14.3#72e80084a8f1f1d79bd57ee8d5905d15e7268187"
+version = "0.15.1"
+source = "git+https://github.com/lakekeeper/console?rev=v0.15.1#b559f3f9d80153ecc25f5481600a8d7e056deae1"
 dependencies = [
  "flate2",
  "fs_extra",

--- a/crates/lakekeeper-bin/Cargo.toml
+++ b/crates/lakekeeper-bin/Cargo.toml
@@ -33,7 +33,7 @@ figment = { workspace = true }
 http = { workspace = true }
 lakekeeper = { path = "../lakekeeper", features = ["s3-signer", "router"] }
 lakekeeper-authz-openfga = { path = "../authz-openfga" }
-lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.14.3", optional = true }
+lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.15.1", optional = true }
 lakekeeper-events-kafka = { path = "../lakekeeper-events-kafka" }
 lakekeeper-events-nats = { path = "../lakekeeper-events-nats" }
 lakekeeper-secrets-kv2 = { path = "../lakekeeper-secrets-kv2" }


### PR DESCRIPTION
Pulls in console-components v0.7.0 → v0.9.0:

- OneLake / Microsoft Fabric storage backend in warehouse create (client-credentials + system-identity auth, workspace/lakehouse IDs, private-endpoint / authority-host options)
- Generic tables (Lance/Delta/Vortex) unified with Iceberg under one Tables tab — navigation, list, detail page, search, and permissions
- Iceberg format-version policy editor; "Change Deletion" renamed to "Catalog Settings" (deletion profile + format policy in one update)
- Per-queue maintenance summary in TaskManager (last/next run, run-now / reschedule / cancel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the console dependency to a newer version, bringing the latest improvements and fixes to console functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->