### PR TITLE
feat(authn): let admission gates contribute resolved roles

### DIFF
--- a/crates/lakekeeper/src/request_metadata.rs
+++ b/crates/lakekeeper/src/request_metadata.rs
@@ -94,6 +94,11 @@ pub struct RequestMetadata {
     project_id: Option<ArcProjectId>,
     authentication: Option<Authentication>,
     token_roles: Option<TokenRoles>,
+    /// Roles resolved by a post-authentication admission gate (see
+    /// [`AdmissionGate`](crate::service::admission::AdmissionGate)) — e.g. from
+    /// an external entitlement service. Kept separate from `token_roles` so the
+    /// provenance (token claim vs externally resolved) stays explicit.
+    admission_roles: Option<TokenRoles>,
     base_url: String,
     actor: InternalActor,
     matched_path: Option<Arc<str>>,
@@ -213,6 +218,21 @@ impl RequestMetadata {
         self
     }
 
+    /// Set the roles resolved by a post-authentication admission gate. Written
+    /// by the auth middleware after the gates run; kept separate from
+    /// [`set_token_roles`](Self::set_token_roles) to preserve provenance.
+    #[cfg_attr(not(feature = "router"), allow(dead_code))]
+    pub(crate) fn set_admission_roles(&mut self, admission_roles: TokenRoles) -> &mut Self {
+        self.admission_roles = Some(admission_roles);
+        self
+    }
+
+    /// Roles resolved by a post-authentication admission gate, if any.
+    #[must_use]
+    pub fn admission_roles(&self) -> Option<&TokenRoles> {
+        self.admission_roles.as_ref()
+    }
+
     #[must_use]
     pub fn user_agent(&self) -> Option<&UserAgent> {
         self.user_agent.as_ref()
@@ -257,6 +277,7 @@ impl RequestMetadata {
             user_agent: None,
             engines: MatchedEngines::default(),
             token_roles: None,
+            admission_roles: None,
             idempotency_key: None,
             is_instance_admin: false,
         }
@@ -321,6 +342,7 @@ impl RequestMetadata {
             user_agent: None,
             engines: MatchedEngines::default(),
             token_roles: None,
+            admission_roles: None,
             idempotency_key: None,
             is_instance_admin: false,
         }
@@ -562,6 +584,7 @@ impl From<RequestMetadataTestBuilder> for RequestMetadata {
             user_agent: None,
             engines: MatchedEngines::default(),
             token_roles: b.token_roles,
+            admission_roles: None,
             idempotency_key: None,
             is_instance_admin: b.is_instance_admin,
         }
@@ -639,6 +662,7 @@ pub(crate) async fn create_request_metadata_with_trace_and_project_fn(
         request_id,
         authentication: None,
         token_roles: None,
+        admission_roles: None,
         base_url: base_uri,
         actor: Actor::Anonymous.into(),
         project_id: project_id.map(Arc::new),

--- a/crates/lakekeeper/src/request_metadata.rs
+++ b/crates/lakekeeper/src/request_metadata.rs
@@ -132,6 +132,13 @@ impl TokenRoles {
     pub fn roles(&self) -> &XXHashSet<Arc<RoleIdent>> {
         &self.roles
     }
+
+    /// Union `other`'s roles into this set, consuming it (no cloning). Keeps
+    /// `self`'s project id; callers resolve roles for the request's single
+    /// project, so the ids normally match, and if they differ the first wins.
+    pub(crate) fn merge(&mut self, other: TokenRoles) {
+        self.roles.extend(other.roles);
+    }
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/crates/lakekeeper/src/service/admission.rs
+++ b/crates/lakekeeper/src/service/admission.rs
@@ -28,7 +28,7 @@ use std::{sync::Arc, time::Duration};
 use async_trait::async_trait;
 use iceberg_ext::catalog::rest::ErrorModel;
 
-use crate::request_metadata::RequestMetadata;
+use crate::request_metadata::{RequestMetadata, TokenRoles};
 
 /// Why an [`AdmissionGate`] rejected a request.
 ///
@@ -91,6 +91,39 @@ impl AdmissionRejection {
     }
 }
 
+/// What a gate returns when it admits a request: an opt-in enrichment payload
+/// merged into the request's [`RequestMetadata`] for downstream authorization
+/// and audit. A gate that only allows/denies returns [`Admission::admit`].
+///
+/// Non-exhaustive so further enrichment can be added without a breaking change;
+/// construct it with [`Admission::admit`] / [`Admission::with_roles`].
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct Admission {
+    /// Roles the gate resolved for the principal in the same call (for example
+    /// from an external entitlement service). Merged into
+    /// [`RequestMetadata::admission_roles`] by the auth middleware, kept
+    /// separate from token-claim roles so the provenance stays explicit.
+    /// `None` when the gate resolves no roles.
+    pub resolved_roles: Option<TokenRoles>,
+}
+
+impl Admission {
+    /// Admit the request without contributing any enrichment.
+    #[must_use]
+    pub fn admit() -> Self {
+        Self::default()
+    }
+
+    /// Admit the request and contribute the roles the gate resolved.
+    #[must_use]
+    pub fn with_roles(roles: TokenRoles) -> Self {
+        Self {
+            resolved_roles: Some(roles),
+        }
+    }
+}
+
 /// A single post-authentication admission check.
 ///
 /// Implementations are expected to be cheap and to cache aggressively: `admit`
@@ -102,13 +135,15 @@ pub trait AdmissionGate: std::fmt::Debug + Send + Sync {
 
     /// Decide whether the (already authenticated) request may proceed.
     ///
-    /// Return `Ok(())` to admit, or `Err(..)` to reject the request before it
-    /// reaches any handler. The implementation owns the fail-open vs
+    /// Return `Ok(`[`Admission`]`)` to admit — use [`Admission::admit`] for a
+    /// plain allow, or [`Admission::with_roles`] to also contribute roles
+    /// resolved in the same call. Return `Err(..)` to reject the request before
+    /// it reaches any handler. The implementation owns the fail-open vs
     /// fail-closed policy by choosing the [`AdmissionRejection`] variant:
     /// [`AdmissionRejection::forbidden`] for an authoritative deny, or
     /// [`AdmissionRejection::unavailable`] to fail closed when an upstream the
     /// gate depends on is unreachable.
-    async fn admit(&self, metadata: &RequestMetadata) -> Result<(), AdmissionRejection>;
+    async fn admit(&self, metadata: &RequestMetadata) -> Result<Admission, AdmissionRejection>;
 }
 
 /// An ordered collection of [`AdmissionGate`]s.
@@ -135,27 +170,48 @@ impl AdmissionGates {
         self.gates.is_empty()
     }
 
-    /// Run every gate in order, returning the first rejection.
+    /// Run every gate in order, returning the first rejection. On success the
+    /// returned [`Admission`] carries the union of every gate's resolved roles.
     ///
     /// # Errors
     /// Returns the [`AdmissionRejection`] from the first gate that rejects the
     /// request.
-    pub async fn admit(&self, metadata: &RequestMetadata) -> Result<(), AdmissionRejection> {
+    pub async fn admit(&self, metadata: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
+        let mut resolved_roles: Option<TokenRoles> = None;
         for gate in &self.gates {
-            if let Err(rejection) = gate.admit(metadata).await {
-                let error = rejection.error();
-                tracing::info!(
-                    gate = gate.name(),
-                    status = error.code,
-                    error_type = %error.r#type,
-                    request_id = %metadata.request_id(),
-                    "Request rejected by admission gate"
-                );
-                return Err(rejection);
+            match gate.admit(metadata).await {
+                Ok(admission) => {
+                    if let Some(roles) = admission.resolved_roles {
+                        resolved_roles = Some(match resolved_roles {
+                            None => roles,
+                            Some(existing) => merge_roles(existing, roles),
+                        });
+                    }
+                }
+                Err(rejection) => {
+                    let error = rejection.error();
+                    tracing::info!(
+                        gate = gate.name(),
+                        status = error.code,
+                        error_type = %error.r#type,
+                        request_id = %metadata.request_id(),
+                        "Request rejected by admission gate"
+                    );
+                    return Err(rejection);
+                }
             }
         }
-        Ok(())
+        Ok(Admission { resolved_roles })
     }
+}
+
+/// Union two project-scoped role sets, keeping the first set's project. Gates
+/// are expected to resolve roles for the request's project, so the project ids
+/// normally match; if they differ, the first gate's project wins.
+fn merge_roles(a: TokenRoles, b: TokenRoles) -> TokenRoles {
+    let mut roles = a.roles().clone();
+    roles.extend(b.roles().iter().cloned());
+    TokenRoles::new(a.project_id().clone(), roles)
 }
 
 #[cfg(test)]
@@ -163,6 +219,28 @@ mod tests {
     use http::StatusCode;
 
     use super::*;
+    use crate::service::{ProjectId, RoleIdent};
+
+    /// Build a project-scoped role set from role source-id names.
+    fn token_roles(names: &[&str]) -> TokenRoles {
+        let roles = names
+            .iter()
+            .map(|n| Arc::new(RoleIdent::new_unchecked("test", *n)))
+            .collect();
+        TokenRoles::new(Arc::new(ProjectId::new_random()), roles)
+    }
+
+    #[derive(Debug)]
+    struct RolesGate(&'static [&'static str]);
+    #[async_trait]
+    impl AdmissionGate for RolesGate {
+        fn name(&self) -> &'static str {
+            "roles"
+        }
+        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
+            Ok(Admission::with_roles(token_roles(self.0)))
+        }
+    }
 
     #[derive(Debug)]
     struct AllowGate;
@@ -171,8 +249,8 @@ mod tests {
         fn name(&self) -> &'static str {
             "allow"
         }
-        async fn admit(&self, _: &RequestMetadata) -> Result<(), AdmissionRejection> {
-            Ok(())
+        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
+            Ok(Admission::admit())
         }
     }
 
@@ -183,7 +261,7 @@ mod tests {
         fn name(&self) -> &'static str {
             "deny"
         }
-        async fn admit(&self, _: &RequestMetadata) -> Result<(), AdmissionRejection> {
+        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
             Err(AdmissionRejection::forbidden("nope", "TestDenied", None))
         }
     }
