### PR TITLE
chore(test-utils): let the test builder set admission_roles

### DIFF
--- a/crates/lakekeeper/src/request_metadata.rs
+++ b/crates/lakekeeper/src/request_metadata.rs
@@ -575,6 +575,12 @@ pub struct RequestMetadataTestBuilder {
     pub is_instance_admin: bool,
     #[builder(default, setter(strip_option))]
     pub token_roles: Option<TokenRoles>,
+    /// Roles a post-authentication admission gate resolved for the caller. In
+    /// production only the auth middleware sets these (via the `pub(crate)`
+    /// [`RequestMetadata::set_admission_roles`]); this builder field lets tests
+    /// construct a request that carries them.
+    #[builder(default, setter(strip_option))]
+    pub admission_roles: Option<TokenRoles>,
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -591,7 +597,7 @@ impl From<RequestMetadataTestBuilder> for RequestMetadata {
             user_agent: None,
             engines: MatchedEngines::default(),
             token_roles: b.token_roles,
-            admission_roles: None,
+            admission_roles: b.admission_roles,
             idempotency_key: None,
             is_instance_admin: b.is_instance_admin,
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced request metadata test coverage to support post-authentication admission roles.
  * Improved test setup for scenarios involving role-based admission decisions.

* **User Impact**
  * No user-facing behavior or configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->