### PR TITLE
feat(tasks): surface failure message in task details

### DIFF
--- a/crates/lakekeeper-storage-postgres/src/tasks/get_task_details.rs
+++ b/crates/lakekeeper-storage-postgres/src/tasks/get_task_details.rs
@@ -122,6 +122,7 @@ fn parse_task_details(
         data: most_recent.task_data,
         attempts,
         execution_details: most_recent.execution_details,
+        message: most_recent.message,
     }))
 }
 
@@ -807,6 +808,68 @@ mod tests {
 
         // No historical attempts for single completed task
         assert!(result.attempts.is_empty());
+        // The current attempt's message (here: success result details) is
+        // surfaced at the top level.
+        assert_eq!(
+            result.message,
+            Some("Task completed successfully".to_string())
+        );
+    }
+
+    #[sqlx::test]
+    async fn test_get_task_details_single_terminal_failure(pool: PgPool) {
+        let mut conn = pool.acquire().await.unwrap();
+        let (warehouse_id, project_id) = setup_warehouse(pool.clone()).await;
+        let entity_id = WarehouseTaskEntityId::Table {
+            table_id: Uuid::now_v7().into(),
+        };
+        let tq_name = generate_tq_name();
+
+        let task_id = queue_wh_task_helper(
+            &mut conn,
+            &tq_name,
+            None,
+            entity_id,
+            vec!["ns".to_string(), "table".to_string()],
+            project_id.clone(),
+            warehouse_id,
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Pick and fail terminally (max_retries = 1 => attempt 1 is terminal,
+        // mirroring how remove_orphan_files runs as a single-attempt task).
+        let task = pick_task(&pool, &tq_name, DEFAULT_MAX_TIME_SINCE_LAST_HEARTBEAT)
+            .await
+            .unwrap()
+            .unwrap();
+        record_failure(&task, 1, "only attempt failed", &mut conn)
+            .await
+            .unwrap();
+
+        let result = get_task_details(
+            task_id,
+            TaskDetailsScope::Warehouse {
+                project_id,
+                warehouse_id,
+            },
+            10,
+            &pool,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(result.task.task_id(), task_id);
+        assert_eq!(result.task.attempt(), 1);
+        assert!(matches!(result.task.status, TaskStatus::Failed));
+        // The reported bug: a single failed attempt has no historical attempts,
+        // and its message used to be dropped. It is now surfaced top-level.
+        assert!(result.attempts.is_empty());
+        assert_eq!(result.message, Some("only attempt failed".to_string()));
     }
 
     #[sqlx::test]
@@ -886,6 +949,9 @@ mod tests {
         assert_eq!(result.task.task_id(), task_id);
         assert_eq!(result.task.attempt(), 3);
         assert!(matches!(result.task.status, TaskStatus::Success));
+        // Top-level message is the most-recent (3rd) attempt's message; the
+        // current attempt is NOT duplicated into attempts[].
+        assert_eq!(result.message, Some("Third attempt succeeded".to_string()));
 
         // Verify we have 2 historical attempts (failed attempts 1 and 2)
         assert_eq!(result.attempts.len(), 2);

--- a/crates/lakekeeper/src/api/management/v1/tasks.rs
+++ b/crates/lakekeeper/src/api/management/v1/tasks.rs
@@ -262,6 +262,10 @@ pub struct GetTaskDetailsResponse {
     /// Execution details for the current attempt
     #[cfg_attr(feature = "open-api", schema(value_type = Option<Object>))]
     pub execution_details: Option<serde_json::Value>,
+    /// Message for the current attempt: success result details if it
+    /// succeeded, or the failure reason if it failed. `null` while the
+    /// attempt is still running or scheduled.
+    pub message: Option<String>,
     /// History of past attempts
     pub attempts: Vec<TaskAttempt>,
 }
@@ -275,12 +279,14 @@ impl TryFrom<TaskDetails> for GetTaskDetailsResponse {
             data,
             execution_details,
             attempts,
+            message,
         } = value;
 
         Ok(Self {
             task: WarehouseTaskInfo::try_from(task)?,
             task_data: data,
             execution_details,
+            message,
             attempts,
         })
     }
@@ -299,6 +305,10 @@ pub struct GetProjectTaskDetailsResponse {
     /// Execution details for the current attempt
     #[cfg_attr(feature = "open-api", schema(value_type = Option<Object>))]
     pub execution_details: Option<serde_json::Value>,
+    /// Message for the current attempt: success result details if it
+    /// succeeded, or the failure reason if it failed. `null` while the
+    /// attempt is still running or scheduled.
+    pub message: Option<String>,
     /// History of past attempts
     pub attempts: Vec<TaskAttempt>,
 }
@@ -318,12 +328,14 @@ impl TryFrom<TaskDetails> for GetProjectTaskDetailsResponse {
             data,
             execution_details,
             attempts,
+            message,
         } = value;
 
         Ok(Self {
             task: ProjectTaskInfo::try_from(task)?,
             task_data: data,
             execution_details,
+            message,
             attempts,
         })
     }

--- a/crates/lakekeeper/src/service/catalog_store/tasks.rs
+++ b/crates/lakekeeper/src/service/catalog_store/tasks.rs
@@ -70,6 +70,10 @@ pub struct TaskDetails {
     pub execution_details: Option<serde_json::Value>,
     pub data: serde_json::Value,
     pub attempts: Vec<TaskAttempt>,
+    /// Message of the most-recent attempt: success result details if it
+    /// succeeded, or the failure reason if it failed. `None` while the
+    /// current attempt is still running.
+    pub message: Option<String>,
 }
 
 #[derive(thiserror::Error, Debug, PartialEq)]

--- a/crates/lakekeeper/src/service/tasks/tabular_expiration_queue.rs
+++ b/crates/lakekeeper/src/service/tasks/tabular_expiration_queue.rs
@@ -142,11 +142,11 @@ async fn instrumented_expire<C: CatalogStore, A: Authorizer>(
             tracing::error!(
                 "Error in `{QN_STR}` worker. Expiration of {entity_id_str} failed. Error: {err}"
             );
-            task.record_failure::<C>(
-                catalog_state,
-                &format!("Failed to expire soft-deleted {entity_id_str}.\n{err}"),
-            )
-            .await;
+            let detail = format!(
+                "Failed to expire soft-deleted {entity_id_str}.\nError: {}",
+                err.error
+            );
+            task.record_failure::<C>(catalog_state, &detail).await;
         }
     }
 }

