### PR TITLE
feat(migrations): refuse to start against a newer (downgraded) database

### DIFF
--- a/crates/lakekeeper-bin/src/wait_for_db.rs
+++ b/crates/lakekeeper-bin/src/wait_for_db.rs
@@ -1,7 +1,7 @@
 use lakekeeper::{tokio, tracing};
 use lakekeeper_storage_postgres::{
     config::CONFIG as PG_CONFIG,
-    get_reader_pool,
+    get_writer_pool,
     migrations::{MigrationState, check_migration_status},
 };
 
@@ -37,8 +37,13 @@ pub(crate) async fn wait_for_db(
     if check_migrations {
         let mut counter = 0;
         loop {
-            let read_pool = get_reader_pool(PG_CONFIG.to_pool_opts()).await?;
-            let migrations = check_migration_status(&read_pool).await;
+            // Read migration status from the PRIMARY, not a read replica: a
+            // lagging replica may not yet carry the `_sqlx_migrations` rows a
+            // newer binary just committed to the primary, which would hide an
+            // `Ahead` database (and mis-report `Complete`) and let an older
+            // binary start against an incompatible schema.
+            let write_pool = get_writer_pool(PG_CONFIG.to_pool_opts()).await?;
+            let migrations = check_migration_status(&write_pool).await;
             match migrations {
                 Ok(MigrationState::Complete) => {
                     tracing::info!("Database is up to date with binary.");

--- a/crates/lakekeeper-bin/src/wait_for_db.rs
+++ b/crates/lakekeeper-bin/src/wait_for_db.rs
@@ -44,6 +44,21 @@ pub(crate) async fn wait_for_db(
                     tracing::info!("Database is up to date with binary.");
                     break;
                 }
+                Ok(MigrationState::Ahead) => {
+                    // The DB was migrated by a newer Lakekeeper. Retrying never
+                    // resolves this (the DB won't get older), so fail fast
+                    // instead of looping until the retry budget is exhausted.
+                    tracing::error!(
+                        "Database has been migrated by a NEWER Lakekeeper than this binary. \
+                         Refusing to start to avoid running against an incompatible schema. \
+                         Use a binary at least as new as the one that last migrated the database. \
+                         To start anyway (e.g. an emergency rollback, accepting the risk of \
+                         schema incompatibility), run `serve --force-start`."
+                    );
+                    anyhow::bail!(
+                        "Database is newer than this binary (migrated by a newer Lakekeeper); refusing to start."
+                    );
+                }
                 unready => {
                     tracing::info!(?unready, "Database is not up to date with binary.");
                 }

--- a/crates/lakekeeper-storage-postgres/src/migrations/mod.rs
+++ b/crates/lakekeeper-storage-postgres/src/migrations/mod.rs
@@ -423,6 +423,27 @@ pub async fn check_migration_status(pool: &sqlx::PgPool) -> anyhow::Result<Migra
         }
     };
 
+    // Downgrade guard: if the DB carries an applied version this binary's
+    // migrator doesn't contain, the DB was migrated by a newer Lakekeeper.
+    // Compared on version alone — a known-version-but-changed-checksum is
+    // drift (handled by `migrate()` via VersionMismatch / sha_patch), not a
+    // newer DB. Reported before the "missing" check because an older binary's
+    // migrations are a subset of applied, so it would otherwise look Complete.
+    let binary_versions: HashSet<i64> = m.migrations.iter().map(|mig| mig.version).collect();
+    let ahead: Vec<i64> = applied_migrations
+        .iter()
+        .map(|mig| mig.version)
+        .filter(|v| !binary_versions.contains(v))
+        .collect();
+    if !ahead.is_empty() {
+        tracing::warn!(
+            ?ahead,
+            "Database has applied migrations unknown to this binary — it was migrated by a newer \
+             Lakekeeper. This binary is too old to run against it."
+        );
+        return Ok(MigrationState::Ahead);
+    }
+
     let to_be_applied = m
         .migrations
         .iter()
@@ -450,6 +471,11 @@ pub enum MigrationState {
     Complete,
     Missing,
     NoMigrationsTable,
+    /// The database has applied migrations whose versions this binary's
+    /// migrator does not know — it was migrated by a *newer* Lakekeeper.
+    /// Running this (older) binary against it is unsafe; callers must refuse
+    /// to start rather than retry (waiting never resolves a newer DB).
+    Ahead,
 }
 
 pub trait MigrationHook: Send + Sync + 'static {
@@ -518,7 +544,9 @@ mod tests {
     };
     use uuid::Uuid;
 
-    use super::{ExtensionMigrations, migrate, migrate_core_only};
+    use super::{
+        ExtensionMigrations, MigrationState, check_migration_status, migrate, migrate_core_only,
+    };
 
     async fn table_exists(pool: &PgPool, name: &str) -> bool {
         sqlx::query_scalar::<_, bool>(
@@ -529,6 +557,49 @@ mod tests {
         .fetch_one(pool)
         .await
         .unwrap()
+    }
+
+    /// Downgrade guard: a database migrated by a *newer* Lakekeeper — its
+    /// `_sqlx_migrations` carries versions this binary's migrator does not know
+    /// — must be reported as `Ahead`, not `Complete`. The one-directional
+    /// "are all my migrations applied?" check missed this: an older binary's
+    /// migrations are a subset of what's applied, so nothing looks missing.
+    #[sqlx::test(migrations = false)]
+    async fn test_check_migration_status_detects_newer_db(pool: PgPool) {
+        migrate_core_only(&pool)
+            .await
+            .expect("core-only migrate must succeed");
+
+        // Freshly migrated by this same binary → up to date.
+        assert!(
+            matches!(
+                check_migration_status(&pool).await.unwrap(),
+                MigrationState::Complete
+            ),
+            "freshly migrated DB should be Complete"
+        );
+
+        // Simulate a newer binary having migrated this DB: a tracker row whose
+        // version is beyond anything this binary's migrator contains.
+        sqlx::query(
+            "INSERT INTO _sqlx_migrations \
+               (version, description, installed_on, success, checksum, execution_time) \
+             VALUES ($1, $2, now(), true, $3, 0)",
+        )
+        .bind(99_999_999_999_999_i64)
+        .bind("future migration from a newer binary")
+        .bind(vec![0_u8; 32])
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            matches!(
+                check_migration_status(&pool).await.unwrap(),
+                MigrationState::Ahead
+            ),
+            "DB with a migration unknown to this binary must report Ahead"
+        );
     }
 
     /// An operator runs upstream OSS by itself for a while (their


### PR DESCRIPTION
Guard against running an older binary against a database that a newer Lakekeeper has already migrated.

check_migration_status only checked one direction (are the binary's migrations applied?), so an older binary — whose migrations are a subset of what's applied — reported Complete and served against the newer schema. That risks runtime errors or silent data corruption when the binary writes against schema invariants it doesn't know about.

Add MigrationState::Ahead: any applied migration whose version this binary's migrator does not contain means the DB is newer. The serve gate (wait_for_db) now fails fast on Ahead instead of retrying — waiting never resolves a newer DB. Run `serve --force-start` to start anyway (emergency rollback, accepting the risk of schema incompatibility).

The migrate command already aborted on this via VersionMissing; this brings serve in line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved migration safety: the app now detects when the database has been migrated by a newer binary and immediately stops with a clear, non-retryable error to prevent unsafe startup.
  * Migration checks are more accurate when the database contains applied migrations unknown to the running version, reporting this explicitly rather than treating it as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->