### PR TITLE
fix(tasks): stop post-migration cleanup hook spinning to the pagination cap

### DIFF
--- a/crates/lakekeeper/src/service/post_migration_hooks.rs
+++ b/crates/lakekeeper/src/service/post_migration_hooks.rs
@@ -205,11 +205,43 @@ async fn get_scheduled_project_ids<C: CatalogStore>(
                 .map(|task| task.task_metadata.project_id().clone()),
         );
 
-        if response.next_page_token.is_none() {
+        if !has_more_task_pages(
+            response.tasks.is_empty(),
+            response.next_page_token.as_deref(),
+        ) {
             break;
         }
         page_token = response.next_page_token;
     }
 
     Ok(project_ids)
+}
+
+/// Whether [`get_scheduled_project_ids`] should request another page given the
+/// page just returned by `list_tasks`.
+///
+/// `list_tasks` echoes the supplied page token back even when a page comes back
+/// empty (so a caller can resume the same cursor later), so the end of the
+/// result set is signalled by an empty page — not by a missing token.
+fn has_more_task_pages(page_was_empty: bool, next_page_token: Option<&str>) -> bool {
+    !page_was_empty && next_page_token.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_more_task_pages;
+
+    #[test]
+    fn stops_paginating_on_empty_terminal_page() {
+        // A non-empty page with a continuation token: keep going.
+        assert!(has_more_task_pages(false, Some("token")));
+
+        // `list_tasks` echoes the supplied token back on an empty terminal page,
+        // so an empty page must stop pagination even though a token is present.
+        assert!(!has_more_task_pages(true, Some("token")));
+
+        // No token: stop regardless of whether the page had rows.
+        assert!(!has_more_task_pages(false, None));
+        assert!(!has_more_task_pages(true, None));
+    }
 }


### PR DESCRIPTION
`get_scheduled_project_ids` paginated `list_tasks` and only stopped when `next_page_token` came back `None`. But `list_tasks` echoes the supplied page token back on an empty terminal page (so callers can resume the same cursor later), so the token is never `None` once pagination has started. The loop therefore re-requested the same empty page until the 100-iteration safety cap, emitting a spurious "Reached maximum pagination iterations" warning plus ~99 redundant queries on every startup whenever a project already had a task-log-cleanup task scheduled.

Stop paginating when a page comes back empty, not only when the token is absent. Extracts the decision into `has_more_task_pages` with a unit test covering the empty-terminal-page case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination handling when collecting scheduled project IDs after migration.
  * The process now stops correctly on an empty final page, even if a continuation token is still returned, preventing unnecessary extra requests.

* **Tests**
  * Added coverage for both continuing through populated pages and stopping on an empty terminal page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->