### PR TITLE
chore(ci): authenticate and sideload images in kube-auth test

### DIFF
--- a/.github/workflows/kube-auth.yml
+++ b/.github/workflows/kube-auth.yml
@@ -27,10 +27,26 @@ jobs:
   kube_auth:
     needs: docker
     runs-on: ubuntu-24.04
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      # Pinned so the test pod defaults to imagePullPolicy IfNotPresent (an
+      # untagged/`:latest` image defaults to Always, which re-pulls Docker Hub
+      # on every run and hits the per-IP rate limit). Sideloaded below.
+      CURL_IMAGE: curlimages/curl:8.16.0
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+      # Authenticated Docker Hub pulls avoid anonymous per-IP rate limits on
+      # shared CI runners. Applies to every host `docker pull` below (the kind
+      # node image and the sideloaded chart/test images). Skipped when the
+      # secret is absent (e.g. fork PRs) so those still run with anonymous pulls.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       # Pre-pull the kind node image. Docker Hub flakily times out on shared CI
       # IPs; the retried pull means cluster creation below uses the cached image.
       - name: Pre-pull kind node image
@@ -66,12 +82,45 @@ jobs:
           version: v3.18.3
       - run: helm repo add lakekeeper https://lakekeeper.github.io/lakekeeper-charts/
         name: Add lakekeeper helm repo
+      # kind's containerd can't see the host docker credentials, so anonymous
+      # in-cluster pulls hit Docker Hub's per-IP rate limit. Resolve every image
+      # the rendered chart references plus the curl test image, then
+      # authenticated-pull them on the host and load them into the node so
+      # nothing is pulled from inside the cluster. Image strings come straight
+      # from `helm template`, so the loaded refs match what the pods request.
+      # `templates/tests/` (helm-test) resources are dropped: they are never
+      # deployed here (no `helm test`) and would pull unrelated images.
+      - name: Sideload chart and test images into kind
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          max_attempts: 5
+          timeout_minutes: 5
+          retry_wait_seconds: 15
+          command: |
+            set -euo pipefail
+            images="$(helm template my-lakekeeper lakekeeper/lakekeeper --version 0.7.1 \
+              -f tests/kube-auth/values.yaml \
+              --set catalog.image.repository=localhost/lakekeeper-local --set catalog.image.tag=amd64 \
+              | awk '/^# Source:/ { skip = ($0 ~ /\/tests\//) } !skip' \
+              | grep -E '^[[:space:]]*image:[[:space:]]' \
+              | sed -E "s/^[[:space:]]*image:[[:space:]]*//; s/[\"']//g" \
+              | sort -u)"
+            echo "Sideloading images:"
+            printf '%s\n' $images "$CURL_IMAGE"
+            for img in $images "$CURL_IMAGE"; do
+              case "$img" in
+                # Built in the `docker` job and loaded from the artifact above.
+                localhost/lakekeeper-local:*) continue ;;
+              esac
+              docker pull "$img"
+              kind load docker-image "$img"
+            done
       - name: Install lakekeeper - uid subject source
         # `helm --wait` blocks until pods are ready (values sets helmWait: true to
         # make this work); faster and less flaky than a fixed sleep.
         run: helm install -f tests/kube-auth/values.yaml --set catalog.image.repository=localhost/lakekeeper-local --set catalog.image.tag=amd64 my-lakekeeper lakekeeper/lakekeeper --version 0.7.1 --wait --timeout 6m
       - name: Run tests - uid subject source
-        run: kubectl run bootstrap-test-uid --image=curlimages/curl -it --command=true --restart=Never -- /bin/sh -c "$(cat tests/kube-auth/bootstrap.sh)" sh uid
+        run: kubectl run bootstrap-test-uid --image="$CURL_IMAGE" --image-pull-policy=IfNotPresent -it --command=true --restart=Never -- /bin/sh -c "$(cat tests/kube-auth/bootstrap.sh)" sh uid
       # Reinstall with a fresh database: whoami only returns a user that was
       # bootstrapped, and switching the subject source changes the caller's ID,
       # so the username run needs its own bootstrap. Wiping the postgres PVC
@@ -85,7 +134,7 @@ jobs:
             --set-string catalog.config.LAKEKEEPER__KUBERNETES_AUTHENTICATION_SUBJECT_SOURCE=username \
             my-lakekeeper lakekeeper/lakekeeper --version 0.7.1 --wait --timeout 6m
       - name: Run tests - username subject source
-        run: kubectl run bootstrap-test-username --image=curlimages/curl -it --command=true --restart=Never -- /bin/sh -c "$(cat tests/kube-auth/bootstrap.sh)" sh username
+        run: kubectl run bootstrap-test-username --image="$CURL_IMAGE" --image-pull-policy=IfNotPresent -it --command=true --restart=Never -- /bin/sh -c "$(cat tests/kube-auth/bootstrap.sh)" sh username
       - name: bootstrap-logs
         if: failure()
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes authentication test reliability by ensuring required container images are available locally before deployment.
  * Updated test containers to use a pinned image version and avoid unnecessary image pulls.
  * Added conditional Docker Hub authentication for environments that require it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->