### PR TITLE
fix(tables): don't return 304 on loadTable once vended credentials expired

### DIFF
--- a/crates/iceberg-ext/src/catalog/mod.rs
+++ b/crates/iceberg-ext/src/catalog/mod.rs
@@ -28,7 +28,7 @@ pub mod rest {
     pub use table::{
         CommitTableRequest, CommitTableResponse, CommitTransactionRequest, CreateTableRequest,
         ETag, ListTablesResponse, LoadCredentialsResponse, LoadTableResult, RegisterTableRequest,
-        RenameTableRequest, StorageCredential, create_etag,
+        RenameTableRequest, StorageCredential, TableETag, create_etag,
     };
 
     mod view;

--- a/crates/iceberg-ext/src/catalog/rest/table.rs
+++ b/crates/iceberg-ext/src/catalog/rest/table.rs
@@ -38,6 +38,13 @@ pub struct LoadTableResult {
     pub config: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_credentials: Option<Vec<StorageCredential>>,
+    /// Absolute time (epoch ms) until which a conditional request may be answered
+    /// with `304`, or `None` if the response vends no expiring credentials.
+    /// Computed from the credentials' actual expiry; not serialized — it is the
+    /// revalidation point embedded in the [`ETag`] (via [`Self::etag`]), so a 304
+    /// is never served once the client's credentials leave the serve window.
+    #[serde(skip)]
+    pub credentials_revalidate_after_ms: Option<i64>,
 }
 
 impl LoadTableResult {
@@ -48,7 +55,8 @@ impl LoadTableResult {
 
     #[must_use]
     pub fn etag(&self) -> Option<ETag> {
-        self.metadata_location.as_ref().map(|loc| create_etag(loc))
+        let metadata_location = self.metadata_location.as_ref()?;
+        Some(TableETag::new(metadata_location, self.credentials_revalidate_after_ms).into_etag())
     }
 }
 
@@ -148,10 +156,84 @@ impl From<String> for ETag {
     }
 }
 
+/// Version prefix for structured `loadTable` [`ETag`]s. Anything not parsing
+/// under this prefix (pre-upgrade or future-version values) isn't matched, so
+/// the client reloads. Bump the suffix on incompatible encoding changes.
+const ETAG_PREFIX: &str = "lk1";
+
+/// Structured contents of a `loadTable` [`ETag`].
+///
+/// Wire form (inside the quotes): `lk1.<metadata_hash>`, or
+/// `lk1.<metadata_hash>.<revalidate_after_hex>` when credentials are vended
+/// (revalidate-after as epoch-ms in hex). `metadata_hash` is the xxh3-64 hex of
+/// the metadata location. Embedding the revalidation point lets the server
+/// decide, from the client-echoed [`ETag`] alone, whether the held credentials
+/// are still within their serve window — i.e. fresh enough for a 304.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableETag {
+    metadata_hash: String,
+    revalidate_after_ms: Option<i64>,
+}
+
+impl TableETag {
+    #[must_use]
+    pub fn new(metadata_location: &str, revalidate_after_ms: Option<i64>) -> Self {
+        let hash = xxh3_64(metadata_location.as_bytes());
+        Self {
+            metadata_hash: format!("{hash:x}"),
+            // A non-positive value carries no information; drop it.
+            revalidate_after_ms: revalidate_after_ms.filter(|ms| *ms > 0),
+        }
+    }
+
+    #[must_use]
+    pub fn metadata_hash(&self) -> &str {
+        &self.metadata_hash
+    }
+
+    #[must_use]
+    pub fn revalidate_after_ms(&self) -> Option<i64> {
+        self.revalidate_after_ms
+    }
+
+    /// Parse a client-supplied [`ETag`] value (quotes already stripped). Returns
+    /// `None` for unrecognized values so callers can reload.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        let mut parts = value.split('.');
+        if parts.next()? != ETAG_PREFIX {
+            return None;
+        }
+        let metadata_hash = parts.next().filter(|s| !s.is_empty())?.to_string();
+        let revalidate_after_ms = parts
+            .next()
+            .map(|s| i64::from_str_radix(s, 16))
+            .transpose()
+            .ok()?;
+        // Reject trailing junk so an unexpected shape falls back to a reload.
+        if parts.next().is_some() {
+            return None;
+        }
+        Some(Self {
+            metadata_hash,
+            revalidate_after_ms,
+        })
+    }
+
+    /// Render the wire [`ETag`] value, quoted per HTTP `ETag` syntax.
+    #[must_use]
+    pub fn into_etag(self) -> ETag {
+        let inner = match self.revalidate_after_ms {
+            Some(ms) => format!("{ETAG_PREFIX}.{}.{ms:x}", self.metadata_hash),
+            None => format!("{ETAG_PREFIX}.{}", self.metadata_hash),
+        };
+        format!("\"{inner}\"").into()
+    }
+}
+
 #[must_use]
 pub fn create_etag(text: &str) -> ETag {
-    let hash = xxh3_64(text.as_bytes());
-    format!("\"{hash:x}\"").into()
+    TableETag::new(text, None).into_etag()
 }
 
 #[cfg(feature = "axum")]
