### PR TITLE
fix(deps): bump quick-xml to 0.41 (RUSTSEC-2026-0194/0195)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,4 +6,6 @@ ignore = [
     "RUSTSEC-2024-0436", # paste is unmaintained but has no direct harm. We already removed direct dependencies.
     "RUSTSEC-2026-0001", # Review once https://github.com/paupino/rust-decimal/issues/766 is merged
     "RUSTSEC-2025-0134", # https://github.com/nats-io/nats.rs/issues/1502, will be fixed in v0.47
+    "RUSTSEC-2026-0194", # quick-xml <0.41 O(N²) attribute-parse DoS. Client-facing path (S3 remote-signer DeleteObjects body) is on the patched 0.41; only remaining instance is 0.40.1 via the azure_core 0.21 fork (ADLS), which parses Azure responses not attacker input. Remove when the azure fork bumps quick-xml to ≥0.41.
+    "RUSTSEC-2026-0195", # quick-xml <0.41 NsReader namespace-declaration memory-exhaustion DoS. Same exposure/justification as RUSTSEC-2026-0194 — only remaining <0.41 instance is 0.40.1 via the azure_core 0.21 fork. Remove when the azure fork bumps quick-xml to ≥0.41.
 ]

--- a/.cargo/deny.toml
+++ b/.cargo/deny.toml
@@ -74,6 +74,8 @@ ignore = [
     "RUSTSEC-2024-0436", # paste is unmaintained but has no direct harm. We already removed direct dependencies.
     "RUSTSEC-2025-0134", # https://github.com/nats-io/nats.rs/issues/1502, will be fixed in v0.47
     "RUSTSEC-2026-0174", # http-types unsound auth ASCII-invariant. Not affected: only transitive path is azure_core 0.21 (ADLS), which uses http-types solely for Method/StatusCode and never the vulnerable Authorization/WwwAuthenticate types, so that code is never reached. Unmaintained crate, no upgrade available.
+    "RUSTSEC-2026-0194", # quick-xml <0.41 O(N²) attribute-parse DoS. The client-facing path (S3 remote-signer DeleteObjects body) is on the patched 0.41. The only remaining <0.41 instance is 0.40.1 via the azure_core 0.21 fork (ADLS), which parses Azure storage API responses, not attacker input — not reachable. Remove when the azure fork bumps quick-xml to ≥0.41.
+    "RUSTSEC-2026-0195", # quick-xml <0.41 NsReader namespace-declaration memory-exhaustion DoS. Same exposure as RUSTSEC-2026-0194: core is on the patched 0.41; only remaining instance is 0.40.1 via the azure_core 0.21 fork (ADLS), parsing Azure responses not attacker input. Remove when the azure fork bumps quick-xml to ≥0.41.
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,7 +3754,7 @@ dependencies = [
  "pastey",
  "percent-encoding",
  "pretty_assertions",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "reqwest 0.12.28",
  "semver",
  "serde",
@@ -5301,9 +5301,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -5311,9 +5311,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ moka = { version = "^0.12", features = ["future"] }
 pastey = "0.2.1"
 percent-encoding = "2.3.1"
 pretty_assertions = "~1.4"
-quick-xml = { version = "0.38.3", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 rdkafka = { version = "0.38.0", default-features = false, features = [
     "tokio",
     "zstd",


### PR DESCRIPTION
quick-xml <0.41 has two DoS advisories: O(N²) attribute-name parsing (RUSTSEC-2026-0194) and unbounded NsReader namespace-declaration allocation (RUSTSEC-2026-0195).

The exploitable path is the S3 remote-signer, which deserializes the client-supplied DeleteObjects XML body via quick_xml::de::from_str (server/s3_signer/sign.rs) — an authenticated caller could send a crafted <Delete> tag to burn CPU/memory. Bump the workspace quick-xml to 0.41.0 (de::from_str + `serialize` feature unchanged; no code changes needed) to close it.

The only remaining <0.41 instance is 0.40.1, pulled transitively by the azure_core 0.21 fork (ADLS), which parses Azure storage API responses — not attacker input — so it is not reachable. Ignore both advisories in deny.toml with that justification until the fork bumps quick-xml.