### PR TITLE
docs: generic-tables client auth, storage backends, and release-notes signup

### DIFF
--- a/docs/docs/generic-tables-auth.md
+++ b/docs/docs/generic-tables-auth.md
@@ -1,0 +1,165 @@
+# Client Authentication
+
+The Lakekeeper clients — [`pylakekeeper`](generic-tables-pylakekeeper.md) (Python) and the [`lakekeeper-client`](generic-tables-flink.md) (Java, also used from [Spark](generic-tables-spark.md) via py4j) — authenticate to Lakekeeper by sending an OAuth2 **bearer token** on every request. This page covers the **client side**: how to obtain and pass that token. For the **server side** — configuring the OpenID provider, how Lakekeeper validates tokens, and mapping tokens to identities — see [Authentication](authentication.md).
+
+All clients expose the same four strategies behind a common `Auth` interface, so you pick one and hand it to the client; the client attaches the `Authorization` header and refreshes the token as needed.
+
+## Choosing a strategy
+
+| Strategy | Class | Use when |
+|---|---|---|
+| **Static token** | `StaticToken` | You already have a bearer token, or the target is a no-auth dev stack. |
+| **Client credentials** | `ClientCredentials` | A **service** / machine-to-machine job — no human in the loop. The client fetches and refreshes the token. |
+| **Device code** | `DeviceCodeFlow` | An interactive **human** login from a CLI, container, or remote kernel — approve a code in a browser on any device (RFC 8628). |
+| **Authorization code + PKCE** | `AuthorizationCodeFlow` | An interactive **human** login on your own machine — opens a browser and captures the redirect on a loopback port (RFC 7636). |
+
+!!! tip "Which one?"
+    - **Unattended job** (Spark, Flink, cron, CI) → `ClientCredentials`
+    - **A person on a headless / remote host** (CLI, container, notebook kernel) → `DeviceCodeFlow`
+    - **A person on their own machine** (a browser can reach it) → `AuthorizationCodeFlow`
+    - **A pre-issued token or a no-auth dev stack** → `StaticToken`
+
+## Static token
+
+A fixed bearer token — no refresh.
+
+=== "Python"
+
+    ```python
+    from pylakekeeper import StaticToken
+    auth = StaticToken("my-token")
+    ```
+
+=== "Java"
+
+    ```java
+    import io.lakekeeper.client.auth.StaticToken;
+    var auth = new StaticToken("my-token");
+    ```
+
+## Client credentials (service accounts)
+
+The OAuth2 `client_credentials` grant — the client fetches a token and refreshes it before expiry, single-flight under concurrency.
+
+=== "Python"
+
+    ```python
+    from pylakekeeper import ClientCredentials
+
+    auth = ClientCredentials(
+        token_url="http://keycloak/realms/iceberg/protocol/openid-connect/token",
+        client_id="my-service",
+        client_secret="...",
+        scope="lakekeeper",          # audience-granting scope — see the warning below
+    )
+    ```
+
+=== "Java"
+
+    ```java
+    import io.lakekeeper.client.auth.ClientCredentials;
+
+    var auth = new ClientCredentials(
+        "http://keycloak/realms/iceberg/protocol/openid-connect/token",
+        "my-service",
+        "...",
+        "lakekeeper",   // scope (nullable)
+        60,             // refreshMarginSeconds
+        30);            // timeoutSeconds
+    ```
+
+!!! warning "Service accounts need the right audience"
+    Lakekeeper rejects a token with `401` unless its `aud` claim matches the configured audience. Many IdPs (e.g. Keycloak) omit that audience for a bare service-account token unless you request the audience-granting **scope** — commonly `scope="lakekeeper"`. If a `client_credentials` token 401s, this is almost always why. See the server-side [Authentication](authentication.md) guide for configuring the audience.
+
+## Device code — CLI / headless / remote kernels
+
+The OAuth2 Device Authorization Grant (RFC 8628). The client shows a URL + code; the user approves it in a browser on any device, and the client polls until they do. No redirect listener needed, so it works on headless and remote hosts.
+
+=== "Python"
+
+    ```python
+    from pylakekeeper import DeviceCodeFlow
+
+    auth = DeviceCodeFlow(
+        device_authorization_url="http://keycloak/realms/iceberg/protocol/openid-connect/auth/device",
+        token_url="http://keycloak/realms/iceberg/protocol/openid-connect/token",
+        client_id="lakekeeper",           # a public client — no secret
+        scope="openid offline_access",    # offline_access → a refresh token
+    )
+    # The first request prints a URL + code to approve in a browser, then blocks until you do.
+    ```
+
+=== "Java"
+
+    ```java
+    import io.lakekeeper.client.auth.DeviceCodeFlow;
+
+    var auth = new DeviceCodeFlow(
+        "http://keycloak/realms/iceberg/protocol/openid-connect/auth/device",
+        "http://keycloak/realms/iceberg/protocol/openid-connect/token",
+        "lakekeeper");   // a public client — no secret
+    ```
+
+## Authorization code + PKCE — desktop / notebook
+
+The OAuth2 Authorization Code grant with PKCE (RFC 7636). Opens a browser and captures the redirect on a short-lived loopback HTTP server — best when the code runs on your own machine. PKCE means a public client works with no secret on the machine.
+
+=== "Python"
+
+    ```python
+    from pylakekeeper import AuthorizationCodeFlow
+
+    auth = AuthorizationCodeFlow(
+        authorization_url="http://keycloak/realms/iceberg/protocol/openid-connect/auth",
+        token_url="http://keycloak/realms/iceberg/protocol/openid-connect/token",
+        client_id="lakekeeper",           # public client + PKCE — no secret
+        scope="openid offline_access",
+    )
+    # The first request opens your browser and captures the redirect on a loopback port.
+    ```
+
+=== "Java"
+
+    ```java
+    import io.lakekeeper.client.auth.AuthorizationCodeFlow;
+
+    var auth = new AuthorizationCodeFlow(
+        "http://keycloak/realms/iceberg/protocol/openid-connect/auth",
+        "http://keycloak/realms/iceberg/protocol/openid-connect/token",
+        "lakekeeper");   // public client + PKCE — no secret
+    ```
+
+## Refresh & session lifetime
+
+Access tokens are short-lived (often ~1 h). The interactive flows (**device code**, **authorization code**) log the user in **once** and then renew the access token silently with the `refresh_token`, so the session outlives a single access token — a fresh interactive login only happens if the refresh token itself expires or is revoked. `ClientCredentials` simply re-fetches a new token before expiry (no refresh token needed).
+
+Include `offline_access` in the scope if your IdP only issues a refresh token when asked (Keycloak does).
+
+## Passing it to the client
+
+Once you've built an `auth`, hand it to the client:
+
+=== "Python"
+
+    ```python
+    from pylakekeeper import Client
+    client = Client(base_url="http://localhost:8181", warehouse="my-warehouse-uuid", auth=auth)
+    ```
+
+=== "Java"
+
+    ```java
+    var client = io.lakekeeper.client.LakekeeperClient.builder()
+        .baseUrl("http://localhost:8181")
+        .warehouse("my-warehouse-uuid")
+        .auth(auth)
+        .build();
+    ```
+
+From **PySpark**, reach the same Java classes through `spark._jvm.io.lakekeeper.client.auth.*` — see [Apache Spark](generic-tables-spark.md).
+
+## Related
+
+- [Authentication](authentication.md) — server-side: configuring the IdP and how Lakekeeper validates tokens
+- [Python Client](generic-tables-pylakekeeper.md) · [Apache Spark](generic-tables-spark.md) · [Apache Flink](generic-tables-flink.md)
+- Source & examples: [`lakekeeper-clients` on GitHub](https://github.com/lakekeeper/lakekeeper-clients)

--- a/docs/docs/generic-tables-flink.md
+++ b/docs/docs/generic-tables-flink.md
@@ -46,6 +46,9 @@ cp java/.env.local.example java/.env.local
 | `TOKEN` | Static bearer token **—or—** the `OAUTH_*` variables below |
 | `OAUTH_TOKEN_URL`, `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_SCOPE` | OAuth2 client-credentials flow (alternative to `TOKEN`) |
 
+!!! note "Interactive login isn't for streaming jobs"
+    The Java client also ships `DeviceCodeFlow` (RFC 8628) and `AuthorizationCodeFlow` with PKCE (RFC 7636) for signing a **human** in from a CLI or desktop — see [Client Authentication](generic-tables-auth.md). A Flink job runs unattended with no browser, so authenticate it as a **service account** with `ClientCredentials` (the `OAUTH_*` variables above) or a static `TOKEN` — not an interactive flow.
+
 **Optional tuning:**
 
 | Variable | Default | Description |

--- a/docs/docs/generic-tables-pylakekeeper.md
+++ b/docs/docs/generic-tables-pylakekeeper.md
@@ -172,19 +172,20 @@ The `lance` format stores a columnar dataset — here, vector embeddings. Create
                                     format=GenericTableFormat.LANCE, properties={"embedding-dim": "768"})
         except ConflictError:
             pass
