### PR TITLE
chore(docs): Sync documentation from lakekeeper plus

### DIFF
--- a/docs/docs/api/management-open-api-plus.yaml
+++ b/docs/docs/api/management-open-api-plus.yaml
@@ -9589,22 +9589,6 @@ components:
                   type: string
                   enum:
                     - cloudflare-r2
-        - allOf:
-            - $ref: '#/components/schemas/S3AccessKeyCredential'
-              description: |-
-                Authenticate to Alibaba Cloud OSS using access-key and secret-key.
-                Temporary credentials are vended via the Alibaba Cloud STS `AssumeRole` API.
-            - type: object
-              required:
-                - credential-type
-              properties:
-                credential-type:
-                  type: string
-                  enum:
-                    - aliyun-oss
-          description: |-
-            Authenticate to Alibaba Cloud OSS using access-key and secret-key.
-            Temporary credentials are vended via the Alibaba Cloud STS `AssumeRole` API.
     S3CredentialType:
       type: string
       description: The type of S3 credential.
@@ -9612,7 +9596,6 @@ components:
         - access-key
         - aws-system-identity
         - cloudflare-r2
-        - aliyun-oss
     S3Flavor:
       type: string
       enum:

--- a/site/docs/about/enterprise-release-notes.md
+++ b/site/docs/about/enterprise-release-notes.md
@@ -1,5 +1,28 @@
 # Lakekeeper Plus Release Notes
 
+## v0.13.3 (2026-07-24)
+
+_Based on Lakekeeper OSS v0.13.3._
+
+### Highlights
+- **Admission-gate roles now take effect.** Roles granted by a `role_granting` admission check are finally evaluated by authorization — completing the external admission gate shipped in v0.13.0, whose granted roles previously never reached Cedar.
+
+### Features
+- **Apply admission-gate roles in Cedar authorization.** A new `AdmissionRoleProvider` (an uncached role-provider-chain leaf, mirroring the token role provider) serves the caller's admission-granted roles under their configured provider id; Cedar materialises them as `Role` entities and evaluates policies against them. Plus wires one provider per role-provider id the gate can mint under, so a gate-only deployment still resolves roles.
+- **No-Access page for instance-level 403.** An authenticated caller denied access to the instance (e.g. rejected by the admission gate) now lands on a dedicated No-Access page with proper 403 routing, instead of a broken view. (console v0.16.4)
+
+
+### Upgrade Notes
+- **Conflicting role-provider ids now fail fast.** A gate-minted `role_provider_id` that collides with a configured or token role-provider id is rejected at startup with `ExtraProviderIdConflict` — give the gate's minted roles a distinct provider id.
+- **Admission roles apply under Cedar only.** With the OpenFGA authorizer, or Cedar in externally-managed mode, admission-granted roles are not applied; the server logs a warning at startup so a misconfiguration is visible.
+
+## v0.13.2 (2026-07-23)
+
+_Based on Lakekeeper OSS v0.13.3._
+
+### Bug Fixes
+- **Maintenance page.** Console bump to 0.16.3 (console-components 0.17.2, console-plus-components 0.11.0). Redesigned maintenance date-range filters, suppressed spurious 403 notifications for maintenance tasks, and fixed the Home page chart title.
+
 ## v0.13.1 (2026-07-20)
 
 _Based on Lakekeeper OSS v0.13.3._


### PR DESCRIPTION
This PR automatically syncs documentation files from the lakekeeper plus repository.

## Changes
- management-open-api-plus.yaml: ✓ Updated
- lakekeeper.cedarschema: - No changes
- enterprise-release-notes.md: ✓ Updated

Source commit: `b99b7ce86b50dffc42d627b4cbe3f9fb9e7ee90b`
Generated by [workflow run](https://github.com/vakamo-labs/lakekeeper-enterprise/actions/runs/30096072670)