### PR TITLE
chore(docs): Sync documentation from lakekeeper plus

### DIFF
--- a/docs/docs/api/management-open-api-plus.yaml
+++ b/docs/docs/api/management-open-api-plus.yaml
@@ -9589,6 +9589,28 @@ components:
                   type: string
                   enum:
                     - cloudflare-r2
+        - allOf:
+            - $ref: '#/components/schemas/S3AccessKeyCredential'
+              description: |-
+                **Beta:** Alibaba Cloud OSS support is in beta. The API and behavior may change in a
+                future release.
+
+                Authenticate to Alibaba Cloud OSS using access-key and secret-key.
+                Temporary credentials are vended via the Alibaba Cloud STS `AssumeRole` API.
+            - type: object
+              required:
+                - credential-type
+              properties:
+                credential-type:
+                  type: string
+                  enum:
+                    - aliyun-oss
+          description: |-
+            **Beta:** Alibaba Cloud OSS support is in beta. The API and behavior may change in a
+            future release.
+
+            Authenticate to Alibaba Cloud OSS using access-key and secret-key.
+            Temporary credentials are vended via the Alibaba Cloud STS `AssumeRole` API.
     S3CredentialType:
       type: string
       description: The type of S3 credential.
@@ -9596,6 +9618,7 @@ components:
         - access-key
         - aws-system-identity
         - cloudflare-r2
+        - aliyun-oss
     S3Flavor:
       type: string
       enum:


### PR DESCRIPTION
This PR automatically syncs documentation files from the lakekeeper plus repository.

## Changes
- management-open-api-plus.yaml: ✓ Updated
- lakekeeper.cedarschema: - No changes
- enterprise-release-notes.md: - No changes

Source commit: `574b211d4d149a48ee8df1eac5259b1347e2a048`
Generated by [workflow run](https://github.com/vakamo-labs/lakekeeper-enterprise/actions/runs/30159838181)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added beta support for Alibaba Cloud OSS credentials in the management API schema.
  * Introduced the `aliyun-oss` credential type.
  * Documented that temporary credentials are obtained via Alibaba Cloud STS `AssumeRole`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->