### PR TITLE
chore(examples): use SeaweedFS 4.36 and drop the Admin action

### DIFF
--- a/.github/seaweedfs-iam.json
+++ b/.github/seaweedfs-iam.json
@@ -8,7 +8,7 @@
           "secretKey": "some_secret_key1"
         }
       ],
-      "actions": ["Admin", "Read", "List", "Tagging", "Write"]
+      "actions": ["Read", "List", "Tagging", "Write"]
     }
   ],
   "sts": {

--- a/.github/workflows/seaweedfs.yml
+++ b/.github/workflows/seaweedfs.yml
@@ -67,16 +67,16 @@ jobs:
 
       - name: Start SeaweedFS Docker Container
         run: |
-          # Mount an advanced IAM config so the S3 gateway also serves the STS
-          # AssumeRole API. Lakekeeper's vended-credentials tests (S3Compat
-          # flavor) call sts:AssumeRole; without an STS signing key SeaweedFS
-          # returns 503. See .github/seaweedfs-iam.json (the signing key there is
-          # an ephemeral, CI-only value).
+          # SeaweedFS mini serves S3 plus the STS AssumeRole API in one process.
+          # -bucket pre-creates the `tests` bucket so the non-admin lakekeeper
+          # identity (which cannot CreateBucket) suffices; its vended-credentials
+          # tests (S3Compat flavor) call sts:AssumeRole, which needs the STS
+          # signing key in .github/seaweedfs-iam.json (an ephemeral, CI-only value).
           docker run -d --name seaweedfs -p 8333:8333 \
             -e "AWS_ACCESS_KEY_ID=some_access_key1" \
             -e "AWS_SECRET_ACCESS_KEY=some_secret_key1" \
             -v "${GITHUB_WORKSPACE}/.github/seaweedfs-iam.json:/etc/seaweedfs/iam.json:ro" \
-            chrislusf/seaweedfs:4.31 server -s3 -ip.bind=0.0.0.0 \
+            chrislusf/seaweedfs:4.36 mini -dir=/data -bucket=tests -ip.bind=0.0.0.0 \
             -s3.config=/etc/seaweedfs/iam.json -s3.iam.config=/etc/seaweedfs/iam.json
 
       - name: Wait for SeaweedFS S3 to be healthy
@@ -102,15 +102,6 @@ jobs:
           echo "=== Open Ports ==="
           netstat -tlnp
           exit 1
-
-      - name: Create SeaweedFS Bucket
-        env:
-          AWS_ACCESS_KEY_ID: some_access_key1
-          AWS_SECRET_ACCESS_KEY: some_secret_key1
-          AWS_DEFAULT_REGION: local
-          AWS_EC2_METADATA_DISABLED: true
-        run: |
-          aws s3api create-bucket --bucket tests --endpoint-url http://127.0.0.1:8333
 
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         if: ${{ env.AZURE_CLIENT_ID != '' }}

--- a/examples/access-control-advanced/docker-compose.yaml
+++ b/examples/access-control-advanced/docker-compose.yaml
@@ -205,7 +205,7 @@ services:
       iceberg_net:
 
   seaweedfs:
-    image: chrislusf/seaweedfs:4.31
+    image: chrislusf/seaweedfs:4.36
     # `mini` is SeaweedFS' single-process dev mode (master + volume + filer + S3).
     # -bucket pre-creates the `examples` bucket, and the IAM config enables STS so
     # Lakekeeper can vend short-lived credentials to query engines.
@@ -215,7 +215,6 @@ services:
       - -bucket=examples
       - -s3.config=/etc/seaweedfs/iam.json
       - -s3.iam.config=/etc/seaweedfs/iam.json
-      - -s3.iam.readOnly=false
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8333/status" ]
       interval: 2s

--- a/examples/access-control-advanced/seaweedfs-iam.json
+++ b/examples/access-control-advanced/seaweedfs-iam.json
@@ -8,7 +8,7 @@
           "secretKey": "seaweedfs-root-password"
         }
       ],