@@ -225,7 +307,45 @@ mod tests {
     #[cfg(feature = "axum")]
     fn test_create_etag() {
         let ETag(etag) = create_etag("Hello World");
-        assert_eq!(etag, "\"e34615aade2e6333\"");
+        assert_eq!(etag, "\"lk1.e34615aade2e6333\"");
+    }
+
+    #[test]
+    fn test_table_etag_round_trip_metadata_only() {
+        let etag = TableETag::new("s3://bucket/table/metadata.json", None);
+        let ETag(wire) = etag.clone().into_etag();
+        let parsed = TableETag::parse(wire.trim_matches('"')).unwrap();
+        assert_eq!(parsed, etag);
+        assert_eq!(parsed.revalidate_after_ms(), None);
+    }
+
+    #[test]
+    fn test_table_etag_round_trip_with_expiry() {
+        let etag = TableETag::new("s3://bucket/table/metadata.json", Some(1_750_000_000_123));
+        let ETag(wire) = etag.clone().into_etag();
+        let parsed = TableETag::parse(wire.trim_matches('"')).unwrap();
+        assert_eq!(parsed, etag);
+        assert_eq!(parsed.revalidate_after_ms(), Some(1_750_000_000_123));
+    }
+
+    #[test]
+    fn test_table_etag_metadata_hash_matches_legacy() {
+        // The metadata component must stay byte-identical to the legacy hash so
+        // a pre-upgrade client's echoed ETag still matches after upgrade.
+        let location = "s3://bucket/table/metadata.json";
+        let legacy_hash = format!("{:x}", xxh3_64(location.as_bytes()));
+        assert_eq!(TableETag::new(location, None).metadata_hash(), legacy_hash);
+    }
+
+    #[test]
+    fn test_table_etag_parse_rejects_legacy_and_junk() {
+        // Legacy bare hash → not the structured format.
+        assert!(TableETag::parse("e34615aade2e6333").is_none());
+        // Wrong prefix, empty hash, trailing junk, non-hex expiry.
+        assert!(TableETag::parse("lk2.abc").is_none());
+        assert!(TableETag::parse("lk1.").is_none());
+        assert!(TableETag::parse("lk1.abc.def.ghi").is_none());
+        assert!(TableETag::parse("lk1.abc.zzz").is_none());
     }
 
     #[test]
@@ -238,6 +358,7 @@ mod tests {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
+            credentials_revalidate_after_ms: None,
         };
 
         let response = load_table_result.into_response();
@@ -245,6 +366,27 @@ mod tests {
 
         let ETag(etag_expected) = create_etag("s3://bucket/table/metadata.json");
         assert_eq!(headers.get(header::ETAG).unwrap(), &etag_expected);
+    }
+
+    #[test]
+    #[cfg(feature = "axum")]
+    fn test_load_table_result_etag_embeds_revalidate_after() {
+        let table_metadata = create_table_metadata_mock();
+        let load_table_result = LoadTableResult {
+            metadata_location: Some("s3://bucket/table/metadata.json".to_string()),
+            metadata: table_metadata,
+            config: None,
+            storage_credentials: None,
+            credentials_revalidate_after_ms: Some(1_750_000_000_123),
+        };
+
+        let ETag(etag) = load_table_result.etag().unwrap();
+        let expected =
+            TableETag::new("s3://bucket/table/metadata.json", Some(1_750_000_000_123)).into_etag();
+        assert_eq!(ETag(etag), expected);
+        // The revalidation point must round-trip out of the wire ETag.
+        let parsed = TableETag::parse(expected.as_str().trim_matches('"')).unwrap();
+        assert_eq!(parsed.revalidate_after_ms(), Some(1_750_000_000_123));
     }
 
     #[test]
@@ -257,6 +399,7 @@ mod tests {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
+            credentials_revalidate_after_ms: None,
         };
 
         let response = load_table_result.into_response();
@@ -275,6 +418,7 @@ mod tests {
             metadata: table_metadata.clone(),
             config: None,
             storage_credentials: None,
+            credentials_revalidate_after_ms: None,
         };
 
         let response = load_table_result.clone().into_response();

--- a/crates/lakekeeper/src/api/iceberg/v1/tables.rs
+++ b/crates/lakekeeper/src/api/iceberg/v1/tables.rs
@@ -1175,6 +1175,7 @@ mod test {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
+            credentials_revalidate_after_ms: None,
         };
         let load_table_result_response_expected = load_table_result.clone().into_response();
 

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -544,6 +544,8 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             metadata: table_metadata,
             config: Some(config.config.into()),
             storage_credentials: None,
+            // No credentials are vended in the register response.
+            credentials_revalidate_after_ms: None,
         })
     }
 

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -37,7 +37,7 @@ use crate::{
         },
         idempotency::{IdempotencyInfo, IdempotencyKey},
         secrets::SecretStore,