-        t = c.generic_tables.load("ai.test", "image_embeddings", vended=True)  # location is abfss://...
+        # Rebuild storage options from the freshly-loaded table each time — the SAS token is short-lived.
+        def adls_opts(t):   # map the vended SAS token to Lance/object-store Azure options (verify names)
+            creds = {**{k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()},
+                     **(t.config or {})}
+            return {
+                "azure_storage_account_name": creds.get("adls.account-name"),
+                "azure_storage_sas_key": next(v for k, v in creds.items() if k.startswith("adls.sas-token.")),
+            }
 
-        # Vended SAS token → Lance/object-store Azure storage_options (verify option names).
-        creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
-        creds.update(t.config or {})
-        opts = {
-            "azure_storage_account_name": creds.get("adls.account-name"),
-            "azure_storage_sas_key": next(v for k, v in creds.items() if k.startswith("adls.sas-token.")),
-        }
-        lance.write_dataset(my_arrow_table, t.location, storage_options=opts, mode="overwrite")
+        t = c.generic_tables.load("ai.test", "image_embeddings", vended=True)  # location is abfss://...
+        lance.write_dataset(my_arrow_table, t.location, storage_options=adls_opts(t), mode="overwrite")
 
         t = c.generic_tables.load("ai.test", "image_embeddings", vended=True)   # refresh SAS
-        print("rows:", lance.dataset(t.location, storage_options=opts).count_rows())
+        print("rows:", lance.dataset(t.location, storage_options=adls_opts(t)).count_rows())
     ```
 
 === "GCS"

--- a/docs/docs/generic-tables-pylakekeeper.md
+++ b/docs/docs/generic-tables-pylakekeeper.md
@@ -20,30 +20,18 @@ Requires Python 3.10+. The core install depends only on `httpx` and `pydantic`.
 
 ## Connect
 
-Create a `Client` with your Lakekeeper URL, a **warehouse UUID** (it becomes the URL path prefix — use the UUID, not the warehouse name), and an auth strategy. Use it as a context manager to release the connection pool.
+Create a `Client` with your Lakekeeper URL, a **warehouse UUID** (it becomes the URL path prefix — use the UUID, not the warehouse name), and an **auth strategy**. Use it as a context manager to release the connection pool.
 
 ```python
-from pylakekeeper import Client, StaticToken, ClientCredentials
+from pylakekeeper import Client, StaticToken
 
-# Static bearer token (e.g. the no-auth `minimal` stack accepts TOKEN=dev):
-client = Client(
-    base_url="http://localhost:8181",
-    warehouse="my-warehouse-uuid",
-    auth=StaticToken("my-token"),
-)
-
-# ...or OAuth2 client credentials (the client refreshes the token automatically):
-client = Client(
-    base_url="http://localhost:8181",
-    warehouse="my-warehouse-uuid",
-    auth=ClientCredentials(
-        token_url="http://keycloak/realms/iceberg/protocol/openid-connect/token",
-        client_id="...",
-        client_secret="...",
-        scope="lakekeeper",
-    ),
-)
+with Client(base_url="http://localhost:8181",
+            warehouse="my-warehouse-uuid",
+            auth=StaticToken("dev")) as client:      # a no-auth dev stack accepts any token
+    ...
 ```
+
+The `auth=` argument is where you choose *how* you authenticate — a static token, a service account, or an interactive human login. Those strategies are shared across all clients and documented once in **[Client Authentication](generic-tables-auth.md)** (`StaticToken`, `ClientCredentials`, `DeviceCodeFlow`, `AuthorizationCodeFlow`, with automatic token refresh). Build whichever one you need and pass it to `Client(...)` as above.
 
 !!! info "Warehouse and namespace must already exist"
     The client creates *tables*, not warehouses or namespaces — warehouse administration is intentionally out of scope. Create the warehouse via the UI or [Management API](api/management.md) and the namespace via the [Catalog API](api/catalog.md) first.
@@ -64,96 +52,229 @@ Namespaces are given as dotted strings (`"ai.test"`) or lists (`["ai", "test"]`)
 The `load(..., vended=True)` response exposes ready-to-use credential shapes:
 
 - `resp.location` — the table's storage URI (e.g. `s3://bucket/prefix/...`)
