### PR TITLE
feat(deps): bump console to v0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,8 +3844,8 @@ dependencies = [
 
 [[package]]
 name = "lakekeeper-console"
-version = "0.18.0"
-source = "git+https://github.com/lakekeeper/console?rev=v0.18.0#ba5bdd29e5ba5d17dbb4124017107efab7d45999"
+version = "0.18.1"
+source = "git+https://github.com/lakekeeper/console?rev=v0.18.1#0e5af87f796aa7b352c41cd813f76eb2b5da16d7"
 dependencies = [
  "flate2",
  "fs_extra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,8 +3844,8 @@ dependencies = [
 
 [[package]]
 name = "lakekeeper-console"
-version = "0.15.1"
-source = "git+https://github.com/lakekeeper/console?rev=v0.15.1#b559f3f9d80153ecc25f5481600a8d7e056deae1"
+version = "0.18.0"
+source = "git+https://github.com/lakekeeper/console?rev=v0.18.0#ba5bdd29e5ba5d17dbb4124017107efab7d45999"
 dependencies = [
  "flate2",
  "fs_extra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5341,9 +5341,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/crates/lakekeeper-bin/Cargo.toml
+++ b/crates/lakekeeper-bin/Cargo.toml
@@ -33,7 +33,7 @@ figment = { workspace = true }
 http = { workspace = true }
 lakekeeper = { path = "../lakekeeper", features = ["s3-signer", "router"] }
 lakekeeper-authz-openfga = { path = "../authz-openfga" }
-lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.18.0", optional = true }
+lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.18.1", optional = true }
 lakekeeper-events-kafka = { path = "../lakekeeper-events-kafka" }
 lakekeeper-events-nats = { path = "../lakekeeper-events-nats" }
 lakekeeper-secrets-kv2 = { path = "../lakekeeper-secrets-kv2" }

--- a/crates/lakekeeper-bin/Cargo.toml
+++ b/crates/lakekeeper-bin/Cargo.toml
@@ -33,7 +33,7 @@ figment = { workspace = true }
 http = { workspace = true }
 lakekeeper = { path = "../lakekeeper", features = ["s3-signer", "router"] }
 lakekeeper-authz-openfga = { path = "../authz-openfga" }
-lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.15.1", optional = true }
+lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.18.0", optional = true }
 lakekeeper-events-kafka = { path = "../lakekeeper-events-kafka" }
 lakekeeper-events-nats = { path = "../lakekeeper-events-nats" }
 lakekeeper-secrets-kv2 = { path = "../lakekeeper-secrets-kv2" }


### PR DESCRIPTION
Updates embedded UI console from v0.15.1 to v0.18.1 (console-components
v0.9.0 → v0.12.0). User-visible changes:

New
- Files tab / storage explorer for S3, ADLS and GCS with DuckDB-powered
  parquet/avro/csv preview, JSON/text preview, download and copy-path
  (DuckDB WASM vendored for airgapped deployments)
- Entity action cog menus on tables, views, generic tables, namespaces
  and warehouses: rename, deletion protection, change properties,
  download metadata.json, delete — with type-to-confirm force/purge
- Datasets as a first-class entity: dedicated namespace tab, file
  explorer (upload, download, delete, create folders, drag-to-move) and
  storage stats (file count + total size)
- View details redesign: at-a-glance cards, identity, SQL definition
  version picker, schema evolution; branch-aware snapshots and schema
  view/compare dialogs
- Table Health expanded with configuration, column statistics, storage
  composition and on-demand column profiler

Changed
- Maintenance (schedule, configure, advanced overrides) moved into the
  header cog, grouped General/Security/Maintenance; task failure reason
  shown in the task drawer
- Catalog Settings renamed to Warehouse Settings (folds in rename, shows
  storage-provider icons)
- Navigation trees refined: indent lines, compact leaf rows,
  active-route highlight, OneLake icon
- Identities now defaults to the Users tab
- Removed the redundant raw tab (metadata.json downloadable from the cog)

Fixed
- Renew expired vended storage credentials and retry on expiry
- Treat ADLS PathNotFound (404) as an empty prefix when listing datasets
- Hide system lakekeeper.* properties behind a toggle
- Snapshot metrics fall back to added-* instead of showing a fake 0
- Home logo aspect ratio; Roles-tab flash on Identities load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the built-in console component to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->