### PR TITLE
feat(authn): pass the caller's bearer token to admission gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Clippy runs with multiple feature flag combinations — don't just run `cargo cl
 - Use workspace dependencies (`{ workspace = true }`) — don't add versions directly.
 - All crate versions use `version.workspace = true`.
 - Minimize new dependencies — justify additions.
+- Docs prose (`docs/docs/*.md`): one line per paragraph — no hard line wrapping. Rely on soft-wrap.
 
 ## Architecture
 - Before adding new code, check if existing crates already solve the problem. Reuse over reinvention.

--- a/crates/lakekeeper/src/service/admission.rs
+++ b/crates/lakekeeper/src/service/admission.rs
@@ -124,6 +124,40 @@ impl Admission {
     }
 }
 
+/// Per-request inputs handed to an [`AdmissionGate`].
+///
+/// Carries borrowed request state for the duration of the [`AdmissionGate::admit`]
+/// call only. Nothing here is persisted onto [`RequestMetadata`] or logged — in
+/// particular the raw bearer token is exposed to gates that must relay it to an
+/// external service, without it leaking into the request's metadata or audit
+/// trail (which are cloned, debugged, and serialized).
+///
+/// Non-exhaustive so further per-request inputs can be added without a breaking
+/// change. The auth middleware is the only constructor; gates read the fields
+/// they need.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct AdmissionContext<'a> {
+    /// Resolved metadata for the request (actor, project, instance-admin, …).
+    pub metadata: &'a RequestMetadata,
+    /// The caller's raw bearer token — the value after `Bearer `. Present for
+    /// every authenticated request (anonymous requests are rejected before any
+    /// gate runs). A gate that relays it to an external service MUST use TLS and
+    /// MUST NOT log it.
+    pub bearer_token: Option<&'a str>,
+}
+
+impl<'a> AdmissionContext<'a> {
+    /// Construct a context for a request. Called by the auth middleware.
+    #[must_use]
+    pub fn new(metadata: &'a RequestMetadata, bearer_token: Option<&'a str>) -> Self {
+        Self {
+            metadata,
+            bearer_token,
+        }
+    }
+}
+
 /// A single post-authentication admission check.
 ///
 /// Implementations are expected to be cheap and to cache aggressively: `admit`
@@ -135,15 +169,17 @@ pub trait AdmissionGate: std::fmt::Debug + Send + Sync {
 
     /// Decide whether the (already authenticated) request may proceed.
     ///
-    /// Return `Ok(`[`Admission`]`)` to admit — use [`Admission::admit`] for a
-    /// plain allow, or [`Admission::with_roles`] to also contribute roles
+    /// [`AdmissionContext`] carries the resolved [`RequestMetadata`] and the
+    /// caller's raw `bearer_token` (for gates that relay it to an external
+    /// service). Return `Ok(`[`Admission`]`)` to admit — use [`Admission::admit`]
+    /// for a plain allow, or [`Admission::with_roles`] to also contribute roles
     /// resolved in the same call. Return `Err(..)` to reject the request before
     /// it reaches any handler. The implementation owns the fail-open vs
     /// fail-closed policy by choosing the [`AdmissionRejection`] variant:
     /// [`AdmissionRejection::forbidden`] for an authoritative deny, or
     /// [`AdmissionRejection::unavailable`] to fail closed when an upstream the
     /// gate depends on is unreachable.
-    async fn admit(&self, metadata: &RequestMetadata) -> Result<Admission, AdmissionRejection>;
+    async fn admit(&self, ctx: AdmissionContext<'_>) -> Result<Admission, AdmissionRejection>;
 }
 
 /// An ordered collection of [`AdmissionGate`]s.
@@ -176,10 +212,10 @@ impl AdmissionGates {
     /// # Errors
     /// Returns the [`AdmissionRejection`] from the first gate that rejects the
     /// request.
-    pub async fn admit(&self, metadata: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
+    pub async fn admit(&self, ctx: AdmissionContext<'_>) -> Result<Admission, AdmissionRejection> {
         let mut resolved_roles: Option<TokenRoles> = None;
         for gate in &self.gates {
-            match gate.admit(metadata).await {
+            match gate.admit(ctx).await {
                 Ok(admission) => {
                     if let Some(roles) = admission.resolved_roles {
                         // Common case is a single role-resolving gate: just move
@@ -196,7 +232,7 @@ impl AdmissionGates {
                         gate = gate.name(),
                         status = error.code,
                         error_type = %error.r#type,
-                        request_id = %metadata.request_id(),
+                        request_id = %ctx.metadata.request_id(),
                         "Request rejected by admission gate"
                     );
                     return Err(rejection);
@@ -230,7 +266,7 @@ mod tests {
         fn name(&self) -> &'static str {
             "roles"
         }
-        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
+        async fn admit(&self, _: AdmissionContext<'_>) -> Result<Admission, AdmissionRejection> {
             Ok(Admission::with_roles(token_roles(self.0)))
         }
     }
@@ -242,7 +278,7 @@ mod tests {
         fn name(&self) -> &'static str {
             "allow"
         }
-        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
+        async fn admit(&self, _: AdmissionContext<'_>) -> Result<Admission, AdmissionRejection> {
             Ok(Admission::admit())
         }
     }
@@ -254,7 +290,7 @@ mod tests {
         fn name(&self) -> &'static str {
             "deny"
         }
-        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
+        async fn admit(&self, _: AdmissionContext<'_>) -> Result<Admission, AdmissionRejection> {
             Err(AdmissionRejection::forbidden("nope", "TestDenied", None))
         }
     }
@@ -266,7 +302,7 @@ mod tests {
         fn name(&self) -> &'static str {
             "unavailable"
         }
-        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
+        async fn admit(&self, _: AdmissionContext<'_>) -> Result<Admission, AdmissionRejection> {
             Err(AdmissionRejection::unavailable(
                 "upstream down",
                 "TestUnavailable",
@@ -284,8 +320,30 @@ mod tests {
         fn name(&self) -> &'static str {
             "panic"
         }
-        async fn admit(&self, _: &RequestMetadata) -> Result<Admission, AdmissionRejection> {
+        async fn admit(&self, _: AdmissionContext<'_>) -> Result<Admission, AdmissionRejection> {
             panic!("gate after a rejection must not be evaluated");
+        }
+    }
+
+    /// Admits only when the caller's bearer token is threaded through to the
+    /// gate and matches the expected value; otherwise denies.
+    #[derive(Debug)]
+    struct ExpectTokenGate(&'static str);
+    #[async_trait]
+    impl AdmissionGate for ExpectTokenGate {
+        fn name(&self) -> &'static str {
+            "expect-token"
+        }
+        async fn admit(&self, ctx: AdmissionContext<'_>) -> Result<Admission, AdmissionRejection> {
+            if ctx.bearer_token == Some(self.0) {
+                Ok(Admission::admit())
+            } else {
+                Err(AdmissionRejection::forbidden(
+                    "missing or wrong token",
+                    "TestNoToken",
+                    None,
+                ))
+            }
         }
     }
 
@@ -294,23 +352,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bearer_token_is_threaded_to_gates() {
+        let md = RequestMetadata::new_unauthenticated();
+        assert!(
+            gates(vec![Arc::new(ExpectTokenGate("tok-123"))])
+                .admit(AdmissionContext::new(&md, Some("tok-123")))
+                .await
+                .is_ok()
+        );
+        // A gate that needs the token rejects when it is absent.
+        assert!(
+            gates(vec![Arc::new(ExpectTokenGate("tok-123"))])
+                .admit(AdmissionContext::new(&md, None))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
     async fn empty_admits() {
         let md = RequestMetadata::new_unauthenticated();
         assert!(AdmissionGates::default().is_empty());
-        assert!(AdmissionGates::default().admit(&md).await.is_ok());
+        assert!(
+            AdmissionGates::default()
+                .admit(AdmissionContext::new(&md, None))
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
     async fn single_allow_admits() {
         let md = RequestMetadata::new_unauthenticated();
-        assert!(gates(vec![Arc::new(AllowGate)]).admit(&md).await.is_ok());
+        assert!(
+            gates(vec![Arc::new(AllowGate)])
+                .admit(AdmissionContext::new(&md, None))
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
     async fn forbidden_is_403() {
         let md = RequestMetadata::new_unauthenticated();
         let rejection = gates(vec![Arc::new(DenyGate)])
-            .admit(&md)
+            .admit(AdmissionContext::new(&md, None))
             .await
             .expect_err("DenyGate rejects");
         assert!(matches!(rejection, AdmissionRejection::Forbidden(_)));
@@ -322,7 +408,7 @@ mod tests {
     async fn unavailable_is_503_with_gate_chosen_retry_after() {
         let md = RequestMetadata::new_unauthenticated();
         let rejection = gates(vec![Arc::new(UnavailableGate)])
-            .admit(&md)
+            .admit(AdmissionContext::new(&md, None))
             .await
             .expect_err("UnavailableGate rejects");
         match rejection {
@@ -343,7 +429,7 @@ mod tests {
             Arc::new(DenyGate),
             Arc::new(PanicGate),
         ])
-        .admit(&md)
+        .admit(AdmissionContext::new(&md, None))
         .await
         .expect_err("DenyGate rejects before PanicGate is reached");
         assert_eq!(rejection.error().r#type, "TestDenied");
@@ -353,7 +439,7 @@ mod tests {
     async fn resolved_roles_surface_on_admit() {
         let md = RequestMetadata::new_unauthenticated();
         let admission = gates(vec![Arc::new(RolesGate(&["a", "b"]))])
-            .admit(&md)
+            .admit(AdmissionContext::new(&md, None))
             .await
             .expect("RolesGate admits");
         let roles = admission.resolved_roles.expect("roles were resolved");
@@ -369,7 +455,7 @@ mod tests {
             Arc::new(RolesGate(&["a", "b"])),
             Arc::new(RolesGate(&["b", "c"])),
         ])
-        .admit(&md)
+        .admit(AdmissionContext::new(&md, None))
         .await
         .expect("all gates admit");
         let roles = admission.resolved_roles.expect("roles were resolved");

--- a/crates/lakekeeper/src/service/admission.rs
+++ b/crates/lakekeeper/src/service/admission.rs
@@ -135,15 +135,15 @@ impl Admission {
 /// Non-exhaustive so further per-request inputs can be added without a breaking
 /// change. The auth middleware is the only constructor; gates read the fields
 /// they need.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, veil::Redact)]
 #[non_exhaustive]
 pub struct AdmissionContext<'a> {
     /// Resolved metadata for the request (actor, project, instance-admin, …).
     pub metadata: &'a RequestMetadata,
     /// The caller's raw bearer token — the value after `Bearer `. Present for
     /// every authenticated request (anonymous requests are rejected before any
-    /// gate runs). A gate that relays it to an external service MUST use TLS and
-    /// MUST NOT log it.
+    /// gate runs). A gate that relays it to an external service MUST use TLS.
+    #[redact]
     pub bearer_token: Option<&'a str>,
 }
 

--- a/crates/lakekeeper/src/service/authn.rs
+++ b/crates/lakekeeper/src/service/authn.rs
@@ -26,7 +26,7 @@ use crate::{
     request_metadata::{RequestMetadata, TokenRoles},
     service::{
         RoleIdent,
-        admission::{AdmissionGates, AdmissionRejection},
+        admission::{AdmissionContext, AdmissionGates, AdmissionRejection},
         authz::InstanceAdminMembership,
         events::EventDispatcher,
     },
@@ -565,7 +565,15 @@ pub(crate) async fn auth_middleware_fn<
         // honor the instance-admin break-glass and see the resolved actor.
         // No-op unless the host binary registered at least one gate.
         if !state.admission_gates.is_empty() {
-            match state.admission_gates.admit(request_metadata).await {
+            // The raw bearer is handed to gates via a transient context, never
+            // stored on `RequestMetadata`, so a gate can relay it to an external
+            // service without it leaking into metadata/audit.
+            let bearer_token = authorization.token();
+            match state
+                .admission_gates
+                .admit(AdmissionContext::new(request_metadata, Some(bearer_token)))
+                .await
+            {
                 // On admit, fold any roles the gate(s) resolved into the request
                 // metadata for downstream authorization and audit.
                 Ok(admission) => {

--- a/docs/docs/admission.md
+++ b/docs/docs/admission.md
@@ -1,0 +1,138 @@
+# Admission Gates <span class="lkp"></span> {#admission-gates}
+
+An **admission gate** makes a coarse allow/deny decision about an *already-authenticated* request **before it reaches any handler** — distinct from the per-resource [Authorizer](./authorization.md). Use one to consult an external control-plane entitlement service, suspend a tenant or principal, or reject revoked tokens.
+
+Gates run on every authenticated request, in order, after the actor and instance-admin status are resolved; the first rejection wins. A gate returns either a terminal `403 Forbidden` or — when it fails closed because an upstream it depends on is unreachable — a `503` with a `Retry-After`.
+
+The gate seam itself ([`AdmissionGate`](https://github.com/lakekeeper/lakekeeper/blob/main/crates/lakekeeper/src/service/admission.rs)) is a Rust trait; see [Customize](./customize.md) to implement your own. This page documents the **external enforce-endpoint gate** that ships ready-to-configure with Lakekeeper Plus.
+
+## When to use it
+
+This gate is for deployments whose IdP issues **broad, non-instance-scoped tokens**, where a separate service — not the token — is authoritative for whether the caller may use *this* Lakekeeper instance. After authentication, the gate asks that service, per caller, and either lets the request through or rejects it.
+
+If your tokens already carry the entitlement (claims, roles, audience), you don't need this — use [authentication](./authentication.md) and [authorization](./authorization.md).
+
+## How it works
+
+The gate evaluates one or more named **checks** against a configured enforce endpoint. **Each check carries its own complete request body** (any JSON shape), so the gate imposes no schema on the enforce API — you decide what the endpoint sees. Each check is a single `POST`; the decision is the HTTP status:
+
+| Upstream status                            | `kind = "gating"`                       | `kind = "role_granting"`      |
+| ------------------------------------------ | --------------------------------------- | ----------------------------- |
+| `2xx`                                      | admit + grant role                      | grant role                    |
+| `403` (exactly)                            | **reject request (`403`)**              | withhold role, continue       |
+| any other status, timeout, network error  | **`503` + `Retry-After`** (fail closed) | same — `503` fail closed      |
+
+Only an exact `403` is read as an authoritative deny. Every other non-`2xx` status — including other `4xx` (e.g. `400`, `401`, `404`, `429`) and any `5xx` — is treated as the endpoint being unable to give a verdict, so the gate fails closed with a `503`. This is deliberate: a misconfigured or malfunctioning enforce endpoint must never silently admit. If your endpoint signals "denied" with a status other than `403`, map it to `403` on its side.
+
+On admit, each passing check contributes its role to the request's admission roles, consumed by authorization downstream.
+
+- **Operator-defined body.** A check's `body` is arbitrary JSON. The only substitutions the gate makes are the request-derived placeholders `{{subject}}` (the token `sub`) and `{{idp_id}}` inside string values; everything else is sent literally. Unknown placeholders are rejected at startup. The gate models no "actions"/"resource" concepts — those are just whatever you write in the body.
+- **IdP-scoped.** The gate only governs tokens from the configured `idp_id`; tokens from any other identity provider are admitted untouched.
+- **Cached.** Decisions are cached in memory per `(subject, check)` for `cache_ttl_secs`. Both allow *and* deny are cached, so a denied-but-authenticated caller triggers at most one upstream call per TTL and cannot amplify load; transient `5xx`/timeout results are never cached.
+- **Fail closed.** Anything other than `2xx`/`403` becomes a `503` with `Retry-After`.
+- **Token relay is opt-in.** The caller's bearer token is forwarded only when `auth` is `forward_caller_token`; otherwise the endpoint is reached with the static `headers` only. A forwarded token goes over the configured URL (use TLS) and is never logged.
+
+## Configuration
+
+The gate is **disabled unless an `[admission_enforce]` block is present**. Like [Cedar derivations](./authorization-cedar.md) and [role providers](./configuration.md#role-provider), this is nested config, so it is configured via a TOML file with full environment-variable parity — point `LAKEKEEPER__ADMISSION_ENFORCE_FILE` at a TOML file, and/or set `LAKEKEEPER__ADMISSION_ENFORCE__*` variables on top.
+
+### `[admission_enforce]`
+
+| Key                            | Required | Default | Description                                                       |
+| ------------------------------ | -------- | ------- | ----------------------------------------------------------------- |
+| `endpoint`                     | yes      | —       | Enforce endpoint URL (`POST`). Validated at startup.              |
+| `idp_id`                       | yes      | —       | Only govern tokens from this IdP; others are admitted untouched.  |
+| `role_provider_id`             | yes      | —       | Provider namespace for the synthesized admission roles.           |
+| `cache_ttl_secs`               | no       | `60`    | TTL for cached allow/deny decisions.                              |
+| `cache_max_entries`            | no       | `10000` | Max cached decisions.                                             |
+| `request_timeout_secs`         | no       | `5`     | Per-request timeout.                                              |
+| `connect_timeout_secs`         | no       | `2`     | Connection timeout.                                               |
+| `unavailable_retry_after_secs` | no       | `5`     | `Retry-After` returned on the fail-closed `503`.                  |
+| `headers`                      | no       | `{}`    | Extra static headers sent on every call (e.g. a service API key). |
+| `auth`                         | no       | _none_  | How to authenticate (see below). Omit to send no `Authorization`. |
+| `checks`                       | yes      | —       | Named map of checks (at least one). See below.                   |
+
+### `[admission_enforce.auth]`
+
+Omit to forward no token. Currently one scheme — relay the caller's bearer token:
+
+```toml
+[admission_enforce.auth]
+type = "forward_caller_token"   # sent as `Authorization: Bearer <caller token>`
+```
+
+When set, the request **must** carry a bearer token; the gate fails closed if it is absent.
+
+### `[admission_enforce.checks.<name>]`
+
+Each check is keyed by a name you choose (used in the cache key and logs). Use lowercase with `_`/`-` only, so env vars can express it.
+
+| Key                | Required | Default          | Description                                                            |
+| ------------------ | -------- | ---------------- | --------------------------------------------------------------------- |
+| `kind`             | yes      | —                | `gating` (a `403` rejects the request) or `role_granting` (`403` withholds the role). |
+| `body`             | yes      | —                | This check's complete request body (any JSON). `{{subject}}`/`{{idp_id}}` are substituted; everything else is literal. |
+| `role_source_id`   | yes      | —                | Source id of the admission role granted when the check passes.        |
+| `role_provider_id` | no       | gate-level value | Override the role provider namespace for this check.                  |
+
+## Example
+
+```toml
+[admission_enforce]
+endpoint         = "https://control-plane.internal/v1/authorize"
+idp_id           = "oidc"
+role_provider_id = "control-plane"
+cache_ttl_secs   = 60
+
+[admission_enforce.auth]
+type = "forward_caller_token"
+
+# A `403` here rejects the request outright.
+[admission_enforce.checks.instance-access]
+kind           = "gating"
+role_source_id = "instance-access"
+[admission_enforce.checks.instance-access.body]
+subject      = "{{subject}}"
+resource     = "102befc3-424d-479e-b1f7-bb47c1e1a1a2"
+resourceType = "project"
+actions      = ["workflows.instance.read"]
+
+# A `403` here only withholds the role; the request still proceeds.
+[admission_enforce.checks.workflow-editor]
+kind           = "role_granting"
+role_source_id = "workflow-editor"
+[admission_enforce.checks.workflow-editor.body]
+subject      = "{{subject}}"
+resource     = "102befc3-424d-479e-b1f7-bb47c1e1a1a2"
+resourceType = "project"
+actions      = ["workflows.instance.update", "workflows.instance.delete"]
+```
+
+The body shape is entirely yours — a different enforce API (e.g. OPA-style `{"input": {...}}`) is just a different `body`, with no code change:
+
+```toml
+[admission_enforce.checks.can-read.body.input]
+user   = "{{subject}}"
+tenant = "acme"
+verb   = "read"
+```
+
+### Configuring via environment variables
+
+Every field has full env↔TOML parity. The example above is equivalent to:
+
+```bash
+LAKEKEEPER__ADMISSION_ENFORCE__ENDPOINT='https://control-plane.internal/v1/authorize'
+LAKEKEEPER__ADMISSION_ENFORCE__IDP_ID='oidc'
+LAKEKEEPER__ADMISSION_ENFORCE__ROLE_PROVIDER_ID='control-plane'
+LAKEKEEPER__ADMISSION_ENFORCE__AUTH__TYPE='forward_caller_token'
+LAKEKEEPER__ADMISSION_ENFORCE__CHECKS__INSTANCE_ACCESS__KIND='gating'
+LAKEKEEPER__ADMISSION_ENFORCE__CHECKS__INSTANCE_ACCESS__ROLE_SOURCE_ID='instance-access'
+LAKEKEEPER__ADMISSION_ENFORCE__CHECKS__INSTANCE_ACCESS__BODY__SUBJECT='{{subject}}'
+LAKEKEEPER__ADMISSION_ENFORCE__CHECKS__INSTANCE_ACCESS__BODY__RESOURCETYPE='project'
+LAKEKEEPER__ADMISSION_ENFORCE__CHECKS__INSTANCE_ACCESS__BODY__ACTIONS='[workflows.instance.read]'
+```
+
+!!! note "Arrays in a body via env vars"
+    A literal JSON array in a body must use figment's inline form — `BODY__ACTIONS='[a,b]'`, not repeated keys. TOML files use ordinary `actions = ["a", "b"]`. This is the one place the two forms differ, so prefer a TOML file when bodies contain arrays.
+
+As with [role providers](./configuration.md#role-provider), the two approaches combine: load non-sensitive config from the file and inject secrets (e.g. a service API key in `headers`) via env vars on top.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
           - authorization.md
           - Authorization (OpenFGA): authorization-openfga.md
           - Authorization (Cedar): authorization-cedar.md
+          - Admission Gates: admission.md
           - View Security: view-security.md
           - Generic Tables: generic-tables.md
           - logging.md


### PR DESCRIPTION
Admission gates run post-authentication and may need to relay the caller's token to an external service (e.g. a control-plane that authorizes per the user's own identity). The token is deliberately not on `RequestMetadata` — that struct is cloned, debugged, and folded into audit events, so a raw bearer there would sprawl into logs.

Introduce `AdmissionContext<'a> { metadata, bearer_token }` and change `AdmissionGate::admit` / `AdmissionGates::admit` to take it instead of a bare `&RequestMetadata`. The middleware builds the context from `authorization.token()` and passes it by value; the token is borrowed for the duration of the call only and never stored. Anonymous requests are rejected before any gate runs, so the bearer is always present.

`AdmissionContext` is `#[non_exhaustive]` (further per-request inputs can be added without a break) and `Copy` (cheap to forward to each gate). The in-repo fixture gates and tests are updated, with a new test asserting the token is threaded through and that a token-needing gate rejects when it is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admission checks can now use an optional bearer token, enabling token-aware access decisions.
* **Bug Fixes**
  * Post-authentication admission gates now evaluate with the complete admission context, improving consistency of gate outcomes and request tracking.
* **Tests**
  * Added coverage to verify bearer tokens are correctly passed into admission gate evaluation and that token-based admitting/rejecting behaves as expected.
* **Documentation**
  * Added a new “Admission Gates” user guide page and navigation entry.  
* **Chores**
  * Updated markdown formatting guidance for documentation files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->