-- `resp.lance_storage_options` — a dict of AWS-style keys for Lance / `boto3`
+- `resp.lance_storage_options` — object-store option names for **Lance** (`aws_access_key_id`, …)
 - `resp.fsspec_kwargs` — kwargs to unpack into `fsspec.filesystem("s3", ...)`
 
-## Example: Lance table
+## Storage backends
 
-The `lance` format stores a columnar dataset — here, vector embeddings. Create the table, load vended credentials, then write and read directly through Lance:
+`load(vended=True)` returns whatever short-lived credentials Lakekeeper mints for the warehouse's backend, under `t.storage_credentials` / `t.config`. The catalog flow is identical across backends — only the credential **keys** and the storage **library** differ. pylakekeeper ships ready-made credential shapes for **S3 only** (`lance_storage_options`, `fsspec_kwargs`); for Azure and GCS you read the raw vended keys off the response and hand them to your library.
 
-```python
-import lance
-from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
+=== "S3 & S3-compatible"
 
-with Client(base_url="http://localhost:8181",
-            warehouse="my-warehouse-uuid",
-            auth=StaticToken("dev")) as c:
+    Covers **AWS** and every S3-compatible store — **StackIT**, **MinIO**, **Cloudflare R2**, Ceph, … The client-side code is *identical* across them: Lakekeeper vends the correct `s3.endpoint`, and `lance_storage_options` applies it (plus `allow_http` for plaintext endpoints) automatically. There's no per-vendor branch in your code.
 
-    # Create the table (idempotent — tolerate re-runs).
-    try:
-        c.generic_tables.create(
-            "ai.test", "image_embeddings",
-            format=GenericTableFormat.LANCE,   # or just "lance"
-            properties={"embedding-dim": "768"},
-        )
-    except ConflictError:
-        pass  # already exists
+    ```python
+    t = c.generic_tables.load(ns, name, vended=True)
 
-    # Load with vended credentials → base location + short-lived STS creds.
-    t = c.generic_tables.load("ai.test", "image_embeddings", vended=True)
+    # Lance / object-store shape (ready-made):
+    opts = t.lance_storage_options
+    # → aws_access_key_id, aws_secret_access_key, aws_session_token, aws_region, aws_endpoint (+ allow_http)
 
-    # Write, then reload (STS creds are short-lived) and read back.
-    lance.write_dataset(my_arrow_table, t.location,
-                        storage_options=t.lance_storage_options, mode="overwrite")
+    # ...or the raw vended keys for boto3 / another library:
+    creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+    creds.update(t.config or {})
+    # creds["s3.access-key-id"], creds["s3.secret-access-key"], creds.get("s3.session-token"),
+    # creds.get("s3.region") or creds.get("client.region"), creds.get("s3.endpoint")
+    ```
 
-    t = c.generic_tables.load("ai.test", "image_embeddings", vended=True)
-    ds = lance.dataset(t.location, storage_options=t.lance_storage_options)
-    print("rows:", ds.count_rows())
-```
+=== "Azure ADLS"
 
-`t.lance_storage_options` maps Lakekeeper's Iceberg-style credential keys (`s3.access-key-id`, …) to the `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_region`, and `aws_endpoint` names Lance expects (and adds `allow_http=true` for plaintext endpoints like MinIO).
+    Lakekeeper vends an **account-scoped SAS token**. pylakekeeper has no Azure credential helper, so read the keys yourself:
 
-!!! tip "Every format shares the same catalog flow"
-    Create → `load(vended=True)` → write → reload (STS creds are short-lived) → read. Only two things change per format: the **library** that does the I/O, and the **shape** the vended credentials must take. The client maps the Lance/`boto3` shape for you (`t.lance_storage_options`); Delta wants `UPPER_SNAKE` names, so you remap those yourself.
+    ```python
+    t = c.generic_tables.load(ns, name, vended=True)
+    creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+    creds.update(t.config or {})
 
-## Example: Delta table
+    # Iceberg-REST ADLS keys (<account> = storage account, <suffix> e.g. dfs.core.windows.net):
+    #   adls.sas-token.<account>.<suffix>   → the SAS token
+    #   adls.account-name / adls.account-host
+    sas = next(v for k, v in creds.items() if k.startswith("adls.sas-token."))
+    account = creds.get("adls.account-name")
+    ```
 