--- a/crates/lakekeeper/src/service/tasks/tabular_purge_queue.rs
+++ b/crates/lakekeeper/src/service/tasks/tabular_purge_queue.rs
@@ -134,14 +134,11 @@ async fn instrumented_purge<S: SecretStore, C: CatalogStore>(
                 "Error in `{QN_STR}` worker. Failed to purge location {}. {err}",
                 task.data.tabular_location,
             );
-            task.record_failure::<C>(
-                catalog_state,
-                &format!(
-                    "Failed to purge tabular at location `{}`.\n{err}",
-                    task.data.tabular_location
-                ),
-            )
-            .await;
+            let detail = format!(
+                "Failed to purge tabular at location `{}`.\nError: {}",
+                task.data.tabular_location, err.error
+            );
+            task.record_failure::<C>(catalog_state, &detail).await;
         }
     }
 }

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -5729,6 +5729,14 @@ components:
                 - object
                 - 'null'
               description: Execution details for the current attempt
+            message:
+              type:
+                - string
+                - 'null'
+              description: |-
+                Message for the current attempt: success result details if it
+                succeeded, or the failure reason if it failed. `null` while the
+                attempt is still running or scheduled.
             task-data:
               type: object
               description: Task-specific data
@@ -5829,6 +5837,14 @@ components:
                 - object
                 - 'null'
               description: Execution details for the current attempt
+            message:
+              type:
+                - string
+                - 'null'
+              description: |-
+                Message for the current attempt: success result details if it
+                succeeded, or the failure reason if it failed. `null` while the
+                attempt is still running or scheduled.
             task-data:
               type: object
               description: Task-specific data


### PR DESCRIPTION
A task that failed on its only attempt returned no error anywhere via the Management API (`attempts: []`, no message), making maintenance failures undebuggable without server-log access. Surface the current attempt's message and persist a useful one.

- Add an optional top-level `message` to GetTaskDetailsResponse and GetProjectTaskDetailsResponse, carried from the most-recent attempt's `task_log.message` (success result details if it succeeded, the failure reason if it failed; null while running). `attempts[]` keeps its existing "prior attempts only" meaning — purely additive, no migration.
- Maintenance queues (tabular purge, tabular expiration) now persist a clear summary line plus the full error (ErrorModel Display, including the `Caused by:` source chain) so the root cause is visible in the API to task-detail viewers — including cloud operators who cannot read logs. The full chain is still emitted to the tracing logs as before.
- Regenerate the management OpenAPI spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task details now show a top-level message for the latest attempt, making success details and failure reasons easier to see.
  * Project and warehouse task detail responses now include the same message information.

* **Bug Fixes**
  * Improved failure messages for expiration and purge tasks so errors are clearer and more consistent.

* **Documentation**
  * Updated API documentation to describe the new task message field and when it may be empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->