### PR TITLE
fix(authz): stop evaluating discarded Select on target view load

### DIFF
--- a/crates/lakekeeper/src/server/generic_tables/credentials.rs
+++ b/crates/lakekeeper/src/server/generic_tables/credentials.rs
@@ -219,6 +219,7 @@ pub(super) async fn authorize_load_generic_table<C: CatalogStore, A: Authorizer 
     // 9. Build actions and authorize in batch.
     let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
         &sorted_tabulars_with_full_info,
+        &table,
     );
     let authz_results = authorizer
         .are_allowed_tabular_actions_vec(request_metadata, &warehouse, &namespaces, &actions)

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -1066,6 +1066,7 @@ async fn authorize_load_table<C: CatalogStore, A: Authorizer + Clone>(
     // 9. Build actions and check all authorizations in batch.
     let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
         &sorted_tabulars_with_full_info,
+        &table,
     );
     let authz_results = authorizer
         .are_allowed_tabular_actions_vec(request_metadata, &warehouse, &namespaces, &actions)
@@ -2372,7 +2373,8 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
         let results = vec![true, true, true];
 
         let (info, perms) = interpret_authz_results_for_load_table(
@@ -2395,7 +2397,8 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
         let results = vec![true, true, false];
 
         let (_, perms) = interpret_authz_results_for_load_table(
@@ -2417,7 +2420,8 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
         let results = vec![true, false, false];
 
         let (_, perms) = interpret_authz_results_for_load_table(
@@ -2439,7 +2443,8 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
         let results = vec![false, false, false];
 
         let result = interpret_authz_results_for_load_table(
@@ -2464,7 +2469,8 @@ mod unit_tests {
             resolved(view.into(), &actor, view_ns),
             resolved(table.clone().into(), &actor, table_ns),
         ];
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
         let results = vec![false, true, true, true];
 
         let result = interpret_authz_results_for_load_table(
@@ -2484,7 +2490,8 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
         let results = vec![true, true]; // Only 2 results for 3 actions
 
         let result = interpret_authz_results_for_load_table(

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -2373,8 +2373,10 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions =
-            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
+        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
+            &tabulars,
+            &table.tabular_ident,
+        );
         let results = vec![true, true, true];
 
         let (info, perms) = interpret_authz_results_for_load_table(
@@ -2397,8 +2399,10 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions =
-            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
+        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
+            &tabulars,
+            &table.tabular_ident,
+        );
         let results = vec![true, true, false];
 
         let (_, perms) = interpret_authz_results_for_load_table(
@@ -2420,8 +2424,10 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions =
-            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
+        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
+            &tabulars,
+            &table.tabular_ident,
+        );
         let results = vec![true, false, false];
 
         let (_, perms) = interpret_authz_results_for_load_table(
@@ -2443,8 +2449,10 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions =
-            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
+        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
+            &tabulars,
+            &table.tabular_ident,
+        );
         let results = vec![false, false, false];
 
         let result = interpret_authz_results_for_load_table(
@@ -2469,8 +2477,10 @@ mod unit_tests {
             resolved(view.into(), &actor, view_ns),
             resolved(table.clone().into(), &actor, table_ns),
         ];
-        let actions =
-            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
+        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
+            &tabulars,
+            &table.tabular_ident,
+        );
         let results = vec![false, true, true, true];
 
         let result = interpret_authz_results_for_load_table(
@@ -2490,8 +2500,10 @@ mod unit_tests {
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
         let tabulars = vec![resolved(table.clone().into(), &actor, namespace)];
-        let actions =
-            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &table.tabular_ident);
+        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
+            &tabulars,
+            &table.tabular_ident,
+        );
         let results = vec![true, true]; // Only 2 results for 3 actions
 
         let result = interpret_authz_results_for_load_table(

--- a/crates/lakekeeper/src/server/tables/authorize_load.rs
+++ b/crates/lakekeeper/src/server/tables/authorize_load.rs
@@ -341,22 +341,32 @@ pub(crate) fn resolve_users_for_authorize_load_tabular(
 /// chain. Consumers pick which results they care about based on the entry's
 /// role in their operation (target vs. intermediate).
 ///
-/// - **Table** (only ever the last entry) → `GetMetadata` + `ReadData` +
+/// `target` is the tabular being loaded; every other entry is an intermediate
+/// referenced-by view. The role is decided by **ident**, not slice position —
+/// the same key `interpret_authz_results_for_load_view` uses to consume these
+/// results — so the two sides can never disagree about which entry is the
+/// target, regardless of how the chain is ordered or assembled.
+///
+/// - **Table** (only ever the target) → `GetMetadata` + `ReadData` +
 ///   `WriteData`. `loadTable` uses all three: `GetMetadata` to gate presence,
 ///   `ReadData` / `WriteData` to decide which storage-credential scope to
 ///   return.
-/// - **View** → `GetMetadata` + `Select`. `GetMetadata` is the metadata check
-///   (used by `loadView` on the target view). `Select` is the data-plane
-///   check (used by any consumer that enforces denial on intermediate views
-///   — it's what gates DEFINER chain traversal past the control-plane
-///   bypass).
+/// - **Target view** → `GetMetadata` only. `loadView` consults `GetMetadata`
+///   and discards everything else, so emitting `Select` here would make the
+///   authorizer evaluate (and log) a decision that never gates anything.
+/// - **Intermediate view** (a DEFINER referenced-by view) → `GetMetadata` +
+///   `Select`. `Select` is the data-plane check that gates DEFINER chain
+///   traversal past the control-plane bypass; intermediate consumers enforce
+///   denial on it.
 #[must_use]
-pub fn build_actions_from_sorted_tabulars_for_authorize_load_tabular(
-    tabulars: &[ResolvedTabular],
-) -> Vec<TabularAuthzAction<'_>> {
+pub(crate) fn build_actions_from_sorted_tabulars_for_authorize_load_tabular<'a>(
+    tabulars: &'a [ResolvedTabular],
+    target: &TableIdent,
+) -> Vec<TabularAuthzAction<'a>> {
     tabulars
         .iter()
         .flat_map(|resolved| {
+            let is_target = resolved.tabular.tabular_ident() == target;
             let is_delegated_execution = resolved.is_delegated_execution;
             let user = resolved.user.as_ref();
             let tabular = &resolved.tabular;
@@ -381,7 +391,15 @@ pub fn build_actions_from_sorted_tabulars_for_authorize_load_tabular(
                 })
                 .collect::<Vec<_>>(),
                 ViewOrTableInfo::View(info) => {
-                    vec![CatalogViewAction::GetMetadata, CatalogViewAction::Select]
+                    // Target view: only `GetMetadata` is ever consulted (by
+                    // `loadView`). Intermediate views additionally enforce
+                    // `Select` for DEFINER chain traversal.
+                    let view_actions = if is_target {
+                        vec![CatalogViewAction::GetMetadata]
+                    } else {
+                        vec![CatalogViewAction::GetMetadata, CatalogViewAction::Select]
+                    };
+                    view_actions
                         .into_iter()
                         .map(|action| {
                             (
@@ -921,6 +939,7 @@ mod tests {
         let namespace = NamespaceHierarchy::new_with_id(warehouse_id, table.namespace_id);
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
+        let target = table.tabular_ident.clone();
         let tabulars = vec![ResolvedTabular {
             tabular: ViewOrTableInfo::Table(table),
             user: actor.to_user_or_role(),
@@ -928,7 +947,8 @@ mod tests {
             namespace,
         }];
 
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &target);
 
         assert_eq!(actions.len(), 3);
         assert!(
@@ -939,12 +959,16 @@ mod tests {
     }
 
     #[test]
-    fn test_build_actions_single_view_produces_get_metadata_and_select() {
+    fn test_build_actions_target_view_produces_only_get_metadata() {
         let warehouse_id = WarehouseId::new_random();
         let view = ViewInfo::new_random(warehouse_id);
         let namespace = NamespaceHierarchy::new_with_id(warehouse_id, view.namespace_id);
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
+        // A single view is the target. loadView only consults `GetMetadata`,
+        // so `Select` must not be emitted — evaluating it would produce a
+        // discarded authorization decision.
+        let target = view.tabular_ident.clone();
         let tabulars = vec![ResolvedTabular {
             tabular: ViewOrTableInfo::View(view),
             user: actor.to_user_or_role(),
@@ -952,14 +976,9 @@ mod tests {
             namespace,
         }];
 
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &target);
 
-        assert_eq!(actions.len(), 2);
-        assert!(
-            actions
-                .iter()
-                .all(|(_, a)| matches!(a, ActionOnTableOrView::View(_)))
-        );
         let emitted: Vec<_> = actions
             .iter()
             .filter_map(|(_, a)| match a {
@@ -967,8 +986,58 @@ mod tests {
                 ActionOnTableOrView::Table(_) | ActionOnTableOrView::GenericTable(_) => None,
             })
             .collect();
-        assert!(emitted.contains(&CatalogViewAction::GetMetadata));
-        assert!(emitted.contains(&CatalogViewAction::Select));
+        assert_eq!(emitted, vec![CatalogViewAction::GetMetadata]);
+    }
+
+    #[test]
+    fn test_build_actions_intermediate_view_includes_select() {
+        let warehouse_id = WarehouseId::new_random();
+        let intermediate = ViewInfo::new_random(warehouse_id);
+        let target = ViewInfo::new_random(warehouse_id);
+        let intermediate_ns =
+            NamespaceHierarchy::new_with_id(warehouse_id, intermediate.namespace_id);
+        let target_ns = NamespaceHierarchy::new_with_id(warehouse_id, target.namespace_id);
+        let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
+
+        // Chain of two views: the first is an intermediate referenced-by view,
+        // the second is the target.
+        let target_ident = target.tabular_ident.clone();
+        let tabulars = vec![
+            ResolvedTabular {
+                tabular: ViewOrTableInfo::View(intermediate),
+                user: actor.to_user_or_role(),
+                is_delegated_execution: false,
+                namespace: intermediate_ns,
+            },
+            ResolvedTabular {
+                tabular: ViewOrTableInfo::View(target),
+                user: actor.to_user_or_role(),
+                is_delegated_execution: false,
+                namespace: target_ns,
+            },
+        ];
+
+        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
+            &tabulars,
+            &target_ident,
+        );
+
+        let emitted: Vec<_> = actions
+            .iter()
+            .filter_map(|(_, a)| match a {
+                ActionOnTableOrView::View(v) => Some(v.action.clone()),
+                ActionOnTableOrView::Table(_) | ActionOnTableOrView::GenericTable(_) => None,
+            })
+            .collect();
+        // Intermediate view: GetMetadata + Select. Target view: GetMetadata only.
+        assert_eq!(
+            emitted,
+            vec![
+                CatalogViewAction::GetMetadata,
+                CatalogViewAction::Select,
+                CatalogViewAction::GetMetadata,
+            ]
+        );
     }
 
     #[test]
@@ -981,6 +1050,7 @@ mod tests {
         let namespace = NamespaceHierarchy::new_with_id(warehouse_id, view.namespace_id);
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
+        let target = view.tabular_ident.clone();
         let tabulars = vec![ResolvedTabular {
             tabular: ViewOrTableInfo::View(view),
             user: actor.to_user_or_role(),
@@ -988,9 +1058,10 @@ mod tests {
             namespace,
         }];
 
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &target);
 
-        assert_eq!(actions.len(), 2);
+        assert_eq!(actions.len(), 1);
         for (_, a) in &actions {
             match a {
                 ActionOnTableOrView::View(v) => assert!(v.is_delegated_execution),
@@ -1009,6 +1080,7 @@ mod tests {
         let namespace = NamespaceHierarchy::new_with_id(warehouse_id, view.namespace_id);
         let actor = Actor::Principal(UserId::new_unchecked("test", "user"));
 
+        let target = view.tabular_ident.clone();
         let tabulars = vec![ResolvedTabular {
             tabular: ViewOrTableInfo::View(view),
             user: actor.to_user_or_role(),
@@ -1016,9 +1088,10 @@ mod tests {
             namespace,
         }];
 
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars);
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &target);
 
-        assert_eq!(actions.len(), 2);
+        assert_eq!(actions.len(), 1);
         for (_, a) in &actions {
             match a {
                 ActionOnTableOrView::View(v) => assert!(!v.is_delegated_execution),

--- a/crates/lakekeeper/src/server/tables/authorize_load.rs
+++ b/crates/lakekeeper/src/server/tables/authorize_load.rs
@@ -1017,10 +1017,8 @@ mod tests {
             },
         ];
 
-        let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
-            &tabulars,
-            &target_ident,
-        );
+        let actions =
+            build_actions_from_sorted_tabulars_for_authorize_load_tabular(&tabulars, &target_ident);
 
         let emitted: Vec<_> = actions
             .iter()

--- a/crates/lakekeeper/src/server/views/load.rs
+++ b/crates/lakekeeper/src/server/views/load.rs
@@ -219,6 +219,7 @@ async fn authorize_load_view<C: CatalogStore, A: Authorizer + Clone>(
     // 9. Build actions and check all authorizations in batch
     let actions = build_actions_from_sorted_tabulars_for_authorize_load_tabular(
         &sorted_tabulars_with_full_info,
+        view,
     );
     let authz_results = authorizer
         .are_allowed_tabular_actions_vec(request_metadata, &warehouse, &namespaces, &actions)
@@ -253,11 +254,10 @@ fn interpret_authz_results_for_load_view(
     let mut target_is_delegated = false;
     let mut can_get_metadata = false;
 
-    // Each view in the chain emits both `GetMetadata` and `Select` — see
-    // `build_actions_from_sorted_tabulars_for_authorize_load_tabular`. On the
-    // target view we only consult `GetMetadata` (loadView reads the
-    // definition; it doesn't execute). On intermediate views we enforce any
-    // denial, which includes `Select`.
+    // The target view emits only `GetMetadata` — loadView reads the
+    // definition; it doesn't execute. Intermediate views additionally emit
+    // `Select`, and we enforce any denial on them. See
+    // `build_actions_from_sorted_tabulars_for_authorize_load_tabular`.
     for ((_ns, action), &allowed) in actions.iter().zip(authz_results) {
         match action {
             ActionOnTableOrView::View(view_action) => {


### PR DESCRIPTION
Emit Select only for intermediate referenced-by views (where it gates DEFINER chain traversal); the target view's Select was always discarded by interpret_authz_results_for_load_view but still cost an authorizer evaluation and logged a misleading SelectView decision. Target is now identified by ident to stay in lockstep with the consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization handling for loading tables and views, especially in view chains.
  * Target views now require only metadata access, while intermediate views apply stricter checks during traversal.
  * Updated behavior for delegated execution so authorization results are more accurate and consistent.

* **Tests**
  * Refreshed test coverage to match the updated table/view authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->