### PR TITLE
feat(authz): carry force/purge/recursive context on delete actions

### DIFF
--- a/crates/authz-openfga/src/relations.rs
+++ b/crates/authz-openfga/src/relations.rs
@@ -1309,7 +1309,7 @@ impl ReducedRelation for CatalogNamespaceAction {
             CatalogNamespaceAction::CreateTable { .. } => NamespaceRelation::CanCreateTable,
             CatalogNamespaceAction::CreateView { .. } => NamespaceRelation::CanCreateView,
             CatalogNamespaceAction::CreateNamespace { .. } => NamespaceRelation::CanCreateNamespace,
-            CatalogNamespaceAction::Delete => NamespaceRelation::CanDelete,
+            CatalogNamespaceAction::Delete { .. } => NamespaceRelation::CanDelete,
             CatalogNamespaceAction::UpdateProperties { .. } => {
                 NamespaceRelation::CanUpdateProperties
             }
@@ -1578,7 +1578,7 @@ impl ReducedRelation for CatalogTableAction {
 
     fn to_openfga(&self) -> Self::OpenFgaRelation {
         match self {
-            CatalogTableAction::Drop => TableRelation::CanDrop,
+            CatalogTableAction::Drop { .. } => TableRelation::CanDrop,
             CatalogTableAction::WriteData => TableRelation::CanWriteData,
             CatalogTableAction::ReadData => TableRelation::CanReadData,
             CatalogTableAction::GetMetadata => TableRelation::CanGetMetadata,
@@ -1840,7 +1840,7 @@ impl ReducedRelation for CatalogViewAction {
 
     fn to_openfga(&self) -> Self::OpenFgaRelation {
         match self {
-            CatalogViewAction::Drop => ViewRelation::CanDrop,
+            CatalogViewAction::Drop { .. } => ViewRelation::CanDrop,
             CatalogViewAction::Commit { .. } => ViewRelation::CanCommit,
             CatalogViewAction::GetMetadata => ViewRelation::CanGetMetadata,
             CatalogViewAction::Select => ViewRelation::CanSelect,

--- a/crates/lakekeeper-integration-tests/tests/service_authz_table.rs
+++ b/crates/lakekeeper-integration-tests/tests/service_authz_table.rs
@@ -322,7 +322,13 @@ async fn test_are_allowed_tabular_actions_vec_mixed_order(pool: PgPool) {
         "table:{}/{}",
         warehouse_resp.warehouse_id, table2_info.tabular_id
     ));
-    authz.block_action(&format!("view:{:?}", CatalogViewAction::Drop));
+    authz.block_action(&format!(
+        "view:{:?}",
+        CatalogViewAction::Drop {
+            force: false,
+            purge: false,
+        }
+    ));
 
     let warehouse = PostgresBackend::get_active_warehouse_by_id(
         warehouse_resp.warehouse_id,
@@ -360,7 +366,10 @@ async fn test_are_allowed_tabular_actions_vec_mixed_order(pool: PgPool) {
             &ns_hierarchy.namespace,
             ActionOnTableOrView::View(ActionOnView {
                 info: &view1_info,
-                action: CatalogViewAction::Drop,
+                action: CatalogViewAction::Drop {
+                    force: false,
+                    purge: false,
+                },
                 user: None,
                 is_delegated_execution: false,
             }), // Blocked

--- a/crates/lakekeeper/src/api/management/v1/lakekeeper_actions.rs
+++ b/crates/lakekeeper/src/api/management/v1/lakekeeper_actions.rs
@@ -20,12 +20,14 @@ use crate::{
             AuthZProjectActionForbidden, AuthZProjectOps, AuthZRoleOps, AuthZServerOps,
             AuthZTableOps, AuthZUserActionForbidden, AuthZUserOps, AuthZViewOps, Authorizer,
             AuthzNamespaceOps, AuthzWarehouseOps, CatalogGenericTableAction,
-            CatalogNamespaceAction, CatalogProjectAction, CatalogRoleAction, CatalogServerAction,
-            CatalogTableAction, CatalogUserAction, CatalogViewAction, CatalogWarehouseAction,
-            RequireProjectActionError, RequireRoleActionError, RoleAssignee, UserOrRole,
-            UserOrRoleId, fetch_warehouse_namespace_generic_table_by_id,
-            fetch_warehouse_namespace_table_by_id, fetch_warehouse_namespace_view_by_id,
-            refresh_warehouse_and_namespace_if_needed,
+            CatalogNamespaceAction, CatalogNamespaceActionKind, CatalogProjectAction,
+            CatalogProjectActionKind, CatalogRoleAction, CatalogRoleActionKind,
+            CatalogServerAction, CatalogServerActionKind, CatalogTableAction,
+            CatalogTableActionKind, CatalogUserAction, CatalogViewAction, CatalogViewActionKind,
+            CatalogWarehouseAction, CatalogWarehouseActionKind, RequireProjectActionError,
+            RequireRoleActionError, RoleAssignee, UserOrRole, UserOrRoleId,
+            fetch_warehouse_namespace_generic_table_by_id, fetch_warehouse_namespace_table_by_id,
+            fetch_warehouse_namespace_view_by_id, refresh_warehouse_and_namespace_if_needed,
         },
         events::{
             APIEventContext,
@@ -113,20 +115,25 @@ fn set_for_user<P: UserProvidedEntity, R: ResolutionState, A: APIEventActions>(
     }
 }
 
-// Generate response structs for all action types
-action_response!(GetLakekeeperRoleActionsResponse, CatalogRoleAction);
-action_response!(GetLakekeeperServerActionsResponse, CatalogServerAction);
-action_response!(GetLakekeeperProjectActionsResponse, CatalogProjectAction);
+// Generate response structs for all action types. Permission-introspection
+// responses carry the fieldless `*Kind` form (no per-operation context); User and
+// GenericTable actions are already fieldless and used directly.
+action_response!(GetLakekeeperRoleActionsResponse, CatalogRoleActionKind);
+action_response!(GetLakekeeperServerActionsResponse, CatalogServerActionKind);
+action_response!(
+    GetLakekeeperProjectActionsResponse,
+    CatalogProjectActionKind
+);
 action_response!(
     GetLakekeeperWarehouseActionsResponse,
-    CatalogWarehouseAction
+    CatalogWarehouseActionKind
 );
 action_response!(
     GetLakekeeperNamespaceActionsResponse,
-    CatalogNamespaceAction
+    CatalogNamespaceActionKind
 );
-action_response!(GetLakekeeperTableActionsResponse, CatalogTableAction);
-action_response!(GetLakekeeperViewActionsResponse, CatalogViewAction);
+action_response!(GetLakekeeperTableActionsResponse, CatalogTableActionKind);
+action_response!(GetLakekeeperViewActionsResponse, CatalogViewActionKind);
 action_response!(
     GetLakekeeperGenericTableActionsResponse,
     CatalogGenericTableAction
@@ -162,7 +169,7 @@ pub(super) async fn get_allowed_server_actions<C: CatalogStore, A: Authorizer, S
     state: ApiContext<State<A, C, S>>,
     request_metadata: RequestMetadata,
     query: GetAccessQuery,
-) -> Result<Vec<CatalogServerAction>, ErrorModel> {
+) -> Result<Vec<CatalogServerActionKind>, ErrorModel> {
     let for_user_api = query.try_parse()?.principal;
     let actions = CatalogServerAction::variants();
 
@@ -193,11 +200,13 @@ pub(super) async fn get_allowed_server_actions<C: CatalogStore, A: Authorizer, S
     let allowed_actions = results
         .iter()
         .zip(actions)
-        .filter_map(
-            |(allowed, action)| {
-                if *allowed { Some(action.clone()) } else { None }
-            },
-        )
+        .filter_map(|(allowed, action)| {
+            if *allowed {
+                Some(CatalogServerActionKind::from(action))
+            } else {
+                None
+            }
+        })
         .collect();
 
     Ok(allowed_actions)
@@ -284,7 +293,7 @@ pub(super) async fn get_allowed_role_actions<A: Authorizer, C: CatalogStore, S: 
     request_metadata: RequestMetadata,
     query: GetAccessQuery,
     role_id: RoleId,
-) -> Result<Vec<CatalogRoleAction>> {
+) -> Result<Vec<CatalogRoleActionKind>> {
     let authorizer = context.v1_state.authz;
     let for_user_api = query.try_parse()?.principal;
     let project_id = request_metadata.require_project_id(None)?;
@@ -308,7 +317,7 @@ pub(super) async fn get_allowed_role_actions<A: Authorizer, C: CatalogStore, S: 
     .await;
     let (_event_ctx, allowed_actions) = event_ctx.emit_authz(authz_result)?;
 
-    Ok(allowed_actions)
+    Ok(allowed_actions.iter().map(Into::into).collect())
 }
 
 async fn authorize_get_role_actions<C: CatalogStore>(
@@ -380,7 +389,7 @@ pub(super) async fn get_allowed_project_actions<C: CatalogStore, A: Authorizer, 
     request_metadata: RequestMetadata,
     query: GetAccessQuery,
     object: &ArcProjectId,
-) -> Result<Vec<CatalogProjectAction>> {
+) -> Result<Vec<CatalogProjectActionKind>> {
     let for_user_api = query.try_parse()?.principal;
 
     let mut event_ctx = APIEventContext::for_project_arc(
@@ -401,7 +410,7 @@ pub(super) async fn get_allowed_project_actions<C: CatalogStore, A: Authorizer, 
     .await;
     let (_event_ctx, allowed_actions) = event_ctx.emit_authz(authz_result)?;
 
-    Ok(allowed_actions)
+    Ok(allowed_actions.iter().map(Into::into).collect())
 }
 
 async fn authorize_get_project_actions<C: CatalogStore>(
@@ -461,7 +470,7 @@ pub(super) async fn get_allowed_warehouse_actions<
     request_metadata: RequestMetadata,
     query: GetAccessQuery,
     object: WarehouseId,
-) -> Result<Vec<CatalogWarehouseAction>> {
+) -> Result<Vec<CatalogWarehouseActionKind>> {
     let for_user_api = query.try_parse()?.principal;
 
     let mut event_ctx = APIEventContext::for_warehouse(
@@ -482,7 +491,7 @@ pub(super) async fn get_allowed_warehouse_actions<
     .await;
     let (_event_ctx, allowed_actions) = event_ctx.emit_authz(authz_result)?;
 
-    Ok(allowed_actions)
+    Ok(allowed_actions.iter().map(Into::into).collect())
 }
 
 async fn authorize_get_warehouse_actions<C: CatalogStore>(
@@ -550,7 +559,7 @@ pub(super) async fn get_allowed_namespace_actions<
     query: GetAccessQuery,
     warehouse_id: WarehouseId,
     provided_namespace_id: NamespaceId,
-) -> Result<Vec<CatalogNamespaceAction>> {
+) -> Result<Vec<CatalogNamespaceActionKind>> {
     let for_user_api = query.try_parse()?.principal;
 
     let mut event_ctx = APIEventContext::for_namespace(
@@ -573,7 +582,7 @@ pub(super) async fn get_allowed_namespace_actions<
     .await;
     let (_event_ctx, allowed_actions) = event_ctx.emit_authz(authz_result)?;
 
-    Ok(allowed_actions)
+    Ok(allowed_actions.iter().map(Into::into).collect())
 }
 
 async fn authorize_get_namespace_actions<C: CatalogStore>(
@@ -650,7 +659,7 @@ pub(super) async fn get_allowed_table_actions<A: Authorizer, C: CatalogStore, S:
     query: GetAccessQuery,
     warehouse_id: WarehouseId,
     table_id: TableId,
-) -> Result<Vec<CatalogTableAction>> {
+) -> Result<Vec<CatalogTableActionKind>> {
     let for_user_api = query.try_parse()?.principal;
 
     let mut event_ctx = APIEventContext::for_table(
@@ -673,7 +682,7 @@ pub(super) async fn get_allowed_table_actions<A: Authorizer, C: CatalogStore, S:
     .await;
     let (_event_ctx, allowed_actions) = event_ctx.emit_authz(authz_result)?;
 
-    Ok(allowed_actions)
+    Ok(allowed_actions.iter().map(Into::into).collect())
 }
 
 async fn authorize_get_table_actions<C: CatalogStore>(
@@ -766,7 +775,7 @@ pub(super) async fn get_allowed_view_actions<A: Authorizer, C: CatalogStore, S: 
     query: GetAccessQuery,
     warehouse_id: WarehouseId,
     view_id: ViewId,
-) -> Result<Vec<CatalogViewAction>> {
+) -> Result<Vec<CatalogViewActionKind>> {
     let for_user_api = query.try_parse()?.principal;
 
     let mut event_ctx = APIEventContext::for_view(
@@ -789,7 +798,7 @@ pub(super) async fn get_allowed_view_actions<A: Authorizer, C: CatalogStore, S: 
     .await;
     let (_event_ctx, allowed_actions) = event_ctx.emit_authz(authz_result)?;
 
-    Ok(allowed_actions)
+    Ok(allowed_actions.iter().map(Into::into).collect())
 }
 
 async fn authorize_get_view_actions<C: CatalogStore>(

--- a/crates/lakekeeper/src/server/namespace.rs
+++ b/crates/lakekeeper/src/server/namespace.rs
@@ -508,7 +508,11 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             state.v1_state.events,
             warehouse_id,
             parameters.namespace.clone(),
-            CatalogNamespaceAction::Delete,
+            CatalogNamespaceAction::Delete {
+                force: flags.force,
+                purge: flags.purge,
+                recursive: flags.recursive,
+            },
         );
 
         let authz_result = authorizer

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -403,7 +403,10 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
                     event_ctx.dispatcher().clone(),
                     warehouse_id,
                     table_ident.clone(),
-                    CatalogTableAction::Drop,
+                    CatalogTableAction::Drop {
+                        force: false,
+                        purge: false,
+                    },
                 );
                 drop_tbl_event_ctx.push_extra_context("invoked-by", "register_table_overwrite");
 
@@ -746,7 +749,10 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             state.v1_state.events,
             warehouse_id,
             table.clone(),
-            CatalogTableAction::Drop,
+            CatalogTableAction::Drop {
+                force,
+                purge: purge_requested,
+            },
         );
 
         let authz_result = authorizer

--- a/crates/lakekeeper/src/server/views/drop.rs
+++ b/crates/lakekeeper/src/server/views/drop.rs
@@ -60,7 +60,10 @@ pub async fn drop_view<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
         state.v1_state.events,
         warehouse_id,
         view.clone(),
-        CatalogViewAction::Drop,
+        CatalogViewAction::Drop {
+            force,
+            purge: purge_requested,
+        },
     );
 
     let authz_context = authorizer

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -77,6 +77,12 @@ where
     Ok(Arc::new(string_map))
 }
 
+/// `serde` `skip_serializing_if` helper for `bool` fields that default to `false`.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Assignees to a role
 pub struct RoleAssignee(ArcRole);
@@ -792,7 +798,20 @@ pub enum CatalogNamespaceAction {
         #[serde(deserialize_with = "deserialize_string_map")]
         properties: Arc<BTreeMap<String, String>>,
     },
-    Delete,
+    Delete {
+        /// Whether the warehouse-configured soft-deletion is bypassed, i.e.
+        /// contained tabulars are hard-deleted immediately instead of being
+        /// recoverable for the configured grace period.
+        #[serde(default, skip_serializing_if = "is_false")]
+        force: bool,
+        /// Whether the underlying data/metadata files are physically purged.
+        #[serde(default, skip_serializing_if = "is_false")]
+        purge: bool,
+        /// Whether the drop recurses into child namespaces, tables and views,
+        /// deleting the entire subtree rooted at this namespace.
+        #[serde(default, skip_serializing_if = "is_false")]
+        recursive: bool,
+    },
     UpdateProperties {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         removed_properties: Arc<Vec<String>>,
@@ -844,7 +863,11 @@ static NAMESPACE_ACTION_VARIANTS: LazyLock<[CatalogNamespaceAction; 14]> = LazyL
             name: None,
             properties: Arc::new(BTreeMap::new()),
         },
-        CatalogNamespaceAction::Delete,
+        CatalogNamespaceAction::Delete {
+            force: false,
+            purge: false,
+            recursive: false,
+        },
         CatalogNamespaceAction::UpdateProperties {
             removed_properties: Arc::new(Vec::new()),
             updated_properties: Arc::new(BTreeMap::new()),
@@ -933,6 +956,21 @@ impl CatalogAction for CatalogNamespaceAction {
                     b = b.context_list("removed-properties", removed_properties.as_ref().clone());
                 }
             }
+            Self::Delete {
+                force,
+                purge,
+                recursive,
+            } => {
+                if *force {
+                    b = b.context_string("force", "true");
+                }
+                if *purge {
+                    b = b.context_string("purge", "true");
+                }
+                if *recursive {
+                    b = b.context_string("recursive", "true");
+                }
+            }
             _ => {}
         }
         b.build()
@@ -955,7 +993,16 @@ impl CatalogAction for CatalogNamespaceAction {
 #[serde(rename_all = "snake_case", tag = "action")]
 #[strum(serialize_all = "snake_case")]
 pub enum CatalogTableAction {
-    Drop,
+    Drop {
+        /// Whether the warehouse-configured soft-deletion is bypassed, i.e. the
+        /// table is hard-deleted immediately instead of being recoverable for the
+        /// configured grace period. Extra destructive — irreversible right away.
+        #[serde(default, skip_serializing_if = "is_false")]
+        force: bool,
+        /// Whether the underlying data files are physically purged from storage.
+        #[serde(default, skip_serializing_if = "is_false")]
+        purge: bool,
+    },
     WriteData,
     ReadData,
     GetMetadata,
@@ -975,7 +1022,10 @@ pub enum CatalogTableAction {
 }
 static TABLE_ACTION_VARIANTS: LazyLock<[CatalogTableAction; 11]> = LazyLock::new(|| {
     [
-        CatalogTableAction::Drop,
+        CatalogTableAction::Drop {
+            force: false,
+            purge: false,
+        },
         CatalogTableAction::WriteData,
         CatalogTableAction::ReadData,
         CatalogTableAction::GetMetadata,
@@ -1000,17 +1050,27 @@ impl CatalogTableAction {
 impl CatalogAction for CatalogTableAction {
     fn action_descriptor(&self) -> ActionDescriptor {
         let mut b = ActionDescriptor::builder().action_name(self.into());
-        if let Self::Commit {
-            updated_properties,
-            removed_properties,
-        } = self
-        {
-            if !updated_properties.is_empty() {
-                b = b.context_map("updated-properties", updated_properties.as_ref().clone());
+        match self {
+            Self::Commit {
+                updated_properties,
+                removed_properties,
+            } => {
+                if !updated_properties.is_empty() {
+                    b = b.context_map("updated-properties", updated_properties.as_ref().clone());
+                }
+                if !removed_properties.is_empty() {
+                    b = b.context_list("removed-properties", removed_properties.as_ref().clone());
+                }
             }
-            if !removed_properties.is_empty() {
-                b = b.context_list("removed-properties", removed_properties.as_ref().clone());
+            Self::Drop { force, purge } => {
+                if *force {
+                    b = b.context_string("force", "true");
+                }
+                if *purge {
+                    b = b.context_string("purge", "true");
+                }
             }
+            _ => {}
         }
         b.build()
     }
@@ -1032,7 +1092,16 @@ impl CatalogAction for CatalogTableAction {
 #[serde(rename_all = "snake_case", tag = "action")]
 #[strum(serialize_all = "snake_case")]
 pub enum CatalogViewAction {
-    Drop,
+    Drop {
+        /// Whether the warehouse-configured soft-deletion is bypassed, i.e. the
+        /// view is hard-deleted immediately instead of being recoverable for the
+        /// configured grace period. Extra destructive — irreversible right away.
+        #[serde(default, skip_serializing_if = "is_false")]
+        force: bool,
+        /// Whether the underlying metadata files are physically purged from storage.
+        #[serde(default, skip_serializing_if = "is_false")]
+        purge: bool,
+    },
     GetMetadata,
     Select,
     Commit {
@@ -1051,7 +1120,10 @@ pub enum CatalogViewAction {
 }
 static VIEW_ACTION_VARIANTS: LazyLock<[CatalogViewAction; 10]> = LazyLock::new(|| {
     [
-        CatalogViewAction::Drop,
+        CatalogViewAction::Drop {
+            force: false,
+            purge: false,
+        },
         CatalogViewAction::GetMetadata,
         CatalogViewAction::Select,
         CatalogViewAction::Commit {
@@ -1075,17 +1147,27 @@ impl CatalogViewAction {
 impl CatalogAction for CatalogViewAction {
     fn action_descriptor(&self) -> ActionDescriptor {
         let mut b = ActionDescriptor::builder().action_name(self.into());
-        if let Self::Commit {
-            updated_properties,
-            removed_properties,
-        } = self
-        {
-            if !updated_properties.is_empty() {
-                b = b.context_map("updated-properties", updated_properties.as_ref().clone());
+        match self {
+            Self::Commit {
+                updated_properties,
+                removed_properties,
+            } => {
+                if !updated_properties.is_empty() {
+                    b = b.context_map("updated-properties", updated_properties.as_ref().clone());
+                }
+                if !removed_properties.is_empty() {
+                    b = b.context_list("removed-properties", removed_properties.as_ref().clone());
+                }
             }
-            if !removed_properties.is_empty() {
-                b = b.context_list("removed-properties", removed_properties.as_ref().clone());
+            Self::Drop { force, purge } => {
+                if *force {
+                    b = b.context_string("force", "true");
+                }
+                if *purge {
+                    b = b.context_string("purge", "true");
+                }
             }
+            _ => {}
         }
         b.build()
     }
@@ -1657,7 +1739,11 @@ pub mod tests {
                 serde_json::json!({"action": "list_everything"}),
             ),
             (
-                CatalogNamespaceAction::Delete,
+                CatalogNamespaceAction::Delete {
+                    force: false,
+                    purge: false,
+                    recursive: false,
+                },
                 serde_json::json!({"action": "delete"}),
             ),
             (
@@ -1841,7 +1927,10 @@ pub mod tests {
     fn test_catalog_view_action_serde_no_properties() {
         for (action, expected) in [
             (
-                CatalogViewAction::Drop,
+                CatalogViewAction::Drop {
+                    force: false,
+                    purge: false,
+                },
                 serde_json::json!({"action": "drop"}),
             ),
             (
@@ -1899,7 +1988,10 @@ pub mod tests {
     fn test_catalog_table_action_serde_no_properties() {
         for (action, expected) in [
             (
-                CatalogTableAction::Drop,
+                CatalogTableAction::Drop {
+                    force: false,
+                    purge: false,
+                },
                 serde_json::json!({"action": "drop"}),
             ),
             (
@@ -2627,7 +2719,10 @@ pub mod tests {
     );
     test_block_action!(
         table,
-        CatalogTableAction::Drop,
+        CatalogTableAction::Drop {
+            force: false,
+            purge: false,
+        },
         &ResolvedWarehouse::new_with_id(Uuid::nil().into()),
         &NamespaceHierarchy {
             namespace: NamespaceWithParent {
@@ -2650,7 +2745,10 @@ pub mod tests {
     );
     test_block_action!(
         view,
-        CatalogViewAction::Drop,
+        CatalogViewAction::Drop {
+            force: false,
+            purge: false,
+        },
         &ResolvedWarehouse::new_with_id(Uuid::nil().into()),
         &NamespaceHierarchy {
             namespace: NamespaceWithParent {
@@ -2810,7 +2908,16 @@ pub mod tests {
         // Drop (control-plane) — also block it, and verify instance admin STILL
         // bypasses it. This confirms that the bypass applies selectively within
         // a single batch.
-        authz.block_action(format!("table:{:?}", CatalogTableAction::Drop).as_str());
+        authz.block_action(
+            format!(
+                "table:{:?}",
+                CatalogTableAction::Drop {
+                    force: false,
+                    purge: false,
+                }
+            )
+            .as_str(),
+        );
         let allowed = authz
             .is_allowed_table_action(
                 &md,
@@ -2818,7 +2925,10 @@ pub mod tests {
                 &warehouse,
                 &hierarchy,
                 &table_info,
-                CatalogTableAction::Drop,
+                CatalogTableAction::Drop {
+                    force: false,
+                    purge: false,
+                },
             )
             .await
             .unwrap()

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -1227,6 +1227,277 @@ impl CatalogAction for CatalogGenericTableAction {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Fieldless "action kind" enums.
+//
+// The `Catalog*Action` enums above carry per-operation context (e.g. `Drop {
+// force, purge }`, `Commit { .. }`, `CreateTable { .. }`) used by authorization
+// checks and the `/check` request body. That context has no place in the
+// permission-introspection RESPONSE (`GET …/actions`), which only answers *which
+// kinds of action* a principal may perform. These stateless companions are what
+// those responses serialize — `{"action":"drop"}` and nothing more.
+//
+// Only resources whose actions carry context need a companion; `CatalogUserAction`
+// and `CatalogGenericTableAction` are already fieldless and are used directly.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "open-api", schema(as=LakekeeperServerActionKind))]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum CatalogServerActionKind {
+    CreateProject,
+    UpdateUsers,
+    DeleteUsers,
+    ListUsers,
+    ProvisionUsers,
+}
+impl From<&CatalogServerAction> for CatalogServerActionKind {
+    fn from(action: &CatalogServerAction) -> Self {
+        match action {
+            CatalogServerAction::CreateProject { .. } => Self::CreateProject,
+            CatalogServerAction::UpdateUsers => Self::UpdateUsers,
+            CatalogServerAction::DeleteUsers => Self::DeleteUsers,
+            CatalogServerAction::ListUsers => Self::ListUsers,
+            CatalogServerAction::ProvisionUsers => Self::ProvisionUsers,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "open-api", schema(as=LakekeeperProjectActionKind))]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum CatalogProjectActionKind {
+    CreateWarehouse,
+    Delete,
+    Rename,
+    GetMetadata,
+    ListWarehouses,
+    IncludeInList,
+    CreateRole,
+    ListRoles,
+    SearchRoles,
+    GetEndpointStatistics,
+    ModifyTaskQueueConfig,
+    GetTaskQueueConfig,
+    GetProjectTasks,
+    ControlProjectTasks,
+}
+impl From<&CatalogProjectAction> for CatalogProjectActionKind {
+    fn from(action: &CatalogProjectAction) -> Self {
+        match action {
+            CatalogProjectAction::CreateWarehouse { .. } => Self::CreateWarehouse,
+            CatalogProjectAction::Delete => Self::Delete,
+            CatalogProjectAction::Rename => Self::Rename,
+            CatalogProjectAction::GetMetadata => Self::GetMetadata,
+            CatalogProjectAction::ListWarehouses => Self::ListWarehouses,
+            CatalogProjectAction::IncludeInList => Self::IncludeInList,
+            CatalogProjectAction::CreateRole { .. } => Self::CreateRole,
+            CatalogProjectAction::ListRoles => Self::ListRoles,
+            CatalogProjectAction::SearchRoles => Self::SearchRoles,
+            CatalogProjectAction::GetEndpointStatistics => Self::GetEndpointStatistics,
+            CatalogProjectAction::ModifyTaskQueueConfig => Self::ModifyTaskQueueConfig,
+            CatalogProjectAction::GetTaskQueueConfig => Self::GetTaskQueueConfig,
+            CatalogProjectAction::GetProjectTasks => Self::GetProjectTasks,
+            CatalogProjectAction::ControlProjectTasks => Self::ControlProjectTasks,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "open-api", schema(as=LakekeeperRoleActionKind))]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum CatalogRoleActionKind {
+    Read,
+    ReadMetadata,
+    Delete,
+    Update,
+    ManageRoleAssignments,
+    ReadRoleAssignments,
+    UpdateSourceSystem,
+}
+impl From<&CatalogRoleAction> for CatalogRoleActionKind {
+    fn from(action: &CatalogRoleAction) -> Self {
+        match action {
+            CatalogRoleAction::Read => Self::Read,
+            CatalogRoleAction::ReadMetadata => Self::ReadMetadata,
+            CatalogRoleAction::Delete => Self::Delete,
+            CatalogRoleAction::Update => Self::Update,
+            CatalogRoleAction::ManageRoleAssignments => Self::ManageRoleAssignments,
+            CatalogRoleAction::ReadRoleAssignments => Self::ReadRoleAssignments,
+            CatalogRoleAction::UpdateSourceSystem { .. } => Self::UpdateSourceSystem,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "open-api", schema(as=LakekeeperWarehouseActionKind))]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum CatalogWarehouseActionKind {
+    CreateNamespace,
+    Delete,
+    UpdateStorage,
+    UpdateStorageCredential,
+    GetMetadata,
+    GetConfig,
+    ListNamespaces,
+    ListEverything,
+    Use,
+    IncludeInList,
+    Deactivate,
+    Activate,
+    Rename,
+    ListDeletedTabulars,
+    ModifySoftDeletion,
+    GetTaskQueueConfig,
+    ModifyTaskQueueConfig,
+    GetAllTasks,
+    ControlAllTasks,
+    SetProtection,
+    SetFormatVersionPolicy,
+    GetEndpointStatistics,
+}
+impl From<&CatalogWarehouseAction> for CatalogWarehouseActionKind {
+    fn from(action: &CatalogWarehouseAction) -> Self {
+        match action {
+            CatalogWarehouseAction::CreateNamespace { .. } => Self::CreateNamespace,
+            CatalogWarehouseAction::Delete => Self::Delete,
+            CatalogWarehouseAction::UpdateStorage => Self::UpdateStorage,
+            CatalogWarehouseAction::UpdateStorageCredential => Self::UpdateStorageCredential,
+            CatalogWarehouseAction::GetMetadata => Self::GetMetadata,
+            CatalogWarehouseAction::GetConfig => Self::GetConfig,
+            CatalogWarehouseAction::ListNamespaces => Self::ListNamespaces,
+            CatalogWarehouseAction::ListEverything => Self::ListEverything,
+            CatalogWarehouseAction::Use => Self::Use,
+            CatalogWarehouseAction::IncludeInList => Self::IncludeInList,
+            CatalogWarehouseAction::Deactivate => Self::Deactivate,
+            CatalogWarehouseAction::Activate => Self::Activate,
+            CatalogWarehouseAction::Rename => Self::Rename,
+            CatalogWarehouseAction::ListDeletedTabulars => Self::ListDeletedTabulars,
+            CatalogWarehouseAction::ModifySoftDeletion => Self::ModifySoftDeletion,
+            CatalogWarehouseAction::GetTaskQueueConfig => Self::GetTaskQueueConfig,
+            CatalogWarehouseAction::ModifyTaskQueueConfig => Self::ModifyTaskQueueConfig,
+            CatalogWarehouseAction::GetAllTasks => Self::GetAllTasks,
+            CatalogWarehouseAction::ControlAllTasks => Self::ControlAllTasks,
+            CatalogWarehouseAction::SetProtection => Self::SetProtection,
+            CatalogWarehouseAction::SetFormatVersionPolicy => Self::SetFormatVersionPolicy,
+            CatalogWarehouseAction::GetEndpointStatistics => Self::GetEndpointStatistics,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "open-api", schema(as=LakekeeperNamespaceActionKind))]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum CatalogNamespaceActionKind {
+    CreateTable,
+    CreateView,
+    CreateNamespace,
+    Delete,
+    UpdateProperties,
+    GetMetadata,
+    ListTables,
+    ListViews,
+    ListNamespaces,
+    ListEverything,
+    SetProtection,
+    IncludeInList,
+    CreateGenericTable,
+    ListGenericTables,
+}
+impl From<&CatalogNamespaceAction> for CatalogNamespaceActionKind {
+    fn from(action: &CatalogNamespaceAction) -> Self {
+        match action {
+            CatalogNamespaceAction::CreateTable { .. } => Self::CreateTable,
+            CatalogNamespaceAction::CreateView { .. } => Self::CreateView,
+            CatalogNamespaceAction::CreateNamespace { .. } => Self::CreateNamespace,
+            CatalogNamespaceAction::Delete { .. } => Self::Delete,
+            CatalogNamespaceAction::UpdateProperties { .. } => Self::UpdateProperties,
+            CatalogNamespaceAction::GetMetadata => Self::GetMetadata,
+            CatalogNamespaceAction::ListTables => Self::ListTables,
+            CatalogNamespaceAction::ListViews => Self::ListViews,
+            CatalogNamespaceAction::ListNamespaces => Self::ListNamespaces,
+            CatalogNamespaceAction::ListEverything => Self::ListEverything,
+            CatalogNamespaceAction::SetProtection => Self::SetProtection,
+            CatalogNamespaceAction::IncludeInList => Self::IncludeInList,
+            CatalogNamespaceAction::CreateGenericTable { .. } => Self::CreateGenericTable,
+            CatalogNamespaceAction::ListGenericTables => Self::ListGenericTables,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "open-api", schema(as=LakekeeperTableActionKind))]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum CatalogTableActionKind {
+    Drop,
+    WriteData,
+    ReadData,
+    GetMetadata,
+    Commit,
+    Rename,
+    IncludeInList,
+    Undrop,
+    GetTasks,
+    ControlTasks,
+    SetProtection,
+}
+impl From<&CatalogTableAction> for CatalogTableActionKind {
+    fn from(action: &CatalogTableAction) -> Self {
+        match action {
+            CatalogTableAction::Drop { .. } => Self::Drop,
+            CatalogTableAction::WriteData => Self::WriteData,
+            CatalogTableAction::ReadData => Self::ReadData,
+            CatalogTableAction::GetMetadata => Self::GetMetadata,
+            CatalogTableAction::Commit { .. } => Self::Commit,
+            CatalogTableAction::Rename => Self::Rename,
+            CatalogTableAction::IncludeInList => Self::IncludeInList,
+            CatalogTableAction::Undrop => Self::Undrop,
+            CatalogTableAction::GetTasks => Self::GetTasks,
+            CatalogTableAction::ControlTasks => Self::ControlTasks,
+            CatalogTableAction::SetProtection => Self::SetProtection,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "open-api", schema(as=LakekeeperViewActionKind))]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum CatalogViewActionKind {
+    Drop,
+    GetMetadata,
+    Select,
+    Commit,
+    IncludeInList,
+    Rename,
+    Undrop,
+    GetTasks,
+    ControlTasks,
+    SetProtection,
+}
+impl From<&CatalogViewAction> for CatalogViewActionKind {
+    fn from(action: &CatalogViewAction) -> Self {
+        match action {
+            CatalogViewAction::Drop { .. } => Self::Drop,
+            CatalogViewAction::GetMetadata => Self::GetMetadata,
+            CatalogViewAction::Select => Self::Select,
+            CatalogViewAction::Commit { .. } => Self::Commit,
+            CatalogViewAction::IncludeInList => Self::IncludeInList,
+            CatalogViewAction::Rename => Self::Rename,
+            CatalogViewAction::Undrop => Self::Undrop,
+            CatalogViewAction::GetTasks => Self::GetTasks,
+            CatalogViewAction::ControlTasks => Self::ControlTasks,
+            CatalogViewAction::SetProtection => Self::SetProtection,
+        }
+    }
+}
+
 pub trait AsTableId {
     fn as_table_id(&self) -> TableId;
 }
@@ -2072,6 +2343,72 @@ pub mod tests {
         let deserialized: CatalogTableAction =
             serde_json::from_value(serialized).expect("Failed to deserialize");
         assert_eq!(deserialized, action);
+    }
+
+    /// The fieldless `*ActionKind` enums (used in permission-introspection
+    /// responses) must serialize to just `{"action": "<name>"}` — no per-operation
+    /// state — and `From<&operational>` must preserve the action name while
+    /// stripping context. Driving the assertion from each operational `variants()`
+    /// also guarantees the `From` mapping stays exhaustive.
+    #[test]
+    fn test_action_kind_is_stateless_and_matches_operational_name() {
+        fn assert_stateless<'a, Op, Kind>(op: &'a Op)
+        where
+            Kind: From<&'a Op> + Serialize,
+            Op: Serialize,
+        {
+            let op_json = serde_json::to_value(op).expect("serialize operational");
+            let kind_json = serde_json::to_value(Kind::from(op)).expect("serialize kind");
+            // Kind carries only the action discriminant.
+            assert_eq!(
+                kind_json,
+                serde_json::json!({ "action": op_json["action"].clone() }),
+                "kind must be {{action}}-only; operational was {op_json}"
+            );
+        }
+
+        for a in CatalogServerAction::variants() {
+            assert_stateless::<_, CatalogServerActionKind>(a);
+        }
+        for a in CatalogProjectAction::variants() {
+            assert_stateless::<_, CatalogProjectActionKind>(a);
+        }
+        for a in CatalogRoleAction::variants() {
+            assert_stateless::<_, CatalogRoleActionKind>(a);
+        }
+        for a in CatalogWarehouseAction::variants() {
+            assert_stateless::<_, CatalogWarehouseActionKind>(a);
+        }
+        for a in CatalogNamespaceAction::variants() {
+            assert_stateless::<_, CatalogNamespaceActionKind>(a);
+        }
+        for a in CatalogTableAction::variants() {
+            assert_stateless::<_, CatalogTableActionKind>(a);
+        }
+        for a in CatalogViewAction::variants() {
+            assert_stateless::<_, CatalogViewActionKind>(a);
+        }
+
+        // Spot-check that context-bearing variants collapse to the bare action.
+        assert_eq!(
+            serde_json::to_value(CatalogTableActionKind::from(&CatalogTableAction::Drop {
+                force: true,
+                purge: true,
+            }))
+            .unwrap(),
+            serde_json::json!({ "action": "drop" }),
+        );
+        assert_eq!(
+            serde_json::to_value(CatalogNamespaceActionKind::from(
+                &CatalogNamespaceAction::Delete {
+                    force: true,
+                    purge: true,
+                    recursive: true,
+                }
+            ))
+            .unwrap(),
+            serde_json::json!({ "action": "delete" }),
+        );
     }
 
     #[test]

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -5512,7 +5512,7 @@ components:
         allowed-actions:
           type: array
           items:
-            $ref: '#/components/schemas/LakekeeperNamespaceAction'
+            $ref: '#/components/schemas/LakekeeperNamespaceActionKind'
     GetLakekeeperProjectActionsResponse:
       type: object
       required:
@@ -5521,7 +5521,7 @@ components:
         allowed-actions:
           type: array
           items:
-            $ref: '#/components/schemas/LakekeeperProjectAction'
+            $ref: '#/components/schemas/LakekeeperProjectActionKind'
     GetLakekeeperRoleActionsResponse:
       type: object
       required:
@@ -5530,7 +5530,7 @@ components:
         allowed-actions:
           type: array
           items:
-            $ref: '#/components/schemas/LakekeeperRoleAction'
+            $ref: '#/components/schemas/LakekeeperRoleActionKind'
     GetLakekeeperServerActionsResponse:
       type: object
       required:
@@ -5539,7 +5539,7 @@ components:
         allowed-actions:
           type: array
           items:
-            $ref: '#/components/schemas/LakekeeperServerAction'
+            $ref: '#/components/schemas/LakekeeperServerActionKind'
     GetLakekeeperTableActionsResponse:
       type: object
       required:
@@ -5548,7 +5548,7 @@ components:
         allowed-actions:
           type: array
           items:
-            $ref: '#/components/schemas/LakekeeperTableAction'
+            $ref: '#/components/schemas/LakekeeperTableActionKind'
     GetLakekeeperUserActionsResponse:
       type: object
       required:
@@ -5566,7 +5566,7 @@ components:
         allowed-actions:
           type: array
           items:
-            $ref: '#/components/schemas/LakekeeperViewAction'
+            $ref: '#/components/schemas/LakekeeperViewActionKind'
     GetLakekeeperWarehouseActionsResponse:
       type: object
       required:
@@ -5575,7 +5575,7 @@ components:
         allowed-actions:
           type: array
           items:
-            $ref: '#/components/schemas/LakekeeperWarehouseAction'
+            $ref: '#/components/schemas/LakekeeperWarehouseActionKind'
     GetNamespaceAccessResponse:
       type: object
       required:
@@ -6127,6 +6127,20 @@ components:
               type: string
               enum:
                 - delete
+            force:
+              type: boolean
+              description: |-
+                Whether the warehouse-configured soft-deletion is bypassed, i.e.
+                contained tabulars are hard-deleted immediately instead of being
+                recoverable for the configured grace period.
+            purge:
+              type: boolean
+              description: Whether the underlying data/metadata files are physically purged.
+            recursive:
+              type: boolean
+              description: |-
+                Whether the drop recurses into child namespaces, tables and views,
+                deleting the entire subtree rooted at this namespace.
         - type: object
           required:
             - action
@@ -6240,6 +6254,120 @@ components:
                 type: string
               propertyNames:
                 type: string
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_generic_tables
+    LakekeeperNamespaceActionKind:
+      oneOf:
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - create_table
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - create_view
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - create_namespace
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - delete
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - update_properties
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_metadata
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_tables
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_views
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_namespaces
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_everything
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - set_protection
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - include_in_list
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - create_generic_table
         - type: object
           required:
             - action
@@ -6372,7 +6500,121 @@ components:
               type: string
               enum:
                 - control_project_tasks
-    LakekeeperRoleAction:
+    LakekeeperProjectActionKind:
+      oneOf:
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - create_warehouse
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - delete
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - rename
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_metadata
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_warehouses
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - include_in_list
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - create_role
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_roles
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - search_roles
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_endpoint_statistics
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - modify_task_queue_config
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_task_queue_config
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_project_tasks
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - control_project_tasks
+    LakekeeperRoleActionKind:
       oneOf:
         - type: object
           required:
@@ -6407,7 +6649,6 @@ components:
               enum:
                 - update
         - type: object
-          description: Can add/remove members (user or role) of this role.
           required:
             - action
           properties:
@@ -6416,7 +6657,6 @@ components:
               enum:
                 - manage_role_assignments
         - type: object
-          description: Can list members / parents / assignments of this role.
           required:
             - action
           properties:
@@ -6425,31 +6665,13 @@ components:
               enum:
                 - read_role_assignments
         - type: object
-          description: |-
-            Can rebind this role's external identity (provider + source id) to a
-            different source system. `target` is the rebind destination, surfaced as
-            action context (`target_provider_id` / `target_source_id`) so policy-based
-            authorizers can gate it (e.g. forbid moving a role onto a particular
-            provider). The catalog backend treats this the same as
-            `ManageRoleAssignments`.
-
-            The destination is explicit: [`SourceSystemTarget::To`] on the actual write
-            (the handler builds it from the request) and [`SourceSystemTarget::Any`] in
-            the `GET /role/{id}/actions` introspection enumeration / any "may this
-            principal rebind at all?" query. `Any` is a named base-capability marker, not
-            a permissive default: a per-destination policy gates the concrete `To` target
-            and never matches `Any`, and a `/check` caller chooses `To`/`Any`
-            deliberately.
           required:
-            - target
             - action
           properties:
             action:
               type: string
               enum:
                 - update_source_system
-            target:
-              $ref: '#/components/schemas/SourceSystemTarget'
     LakekeeperServerAction:
       oneOf:
         - type: object
@@ -6507,6 +6729,48 @@ components:
               type: string
               enum:
                 - provision_users
+    LakekeeperServerActionKind:
+      oneOf:
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - create_project
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - update_users
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - delete_users
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_users
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - provision_users
     LakekeeperTableAction:
       oneOf:
         - type: object
@@ -6517,6 +6781,15 @@ components:
               type: string
               enum:
                 - drop
+            force:
+              type: boolean
+              description: |-
+                Whether the warehouse-configured soft-deletion is bypassed, i.e. the
+                table is hard-deleted immediately instead of being recoverable for the
+                configured grace period. Extra destructive — irreversible right away.
+            purge:
+              type: boolean
+              description: Whether the underlying data files are physically purged from storage.
         - type: object
           required:
             - action
@@ -6559,6 +6832,96 @@ components:
                 type: string
               propertyNames:
                 type: string
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - rename
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - include_in_list
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - undrop
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_tasks
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - control_tasks
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - set_protection
+    LakekeeperTableActionKind:
+      oneOf:
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - drop
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - write_data
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - read_data
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_metadata
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - commit
         - type: object
           required:
             - action
@@ -6651,6 +7014,15 @@ components:
               type: string
               enum:
                 - drop
+            force:
+              type: boolean
+              description: |-
+                Whether the warehouse-configured soft-deletion is bypassed, i.e. the
+                view is hard-deleted immediately instead of being recoverable for the
+                configured grace period. Extra destructive — irreversible right away.
+            purge:
+              type: boolean
+              description: Whether the underlying metadata files are physically purged from storage.
         - type: object
           required:
             - action
@@ -6733,6 +7105,88 @@ components:
               type: string
               enum:
                 - set_protection
+    LakekeeperViewActionKind:
+      oneOf:
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - drop
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_metadata
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - select
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - commit
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - include_in_list
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - rename
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - undrop
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_tasks
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - control_tasks
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - set_protection
     LakekeeperWarehouseAction:
       oneOf:
         - type: object
@@ -6754,6 +7208,184 @@ components:
                 type: string
               propertyNames:
                 type: string
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - delete
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - update_storage
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - update_storage_credential
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_metadata
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_config
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_namespaces
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_everything
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - use
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - include_in_list
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - deactivate
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - activate
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - rename
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - list_deleted_tabulars
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - modify_soft_deletion
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_task_queue_config
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - modify_task_queue_config
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_all_tasks
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - control_all_tasks
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - set_protection
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - set_format_version_policy
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - get_endpoint_statistics
+    LakekeeperWarehouseActionKind:
+      oneOf:
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
+                - create_namespace
         - type: object
           required:
             - action
@@ -7910,23 +8542,6 @@ components:
       enum:
         - assignee
         - ownership
-    RoleSourceSystem:
-      type: object
-      description: |-
-        The external identity (source system) a role is bound to: a `(provider_id,
-        source_id)` pair. An external identity is always both parts together, so this
-        type makes a partial binding unrepresentable. Used as the rebind destination
-        in [`CatalogRoleAction::UpdateSourceSystem`].
-      required:
-        - provider_id
-        - source_id
-      properties:
-        provider_id:
-          type: string
-          description: Provider that owns the role (e.g. `oidc`, `ldap`).
-        source_id:
-          type: string
-          description: Identifier of the role within the provider.
     S3AccessKeyCredential:
       type: object
       title: S3CredentialAccessKey
@@ -8488,29 +9103,6 @@ components:
           description: |-
             New managed-by marker. Use `self-managed` to clear. Setting or clearing the
             marker requires instance-admin privilege.
-    SourceSystemTarget:
-      oneOf:
-        - type: object
-          description: Concrete rebind destination.
-          required:
-            - to
-          properties:
-            to:
-              $ref: '#/components/schemas/RoleSourceSystem'
-              description: Concrete rebind destination.
-        - type: string
-          description: No specific destination — base-capability / introspection marker.
-          enum:
-            - any
-      description: |-
-        The destination of a [`CatalogRoleAction::UpdateSourceSystem`] rebind.
-
-        `To` names a concrete external identity (the real authorization check); `Any`
-        is the destination-less base-capability marker used for permission
-        introspection and "can this principal rebind at all?" queries. Keeping the base
-        case an explicit, named variant — rather than an absent/`None` value — means an
-        authorizer is never silently asked to allow an unspecified rebind: a
-        per-destination policy gates the concrete `To` target and never matches `Any`.
     StorageCredential:
       oneOf:
         - allOf:


### PR DESCRIPTION
The Drop/Delete catalog actions carried no information about how destructive
a deletion is, so policy-based authorizers (Cedar) could not distinguish a
recoverable drop from one that bypasses warehouse soft-deletion or wipes a
whole namespace subtree.

Add context to the operational action enums, populated from the existing
request flags at the drop handlers:
- CatalogTableAction::Drop { force, purge }
- CatalogViewAction::Drop { force, purge }
- CatalogNamespaceAction::Delete { force, purge, recursive }

The flags are surfaced in the audit action descriptor. OpenFGA maps these
variants to the same relations as before (behavior unchanged); the context is
consumed by policy-based authorizers and the /check request body.

Keep this context out of the permission-introspection responses: GET …/actions
now return fieldless `*ActionKind` companions (one per resource, with exhaustive
From<&operational> impls) so the response advertises only which action *kinds*
are permitted, never per-operation state. The full `Lakekeeper*Action` schema is
retained for the /check request body.

BREAKING CHANGE: GET …/actions response `allowed-actions` items now reference
`Lakekeeper*ActionKind` instead of `Lakekeeper*Action`. The response JSON is
unchanged (`{"action":"drop"}`); generated client SDKs must regenerate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added action-kind enums to the permissions API for simplified action representation.

* **Bug Fixes & Improvements**
  * Updated action introspection endpoints to return streamlined action types in allowed-actions responses.
  * Enhanced delete/drop operations to track operation parameters for improved authorization context.

* **Documentation**
  * Updated API schema definitions to reflect new action-kind response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->