### PR TITLE
docs(roles): correct role-membership API doc inaccuracies

### DIFF
--- a/crates/lakekeeper/src/api/management/v1/role_membership.rs
+++ b/crates/lakekeeper/src/api/management/v1/role_membership.rs
@@ -108,7 +108,7 @@ impl From<RoleMemberType> for RoleMemberKind {
 
 /// A member of a role, returned by `GET /role/{id}/members`. Discriminated by
 /// `type`: a `user` (direct user→role assignment) or a `role` (role→role edge).
-/// Identity is hydrated; for requests and add/remove confirmations use the
+/// Identity is hydrated; for requests and add confirmations use the
 /// un-hydrated [`RoleMemberRef`] instead.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
@@ -162,9 +162,9 @@ impl From<CatalogRoleMember> for RoleMember {
 }
 
 /// An identity reference to a role member — a `user` or a `role`, by typed id.
-/// Sent in `POST /role/{id}/members` requests and echoed by the add/remove
-/// confirmations. Unlike [`RoleMember`] it is never hydrated (no display name):
-/// it names *which* principal, not its display identity.
+/// Sent in `POST /role/{id}/members` requests and echoed by the add confirmation
+/// (remove returns `204` with no body). Unlike [`RoleMember`] it is never hydrated
+/// (no display name): it names *which* principal, not its display identity.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -228,14 +228,15 @@ pub struct AddRoleMembersResponse {
     pub members: Vec<RoleMemberRef>,
 }
 
-/// One page of a role's direct members (users ∪ member roles).
+/// One page of a role's members (users ∪ member roles) — direct for `/members`,
+/// transitive for `/members/transitive`.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct ListRoleMembersResponse {
     pub members: Vec<RoleMember>,
     /// Token for the next page; `null`/absent once the listing is exhausted.
-    /// Note for SDK authors: **stop when `next_page_token` is null/absent.** The
+    /// Note for SDK authors: **stop when `next-page-token` is null/absent.** The
     /// final page of results may itself return a null token, so don't rely on
     /// receiving a separate trailing empty page — keep requesting until the token
     /// is null.
@@ -270,14 +271,15 @@ impl From<RoleMembershipEntry> for RoleMembership {
     }
 }
 
-/// One page of roles (the `member-of` set, or a user's directly-assigned roles).
+/// One page of roles — the `member-of` set or a user's roles, direct or transitive
+/// depending on the endpoint.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct ListRoleMembershipsResponse {
     pub roles: Vec<RoleMembership>,
     /// Token for the next page; `null`/absent once the listing is exhausted.
-    /// Note for SDK authors: **stop when `next_page_token` is null/absent.** The
+    /// Note for SDK authors: **stop when `next-page-token` is null/absent.** The
     /// final page of results may itself return a null token, so don't rely on
     /// receiving a separate trailing empty page — keep requesting until the token
     /// is null.

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -7701,7 +7701,9 @@ components:
           description: List of projects
     ListRoleMembersResponse:
       type: object
-      description: One page of a role's direct members (users ∪ member roles).
+      description: |-
+        One page of a role's members (users ∪ member roles) — direct for `/members`,
+        transitive for `/members/transitive`.
       required:
         - members
       properties:
@@ -7715,13 +7717,15 @@ components:
             - 'null'
           description: |-
             Token for the next page; `null`/absent once the listing is exhausted.
-            Note for SDK authors: **stop when `next_page_token` is null/absent.** The
+            Note for SDK authors: **stop when `next-page-token` is null/absent.** The
             final page of results may itself return a null token, so don't rely on
             receiving a separate trailing empty page — keep requesting until the token
             is null.
     ListRoleMembershipsResponse:
       type: object
-      description: One page of roles (the `member-of` set, or a user's directly-assigned roles).
+      description: |-
+        One page of roles — the `member-of` set or a user's roles, direct or transitive
+        depending on the endpoint.
       required:
         - roles
       properties:
@@ -7731,7 +7735,7 @@ components:
             - 'null'
           description: |-
             Token for the next page; `null`/absent once the listing is exhausted.
-            Note for SDK authors: **stop when `next_page_token` is null/absent.** The
+            Note for SDK authors: **stop when `next-page-token` is null/absent.** The
             final page of results may itself return a null token, so don't rely on
             receiving a separate trailing empty page — keep requesting until the token
             is null.
@@ -8460,7 +8464,7 @@ components:
       description: |-
         A member of a role, returned by `GET /role/{id}/members`. Discriminated by
         `type`: a `user` (direct user→role assignment) or a `role` (role→role edge).
-        Identity is hydrated; for requests and add/remove confirmations use the
+        Identity is hydrated; for requests and add confirmations use the
         un-hydrated [`RoleMemberRef`] instead.
     RoleMemberRef:
       oneOf:
@@ -8491,9 +8495,9 @@ components:
                 - role
       description: |-
         An identity reference to a role member — a `user` or a `role`, by typed id.
-        Sent in `POST /role/{id}/members` requests and echoed by the add/remove
-        confirmations. Unlike [`RoleMember`] it is never hydrated (no display name):
-        it names *which* principal, not its display identity.
+        Sent in `POST /role/{id}/members` requests and echoed by the add confirmation
+        (remove returns `204` with no body). Unlike [`RoleMember`] it is never hydrated
+        (no display name): it names *which* principal, not its display identity.
     RoleMemberType:
       type: string
       description: Kind of a role member. Serializes as `"user"` / `"role"`.


### PR DESCRIPTION
Three doc-comment fixes in the role-membership management API; these descriptions feed the generated OpenAPI spec (and the downstream plus spec), so they directly affect generated clients and SDK authors.

- Pagination: the SDK-author note told clients to stop on `next_page_token`, but the serialized field is `next-page-token` (responses derive `rename_all = "kebab-case"`). A client following the prose would poll the wrong key.
- ListRoleMembersResponse / ListRoleMembershipsResponse described their contents as "direct" only, but both schemas are also returned by the transitive endpoints (`/members/transitive`, `/member-of/transitive`, `/roles/transitive`). Reworded to cover direct or transitive.
- RoleMember / RoleMemberRef claimed to be echoed by "add/remove confirmations", but DELETE returns 204 with no body — only add echoes the members. Reworded to "add confirmation".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified role membership API descriptions for listing members and memberships, including direct vs. transitive results.
  * Updated pagination guidance to use the `next-page-token` wording and improved instructions for when to stop requesting more pages.
  * Refined role member reference descriptions to better explain add confirmations and removal responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->