-      "actions": ["Admin", "Read", "List", "Tagging", "Write"]
+      "actions": ["Read", "List", "Tagging", "Write"]
     }
   ],
   "sts": {

--- a/examples/access-control-simple/docker-compose.yaml
+++ b/examples/access-control-simple/docker-compose.yaml
@@ -154,7 +154,7 @@ services:
       iceberg_net:
 
   seaweedfs:
-    image: chrislusf/seaweedfs:4.31
+    image: chrislusf/seaweedfs:4.36
     # `mini` is SeaweedFS' single-process dev mode (master + volume + filer + S3).
     # -bucket pre-creates the `examples` bucket, and the IAM config enables STS so
     # Lakekeeper can vend short-lived credentials to query engines.
@@ -164,7 +164,6 @@ services:
       - -bucket=examples
       - -s3.config=/etc/seaweedfs/iam.json
       - -s3.iam.config=/etc/seaweedfs/iam.json
-      - -s3.iam.readOnly=false
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8333/status"]
       interval: 2s

--- a/examples/access-control-simple/seaweedfs-iam.json
+++ b/examples/access-control-simple/seaweedfs-iam.json
@@ -8,7 +8,7 @@
           "secretKey": "seaweedfs-root-password"
         }
       ],
-      "actions": ["Admin", "Read", "List", "Tagging", "Write"]
+      "actions": ["Read", "List", "Tagging", "Write"]
     }
   ],
   "sts": {

--- a/examples/minimal/docker-compose.yaml
+++ b/examples/minimal/docker-compose.yaml
@@ -128,7 +128,7 @@ services:
       iceberg_net:
 
   seaweedfs:
-    image: chrislusf/seaweedfs:4.31
+    image: chrislusf/seaweedfs:4.36
     # `mini` is SeaweedFS' single-process dev mode (master + volume + filer + S3).
     # -bucket pre-creates the `examples` bucket, and the IAM config enables STS so
     # Lakekeeper can vend short-lived credentials to query engines.
@@ -138,7 +138,6 @@ services:
       - -bucket=examples
       - -s3.config=/etc/seaweedfs/iam.json
       - -s3.iam.config=/etc/seaweedfs/iam.json
-      - -s3.iam.readOnly=false
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8333/status"]
       interval: 2s

--- a/examples/minimal/seaweedfs-iam.json
+++ b/examples/minimal/seaweedfs-iam.json
@@ -8,7 +8,7 @@
           "secretKey": "seaweedfs-root-password"
         }
       ],
-      "actions": ["Admin", "Read", "List", "Tagging", "Write"]
+      "actions": ["Read", "List", "Tagging", "Write"]
     }
   ],
   "sts": {


### PR DESCRIPTION
SeaweedFS 4.36 authorizes `sts:AssumeRole` through the role's trust policy, so the storage credential no longer needs the `Admin` action that earlier versions required to vend credentials. This drops `Admin` from the example and CI identities (leaving `Read`/`List`/`Write`/`Tagging`) and bumps the image to 4.36.

CreateBucket still requires `Admin` in SeaweedFS, and the CI created its test bucket with `aws s3api create-bucket`. To keep the test identity non-admin, the CI now starts SeaweedFS with `mini -bucket=tests` (pre-creating the bucket) and drops the manual create-bucket step.

Verified against `chrislusf/seaweedfs:4.36`: the non-admin identity performs S3 object operations and `sts:AssumeRole` on the pre-created bucket, and the minimal example creates its warehouse end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the `lakekeeper` identity’s IAM permissions by removing admin-level access while keeping read, list, tagging, and write capabilities across all included IAM configurations and examples.

* **Chores**
  * Updated SeaweedFS to a newer release in CI and example Docker setups.
  * Adjusted the startup approach to rely on the bundled mini mode, updated S3 binding behavior, and removed the prior read-only IAM override; CI now expects the test bucket to be available at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->