### PR TITLE
chore(docs): Sync documentation from lakekeeper plus

### DIFF
--- a/docs/docs/api/lakekeeper.cedarschema
+++ b/docs/docs/api/lakekeeper.cedarschema
@@ -52,7 +52,7 @@ namespace Lakekeeper {
   //
   //   User       "<provider_id>~<subject-in-provider>"
   //              "oidc~alice@example.com"
-  //              "kubernetes~system:serviceaccount:default:my-sa"
+  //              "kubernetes~eb952f26-3a1a-4020-bcb4-3f7d43049284"
   //
   //   Role       "<project-id>/<provider_id>~<source_id>"
   //              "my-project/lakekeeper~01943e3d-43c5-7a4e-b6dd-a88f0029gcgd"

--- a/docs/docs/api/management-open-api-plus.yaml
+++ b/docs/docs/api/management-open-api-plus.yaml
@@ -4280,13 +4280,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
-  /management/v1/warehouse/{warehouse_id}/task-queue/tabular_expiration/config:
+  /management/v1/warehouse/{warehouse_id}/task-queue/soft_deletion/config:
     get:
       tags:
         - tasks
       summary: Get the configuration for a Task Queue.
       description: These configurations are global per warehouse and shared across all instances of this kind of task.
-      operationId: get_task_queue_config_tabular_expiration
+      operationId: get_task_queue_config_soft_deletion
       parameters:
         - name: warehouse_id
           in: path
@@ -4306,7 +4306,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetTabularExpirationQueueConfig'
+                $ref: '#/components/schemas/GetSoftDeletionQueueConfig'
         4XX:
           description: ''
           content:
@@ -4318,7 +4318,7 @@ paths:
         - tasks
       summary: Set the configuration for a Task Queue.
       description: These configurations are global per warehouse and shared across all instances of this kind of task.
-      operationId: set_task_queue_config_tabular_expiration
+      operationId: set_task_queue_config_soft_deletion
       parameters:
         - name: warehouse_id
           in: path
@@ -4330,7 +4330,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SetTabularExpirationQueueConfig'
+              $ref: '#/components/schemas/SetSoftDeletionQueueConfig'
         required: true
       responses:
         '204':
@@ -6536,6 +6536,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ServerAssignment'
+    GetSoftDeletionQueueConfig:
+      type: object
+      required:
+        - queue-config
+      properties:
+        max-seconds-since-last-heartbeat:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        queue-config:
+          $ref: '#/components/schemas/SoftDeletionQueueConfig'
     GetTableAccessResponse:
       type: object
       required:
@@ -6554,18 +6566,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TableAssignment'
-    GetTabularExpirationQueueConfig:
-      type: object
-      required:
-        - queue-config
-      properties:
-        max-seconds-since-last-heartbeat:
-          type:
-            - integer
-            - 'null'
-          format: int64
-        queue-config:
-          $ref: '#/components/schemas/TabularExpirationQueueConfig'
     GetTaskDetailsResponse:
       allOf:
         - $ref: '#/components/schemas/WarehouseTaskInfo'
@@ -10098,7 +10098,7 @@ components:
           format: int64
         queue-config:
           $ref: '#/components/schemas/RemoveOrphanFilesQueueConfig'
-    SetTabularExpirationQueueConfig:
+    SetSoftDeletionQueueConfig:
       type: object
       required:
         - queue-config
@@ -10109,7 +10109,7 @@ components:
             - 'null'
           format: int64
         queue-config:
-          $ref: '#/components/schemas/TabularExpirationQueueConfig'
+          $ref: '#/components/schemas/SoftDeletionQueueConfig'
     SetTaskLogCleanupConfig:
       type: object
       required:
@@ -10132,6 +10132,9 @@ components:
           description: |-
             New managed-by marker. Use `self-managed` to clear. Setting or clearing the
             marker requires instance-admin privilege.
+    SoftDeletionQueueConfig:
+      type: object
+      description: Warehouse-specific configuration for the soft-deletion (tabular expiration) queue.
     StorageCredential:
       oneOf:
         - allOf:
@@ -10592,9 +10595,6 @@ components:
               type: string
               enum:
                 - soft
-    TabularExpirationQueueConfig:
-      type: object
-      description: Warehouse-specific configuration for the tabular expiration (Soft-Deletion) queue.
     TabularIdentOrUuid:
       oneOf:
         - type: object

--- a/site/docs/about/enterprise-release-notes.md
+++ b/site/docs/about/enterprise-release-notes.md
@@ -1,10 +1,33 @@
 # Lakekeeper Plus Release Notes
 
---8<-- "_includes/subscribe-form.html"
+## v0.13.1 (2026-07-20)
 
-_[Subscribe by email](subscribe.md) to hear about new releases, or **Watch → Releases** on [GitHub](https://github.com/lakekeeper/lakekeeper/releases)._
+_Based on Lakekeeper OSS v0.13.3._
 
-## v0.13.0 (2026-06-30)
+### Highlights
+- **Okta role provider.** Resolve a user's Okta group memberships to Lakekeeper roles via the Okta management API — private-key-JWT client auth with DPoP (RFC 9449) proofs enabled by default.
+- **Provider-synced roles are now protected.** Roles owned by a configured role provider (Okta, Entra, LDAP, or token IdP) can no longer be mutated through the management API, so the next provider sync can't silently clobber manual edits.
+
+### Features
+- **Okta role provider (with DPoP).** Group memberships resolved via `GET /users/{id}/groups` (Link-header pagination, keyed by immutable group id). OAuth2 client-credentials + private-key-JWT (JWK or PEM key); DPoP on by default with ephemeral P-256 proofs and nonce challenge/replay handling — opt out to Bearer. Requires the `okta.users.read` scope; wrapped in the shared role cache. See the Okta role-provider docs.
+- **Managed-role write protection.** The Cedar authorizer now reports its configured provider namespaces to the management-API guard, so create / update / delete / source-system rebind / member (un)assignment on a provider-owned role is rejected with `400 ManagedRoleImmutable`. Native `lakekeeper` roles and the reserved `system` namespace are never included, so API-native and catalog-managed roles stay writable. Active only when a role provider is configured.
+- **Post-logout redirect controls.** Two new UI env vars — `LAKEKEEPER__UI__OPENID_POST_LOGOUT_REDIRECT_URL` and `LAKEKEEPER__UI__OPENID_POST_LOGOUT_REDIRECT_DISABLED`.
+- **Static-asset caching in the UI server.** Per-class `Cache-Control` plus weak `ETag`/`304` on bundled assets: content-hashed `assets/*` are cached immutably and the DuckDB WASM is no longer re-downloaded on every load, while `index.html` stays uncached so runtime config placeholders remain fresh.
+
+### Bug Fixes
+- **Maintenance page for warehouse-only permissions.** Console bump to 0.16.1 (console-components 0.17.1) fixes the maintenance view for users who hold only warehouse-level permissions.
+
+### Upgrade Notes
+- **Provider-role edits now return `400 ManagedRoleImmutable`.** If you previously edited provider-synced roles (Okta/Entra/LDAP/token) through the management API, those calls are now rejected — such edits were overwritten by the next sync anyway. Manage those roles at the source. No migration.
+- **Building Plus from source:** the Kubernetes client stack moved to k8s-openapi 0.28 / kube 4.0 (pulled in by the upstream limes 0.4.2 bump). Prebuilt binaries and images are unaffected.
+
+### Upstream Lakekeeper changes (up to Lakekeeper v0.13.3)
+Notable for Plus users:
+- **Configurable Kubernetes subject source.** `LAKEKEEPER__KUBERNETES_AUTHENTICATION_SUBJECT_SOURCE=username` derives a service account's Lakekeeper user id from `system:serviceaccount:<namespace>:<name>` (stable across clusters) instead of the per-cluster `uid` (default, unchanged), so Kubernetes roles and instance admins can be pre-provisioned ([lakekeeper#1899](https://github.com/lakekeeper/lakekeeper/pull/1899)).
+- **Reject role writes in provider-managed namespaces** — the upstream API guard behind the managed-role protection above ([lakekeeper#1891](https://github.com/lakekeeper/lakekeeper/pull/1891)).
+- Stop evaluating a discarded `Select` on target-view load, avoiding a spurious authorization check ([lakekeeper#1886](https://github.com/lakekeeper/lakekeeper/pull/1886)).
+
+## v0.13.0 (2026-07-02)
 
 _Based on Lakekeeper OSS v0.13.1._
 


### PR DESCRIPTION
This PR automatically syncs documentation files from the lakekeeper plus repository.

## Changes
- management-open-api-plus.yaml: ✓ Updated
- lakekeeper.cedarschema: ✓ Updated
- enterprise-release-notes.md: ✓ Updated

Source commit: `0c5528f3db7515661d37eafc57c4b889d6ba41eb`
Generated by [workflow run](https://github.com/vakamo-labs/lakekeeper-enterprise/actions/runs/29765643798)