### PR TITLE
feat(authz): reject role writes in provider-managed namespaces

### DIFF
--- a/crates/lakekeeper-integration-tests/tests/role_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/role_ops.rs
@@ -926,7 +926,7 @@ async fn test_create_role_rejects_system_provider_id(pool: PgPool) {
 }
 
 /// Create a system role directly via the catalog layer (bypasses the
-/// `reject_system_provider` API guard). Used as fixture by tests that need
+/// `reject_managed_provider` API guard). Used as fixture by tests that need
 /// an existing system row to verify the immutability guards.
 async fn seed_test_system_role(
     ctx: &lakekeeper::api::ApiContext<

--- a/crates/lakekeeper/src/api/management/v1/role.rs
+++ b/crates/lakekeeper/src/api/management/v1/role.rs
@@ -66,10 +66,7 @@ fn reject_managed_provider(
 /// separately with an `is_system()` check yielding `SystemRoleImmutable`, while
 /// the membership sites deliberately permit it — `system` (and `lakekeeper`)
 /// roles are `manually_assignable`, so their member lists stay editable.
-pub(crate) fn reject_managed_role<A, E>(
-    authorizer: &A,
-    role: &ArcRole,
-) -> std::result::Result<(), E>
+pub(crate) fn reject_managed_role<A, E>(authorizer: &A, role: &ArcRole) -> Result<(), E>
 where
     A: Authorizer,
     E: From<ManagedRoleImmutable>,

--- a/crates/lakekeeper/src/api/management/v1/role.rs
+++ b/crates/lakekeeper/src/api/management/v1/role.rs
@@ -26,14 +26,14 @@ use crate::{
     },
 };
 
-/// Rejects a request whose `provider_id` is not writable through the
-/// role-management API: the catalog-managed `system` namespace (see
+/// Rejects a `provider_id` **supplied in a request body** that is not writable
+/// through the role-management API: the catalog-managed `system` namespace (see
 /// [`crate::service::SYSTEM_ROLE_PROVIDER_ID`]), or any namespace owned by a
 /// configured role provider (`managed`, from
 /// [`Authorizer::managed_role_provider_ids`]) whose roles are maintained by
 /// provider sync. Used as a pre-authz check on endpoints that accept a provider
-/// in the request body, and on the resolved role's provider for endpoints that
-/// mutate an existing role.
+/// in the request body (create, source-system rebind target). To guard the
+/// provider of an *already-resolved* role, use [`reject_managed_role`].
 fn reject_managed_provider(
     provider_id: &RoleProviderId,
     managed: &HashSet<RoleProviderId>,
@@ -49,6 +49,34 @@ fn reject_managed_provider(
     }
     if managed.contains(provider_id) {
         return Err(ErrorModel::from(ManagedRoleImmutable::new(provider_id.to_string())).into());
+    }
+    Ok(())
+}
+
+/// Rejects mutating an **already-resolved role** whose provider namespace is
+/// owned by a configured role provider (from
+/// [`Authorizer::managed_role_provider_ids`]) — such roles are maintained by
+/// provider sync and must not be changed through the API. The caller's error
+/// type is produced via its `From<ManagedRoleImmutable>` conversion (e.g.
+/// [`DeleteRoleError`], [`UpdateRoleError`], or [`ErrorModel`]).
+///
+/// Complements [`reject_managed_provider`], which guards a provider taken from a
+/// request body. The reserved `system` namespace is **not** checked here: the
+/// mutate-existing-role sites (delete, update, source-system rebind) reject it
+/// separately with an `is_system()` check yielding `SystemRoleImmutable`, while
+/// the membership sites deliberately permit it — `system` (and `lakekeeper`)
+/// roles are `manually_assignable`, so their member lists stay editable.
+pub(crate) fn reject_managed_role<A, E>(
+    authorizer: &A,
+    role: &ArcRole,
+) -> std::result::Result<(), E>
+where
+    A: Authorizer,
+    E: From<ManagedRoleImmutable>,
+{
+    let provider_id = role.ident.provider_id();
+    if authorizer.managed_role_provider_ids().contains(provider_id) {
+        return Err(ManagedRoleImmutable::new(provider_id.to_string()).into());
     }
     Ok(())
 }
@@ -727,15 +755,7 @@ async fn authorized_delete_role<A: Authorizer, C: CatalogStore>(
     if role.ident.is_system() {
         return Err(DeleteRoleError::from(SystemRoleImmutable::new()).into());
     }
-    if authorizer
-        .managed_role_provider_ids()
-        .contains(role.ident.provider_id())
-    {
-        return Err(DeleteRoleError::from(ManagedRoleImmutable::new(
-            role.ident.provider_id().to_string(),
-        ))
-        .into());
-    }
+    reject_managed_role::<_, DeleteRoleError>(&authorizer, &role)?;
 
     let mut t = C::Transaction::begin_write(catalog_state)
         .await
@@ -793,15 +813,7 @@ async fn authorize_update_role<A: Authorizer, C: CatalogStore>(
     if role.ident.is_system() {
         return Err(UpdateRoleError::from(SystemRoleImmutable::new()).into());
     }
-    if authorizer
-        .managed_role_provider_ids()
-        .contains(role.ident.provider_id())
-    {
-        return Err(UpdateRoleError::from(ManagedRoleImmutable::new(
-            role.ident.provider_id().to_string(),
-        ))
-        .into());
-    }
+    reject_managed_role::<_, UpdateRoleError>(&authorizer, &role)?;
 
     // -------------------- Business Logic --------------------
     let description = request.description.filter(|d| !d.is_empty());
@@ -852,15 +864,7 @@ async fn authorize_update_role_source_system<A: Authorizer, C: CatalogStore>(
     // Reject rebinding a role that is *currently* owned by a configured role
     // provider — its identity is the provider's to manage. (Rebinding *into* a
     // managed/`system` namespace is rejected on the request in the handler.)
-    if authorizer
-        .managed_role_provider_ids()
-        .contains(role.ident.provider_id())
-    {
-        return Err(UpdateRoleError::from(ManagedRoleImmutable::new(
-            role.ident.provider_id().to_string(),
-        ))
-        .into());
-    }
+    reject_managed_role::<_, UpdateRoleError>(&authorizer, &role)?;
 
     // -------------------- Business Logic --------------------
     let mut t = C::Transaction::begin_write(catalog_state)

--- a/crates/lakekeeper/src/api/management/v1/role.rs
+++ b/crates/lakekeeper/src/api/management/v1/role.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use axum::{Json, response::IntoResponse};
 use iceberg_ext::catalog::rest::ErrorModel;
@@ -15,8 +15,8 @@ use crate::{
     service::{
         ArcProjectId, ArcRole, ArcRoleIdent, CachePolicy, CatalogBackendError,
         CatalogCreateRoleRequest, CatalogListRolesByIdFilter, CatalogRoleOps, CatalogStore,
-        CreateRoleError, DeleteRoleError, Result, RoleId, RoleProviderId, RoleSourceId,
-        SecretStore, State, SystemRoleImmutable, Transaction, UpdateRoleError,
+        CreateRoleError, DeleteRoleError, ManagedRoleImmutable, Result, RoleId, RoleProviderId,
+        RoleSourceId, SecretStore, State, SystemRoleImmutable, Transaction, UpdateRoleError,
         authz::{
             AuthZError, AuthZProjectOps, AuthZRoleOps, Authorizer, CatalogProjectAction,
             CatalogRoleAction, RoleSourceSystem, SourceSystemTarget,
@@ -26,10 +26,18 @@ use crate::{
     },
 };
 
-/// Rejects a request whose `provider_id` names the catalog-managed system
-/// namespace. Used as a pre-authz check on endpoints that accept a provider
-/// in the request body. See [`crate::service::SYSTEM_ROLE_PROVIDER_ID`].
-fn reject_system_provider(provider_id: &RoleProviderId) -> Result<()> {
+/// Rejects a request whose `provider_id` is not writable through the
+/// role-management API: the catalog-managed `system` namespace (see
+/// [`crate::service::SYSTEM_ROLE_PROVIDER_ID`]), or any namespace owned by a
+/// configured role provider (`managed`, from
+/// [`Authorizer::managed_role_provider_ids`]) whose roles are maintained by
+/// provider sync. Used as a pre-authz check on endpoints that accept a provider
+/// in the request body, and on the resolved role's provider for endpoints that
+/// mutate an existing role.
+fn reject_managed_provider(
+    provider_id: &RoleProviderId,
+    managed: &HashSet<RoleProviderId>,
+) -> Result<()> {
     if provider_id.is_system() {
         return Err(ErrorModel::bad_request(
             "provider_id `system` is reserved for catalog-managed roles \
@@ -38,6 +46,9 @@ fn reject_system_provider(provider_id: &RoleProviderId) -> Result<()> {
             None,
         )
         .into());
+    }
+    if managed.contains(provider_id) {
+        return Err(ErrorModel::from(ManagedRoleImmutable::new(provider_id.to_string())).into());
     }
     Ok(())
 }
@@ -305,7 +316,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             .into());
         }
         if let Some(p) = &request.provider_id {
-            reject_system_provider(p)?;
+            reject_managed_provider(p, context.v1_state.authz.managed_role_provider_ids())?;
         }
         match (&request.provider_id, &request.source_id) {
             (None, None) | (Some(_), Some(_)) => {}
@@ -511,11 +522,15 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         request: UpdateRoleSourceSystemRequest,
     ) -> Result<Role> {
         // -------------------- VALIDATIONS --------------------
-        // Reject rebinding any role into the catalog-managed `system`
-        // namespace. The check on the *current* role (cannot rebind a system
-        // role to a different provider) lives inside the authz helper
-        // because it needs the role resolved.
-        reject_system_provider(&request.provider_id)?;
+        // Reject rebinding any role into the catalog-managed `system` namespace
+        // or into a namespace owned by a configured role provider. The check on
+        // the *current* role (cannot rebind a system- or provider-managed role
+        // to a different provider) lives inside the authz helper because it
+        // needs the role resolved.
+        reject_managed_provider(
+            &request.provider_id,
+            context.v1_state.authz.managed_role_provider_ids(),
+        )?;
 
         let project_id = request_metadata.require_project_id(None)?;
 
@@ -577,7 +592,7 @@ async fn authorize_create_role<A: Authorizer, C: CatalogStore>(
     // No provider in the request → the catalog itself is the system of
     // record for this role (i.e. the `lakekeeper` provider). Not the
     // catalog-managed `system` provider — those are seeded internally and
-    // never accepted via this endpoint (see `reject_system_provider`).
+    // never accepted via this endpoint (see `reject_managed_provider`).
     let provider_id = request
         .provider_id
         .unwrap_or_else(RoleProviderId::lakekeeper);
@@ -712,6 +727,15 @@ async fn authorized_delete_role<A: Authorizer, C: CatalogStore>(
     if role.ident.is_system() {
         return Err(DeleteRoleError::from(SystemRoleImmutable::new()).into());
     }
+    if authorizer
+        .managed_role_provider_ids()
+        .contains(role.ident.provider_id())
+    {
+        return Err(DeleteRoleError::from(ManagedRoleImmutable::new(
+            role.ident.provider_id().to_string(),
+        ))
+        .into());
+    }
 
     let mut t = C::Transaction::begin_write(catalog_state)
         .await
@@ -769,6 +793,15 @@ async fn authorize_update_role<A: Authorizer, C: CatalogStore>(
     if role.ident.is_system() {
         return Err(UpdateRoleError::from(SystemRoleImmutable::new()).into());
     }
+    if authorizer
+        .managed_role_provider_ids()
+        .contains(role.ident.provider_id())
+    {
+        return Err(UpdateRoleError::from(ManagedRoleImmutable::new(
+            role.ident.provider_id().to_string(),
+        ))
+        .into());
+    }
 
     // -------------------- Business Logic --------------------
     let description = request.description.filter(|d| !d.is_empty());
@@ -816,6 +849,18 @@ async fn authorize_update_role_source_system<A: Authorizer, C: CatalogStore>(
     if role.ident.is_system() {
         return Err(UpdateRoleError::from(SystemRoleImmutable::new()).into());
     }
+    // Reject rebinding a role that is *currently* owned by a configured role
+    // provider — its identity is the provider's to manage. (Rebinding *into* a
+    // managed/`system` namespace is rejected on the request in the handler.)
+    if authorizer
+        .managed_role_provider_ids()
+        .contains(role.ident.provider_id())
+    {
+        return Err(UpdateRoleError::from(ManagedRoleImmutable::new(
+            role.ident.provider_id().to_string(),
+        ))
+        .into());
+    }
 
     // -------------------- Business Logic --------------------
     let mut t = C::Transaction::begin_write(catalog_state)
@@ -841,4 +886,33 @@ async fn authorize_update_role_source_system<A: Authorizer, C: CatalogStore>(
     role_assignments_cache::user_assignments_cache_invalidate_many(&affected_users).await;
     role_assignments_cache::role_members_cache_invalidate(role_id).await;
     Ok(role)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::{RoleProviderId, reject_managed_provider};
+
+    #[test]
+    fn reject_managed_provider_denies_system_and_configured_providers() {
+        let okta = RoleProviderId::try_new("okta").unwrap();
+        let entra = RoleProviderId::try_new("entra").unwrap();
+        let mut managed = HashSet::new();
+        managed.insert(okta.clone());
+
+        // `system` is reserved and always rejected, regardless of the managed set.
+        let system = RoleProviderId::try_new("system").unwrap();
+        assert!(reject_managed_provider(&system, &managed).is_err());
+        assert!(reject_managed_provider(&system, &HashSet::new()).is_err());
+
+        // A configured role provider's namespace is rejected.
+        assert!(reject_managed_provider(&okta, &managed).is_err());
+
+        // The native `lakekeeper` namespace and any unconfigured namespace stay
+        // writable (deny-list: only `system` + currently-configured providers).
+        assert!(reject_managed_provider(&RoleProviderId::lakekeeper(), &managed).is_ok());
+        assert!(reject_managed_provider(&entra, &managed).is_ok());
+        assert!(reject_managed_provider(&okta, &HashSet::new()).is_ok());
+    }
 }

--- a/crates/lakekeeper/src/api/management/v1/role_membership.rs
+++ b/crates/lakekeeper/src/api/management/v1/role_membership.rs
@@ -75,8 +75,9 @@ use crate::{
     request_metadata::RequestMetadata,
     service::{
         ArcProjectId, ArcRole, ArcRoleIdent, CachePolicy, CatalogListRolesByIdFilter,
-        CatalogRoleAssignmentOps, CatalogRoleMember, CatalogRoleOps, CatalogStore, Result, RoleId,
-        RoleMemberKind, RoleMembershipEntry, SecretStore, State, UserId, UserMembershipEntry,
+        CatalogRoleAssignmentOps, CatalogRoleMember, CatalogRoleOps, CatalogStore,
+        ManagedRoleImmutable, Result, RoleId, RoleMemberKind, RoleMembershipEntry, SecretStore,
+        State, UserId, UserMembershipEntry,
         authz::{
             AuthZError, AuthZProjectOps, AuthZRoleOps, AuthZUserOps, Authorizer,
             CatalogProjectAction, CatalogRoleAction, CatalogUserAction, ManagesRoleAssignments,
@@ -763,7 +764,20 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 CatalogRoleAction::ManageRoleAssignments,
             )
             .await;
-        let (event_ctx, _role) = event_ctx.emit_authz(authz_result)?;
+        let (event_ctx, role) = event_ctx.emit_authz(authz_result)?;
+
+        // A provider-managed role's member list is authoritative from its role
+        // provider and converged by sync; reject manual (un)assignment via the
+        // API so it cannot drift from what the next sync would produce.
+        if authorizer
+            .managed_role_provider_ids()
+            .contains(role.ident.provider_id())
+        {
+            return Err(ErrorModel::from(ManagedRoleImmutable::new(
+                role.ident.provider_id().to_string(),
+            ))
+            .into());
+        }
 
         // Dedup on the typed identifier so a member named twice (the request is
         // already typed, so no string-spelling ambiguity remains) collapses to one
@@ -850,7 +864,19 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 CatalogRoleAction::ManageRoleAssignments,
             )
             .await;
-        let (event_ctx, _role) = event_ctx.emit_authz(authz_result)?;
+        let (event_ctx, role) = event_ctx.emit_authz(authz_result)?;
+
+        // A provider-managed role's member list is maintained by provider sync;
+        // reject manual removal via the API so it cannot drift from sync.
+        if authorizer
+            .managed_role_provider_ids()
+            .contains(role.ident.provider_id())
+        {
+            return Err(ErrorModel::from(ManagedRoleImmutable::new(
+                role.ident.provider_id().to_string(),
+            ))
+            .into());
+        }
 
         let subject = parse_member(member_type, &member_id)?;
         match authorizer.role_assignments() {

--- a/crates/lakekeeper/src/api/management/v1/role_membership.rs
+++ b/crates/lakekeeper/src/api/management/v1/role_membership.rs
@@ -65,7 +65,7 @@ use http::StatusCode;
 use iceberg_ext::catalog::rest::ErrorModel;
 use serde::{Deserialize, Serialize};
 
-use super::user::UserType;
+use super::{role::reject_managed_role, user::UserType};
 use crate::{
     api::{
         ApiContext,
@@ -75,9 +75,8 @@ use crate::{
     request_metadata::RequestMetadata,
     service::{
         ArcProjectId, ArcRole, ArcRoleIdent, CachePolicy, CatalogListRolesByIdFilter,
-        CatalogRoleAssignmentOps, CatalogRoleMember, CatalogRoleOps, CatalogStore,
-        ManagedRoleImmutable, Result, RoleId, RoleMemberKind, RoleMembershipEntry, SecretStore,
-        State, UserId, UserMembershipEntry,
+        CatalogRoleAssignmentOps, CatalogRoleMember, CatalogRoleOps, CatalogStore, Result, RoleId,
+        RoleMemberKind, RoleMembershipEntry, SecretStore, State, UserId, UserMembershipEntry,
         authz::{
             AuthZError, AuthZProjectOps, AuthZRoleOps, AuthZUserOps, Authorizer,
             CatalogProjectAction, CatalogRoleAction, CatalogUserAction, ManagesRoleAssignments,
@@ -769,15 +768,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // A provider-managed role's member list is authoritative from its role
         // provider and converged by sync; reject manual (un)assignment via the
         // API so it cannot drift from what the next sync would produce.
-        if authorizer
-            .managed_role_provider_ids()
-            .contains(role.ident.provider_id())
-        {
-            return Err(ErrorModel::from(ManagedRoleImmutable::new(
-                role.ident.provider_id().to_string(),
-            ))
-            .into());
-        }
+        reject_managed_role::<_, ErrorModel>(&authorizer, &role)?;
 
         // Dedup on the typed identifier so a member named twice (the request is
         // already typed, so no string-spelling ambiguity remains) collapses to one
@@ -868,15 +859,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         // A provider-managed role's member list is maintained by provider sync;
         // reject manual removal via the API so it cannot drift from sync.
-        if authorizer
-            .managed_role_provider_ids()
-            .contains(role.ident.provider_id())
-        {
-            return Err(ErrorModel::from(ManagedRoleImmutable::new(
-                role.ident.provider_id().to_string(),
-            ))
-            .into());
-        }
+        reject_managed_role::<_, ErrorModel>(&authorizer, &role)?;
 
         let subject = parse_member(member_type, &member_id)?;
         match authorizer.role_assignments() {

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -1592,6 +1592,27 @@ where
     /// the IDs internally. The default implementation is a no-op.
     fn set_registered_idp_ids(&mut self, _idp_ids: Arc<[RoleProviderId]>) {}
 
+    /// Provider IDs whose roles are maintained by a configured role provider
+    /// (LDAP/Entra/Okta/token). Roles in these namespaces are the provider's to
+    /// create, modify, delete, and (un)assign — the management API rejects those
+    /// mutations to avoid drift that provider sync would clobber. Used as the
+    /// deny-set by the role-management guard; the reserved `system` namespace is
+    /// handled separately and never appears here.
+    ///
+    /// The default returns an empty set: without a role provider (OSS, `AllowAll`,
+    /// OpenFGA) only the reserved `system` namespace is protected, so
+    /// `lakekeeper`-native and unmanaged roles stay writable exactly as before.
+    ///
+    /// Implementors MUST NOT include the native `lakekeeper` namespace or the
+    /// reserved `system` namespace in the returned set — doing so would wrongly
+    /// block writes to API-native or catalog-managed roles. (`system` is also
+    /// rejected independently by the guard, but native roles are not.)
+    fn managed_role_provider_ids(&self) -> &std::collections::HashSet<RoleProviderId> {
+        static EMPTY: std::sync::LazyLock<std::collections::HashSet<RoleProviderId>> =
+            std::sync::LazyLock::new(std::collections::HashSet::new);
+        &EMPTY
+    }
+
     /// API Doc
     #[cfg(feature = "open-api")]
     fn api_doc() -> utoipa::openapi::OpenApi;

--- a/crates/lakekeeper/src/service/catalog_store/role.rs
+++ b/crates/lakekeeper/src/service/catalog_store/role.rs
@@ -382,6 +382,41 @@ impl From<SystemRoleImmutable> for ErrorModel {
     }
 }
 
+// Raised when a customer-facing role-management endpoint targets a role whose
+// provider namespace is owned by a configured role provider (LDAP/Entra/Okta/
+// token). Such roles are maintained by provider sync and are immutable through
+// the role-management API — they change only when the provider re-syncs. The
+// `system` namespace has its own error (`SystemRoleImmutable`); this covers the
+// external, configurable providers.
+#[derive(thiserror::Error, PartialEq, Debug, Default)]
+#[error(
+    "Cannot create, modify, delete, or assign a role in the `{provider_id}` namespace through the role-management API: it is managed by a configured role provider and is maintained by provider sync."
+)]
+pub struct ManagedRoleImmutable {
+    pub provider_id: String,
+    pub stack: Vec<String>,
+}
+impl ManagedRoleImmutable {
+    #[must_use]
+    pub fn new(provider_id: impl Into<String>) -> Self {
+        Self {
+            provider_id: provider_id.into(),
+            stack: Vec::new(),
+        }
+    }
+}
+impl_error_stack_methods!(ManagedRoleImmutable);
+impl From<ManagedRoleImmutable> for ErrorModel {
+    fn from(err: ManagedRoleImmutable) -> Self {
+        ErrorModel::builder()
+            .r#type("ManagedRoleImmutable")
+            .code(StatusCode::BAD_REQUEST.as_u16())
+            .message(err.to_string())
+            .stack(err.stack)
+            .build()
+    }
+}
+
 // --------------------------- DELETE ERROR ---------------------------
 define_transparent_error! {
     pub enum DeleteRoleError,
@@ -389,7 +424,8 @@ define_transparent_error! {
     variants: [
         CatalogBackendError,
         RoleIdNotFoundInProject,
-        SystemRoleImmutable
+        SystemRoleImmutable,
+        ManagedRoleImmutable
     ]
 }
 
@@ -403,6 +439,7 @@ define_transparent_error! {
         RoleNameAlreadyExists,
         RoleIdNotFoundInProject,
         SystemRoleImmutable,
+        ManagedRoleImmutable,
     ]
 }
 


### PR DESCRIPTION
Roles carry a provider namespace in their identity (`provider~source_id`). Roles resolved from a configured role provider (LDAP/Entra/Okta/token) are maintained by provider sync, so mutating them through the management API creates drift the next sync silently clobbers.

Add an `Authorizer::managed_role_provider_ids()` hook (default empty) that reports the provider namespaces owned by a configured role provider, plus a guard `reject_managed_provider` (renamed from `reject_system_provider`) that rejects create, update, delete, source-system rebind, and member (un)assignment on roles in those namespaces — and the reserved `system` namespace, as before. A new `ManagedRoleImmutable` error carries the 400.

Deny-list semantics: only `system` and currently-configured providers are blocked, so unknown namespaces (external provisioning) and the roles of a de-configured provider stay editable. `lakekeeper`-native roles are always writable. Enforcement is API-layer, matching `SystemRoleImmutable`.

No behavior change without a role provider — the default set is empty, so OSS, AllowAll and OpenFGA are unaffected. The enterprise Cedar authorizer populates the set (separate change). No migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enforced role immutability for namespaces owned by configured managed providers across role creation, role source updates, deletion, role updates, and role member add/remove operations.
  - Returns **400 Bad Request** with a dedicated managed-role immutability error when a protected provider namespace is targeted, including during mutations based on resolved role ownership.
- **Tests**
  - Added unit coverage for managed-provider immutability, including `system`, configured managed providers, and allowed namespaces.
- **Chores**
  - Pinned OpenAPI TypeScript generation tooling in CI (generator and TypeScript versions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->