### PR TITLE
feat(deps): bump console to v0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,8 +3844,8 @@ dependencies = [
 
 [[package]]
 name = "lakekeeper-console"
-version = "0.18.1"
-source = "git+https://github.com/lakekeeper/console?rev=v0.18.1#0e5af87f796aa7b352c41cd813f76eb2b5da16d7"
+version = "0.18.2"
+source = "git+https://github.com/lakekeeper/console?rev=v0.18.2#43dd2de6726e185b8078b91543fc91de7d4df561"
 dependencies = [
  "flate2",
  "fs_extra",

--- a/crates/lakekeeper-bin/Cargo.toml
+++ b/crates/lakekeeper-bin/Cargo.toml
@@ -33,7 +33,7 @@ figment = { workspace = true }
 http = { workspace = true }
 lakekeeper = { path = "../lakekeeper", features = ["s3-signer", "router"] }
 lakekeeper-authz-openfga = { path = "../authz-openfga" }
-lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.18.1", optional = true }
+lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.18.2", optional = true }
 lakekeeper-events-kafka = { path = "../lakekeeper-events-kafka" }
 lakekeeper-events-nats = { path = "../lakekeeper-events-nats" }
 lakekeeper-secrets-kv2 = { path = "../lakekeeper-secrets-kv2" }


### PR DESCRIPTION
Updates embedded UI console v0.18.1 → v0.18.2
(console-components v0.14.1 → v0.14.2).

- LoQE surfaces a blocked object-storage fetch as a clear CORS/credentials error instead of an opaque failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an optional console dependency to a newer release, which may include general improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->