@@ -195,7 +273,7 @@ mod tests {
         fn name(&self) -> &'static str {
             "unavailable"
         }
-        async fn admit(&self, _: &RequestMetadata) -> Result<(), AdmissionRejection> {
+        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
             Err(AdmissionRejection::unavailable(
                 "upstream down",
                 "TestUnavailable",
@@ -213,7 +291,7 @@ mod tests {
         fn name(&self) -> &'static str {
             "panic"
         }
-        async fn admit(&self, _: &RequestMetadata) -> Result<(), AdmissionRejection> {
+        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
             panic!("gate after a rejection must not be evaluated");
         }
     }
@@ -276,5 +354,32 @@ mod tests {
         .await
         .expect_err("DenyGate rejects before PanicGate is reached");
         assert_eq!(rejection.error().r#type, "TestDenied");
+    }
+
+    #[tokio::test]
+    async fn resolved_roles_surface_on_admit() {
+        let md = RequestMetadata::new_unauthenticated();
+        let admission = gates(vec![Arc::new(RolesGate(&["a", "b"]))])
+            .admit(&md)
+            .await
+            .expect("RolesGate admits");
+        let roles = admission.resolved_roles.expect("roles were resolved");
+        assert_eq!(roles.roles().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn resolved_roles_are_unioned_across_gates() {
+        let md = RequestMetadata::new_unauthenticated();
+        // Overlapping ("b") plus distinct roles: union is {a, b, c}.
+        let admission = gates(vec![
+            Arc::new(AllowGate),
+            Arc::new(RolesGate(&["a", "b"])),
+            Arc::new(RolesGate(&["b", "c"])),
+        ])
+        .admit(&md)
+        .await
+        .expect("all gates admit");
+        let roles = admission.resolved_roles.expect("roles were resolved");
+        assert_eq!(roles.roles().len(), 3);
     }
 }

--- a/crates/lakekeeper/src/service/admission.rs
+++ b/crates/lakekeeper/src/service/admission.rs
@@ -182,10 +182,12 @@ impl AdmissionGates {
             match gate.admit(metadata).await {
                 Ok(admission) => {
                     if let Some(roles) = admission.resolved_roles {
-                        resolved_roles = Some(match resolved_roles {
-                            None => roles,
-                            Some(existing) => merge_roles(existing, roles),
-                        });
+                        // Common case is a single role-resolving gate: just move
+                        // the set in. Extra gates union in place (no cloning).
+                        match resolved_roles.as_mut() {
+                            Some(acc) => acc.merge(roles),
+                            None => resolved_roles = Some(roles),
+                        }
                     }
                 }
                 Err(rejection) => {
@@ -203,15 +205,6 @@ impl AdmissionGates {
         }
         Ok(Admission { resolved_roles })
     }
-}
-
-/// Union two project-scoped role sets, keeping the first set's project. Gates
-/// are expected to resolve roles for the request's project, so the project ids
-/// normally match; if they differ, the first gate's project wins.
-fn merge_roles(a: TokenRoles, b: TokenRoles) -> TokenRoles {
-    let mut roles = a.roles().clone();
-    roles.extend(b.roles().iter().cloned());
-    TokenRoles::new(a.project_id().clone(), roles)
 }
 
 #[cfg(test)]

--- a/crates/lakekeeper/src/service/authn.rs
+++ b/crates/lakekeeper/src/service/authn.rs
@@ -564,28 +564,38 @@ pub(crate) async fn auth_middleware_fn<
         // Runs after instance-admin and assumed-role resolution so a gate can
         // honor the instance-admin break-glass and see the resolved actor.
         // No-op unless the host binary registered at least one gate.
-        if !state.admission_gates.is_empty()
-            && let Err(rejection) = state.admission_gates.admit(request_metadata).await
-        {
-            // The rejection variant carries its own HTTP semantics: an
-            // authoritative deny is a plain 403, while a fail-closed
-            // `Unavailable` is a 503 with the gate's chosen `Retry-After`.
-            return match rejection {
-                AdmissionRejection::Forbidden(error) => error.into_response(),
-                AdmissionRejection::Unavailable { error, retry_after } => {
-                    // `Retry-After` is whole seconds; round any sub-second
-                    // remainder up so a sub-second Duration still asks for at
-                    // least 1s of backoff rather than truncating to 0 ("retry
-                    // immediately").
-                    let secs = retry_after.as_secs() + u64::from(retry_after.subsec_nanos() > 0);
-                    let mut response = error.into_response();
-                    response.headers_mut().insert(
-                        axum::http::header::RETRY_AFTER,
-                        axum::http::HeaderValue::from(secs),
-                    );
-                    response
+        if !state.admission_gates.is_empty() {
+            match state.admission_gates.admit(request_metadata).await {
+                // On admit, fold any roles the gate(s) resolved into the request
+                // metadata for downstream authorization and audit.
+                Ok(admission) => {
+                    if let Some(roles) = admission.resolved_roles {
+                        request_metadata.set_admission_roles(roles);
+                    }
                 }
-            };
+                // The rejection variant carries its own HTTP semantics: an
+                // authoritative deny is a plain 403, while a fail-closed
+                // `Unavailable` is a 503 with the gate's chosen `Retry-After`.
+                Err(rejection) => {
+                    return match rejection {
+                        AdmissionRejection::Forbidden(error) => error.into_response(),
+                        AdmissionRejection::Unavailable { error, retry_after } => {
+                            // `Retry-After` is whole seconds; round any
+                            // sub-second remainder up so a sub-second Duration
+                            // still asks for at least 1s of backoff rather than
+                            // truncating to 0 ("retry immediately").
+                            let secs =
+                                retry_after.as_secs() + u64::from(retry_after.subsec_nanos() > 0);
+                            let mut response = error.into_response();
+                            response.headers_mut().insert(
+                                axum::http::header::RETRY_AFTER,
+                                axum::http::HeaderValue::from(secs),
+                            );
+                            response
+                        }
+                    };
+                }
+            }
         }
     }
 


### PR DESCRIPTION
`AdmissionGate::admit` now returns `Admission` instead of `()`, carrying optional `resolved_roles` a gate resolved while admitting the request — so a gate that calls an external entitlement service can return the principal's roles in the same round-trip it uses for the allow/deny decision, rather than resolving them again later. `AdmissionGates` unions the roles contributed by all passing gates.

The auth middleware folds these into a new `RequestMetadata::admission_roles` field, kept separate from `token_roles` so provenance (token claim vs externally resolved) stays explicit. They feed downstream authorization — via the role provider, the same path as token roles — and audit/UI.

- `Admission` success payload with `admit()` / `with_roles()` constructors
- `RequestMetadata::admission_roles` (+ setter/getter), reusing `TokenRoles`
- middleware writes the resolved roles onto the request after gates pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved post-login access handling to carry forward roles resolved during authorization checks.
  * When multiple access checks succeed, resolved role sets are combined so users retain the fullest permitted access.

* **Bug Fixes**
  * Access-denied responses still behave as before.
  * Temporary-unavailable responses still include an updated `Retry-After` header for better short-delay retry timing.
  * Request metadata now cleanly distinguishes admission-derived roles from token-derived roles for downstream use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->