-The `delta` format writes a Delta Lake table with [`deltalake`](https://pypi.org/project/deltalake/) (`pip install deltalake`). Delta reads storage options under **`UPPER_SNAKE`** names (`AWS_ACCESS_KEY_ID`, …) rather than Lance's lower-case shape, so remap the vended keys:
+    Hand these to your Azure library — e.g. `adlfs.AzureBlobFileSystem(account_name=account, sas_token=sas)`, or Lance / object-store `storage_options={"azure_storage_account_name": account, "azure_storage_sas_key": sas}`. Confirm the exact option names against your library's docs.
 
-```python
-from deltalake import DeltaTable, write_deltalake
-from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
+=== "GCS"
 
-# deltalake wants UPPER_SNAKE storage-option names; the client only maps the Lance shape.
-ICEBERG_TO_DELTA = {
-    "s3.access-key-id":     "AWS_ACCESS_KEY_ID",
-    "s3.secret-access-key": "AWS_SECRET_ACCESS_KEY",
-    "s3.session-token":     "AWS_SESSION_TOKEN",
-    "s3.region":            "AWS_REGION",
-    "client.region":        "AWS_REGION",
-    "s3.endpoint":          "AWS_ENDPOINT_URL",
-}
+    Lakekeeper vends a short-lived **OAuth2 bearer token** (`gcs.oauth2.token`). Again there is no pylakekeeper helper:
 
-def delta_options(t):
-    props = {**{k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()},
-             **(t.config or {})}
-    opts = {ICEBERG_TO_DELTA[k]: v for k, v in props.items() if k in ICEBERG_TO_DELTA}
-    opts.setdefault("AWS_S3_ALLOW_UNSAFE_RENAME", "true")   # plain S3 has no atomic rename
-    if opts.get("AWS_ENDPOINT_URL", "").startswith("http://"):
-        opts["AWS_ALLOW_HTTP"] = "true"                     # MinIO/SeaweedFS over http
-    return opts
+    ```python
+    t = c.generic_tables.load(ns, name, vended=True)
+    creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+    creds.update(t.config or {})
 
-with Client(base_url="http://localhost:8181",
-            warehouse="my-warehouse-uuid",
-            auth=StaticToken("dev")) as c:
+    gcs_token = creds["gcs.oauth2.token"]        # also: gcs.oauth2.token-expires-at
+    ```
 
-    try:
-        c.generic_tables.create("ai.test", "events", format=GenericTableFormat.DELTA)
-    except ConflictError:
-        pass
+    You can hand the bearer token to an fsspec-based tool (e.g. `gcsfs`) for direct file access. But the object-store writers (**Lance**, **`deltalake`**) expect a service-account key / ADC, not a raw bearer token — first-class GCS support for those is **coming soon**. Follow [lakekeeper-clients](https://github.com/lakekeeper/lakekeeper-clients).
 
-    t = c.generic_tables.load("ai.test", "events", vended=True)
-    write_deltalake(t.location, my_arrow_table,
-                    storage_options=delta_options(t), mode="overwrite")
+!!! note "S3 has first-class helpers; Azure/GCS are manual today"
+    The `lance_storage_options` / `fsspec_kwargs` helpers only translate the S3 (`s3.*`) keys. Azure/GCS work, but you map their vended keys yourself — first-class helpers for them are a planned client addition.
 
-    t = c.generic_tables.load("ai.test", "events", vended=True)   # refresh STS creds
-    dt = DeltaTable(t.location, storage_options=delta_options(t))
-    print("rows:", dt.to_pyarrow_table().num_rows)
-```
+## Examples
 
-## Example: Vortex table
+Every format follows the **same catalog flow** — create → `load(vended=True)` → write → reload (STS creds are short-lived) → read. Only the **library** that does the I/O and the **shape** of the vended credentials change per backend.
 
-The [`vortex`](https://pypi.org/project/vortex-data/) writer (`pip install vortex-data`) targets a local path, so the pattern is **write-local-then-upload**: build a `boto3` client from the vended credentials (the Lance option names double as `boto3` kwargs), write the `.vortex` file to a temp dir, then upload it to the table location.
+The **Lance**, **Delta**, and **`dataset`** examples show a tab per storage backend. The other upload-based examples (**Vortex**, **Paimon**, **HDF5**) are shown for **S3**; they follow the same file-upload pattern as `dataset`, so swap the upload client + credentials per that example / [Storage backends](#storage-backends).
+
+!!! warning "S3 is tested; Azure & GCS are illustrative"
+    The **S3 & S3-compatible** tab is the tested path (it also covers StackIT, MinIO, R2 — the endpoint is auto-vended). The **Azure ADLS** and **GCS** tabs have **not** been run against a live warehouse — treat their credentials / `storage_options` / upload calls as best-effort and confirm them against your storage library. Note the split on **GCS**: the file-upload `dataset` path accepts the vended bearer token via `google-cloud-storage`, but the columnar writers (**Lance**, **Delta**) go through object-store, which wants a service-account key / ADC — so their GCS tabs are marked *coming soon*.
+
+### Lance
+
+The `lance` format stores a columnar dataset — here, vector embeddings. Create the table, load vended credentials, then write and read directly through Lance.
+
+=== "S3 & S3-compatible"
+
+    ```python
+    import lance
+    from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
+
+    with Client(base_url="http://localhost:8181",
+                warehouse="my-warehouse-uuid",
+                auth=StaticToken("dev")) as c:
+
+        # Create the table (idempotent — tolerate re-runs).
+        try:
+            c.generic_tables.create(
+                "ai.test", "image_embeddings",
+                format=GenericTableFormat.LANCE,   # or just "lance"
+                properties={"embedding-dim": "768"},
+            )
+        except ConflictError:
+            pass  # already exists
+
+        # Load with vended credentials → base location + short-lived STS creds.
+        t = c.generic_tables.load("ai.test", "image_embeddings", vended=True)
+
+        # Write, then reload (STS creds are short-lived) and read back.
+        lance.write_dataset(my_arrow_table, t.location,
+                            storage_options=t.lance_storage_options, mode="overwrite")
+
+        t = c.generic_tables.load("ai.test", "image_embeddings", vended=True)
+        ds = lance.dataset(t.location, storage_options=t.lance_storage_options)
+        print("rows:", ds.count_rows())
+    ```
+
+    `t.lance_storage_options` maps the vended `s3.*` keys to the `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_region`, `aws_endpoint` names Lance expects (and adds `allow_http=true` for plaintext endpoints like MinIO).
+
+=== "Azure ADLS"
+
+    ```python
+    import lance
+    from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
+
+    with Client(base_url="http://localhost:8181", warehouse="my-warehouse-uuid",
+                auth=StaticToken("dev")) as c:
+        try:
+            c.generic_tables.create("ai.test", "image_embeddings",
+                                    format=GenericTableFormat.LANCE, properties={"embedding-dim": "768"})
+        except ConflictError:
+            pass
+        t = c.generic_tables.load("ai.test", "image_embeddings", vended=True)  # location is abfss://...
+
+        # Vended SAS token → Lance/object-store Azure storage_options (verify option names).
+        creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+        creds.update(t.config or {})
+        opts = {
+            "azure_storage_account_name": creds.get("adls.account-name"),
+            "azure_storage_sas_key": next(v for k, v in creds.items() if k.startswith("adls.sas-token.")),
+        }
+        lance.write_dataset(my_arrow_table, t.location, storage_options=opts, mode="overwrite")
+
+        t = c.generic_tables.load("ai.test", "image_embeddings", vended=True)   # refresh SAS
+        print("rows:", lance.dataset(t.location, storage_options=opts).count_rows())
+    ```
+
+=== "GCS"
+
+    !!! info "GCS support is in progress"
+        Lakekeeper vends a short-lived OAuth2 **bearer token** (`gcs.oauth2.token`), but Lance (via object-store) authenticates to GCS with a service-account key / ADC — so the vended token doesn't yet plug into `storage_options`. A first-class GCS path in `pylakekeeper` is **coming soon**; follow [lakekeeper-clients](https://github.com/lakekeeper/lakekeeper-clients).
+
+### Delta
+
+The `delta` format writes a Delta Lake table with [`deltalake`](https://pypi.org/project/deltalake/) (`pip install deltalake`). `deltalake` reads storage options under **`UPPER_SNAKE`** names rather than Lance's lower-case shape, so remap the vended keys.
+
+=== "S3 & S3-compatible"
+
+    ```python
+    from deltalake import DeltaTable, write_deltalake
+    from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
+
+    # deltalake wants UPPER_SNAKE storage-option names; the client only maps the Lance shape.
+    ICEBERG_TO_DELTA = {
+        "s3.access-key-id":     "AWS_ACCESS_KEY_ID",
+        "s3.secret-access-key": "AWS_SECRET_ACCESS_KEY",
+        "s3.session-token":     "AWS_SESSION_TOKEN",
+        "s3.region":            "AWS_REGION",
+        "client.region":        "AWS_REGION",
+        "s3.endpoint":          "AWS_ENDPOINT_URL",
+    }
+
+    def delta_options(t):
+        props = {**{k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()},
+                 **(t.config or {})}
+        opts = {ICEBERG_TO_DELTA[k]: v for k, v in props.items() if k in ICEBERG_TO_DELTA}
+        opts.setdefault("AWS_S3_ALLOW_UNSAFE_RENAME", "true")   # plain S3 has no atomic rename
+        if opts.get("AWS_ENDPOINT_URL", "").startswith("http://"):
+            opts["AWS_ALLOW_HTTP"] = "true"                     # MinIO/SeaweedFS over http
+        return opts
+
+    with Client(base_url="http://localhost:8181",
+                warehouse="my-warehouse-uuid",
+                auth=StaticToken("dev")) as c:
+
+        try:
+            c.generic_tables.create("ai.test", "events", format=GenericTableFormat.DELTA)
+        except ConflictError:
+            pass
+
+        t = c.generic_tables.load("ai.test", "events", vended=True)
+        write_deltalake(t.location, my_arrow_table,
+                        storage_options=delta_options(t), mode="overwrite")
+
+        t = c.generic_tables.load("ai.test", "events", vended=True)   # refresh STS creds
+        dt = DeltaTable(t.location, storage_options=delta_options(t))
+        print("rows:", dt.to_pyarrow_table().num_rows)
+    ```
+
+=== "Azure ADLS"
+
+    ```python
+    from deltalake import DeltaTable, write_deltalake
+    from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
+
+    def delta_options(t):   # map the vended SAS token to deltalake's Azure options (verify names)
+        creds = {**{k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()},
+                 **(t.config or {})}
+        sas = next(v for k, v in creds.items() if k.startswith("adls.sas-token."))
+        return {
+            "AZURE_STORAGE_ACCOUNT_NAME": creds.get("adls.account-name"),
+            "AZURE_STORAGE_SAS_KEY": sas,
+        }
+
+    with Client(base_url="http://localhost:8181", warehouse="my-warehouse-uuid",
+                auth=StaticToken("dev")) as c:
+        try:
+            c.generic_tables.create("ai.test", "events", format=GenericTableFormat.DELTA)
+        except ConflictError:
+            pass
+        t = c.generic_tables.load("ai.test", "events", vended=True)   # location is abfss://...
+        write_deltalake(t.location, my_arrow_table, storage_options=delta_options(t), mode="overwrite")
+
+        t = c.generic_tables.load("ai.test", "events", vended=True)   # refresh SAS
+        print("rows:", DeltaTable(t.location, storage_options=delta_options(t)).to_pyarrow_table().num_rows)
+    ```
+
+=== "GCS"
+
+    !!! info "GCS support is in progress"
+        Lakekeeper vends a short-lived OAuth2 **bearer token** (`gcs.oauth2.token`), but `deltalake` (via object-store) authenticates to GCS with a service-account key / ADC — so the vended token doesn't yet plug into `storage_options`. A first-class GCS path in `pylakekeeper` is **coming soon**; follow [lakekeeper-clients](https://github.com/lakekeeper/lakekeeper-clients).
+
+### Vortex
+
+The [`vortex`](https://pypi.org/project/vortex-data/) writer (`pip install vortex-data`) targets a local path, so the pattern is **write-local-then-upload**: build a `boto3` client from the vended `s3.*` credentials, write the `.vortex` file to a temp dir, then upload it to the table location.
 
 ```python
 import os, tempfile
@@ -172,13 +293,15 @@ with Client(base_url="http://localhost:8181",
         pass
 
     t = c.generic_tables.load("ai.test", "signals", vended=True)
-    opts = t.lance_storage_options            # lower_snake keys double as boto3 kwargs
+    # Vortex isn't Lance — build the S3 client from the raw vended `s3.*` credentials.
+    creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+    creds.update(t.config or {})
     s3 = boto3.client("s3",
-        aws_access_key_id=opts["aws_access_key_id"],
-        aws_secret_access_key=opts["aws_secret_access_key"],
-        aws_session_token=opts.get("aws_session_token"),
-        region_name=opts.get("aws_region"),
-        endpoint_url=opts.get("aws_endpoint"))
+        aws_access_key_id=creds["s3.access-key-id"],
+        aws_secret_access_key=creds["s3.secret-access-key"],
+        aws_session_token=creds.get("s3.session-token"),
+        region_name=creds.get("s3.region") or creds.get("client.region"),
+        endpoint_url=creds.get("s3.endpoint"))
 
     parsed = urlparse(t.location)
     bucket, key = parsed.netloc, f"{parsed.path.strip('/')}/data.vortex"
@@ -195,7 +318,7 @@ with Client(base_url="http://localhost:8181",
         print("rows:", table.num_rows)
 ```
 
-## Example: Paimon table
+### Paimon
 
 [`pypaimon`](https://pypi.org/project/pypaimon/) (`pip install pypaimon`, needs a JVM on `PATH`) also writes through a local filesystem catalog, so it uses the same **write-local-then-upload** approach as Vortex — except a Paimon table is a *directory tree*, so the whole tree is walked and uploaded.
 
@@ -216,13 +339,15 @@ with Client(base_url="http://localhost:8181",
         pass
 
     t = c.generic_tables.load("ai.test", "orders", vended=True)
-    opts = t.lance_storage_options
+    # Paimon isn't Lance — build the S3 client from the raw vended `s3.*` credentials.
+    creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+    creds.update(t.config or {})
     s3 = boto3.client("s3",
-        aws_access_key_id=opts["aws_access_key_id"],
-        aws_secret_access_key=opts["aws_secret_access_key"],
-        aws_session_token=opts.get("aws_session_token"),
-        region_name=opts.get("aws_region"),
-        endpoint_url=opts.get("aws_endpoint"))
+        aws_access_key_id=creds["s3.access-key-id"],
+        aws_secret_access_key=creds["s3.secret-access-key"],
+        aws_session_token=creds.get("s3.session-token"),
+        region_name=creds.get("s3.region") or creds.get("client.region"),
+        endpoint_url=creds.get("s3.endpoint"))
 
     parsed = urlparse(t.location)
     bucket, prefix = parsed.netloc, parsed.path.strip("/")
@@ -254,14 +379,120 @@ with Client(base_url="http://localhost:8181",
 
 Reading a Paimon table back is the mirror image: download the object tree under the prefix into a temp dir, then open it with a local `CatalogFactory(...).get_table("default.orders")` and a `new_read_builder()`.
 
-## Example: dataset format (unstructured files)
+### `dataset` — unstructured files
 
-The `dataset` format catalogs unstructured data — raw files rather than a columnar table. Lakekeeper vends credentials; the actual upload is done with a backend-specific client (`boto3` for S3, `azure-storage-blob` for ADLS, `google-cloud-storage` for GCS). Only the upload step changes — the catalog flow is identical.
+The `dataset` format catalogs unstructured data — raw files rather than a columnar table. The catalog flow is identical across backends; only the **upload client** changes (`boto3` / `azure-storage-blob` / `google-cloud-storage`). Because these are plain file-upload SDKs, each accepts the vended credential type directly — so unlike the columnar formats, **all three backends work here**, including GCS.
+
+=== "S3 & S3-compatible"
+
+    ```python
+    import boto3, mimetypes
+    from pathlib import Path
+    from urllib.parse import urlparse
+    from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
+
+    with Client(base_url="http://localhost:8181",
+                warehouse="my-warehouse-uuid",
+                auth=StaticToken("dev")) as c:
+
+        try:
+            c.generic_tables.create("ai.test", "product_images",
+                                    format=GenericTableFormat.DATASET, doc="product images")
+        except ConflictError:
+            pass
+
+        t = c.generic_tables.load("ai.test", "product_images", vended=True)
+
+        # boto3 client from the raw vended s3.* credentials.
+        creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+        creds.update(t.config or {})
+        s3 = boto3.client("s3",
+            aws_access_key_id=creds["s3.access-key-id"],
+            aws_secret_access_key=creds["s3.secret-access-key"],
+            aws_session_token=creds.get("s3.session-token"),
+            region_name=creds.get("s3.region") or creds.get("client.region"),
+            endpoint_url=creds.get("s3.endpoint"),  # None on real AWS; set for MinIO/SeaweedFS
+        )
+
+        parsed = urlparse(t.location)          # s3://<bucket>/<key-prefix>
+        bucket, prefix = parsed.netloc, parsed.path.strip("/")
+
+        for p in Path("images").iterdir():
+            s3.put_object(Bucket=bucket, Key=f"{prefix}/{p.name}", Body=p.read_bytes(),
+                          ContentType=mimetypes.guess_type(p.name)[0] or "application/octet-stream")
+    ```
+
+=== "Azure ADLS"
+
+    ```python
+    from azure.storage.blob import BlobServiceClient
+    from pathlib import Path
+    from urllib.parse import urlparse
+    from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
+
+    with Client(base_url="http://localhost:8181", warehouse="my-warehouse-uuid",
+                auth=StaticToken("dev")) as c:
+        try:
+            c.generic_tables.create("ai.test", "product_images",
+                                    format=GenericTableFormat.DATASET, doc="product images")
+        except ConflictError:
+            pass
+        t = c.generic_tables.load("ai.test", "product_images", vended=True)
+
+        # Vended SAS token is accepted directly as the BlobServiceClient credential.
+        creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+        creds.update(t.config or {})
+        sas = next(v for k, v in creds.items() if k.startswith("adls.sas-token."))
+        account = creds.get("adls.account-name")
+
+        parsed = urlparse(t.location)          # abfss://<container>@<account>.dfs.core.windows.net/<prefix>
+        container, prefix = parsed.username, parsed.path.strip("/")
+
+        bsc = BlobServiceClient(f"https://{account}.blob.core.windows.net", credential=sas)
+        for p in Path("images").iterdir():
+            bsc.get_blob_client(container=container, blob=f"{prefix}/{p.name}") \
+               .upload_blob(p.read_bytes(), overwrite=True)
+    ```
+
+=== "GCS"
+
+    ```python
+    from google.cloud import storage
+    from google.oauth2.credentials import Credentials
+    from pathlib import Path
+    from urllib.parse import urlparse
+    from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
+
+    with Client(base_url="http://localhost:8181", warehouse="my-warehouse-uuid",
+                auth=StaticToken("dev")) as c:
+        try:
+            c.generic_tables.create("ai.test", "product_images",
+                                    format=GenericTableFormat.DATASET, doc="product images")
+        except ConflictError:
+            pass
+        t = c.generic_tables.load("ai.test", "product_images", vended=True)
+
+        # The vended OAuth2 bearer token works via google.oauth2.credentials.Credentials.
+        creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+        creds.update(t.config or {})
+        gcs = storage.Client(credentials=Credentials(token=creds["gcs.oauth2.token"]))
+
+        parsed = urlparse(t.location)          # gs://<bucket>/<prefix>
+        bucket, prefix = gcs.bucket(parsed.netloc), parsed.path.strip("/")
+
+        for p in Path("images").iterdir():
+            bucket.blob(f"{prefix}/{p.name}").upload_from_filename(str(p))
+    ```
+
+### HDF5
+
+HDF5 is another `dataset`-format case — an opaque binary file that Lakekeeper catalogs and vends credentials for, read and written with [`h5py`](https://pypi.org/project/h5py/) (`pip install h5py`). Write the `.h5` locally, upload it, then read it back from the downloaded bytes:
 
 ```python
-import boto3, mimetypes
+import io, tempfile
 from pathlib import Path
 from urllib.parse import urlparse
+import boto3, h5py, numpy as np
 from pylakekeeper import Client, StaticToken, GenericTableFormat, ConflictError
 
 with Client(base_url="http://localhost:8181",
@@ -269,42 +500,45 @@ with Client(base_url="http://localhost:8181",
             auth=StaticToken("dev")) as c:
 
     try:
-        c.generic_tables.create("ai.test", "product_images",
-                                format=GenericTableFormat.DATASET, doc="product images")
+        c.generic_tables.create("ai.test", "sensor_hdf5",
+                                format=GenericTableFormat.DATASET, doc="HDF5 sensor data")
     except ConflictError:
         pass
 
-    t = c.generic_tables.load("ai.test", "product_images", vended=True)
+    t = c.generic_tables.load("ai.test", "sensor_hdf5", vended=True)
 
-    # Build a boto3 client straight from the vended credentials.
-    opts = t.lance_storage_options
+    # boto3 client from the raw vended s3.* credentials (same as the dataset example).
+    creds = {k: v for cred in (t.storage_credentials or []) for k, v in cred.config.items()}
+    creds.update(t.config or {})
     s3 = boto3.client("s3",
-        aws_access_key_id=opts["aws_access_key_id"],
-        aws_secret_access_key=opts["aws_secret_access_key"],
-        aws_session_token=opts.get("aws_session_token"),
-        region_name=opts.get("aws_region"),
-        endpoint_url=opts.get("aws_endpoint"),  # None on real AWS; set for MinIO/SeaweedFS
-    )
+        aws_access_key_id=creds["s3.access-key-id"],
+        aws_secret_access_key=creds["s3.secret-access-key"],
+        aws_session_token=creds.get("s3.session-token"),
+        region_name=creds.get("s3.region") or creds.get("client.region"),
+        endpoint_url=creds.get("s3.endpoint"))
 
-    parsed = urlparse(t.location)          # s3://<bucket>/<key-prefix>
-    bucket, prefix = parsed.netloc, parsed.path.strip("/")
+    parsed = urlparse(t.location)
+    bucket, key = parsed.netloc, f"{parsed.path.strip('/')}/data.h5"
 
-    for p in Path("images").iterdir():
-        s3.put_object(Bucket=bucket, Key=f"{prefix}/{p.name}", Body=p.read_bytes(),
-                      ContentType=mimetypes.guess_type(p.name)[0] or "application/octet-stream")
+    # Write an HDF5 file locally, then upload it.
+    with tempfile.TemporaryDirectory() as tmp:
+        local = Path(tmp) / "data.h5"
+        with h5py.File(local, "w") as f:
+            f.create_dataset("embeddings",
+                             data=np.random.default_rng(0).standard_normal((100, 8)),
+                             compression="gzip")
+            f.attrs["rows"] = 100
+        s3.upload_file(str(local), bucket, key)
+
+    # Read it back: download the object and open the bytes with h5py.
+    raw = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+    with h5py.File(io.BytesIO(raw), "r") as f:
+        print("datasets:", list(f.keys()), "rows:", int(f.attrs["rows"]))
 ```
-
-## Authentication
-
-| Strategy | Class | Use when |
-|---|---|---|
-| Static token | `StaticToken(token)` | You already have a bearer token, or the target is a no-auth dev stack. |
-| Client credentials | `ClientCredentials(token_url=, client_id=, client_secret=, scope=)` | Production OAuth2 — the client fetches and refreshes the token for you. |
-
-See [Authentication](authentication.md) for how Lakekeeper validates tokens and maps them to identities.
 
 ## Related
 
+- [Client Authentication](generic-tables-auth.md) — all auth strategies (static / client-credentials / device-code / PKCE)
 - [Generic Tables](generic-tables.md) — the catalog concept this client operates on
 - [Apache Flink](generic-tables-flink.md) — the same vending flow from Java/Flink
 - [Query Engines](engines.md) — Iceberg-native engines against Lakekeeper

--- a/docs/docs/generic-tables-spark.md
+++ b/docs/docs/generic-tables-spark.md
@@ -55,7 +55,7 @@ spark = (
 
 ## Build the Lakekeeper client via py4j
 
-`spark._jvm` gives direct access to any class on the Spark JVM classpath:
+`spark._jvm` gives direct access to any class on the Spark JVM classpath. The auth classes are the same ones described in [Client Authentication](generic-tables-auth.md) — from PySpark you construct them through `spark._jvm` instead of a Python import:
 
 ```python
 jvm = spark._jvm
@@ -81,6 +81,27 @@ client = (
     .build()
 )
 ```
+
+!!! note "Interactive login (device code / PKCE)"
+    For a **human** signing in from a laptop or notebook — rather than a service account — the Java client also offers `DeviceCodeFlow` and `AuthorizationCodeFlow` (PKCE); see [Client Authentication](generic-tables-auth.md) for what each flow does. Reach them the same way via `spark._jvm`:
+
+    ```python
+    # Device code — prints a URL + code to approve in a browser, then polls until you do.
+    auth = jvm.io.lakekeeper.client.auth.DeviceCodeFlow(
+        os.environ["OAUTH_DEVICE_URL"],   # .../protocol/openid-connect/auth/device
+        os.environ["OAUTH_TOKEN_URL"],
+        os.environ["OAUTH_CLIENT_ID"],    # a public client — no secret
+    )
+
+    # ...or authorization code + PKCE (opens a browser, captures a loopback redirect):
+    auth = jvm.io.lakekeeper.client.auth.AuthorizationCodeFlow(
+        os.environ["OAUTH_AUTH_URL"],     # .../protocol/openid-connect/auth
+        os.environ["OAUTH_TOKEN_URL"],
+        os.environ["OAUTH_CLIENT_ID"],
+    )
+    ```
+
+    These fit **local / interactive** Spark. A **cluster job** has no browser and no human at the keyboard — use `ClientCredentials` (above) there.
 
 ## Create the Lance table
 

--- a/docs/docs/generic-tables.md
+++ b/docs/docs/generic-tables.md
@@ -37,7 +37,7 @@ The flow is the same for every format: create the table, load it with *vended* c
 
 You don't need to hand-roll these HTTP calls:
 
-- **Python** — the [Python client (`pylakekeeper`)](generic-tables-pylakekeeper.md) wraps create/load/list/drop and maps vended credentials into the keys Lance, `boto3`, and `fsspec` expect. See its [Lance example](generic-tables-pylakekeeper.md#example-lance-table).
+- **Python** — the [Python client (`pylakekeeper`)](generic-tables-pylakekeeper.md) wraps create/load/list/drop and maps vended credentials into the keys Lance, `boto3`, and `fsspec` expect. See its [Lance example](generic-tables-pylakekeeper.md#lance).
 - **PySpark** — [Apache Spark](generic-tables-spark.md) reads and writes generic tables through the same vending flow.
 - **Java / Flink** — [Apache Flink](generic-tables-flink.md) shows the same vending flow.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
     - Query Engines: engines.md
     - Generic Tables:
           - Overview: generic-tables.md
+          - Client Authentication: generic-tables-auth.md
           - Python Client: generic-tables-pylakekeeper.md
           - Apache Spark (PySpark): generic-tables-spark.md
           - Apache Flink (Java): generic-tables-flink.md

--- a/site/_includes/subscribe-form.html
+++ b/site/_includes/subscribe-form.html
@@ -1,0 +1,29 @@
+<div class="lk-subscribe" markdown="0">
+  <p>📬 Get notified about new Lakekeeper releases</p>
+  <form
+    action="https://buttondown.com/api/emails/embed-subscribe/lakekeeper"
+    method="post"
+    target="popupwindow"
+    onsubmit="window.open('https://buttondown.com/lakekeeper', 'popupwindow')"
+    class="embeddable-buttondown-form"
+  >
+    <div class="lk-subscribe-row">
+      <label for="bd-email" class="lk-visually-hidden">Email address</label>
+      <input
+        type="email"
+        name="email"
+        id="bd-email"
+        placeholder="you@example.com"
+        autocomplete="email"
+        required
+      />
+      <input type="hidden" name="tag" value="docs-subscribe" />
+      <input type="hidden" name="embed" value="1" />
+      <input type="submit" value="Subscribe" />
+    </div>
+    <p class="lk-subscribe-fine">
+      No spam — occasional release announcements only.
+      <a href="https://buttondown.com/refer/lakekeeper" target="_blank" rel="noopener">Powered by Buttondown.</a>
+    </p>
+  </form>
+</div>

--- a/site/docs/about/enterprise-release-notes.md
+++ b/site/docs/about/enterprise-release-notes.md
@@ -1,5 +1,9 @@
 # Lakekeeper Plus Release Notes
 
+--8<-- "_includes/subscribe-form.html"
+
+_[Subscribe by email](subscribe.md) to hear about new releases, or **Watch → Releases** on [GitHub](https://github.com/lakekeeper/lakekeeper/releases)._
+
 ## v0.13.0 (2026-06-30)
 
 _Based on Lakekeeper OSS v0.13.1._

--- a/site/docs/about/release-notes.md
+++ b/site/docs/about/release-notes.md
@@ -8,6 +8,10 @@ For Lakekeeper Plus releases, see the [Lakekeeper Plus Release Notes](enterprise
 
 <!-- Maintainers: how to update this page at release → .github/RELEASING.md -->
 
+--8<-- "_includes/subscribe-form.html"
+
+_[Subscribe by email](subscribe.md) to hear about new releases, or **Watch → Releases** on [GitHub](https://github.com/lakekeeper/lakekeeper/releases)._
+
 ## v0.13.1 (2026-06-30)
 
 ### Bug Fixes

--- a/site/docs/about/subscribe.md
+++ b/site/docs/about/subscribe.md
@@ -1,0 +1,9 @@
+# Stay Updated
+
+Want to hear about new Lakekeeper releases? Subscribe below and we'll email you when a notable release ships — new features, breaking changes, and upgrade notes worth knowing about.
+
+- **Low volume.** Only occasional release announcements — no marketing, no drip campaigns.
+- **You're in control.** Confirm your address after signing up, and unsubscribe anytime with one click.
+- **Prefer a feed?** Every release is also on [GitHub Releases](https://github.com/lakekeeper/lakekeeper/releases) — click **Watch → Custom → Releases** to get GitHub notifications instead.
+
+--8<-- "_includes/subscribe-form.html"

--- a/site/docs/assets/css/extra.css
+++ b/site/docs/assets/css/extra.css
@@ -109,7 +109,8 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip: rect(0, 0, 0, 0); /* fallback for older browsers */
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/site/docs/assets/css/extra.css
+++ b/site/docs/assets/css/extra.css
@@ -44,6 +44,76 @@
   color: var(--md-default-fg-color);
 }
 
+/* Release-notes email subscribe callout (Buttondown embed).
+   Theme-aware: uses Material's own fg/bg/primary variables so it renders
+   cleanly in both light and dark schemes. */
+.lk-subscribe {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  padding: 1rem 1.2rem;
+  margin: 1.2rem 0 2rem;
+  background: var(--md-code-bg-color);
+}
+.lk-subscribe > p:first-child {
+  margin-top: 0;
+  font-weight: 600;
+}
+.lk-subscribe form {
+  margin: 0;
+}
+.lk-subscribe .lk-subscribe-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+.lk-subscribe input[type="email"] {
+  flex: 1 1 16rem;
+  min-width: 0;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--md-default-fg-color--light);
+  border-radius: 6px;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  font-size: 0.8rem;
+}
+.lk-subscribe input[type="email"]:focus {
+  outline: none;
+  border-color: var(--md-accent-fg-color);
+}
+.lk-subscribe input[type="submit"] {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 6px;
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+  font-weight: 600;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.lk-subscribe input[type="submit"]:hover {
+  background: var(--md-accent-fg-color);
+}
+.lk-subscribe .lk-subscribe-fine {
+  margin: 0.6rem 0 0;
+  font-size: 0.65rem;
+  color: var(--md-default-fg-color--light);
+}
+.lk-subscribe .lk-subscribe-fine a {
+  color: inherit;
+}
+.lk-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Short Lakekeeper Plus Badge with auto-generated content */
 .lkp::after {
   content: "★ lakekeeper +";

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Release 0.6.x: "!include docs/docs/0.6.x/mkdocs.yml"
       - Release 0.5.x: "!include docs/docs/0.5.x/mkdocs.yml"
   - Release Notes:
+      - Stay Updated: about/subscribe.md
       - Lakekeeper (OSS): about/release-notes.md
       - Lakekeeper Plus: about/enterprise-release-notes.md
   - Community: support.md


### PR DESCRIPTION
Docs-only PR bundling two changes to the documentation site.

## 1. Generic-tables client auth + storage backends

Documents the interactive OAuth2 flows shipped in the clients (`pylakekeeper` 0.3.0, `lakekeeper-client-java` 0.2.0).

- **New shared page — Client Authentication** (`generic-tables-auth.md`): all four strategies — `StaticToken`, `ClientCredentials`, `DeviceCodeFlow` (RFC 8628), `AuthorizationCodeFlow` + PKCE (RFC 7636) — with Python/Java content tabs, a "choosing a strategy" table, refresh/session-lifetime notes, and a `401` audience / `scope="lakekeeper"` warning. Added to the nav after *Overview*.
- **Cross-links** from the Python (pylakekeeper), Spark, and Flink guides, clarifying device-code/PKCE are for **human** logins (CLI, notebook) while unattended jobs (Spark clusters, Flink streaming, CI) use `ClientCredentials`.
- **Expanded Python storage coverage**: per-backend config (S3, Azure ADLS, GCS) and worked examples (Lance, Delta, Vortex, Paimon, `dataset`, HDF5).
- Fixed the inbound Lance-example anchor in `generic-tables.md` after the pylakekeeper Examples section was restructured (`#example-lance-table` → `#lance`), so the nightly anchor linkcheck passes.

## 2. Release-notes email subscribe form

- Buttondown-backed email signup so readers can subscribe to release announcements. Single reusable snippet (`site/_includes/subscribe-form.html`) on a new **Stay Updated** page and inline atop both OSS and Plus release-notes pages, with theme-aware styling (light + dark).
- **Collection only** — sending stays manual from Buttondown; no RSS/automation wired up.

## Verification

- Built the docs unit and the assembled site locally — content tabs render (`pymdownx.tabbed`), no broken `docs/nightly` anchors.

BEGIN_COMMIT_OVERRIDE
docs(generic-tables): document client auth strategies and storage backends
docs(release-notes): add email subscribe form for release announcements
END_COMMIT_OVERRIDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Client Authentication guide (static tokens, client credentials, device code, and authorization code with PKCE), including token lifetime/refresh behavior and service-account guidance.
  * Clarified interactive login suitability for unattended Flink/Spark jobs and updated Py4J/PySpark instructions for auth construction.
  * Refreshed `pylakekeeper` generic table examples and reworked backend-specific credential guidance.

* **Website**
  * Added a “Stay Updated” email subscription form, styling, and embedded prompts across release notes, plus a dedicated subscription page and navigation entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->