-        storage::{StoragePermissions, ValidationError},
+        storage::{StoragePermissions, ValidationError, credential_revalidate_after_ms},
     },
 };
 
@@ -335,6 +335,9 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
         )
         .await?;
 
+    let credentials_revalidate_after_ms = config
+        .credentials_expiration_ms
+        .map(credential_revalidate_after_ms);
     let storage_credentials = (!config.creds.inner().is_empty()).then(|| {
         vec![StorageCredential {
             prefix: table_location.to_string(),
@@ -347,6 +350,7 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
         metadata: table_metadata.clone(),
         config: Some(config.config.into()),
         storage_credentials,
+        credentials_revalidate_after_ms,
     };
 
     // Create table in authorizer

--- a/crates/lakekeeper/src/server/tables/load_table.rs
+++ b/crates/lakekeeper/src/server/tables/load_table.rs
@@ -324,7 +324,7 @@ mod etag_tests {
 
     const LOC: &str = "s3://bucket/table/metadata.json";
     const NOW: i64 = 1_750_000_000_000;
-    /// Build a client-supplied ETag (quotes stripped, as `parse_etags` yields).
+    /// Build a client-supplied `ETag` (quotes stripped, as `parse_etags` yields).
     /// `revalidate_after` = `None` for a metadata-only cached response.
     fn client_etag(loc: &str, revalidate_after: Option<i64>) -> ETag {
         let quoted = TableETag::new(loc, revalidate_after).into_etag();
@@ -354,7 +354,7 @@ mod etag_tests {
     #[test]
     fn no_match_when_metadata_differs() {
         let other = client_etag("s3://bucket/table/metadata-2.json", Some(NOW + 60_000));
-        assert!(!matches(&[other.clone()], false));
+        assert!(!matches(std::slice::from_ref(&other), false));
         assert!(!matches(&[other], true));
     }
 
@@ -379,7 +379,8 @@ mod etag_tests {
             let etag = client_etag(LOC, Some(revalidate_after_at(expiry, vend_now)));
             for check_now in [expiry, expiry + 1, expiry + 60_000] {
                 assert!(
-                    match_not_modified(&[etag.clone()], Some(LOC), check_now, true).is_none(),
+                    match_not_modified(std::slice::from_ref(&etag), Some(LOC), check_now, true)
+                        .is_none(),
                     "served a 304 at/after expiry (expiry={expiry}, check_now={check_now})"
                 );
             }

--- a/crates/lakekeeper/src/server/tables/load_table.rs
+++ b/crates/lakekeeper/src/server/tables/load_table.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use http::StatusCode;
-use iceberg_ext::catalog::rest::{ETag, StorageCredential, create_etag};
+use iceberg_ext::catalog::rest::{ETag, StorageCredential, TableETag};
 
 use crate::{
     WarehouseId,
@@ -17,7 +17,7 @@ use crate::{
     },
     service::{
         AuthZTableInfo as _, CachePolicy, CatalogStore, CatalogTableOps, CatalogWarehouseOps,
-        LoadTableResponse as CatalogLoadTableResult, State, TableId, TableIdentOrId, TabularInfo,
+        LoadTableResponse as CatalogLoadTableResult, State, TableId, TableIdentOrId,
         TabularListFlags, TabularNotFound, Transaction, WarehouseStatus,
         authz::{Authorizer, AuthzWarehouseOps, CatalogTableAction},
         events::{
@@ -25,20 +25,9 @@ use crate::{
             context::{ResolvedTable, authz_to_error_no_audit},
         },
         secrets::SecretStore,
+        storage::{credential_revalidate_after_ms, now_epoch_ms},
     },
 };
-
-fn get_etag(table_info: &TabularInfo<TableId>) -> Option<ETag> {
-    table_info
-        .metadata_location
-        .as_ref()
-        .map(lakekeeper_io::Location::as_str)
-        .map(create_etag)
-}
-
-fn etag_already_present(etags: &[ETag], etag: &ETag) -> bool {
-    etags.iter().any(|e| e == etag || e == &ETag::from("*"))
-}
 
 /// Load a table from the catalog.
 ///
@@ -104,16 +93,29 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
     });
 
     // ------------------- ETAG CHECK -------------------
-    let etag = get_etag(&event_ctx.resolved().table);
-    if let Some(etag_value) = etag
-        .as_ref()
-        .map(|e| e.as_str().trim_matches('"'))
-        .map(ETag::from)
-        && etag_already_present(&etags, &etag_value)
-    {
-        return Ok(LoadTableResultOrNotModified::NotModifiedResponse(
-            etag.unwrap(),
-        ));
+    // The 304 decision rides on the client-echoed ETag's revalidation point; this
+    // flag only governs the cases where the ETag carries none (metadata-only /
+    // wildcard). Not the raw `vended-credentials` flag, since backends vend
+    // expiring credentials even for the default request (S3 auto-promotes;
+    // GCS/Azure vend for any delegated access).
+    let vends_credentials = storage_permissions.is_some()
+        && event_ctx
+            .resolved()
+            .warehouse
+            .storage_profile
+            .vends_expiring_credentials(data_access);
+    if let Some(etag) = match_not_modified(
+        &etags,
+        event_ctx
+            .resolved()
+            .table
+            .metadata_location
+            .as_ref()
+            .map(lakekeeper_io::Location::as_str),
+        now_epoch_ms(),
+        vends_credentials,
+    ) {
+        return Ok(LoadTableResultOrNotModified::NotModifiedResponse(etag));
     }
 
     // ------------------- BUSINESS LOGIC -------------------
@@ -183,6 +185,10 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
             }]
         })
     });
+    let credentials_revalidate_after_ms = storage_config
+        .as_ref()
+        .and_then(|c| c.credentials_expiration_ms)
+        .map(credential_revalidate_after_ms);
 
     let metadata_ref = Arc::new(table_metadata);
     let metadata_location_ref = metadata_location.map(Arc::new);
@@ -194,6 +200,7 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
         metadata: metadata_ref,
         config: storage_config.map(|c| c.config.into()),
         storage_credentials,
+        credentials_revalidate_after_ms,
     };
 
     Ok(LoadTableResultOrNotModified::LoadTableResult(
@@ -255,4 +262,163 @@ fn require_not_staged<T>(
     }
 
     Ok(())
+}
+
+/// Decide whether a conditional `loadTable` may return `304 Not Modified`,
+/// returning the [`ETag`] to echo back if so.
+///
+/// When the client-echoed [`ETag`] carries a revalidation point (it cached a
+/// credential-bearing response), a 304 is served only while `now` is before it.
+/// When it carries none (metadata-only / wildcard), a 304 is served only if this
+/// load also vends no expiring credentials (`!vends_credentials`). Anything we
+/// can't parse isn't matched, so the client reloads — never a 304 with stale
+/// credentials.
+fn match_not_modified(
+    client_etags: &[ETag],
+    metadata_location: Option<&str>,
+    now_ms: i64,
+    vends_credentials: bool,
+) -> Option<ETag> {
+    let metadata_location = metadata_location?;
+    let current = TableETag::new(metadata_location, None);
+
+    for client in client_etags {
+        let value = client.as_str();
+
+        // Wildcard matches the metadata, but carries no revalidation point.
+        if value == "*" {
+            if vends_credentials {
+                continue;
+            }
+            return Some(current.clone().into_etag());
+        }
+
+        // Not parseable as one of our ETags → reload.
+        let Some(parsed) = TableETag::parse(value) else {
+            continue;
+        };
+        if parsed.metadata_hash() != current.metadata_hash() {
+            continue;
+        }
+        match parsed.revalidate_after_ms() {
+            // Client holds credentials: 304 only while still within their window.
+            Some(revalidate_after) => {
+                if now_ms < revalidate_after {
+                    return Some(parsed.into_etag());
+                }
+            }
+            // Metadata-only cached response: 304 only if we'd add no creds now.
+            None => {
+                if !vends_credentials {
+                    return Some(parsed.into_etag());
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod etag_tests {
+    use super::*;
+
+    const LOC: &str = "s3://bucket/table/metadata.json";
+    const NOW: i64 = 1_750_000_000_000;
+    /// Build a client-supplied ETag (quotes stripped, as `parse_etags` yields).
+    /// `revalidate_after` = `None` for a metadata-only cached response.
+    fn client_etag(loc: &str, revalidate_after: Option<i64>) -> ETag {
+        let quoted = TableETag::new(loc, revalidate_after).into_etag();
+        ETag::from(quoted.as_str().trim_matches('"'))
+    }
+
+    fn matches(etags: &[ETag], vends_credentials: bool) -> bool {
+        match_not_modified(etags, Some(LOC), NOW, vends_credentials).is_some()
+    }
+
+    #[test]
+    fn metadata_only_load_returns_304_for_matching_etags() {
+        // A metadata-only ETag and the wildcard match when this load vends no creds.
+        assert!(matches(&[client_etag(LOC, None)], false));
+        assert!(matches(&[ETag::from("*")], false));
+    }
+
+    #[test]
+    fn unparseable_etag_triggers_reload() {
+        // A pre-upgrade bare-hash ETag (or any non-`lk1` value) can't be parsed,
+        // so it never yields a 304. The client reloads once and re-primes.
+        let legacy = ETag::from(TableETag::new(LOC, None).metadata_hash());
+        assert!(!matches(&[legacy], false));
+        assert!(!matches(&[ETag::from("not-our-etag")], false));
+    }
+
+    #[test]
+    fn no_match_when_metadata_differs() {
+        let other = client_etag("s3://bucket/table/metadata-2.json", Some(NOW + 60_000));
+        assert!(!matches(&[other.clone()], false));
+        assert!(!matches(&[other], true));
+    }
+
+    #[test]
+    fn no_match_when_metadata_location_absent() {
+        assert!(match_not_modified(&[ETag::from("*")], None, NOW, false).is_none());
+    }
+
+    #[test]
+    fn never_304s_at_or_after_credential_expiry() {
+        // The safety invariant, end-to-end: compose the producer
+        // (`revalidate_after_at`, including its clamp) with the checker. Whatever
+        // revalidation point we mint for a credential, a conditional request at or
+        // after the real expiry must never be answered with a 304.
+        use crate::service::storage::revalidate_after_at;
+        for (expiry, vend_now) in [
+            (NOW + 600_000, NOW),       // 10-min credential
+            (NOW + 4 * 3_600_000, NOW), // long credential (1h cap)
+            (NOW + 1, NOW),             // about to expire
+            (NOW, NOW),                 // already at expiry
+        ] {
+            let etag = client_etag(LOC, Some(revalidate_after_at(expiry, vend_now)));
+            for check_now in [expiry, expiry + 1, expiry + 60_000] {
+                assert!(
+                    match_not_modified(&[etag.clone()], Some(LOC), check_now, true).is_none(),
+                    "served a 304 at/after expiry (expiry={expiry}, check_now={check_now})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn credential_load_honors_embedded_revalidate_after() {
+        // Revalidation point still in the future → 304.
+        assert!(matches(&[client_etag(LOC, Some(NOW + 1))], true));
+        // Reached/passed → must re-vend (200).
+        assert!(!matches(&[client_etag(LOC, Some(NOW))], true));
+        assert!(!matches(&[client_etag(LOC, Some(NOW - 60_000))], true));
+        // No revalidation point (client cached a metadata-only response) while we
+        // now vend creds → must re-vend so the client gets them.
+        assert!(!matches(&[client_etag(LOC, None)], true));
+    }
+
+    #[test]
+    fn future_revalidate_after_serves_304_even_for_metadata_only_load() {
+        // The decision rides on the echoed ETag, not the current load's flag.
+        assert!(matches(&[client_etag(LOC, Some(NOW + 60_000))], false));
+    }
+
+    #[test]
+    fn credential_load_rejects_unparseable_and_wildcard() {
+        // Unparseable ETag and wildcard carry no revalidation point → reload.
+        let legacy = ETag::from(TableETag::new(LOC, None).metadata_hash());
+        assert!(!matches(&[legacy], true));
+        assert!(!matches(&[ETag::from("*")], true));
+    }
+
+    #[test]
+    fn credential_load_picks_valid_etag_among_several() {
+        let etags = vec![
+            client_etag("s3://other/metadata.json", Some(NOW + 60_000)),
+            client_etag(LOC, Some(NOW - 1)),      // passed
+            client_etag(LOC, Some(NOW + 60_000)), // valid
+        ];
+        assert!(matches(&etags, true));
+    }
 }

--- a/crates/lakekeeper/src/service/storage/az/az_profile.rs
+++ b/crates/lakekeeper/src/service/storage/az/az_profile.rs
@@ -249,6 +249,7 @@ impl GenericAdlsProfile {
             return Ok(TableConfig {
                 creds: TableProperties::default(),
                 config: TableProperties::default(),
+                credentials_expiration_ms: None,
             });
         }
 

--- a/crates/lakekeeper/src/service/storage/az/mod.rs
+++ b/crates/lakekeeper/src/service/storage/az/mod.rs
@@ -526,6 +526,7 @@ pub(super) async fn generate_adls_table_config<T: BasicTabularInfo>(
         // Back-compat: clients still expect creds duplicated in config.
         config: creds.clone(),
         creds,
+        credentials_expiration_ms: Some(expiration_ms),
     })
 }
 

--- a/crates/lakekeeper/src/service/storage/az/onelake_profile.rs
+++ b/crates/lakekeeper/src/service/storage/az/onelake_profile.rs
@@ -527,6 +527,7 @@ impl OneLakeProfile {
             return Ok(TableConfig {
                 creds: TableProperties::default(),
                 config: TableProperties::default(),
+                credentials_expiration_ms: None,
             });
         }
 

--- a/crates/lakekeeper/src/service/storage/cache.rs
+++ b/crates/lakekeeper/src/service/storage/cache.rs
@@ -97,8 +97,7 @@ impl<V> Expiry<STCCacheKey, CachedStc<V>> for StcExpiry {
         let Some(valid_for_duration) = valid_until.checked_duration_since(created_at) else {
             return Some(Duration::from_secs(0));
         };
-        // Cache until half the validity duration, capped at 1 hour.
-        Some((valid_for_duration / 2).min(Duration::from_hours(1)))
+        Some(super::credential_serve_window(valid_for_duration))
     }
 }
 

--- a/crates/lakekeeper/src/service/storage/gcs/mod.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/mod.rs
@@ -364,6 +364,7 @@ impl GcsProfile {
             return Ok(TableConfig {
                 creds: table_properties.clone(),
                 config: table_properties,
+                credentials_expiration_ms: None,
             });
         }
 
@@ -404,6 +405,7 @@ impl GcsProfile {
             table_properties.insert(&gcs::ProjectId(project_id));
         }
 
+        let mut credentials_expiration_ms: Option<i64> = None;
         if let Some(expiry) = response.expires_at_system_time {
             match expiry.duration_since(std::time::UNIX_EPOCH) {
                 Ok(expiry_since_epoch) => {
@@ -413,6 +415,7 @@ impl GcsProfile {
                     match i64::try_from(expiry_since_epoch.as_millis()) {
                         Ok(expiration) => {
                             table_properties.insert(&creds::ExpirationTimeMs(expiration));
+                            credentials_expiration_ms = Some(expiration);
                         }
                         Err(e) => {
                             tracing::warn!(
@@ -440,6 +443,7 @@ impl GcsProfile {
             // Due to backwards compat reasons we still return creds within config too
             config: table_properties.clone(),
             creds: table_properties,
+            credentials_expiration_ms,
         })
     }
 

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -7,7 +7,11 @@ pub(crate) mod gcs;
 pub mod s3;
 pub mod storage_layout;
 
-use std::{collections::HashMap, str::FromStr as _};
+use std::{
+    collections::HashMap,
+    str::FromStr as _,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 pub use az::{AzCredential, EndpointMode, GenericAdlsProfile, OneLakeProfile, TopLevelFolder};
 pub(crate) use error::ValidationError;
@@ -113,6 +117,51 @@ pub enum StoragePermissions {
 pub struct TableConfig {
     pub(crate) creds: TableProperties,
     pub(crate) config: TableProperties,
+    /// Actual expiry (epoch ms) of the vended credentials in [`Self::creds`], or
+    /// `None` if none expire. Set wherever a backend vends an expiring
+    /// credential; the source for the `loadTable` `ETag`'s revalidation point.
+    pub(crate) credentials_expiration_ms: Option<i64>,
+}
+
+/// Half of a credential's remaining lifetime, capped at 1h — the window during
+/// which the STC cache keeps serving it ([`cache`]) and during which a
+/// conditional `loadTable` may still answer `304`.
+pub(crate) fn credential_serve_window(remaining: Duration) -> Duration {
+    (remaining / 2).min(Duration::from_hours(1))
+}
+
+/// Current time in epoch ms. Fails closed to `i64::MAX` for an unknowable clock
+/// (pre-1970 / overflow): as a "now" this makes freshness checks reload rather
+/// than serve a possibly-stale `304`.
+pub(crate) fn now_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_millis()).ok())
+        .unwrap_or(i64::MAX)
+}
+
+/// Absolute time (epoch ms) until which a conditional `loadTable` may answer
+/// `304` for a credential expiring at `expiry_ms`: `now + credential_serve_window`,
+/// clamped to never exceed `expiry_ms` so a bogus clock can't push it past the
+/// real expiry. Always reflects the credential the client actually holds.
+#[must_use]
+pub(crate) fn credential_revalidate_after_ms(expiry_ms: i64) -> i64 {
+    revalidate_after_at(expiry_ms, now_epoch_ms())
+}
+
+pub(crate) fn revalidate_after_at(expiry_ms: i64, now_ms: i64) -> i64 {
+    let remaining =
+        Duration::from_millis(u64::try_from(expiry_ms.saturating_sub(now_ms)).unwrap_or(0));
+    let window = credential_serve_window(remaining);
+    let revalidate_after = now_ms
+        .saturating_add(i64::try_from(window.as_millis()).unwrap_or(i64::MAX))
+        .min(expiry_ms);
+    // Load-bearing safety invariant: a 304 is served only while `now <
+    // revalidate_after`, so this must never reach `expiry_ms` or a 304 could hand
+    // back an expired credential. Enforced by the `.min(expiry_ms)` clamp above.
+    debug_assert!(revalidate_after <= expiry_ms);
+    revalidate_after
 }
 
 #[derive(Debug, Hash, Clone, Eq, PartialEq)]
@@ -289,6 +338,31 @@ impl StorageProfile {
         }
     }
 
+    /// Whether [`Self::generate_table_config`] for `data_access` may vend
+    /// credentials that expire. Gates the conditional-`loadTable` 304 path for
+    /// the cases where the client's echoed `ETag` carries no revalidation point
+    /// (metadata-only / wildcard).
+    ///
+    /// Conservative: may return `true` when the concrete response ends up without
+    /// credentials (only forgoes the 304 fast-path); never `false` while expiring
+    /// credentials are vended.
+    #[must_use]
+    pub fn vends_expiring_credentials(&self, data_access: DataAccessMode) -> bool {
+        if !data_access.provide_credentials() {
+            return false;
+        }
+        match self {
+            // Real backends vend expiring credentials — a new one should land here.
+            StorageProfile::S3(_)
+            | StorageProfile::Adls(_)
+            | StorageProfile::OneLake(_)
+            | StorageProfile::Gcs(_) => true,
+            // The in-memory test profile never vends credentials.
+            #[cfg(feature = "test-utils")]
+            StorageProfile::Memory(_) => false,
+        }
+    }
+
     /// Generate the table config for the storage profile.
     ///
     /// # Errors
@@ -376,6 +450,7 @@ impl StorageProfile {
             StorageProfile::Memory(_) => Ok(TableConfig {
                 creds: TableProperties::default(),
                 config: TableProperties::default(),
+                credentials_expiration_ms: None,
             }),
         }
     }
@@ -1835,5 +1910,53 @@ mod tests {
         Box::pin(profile.validate_access(cred.as_ref(), None, &request_metadata))
             .await
             .unwrap();
+    }
+}
+
+#[cfg(all(test, feature = "test-utils"))]
+mod vends_expiring_credentials_tests {
+    use super::{MemoryProfile, StorageProfile};
+    use crate::api::iceberg::v1::{DataAccess, tables::DataAccessMode};
+
+    #[test]
+    fn memory_profile_never_vends_expiring_credentials() {
+        let profile = StorageProfile::Memory(MemoryProfile::default());
+        // The in-memory test profile vends no credentials, so the conditional
+        // `loadTable` 304 fast-path must stay available for it regardless of the
+        // requested access mode.
+        assert!(!profile.vends_expiring_credentials(DataAccessMode::default()));
+        assert!(
+            !profile.vends_expiring_credentials(DataAccessMode::ServerDelegated(DataAccess {
+                vended_credentials: true,
+                remote_signing: false,
+            }))
+        );
+        assert!(!profile.vends_expiring_credentials(DataAccessMode::ClientManaged));
+    }
+}
+
+#[cfg(test)]
+mod revalidate_after_tests {
+    use super::revalidate_after_at;
+
+    const NOW: i64 = 1_750_000_000_000;
+
+    #[test]
+    fn revalidate_after_is_half_remaining_and_before_expiry() {
+        // 10-min credential → revalidate at +5 min, always before expiry.
+        let expiry = NOW + 600_000;
+        let reval = revalidate_after_at(expiry, NOW);
+        assert_eq!(reval, NOW + 300_000);
+        assert!(reval < expiry);
+        // Capped at 1h: a 4h credential revalidates at +1h, not +2h.
+        assert_eq!(
+            revalidate_after_at(NOW + 4 * 3_600_000, NOW),
+            NOW + 3_600_000
+        );
+        // Already expired → clamped to expiry, so the check never serves a 304.
+        assert_eq!(revalidate_after_at(NOW - 1, NOW), NOW - 1);
+        // Bogus clock (pre-1970 → now == i64::MAX) must not poison the result
+        // with a far-future revalidation point: clamp to the real expiry.
+        assert_eq!(revalidate_after_at(expiry, i64::MAX), expiry);
     }
 }

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -496,6 +496,7 @@ impl S3Profile {
 
         let mut config = TableProperties::default();
         let mut creds = TableProperties::default();
+        let mut credentials_expiration_ms: Option<i64> = None;
 
         if let Some(true) = self.path_style_access {
             config.insert(&s3::PathStyleAccess(true));
@@ -564,6 +565,7 @@ impl S3Profile {
             if let Some(expiration) = expiration_ms_since_epoch {
                 creds.insert(&s3::SesionTokenExpiresAtMs(expiration));
                 creds.insert(&creds::ExpirationTimeMs(expiration));
+                credentials_expiration_ms = Some(expiration);
             }
             if tabular_info.tabular_id().is_table() {
                 creds.insert(&client::RefreshClientCredentialsEndpoint(
@@ -591,7 +593,11 @@ impl S3Profile {
             config.insert(&s3::SignerEndpoint(signer_endpoint));
         }
 
-        Ok(TableConfig { creds, config })
+        Ok(TableConfig {
+            creds,
+            config,
+            credentials_expiration_ms,
+        })
     }
 
     async fn get_or_fetch_temporary_credentials(


### PR DESCRIPTION
Conditional `loadTable` (If-None-Match) returned `304 Not Modified` whenever the table metadata was unchanged — even after the vended storage credentials in the cached response had expired. Clients that reuse the cached body (e.g. the Iceberg Java client) kept using dead credentials.

The loadTable ETag is now self-describing: `lk1.<metadata-hash>` for metadata-only responses, or `lk1.<metadata-hash>.<revalidate-after>` when the response vends expiring credentials. `revalidate-after` is an absolute epoch-ms deadline derived from the credential's actual expiry — half its remaining lifetime, capped at 1h, mirroring the STC cache serve window — clamped to never exceed the expiry. On a conditional request the server decodes the client-echoed ETag and serves `304` only while the metadata is unchanged AND the held credentials are still within that window; otherwise it returns a full `200` with fresh credentials. The decision needs no DB or cache lookup and is correct across replicas (the deadline is absolute and travels in the ETag).

Metadata-only loads still benefit from `304`. ETags that don't parse (e.g. pre-upgrade bare-hash values) simply trigger a reload. The real credential expiry is still sent to clients via `expiration-time`, so out-of-band credential refresh is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `loadTable` ETags to include optional credential revalidation timing, enabling more precise conditional requests.
  * Added credential revalidation metadata to `LoadTableResult` so responses can signal when a reload is required.
* **Bug Fixes**
  * Improved `loadTable` “not modified” behavior to prevent returning `304` once short-lived credentials reach their expiry.
* **Tests**
  * Expanded ETag parsing/matching coverage, including correct wildcard handling and rejection of malformed ETags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->