### PR TITLE
fix(s3): don't vend a credential-less `storage-credentials` entry

### DIFF
--- a/crates/lakekeeper-integration-tests/tests/server_generic_table_signing.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_generic_table_signing.rs
@@ -715,4 +715,58 @@ async fn test_generic_table_load_advertises_remote_signing(pool: PgPool) {
             "config[{key}] must point at the catalog signer uri: {config:?}"
         );
     }
+
+    assert!(
+        response.storage_credentials.is_none(),
+        "nothing was vended, so no storage-credentials entry may be returned: {:?}",
+        response.storage_credentials
+    );
+}
+
+/// A client asking for vended credentials against a warehouse that cannot vend them must get no
+/// `storage-credentials` entry at all. An entry holding only region/endpoint makes clients scope a
+/// key-less secret to the table prefix and stop signing requests for the files below it.
+#[sqlx::test]
+async fn test_generic_table_load_omits_credentials_when_nothing_is_vended(pool: PgPool) {
+    let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
+    create_generic_table(&ctx, &namespace_name, warehouse_id, GENERIC_TABLE).await;
+
+    let response = CatalogServer::load_generic_table(
+        GenericTableParameters {
+            prefix: Some(warehouse_id.to_string().into()),
+            namespace: namespace(&namespace_name),
+            table_name: GENERIC_TABLE.to_string(),
+        },
+        ctx.clone(),
+        // What DuckDB sends by default: `ACCESS_DELEGATION_MODE 'vended_credentials'`. STS is
+        // disabled on this warehouse, so there is nothing to vend.
+        DataAccess {
+            vended_credentials: true,
+            remote_signing: false,
+        },
+        random_request_metadata(),
+    )
+    .await
+    .expect("loading a generic table must succeed");
+
+    assert!(
+        response.storage_credentials.is_none(),
+        "no credential was vended, so no storage-credentials entry may be returned: {:?}",
+        response.storage_credentials
+    );
+
+    // The client still learns how to reach the storage with its own credentials.
+    let config = response
+        .config
+        .expect("load response must carry a config when access is delegated");
+    assert_eq!(
+        config.get("s3.region").map(String::as_str),
+        Some(REGION),
+        "config must still carry the region: {config:?}"
+    );
+    assert_eq!(
+        config.get("s3.endpoint").map(String::as_str),
+        Some(format!("{ENDPOINT}/").as_str()),
+        "config must still carry the endpoint: {config:?}"
+    );
 }

--- a/crates/lakekeeper/src/server/generic_tables/credentials.rs
+++ b/crates/lakekeeper/src/server/generic_tables/credentials.rs
@@ -1,7 +1,5 @@
 use std::{collections::HashMap, sync::Arc};
 
-use iceberg_ext::catalog::rest::StorageCredential;
-
 use crate::{
     WarehouseId,
     api::{
@@ -115,14 +113,9 @@ pub(super) async fn load_generic_table_credentials<
         )
         .await?;
 
-    let storage_credentials = if storage_config.creds.inner().is_empty() {
-        vec![]
-    } else {
-        vec![StorageCredential {
-            prefix: gt_info.location.to_string(),
-            config: storage_config.creds.into(),
-        }]
-    };
+    let storage_credentials = storage_config
+        .storage_credentials(&gt_info.location)
+        .unwrap_or_default();
 
     Ok(LoadGenericTableCredentialsResponse {
         storage_credentials,

--- a/crates/lakekeeper/src/server/generic_tables/load.rs
+++ b/crates/lakekeeper/src/server/generic_tables/load.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use iceberg::TableIdent;
-use iceberg_ext::catalog::rest::StorageCredential;
 
 use crate::{
     api::{
@@ -87,13 +86,7 @@ pub(super) async fn load_generic_table<C: CatalogStore, A: Authorizer + Clone, S
             )
             .await?;
 
-        let base_location = info.location.to_string();
-        let creds = (!table_config.creds.inner().is_empty()).then(|| {
-            vec![StorageCredential {
-                prefix: base_location,
-                config: table_config.creds.clone().into(),
-            }]
-        });
+        let creds = table_config.storage_credentials(&info.location);
 
         (Some(table_config.config.into()), creds)
     } else {

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -14,7 +14,7 @@ use iceberg::{
     },
 };
 use iceberg_ext::{
-    catalog::rest::{IcebergErrorResponse, LoadCredentialsResponse, StorageCredential},
+    catalog::rest::{IcebergErrorResponse, LoadCredentialsResponse},
     configs::ParseFromStr,
 };
 use itertools::Itertools;
@@ -633,14 +633,9 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             )
             .await?;
 
-        let storage_credentials = if storage_config.creds.inner().is_empty() {
-            vec![]
-        } else {
-            vec![StorageCredential {
-                prefix: tabular_info.location.to_string(),
-                config: storage_config.creds.into(),
-            }]
-        };
+        let storage_credentials = storage_config
+            .storage_credentials(&tabular_info.location)
+            .unwrap_or_default();
 
         Ok(LoadCredentialsResponse {
             storage_credentials,

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -5,7 +5,6 @@ use iceberg::spec::{
     FormatVersion, SortOrder, TableMetadata, TableMetadataBuilder, TableProperties,
     UnboundPartitionSpec,
 };
-use iceberg_ext::catalog::rest::StorageCredential;
 use lakekeeper_io::{InvalidLocationError, LakekeeperStorage as _, Location, StorageBackend};
 use uuid::Uuid;
 
@@ -338,12 +337,7 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
     let credentials_revalidate_after_ms = config
         .credentials_expiration_ms
         .map(credential_revalidate_after_ms);
-    let storage_credentials = (!config.creds.inner().is_empty()).then(|| {
-        vec![StorageCredential {
-            prefix: table_location.to_string(),
-            config: config.creds.into(),
-        }]
-    });
+    let storage_credentials = config.storage_credentials(&table_location);
 
     let load_table_result = LoadTableResult {
         metadata_location: metadata_location.as_ref().map(ToString::to_string),

--- a/crates/lakekeeper/src/server/tables/load_table.rs
+++ b/crates/lakekeeper/src/server/tables/load_table.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use http::StatusCode;
-use iceberg_ext::catalog::rest::{ETag, StorageCredential, TableETag};
+use iceberg_ext::catalog::rest::{ETag, TableETag};
 
 use crate::{
     WarehouseId,
@@ -177,14 +177,9 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
         None
     };
 
-    let storage_credentials = storage_config.as_ref().and_then(|c| {
-        (!c.creds.inner().is_empty()).then(|| {
-            vec![StorageCredential {
-                prefix: table_location.to_string(),
-                config: c.creds.clone().into(),
-            }]
-        })
-    });
+    let storage_credentials = storage_config
+        .as_ref()
+        .and_then(|c| c.storage_credentials(&table_location));
     let credentials_revalidate_after_ms = storage_config
         .as_ref()
         .and_then(|c| c.credentials_expiration_ms)

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -19,7 +19,12 @@ use error::{CredentialsError, TableConfigError, UpdateError};
 use futures::StreamExt;
 pub use gcs::{GcsCredential, GcsProfile, GcsServiceKey};
 use iceberg::{NamespaceIdent, TableIdent};
-use iceberg_ext::{catalog::rest::ErrorModel, configs::table::TableProperties};
+// `rest::StorageCredential` is the response-side credential entry; `StorageCredential` in this
+// module is the warehouse's stored secret. Aliased to keep the two apart.
+use iceberg_ext::{
+    catalog::rest::{ErrorModel, StorageCredential as VendedStorageCredential},
+    configs::table::TableProperties,
+};
 use lakekeeper_io::{
     InvalidLocationError, LakekeeperStorage, Location, LocationParseError, StorageBackend,
     s3::S3Location,
@@ -115,12 +120,39 @@ pub enum StoragePermissions {
 
 #[derive(Debug)]
 pub struct TableConfig {
+    /// The vended credential plus the properties qualifying it (region, endpoint,
+    /// refresh endpoint, ...), or empty when no credential was vended.
+    ///
+    /// Empty exactly when nothing was vended — backends must not park properties
+    /// here that make sense without a credential. [`Self::storage_credentials`]
+    /// relies on it.
     pub(crate) creds: TableProperties,
     pub(crate) config: TableProperties,
     /// Actual expiry (epoch ms) of the vended credentials in [`Self::creds`], or
     /// `None` if none expire. Set wherever a backend vends an expiring
     /// credential; the source for the `loadTable` `ETag`'s revalidation point.
     pub(crate) credentials_expiration_ms: Option<i64>,
+}
+
+impl TableConfig {
+    /// The `storage-credentials` entry to return for a tabular at `prefix`, or
+    /// `None` if no credential was vended.
+    ///
+    /// A credential-less entry is never emitted: clients honouring it scope a
+    /// key-less secret to `prefix` and then send unsigned requests for every file
+    /// below it, which the storage rejects — while the credentials the client
+    /// already had would have worked.
+    pub(crate) fn storage_credentials(
+        &self,
+        prefix: &Location,
+    ) -> Option<Vec<VendedStorageCredential>> {
+        (!self.creds.inner().is_empty()).then(|| {
+            vec![VendedStorageCredential {
+                prefix: prefix.to_string(),
+                config: self.creds.clone().into(),
+            }]
+        })
+    }
 }
 
 /// Half of a credential's remaining lifetime, capped at 1h — the window during

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -511,41 +511,48 @@ impl S3Profile {
         };
 
         let mut config = TableProperties::default();
-        let mut creds = TableProperties::default();
+        // Properties that qualify a credential — which endpoint, region and encryption it is for.
+        // Always emitted into `config`; they reach the client as `storage-credentials` only
+        // alongside an actual credential, which is why they are accumulated separately.
+        let mut credential_qualifiers = TableProperties::default();
         let mut credentials_expiration_ms: Option<i64> = None;
 
         if let Some(true) = self.path_style_access {
             config.insert(&s3::PathStyleAccess(true));
-            creds.insert(&s3::PathStyleAccess(true));
+            credential_qualifiers.insert(&s3::PathStyleAccess(true));
         }
 
         config.insert(&s3::Region(self.region.clone()));
-        creds.insert(&s3::Region(self.region.clone()));
+        credential_qualifiers.insert(&s3::Region(self.region.clone()));
         config.insert(&custom::CustomConfig {
             key: "region".to_string(),
             value: self.region.clone(),
         });
         config.insert(&client::Region(self.region.clone()));
-        creds.insert(&client::Region(self.region.clone()));
+        credential_qualifiers.insert(&client::Region(self.region.clone()));
 
         if let Some(endpoint) = &self.endpoint {
             config.insert(&s3::Endpoint(endpoint.clone()));
-            creds.insert(&s3::Endpoint(endpoint.clone()));
+            credential_qualifiers.insert(&s3::Endpoint(endpoint.clone()));
         }
 
         // When the warehouse is configured with a KMS key, advertise SSE-KMS to clients so
         // their own writes (vended credentials or remote signing) encrypt with the same key,
         // independent of any S3 bucket-default-encryption configuration. Lakekeeper's own writes
-        // already set this header via lakekeeper-io. Mirrors region/endpoint by emitting into both
-        // the load config and the credential-refresh properties.
+        // already set this header via lakekeeper-io.
         if let Some(kms_key_arn) = self.aws_kms_key_arn.as_ref() {
             config.insert(&s3::SseType("kms".to_string()));
             config.insert(&s3::SseKey(kms_key_arn.clone()));
-            creds.insert(&s3::SseType("kms".to_string()));
-            creds.insert(&s3::SseKey(kms_key_arn.clone()));
+            credential_qualifiers.insert(&s3::SseType("kms".to_string()));
+            credential_qualifiers.insert(&s3::SseKey(kms_key_arn.clone()));
         }
 
-        if vended_credentials {
+        // Only a vended credential may populate `creds`: callers turn a non-empty `creds` into a
+        // `storage-credentials` entry scoped to the table prefix, and a client honouring an entry
+        // that holds no credential builds a key-less secret for that prefix and then sends
+        // unsigned requests for every file below it, which the storage rejects with 403.
+        let creds = if vended_credentials {
+            let mut creds = credential_qualifiers;
             let cache_key = STCCacheKey::new(
                 stc_request.clone(),
                 self.into(),
@@ -591,7 +598,10 @@ impl S3Profile {
                     ),
                 ));
             }
-        }
+            creds
+        } else {
+            TableProperties::default()
+        };
 
         if remote_signing {
             let warehouse_id = stc_request.warehouse_id;
@@ -3010,6 +3020,10 @@ pub(crate) mod test {
     }
 
     fn client_managed_table_config(profile: &S3Profile) -> TableConfig {
+        table_config_for(profile, DataAccessMode::ClientManaged)
+    }
+
+    fn table_config_for(profile: &S3Profile, data_access: DataAccessMode) -> TableConfig {
         let warehouse_id = WarehouseId::new_random();
         let tabular_info = crate::service::TableInfo::new_random(warehouse_id);
         let table_location: Location = "s3://bucket-name/path/to/table".parse().unwrap();
@@ -3021,7 +3035,7 @@ pub(crate) mod test {
         };
         test_block_on(
             profile.generate_table_config(
-                DataAccessMode::ClientManaged,
+                data_access,
                 None,
                 stc_request,
                 &tabular_info,
@@ -3030,6 +3044,182 @@ pub(crate) mod test {
             false,
         )
         .expect("generate_table_config failed")
+    }
+
+    /// Without STS there is nothing to vend, so `creds` must stay empty — whatever the client
+    /// asked for and whether or not remote signing takes over. A non-empty `creds` becomes a
+    /// `storage-credentials` entry scoped to the table prefix, and one holding no actual
+    /// credential makes clients stop signing requests for every file below that prefix.
+    #[test]
+    fn test_no_vendable_credential_yields_no_creds() {
+        for remote_signing_enabled in [false, true] {
+            let profile = S3Profile::builder()
+                .bucket("bucket-name".to_string())
+                .region("local".to_string())
+                .endpoint("http://s3-compatible:8333".parse().unwrap())
+                .sts_enabled(false)
+                .remote_signing_enabled(remote_signing_enabled)
+                .path_style_access(true)
+                .aws_kms_key_arn("arn:aws:kms:local:0:key/abcd-1234".to_string())
+                .flavor(S3Flavor::S3Compat)
+                .build();
+
+            for data_access in [
+                // What DuckDB sends by default: `ACCESS_DELEGATION_MODE 'vended_credentials'`.
+                DataAccessMode::ServerDelegated(DataAccess {
+                    vended_credentials: true,
+                    remote_signing: false,
+                }),
+                DataAccessMode::ServerDelegated(DataAccess::not_specified()),
+                DataAccessMode::ClientManaged,
+            ] {
+                let table_config = table_config_for(&profile, data_access);
+                let context =
+                    format!("remote_signing_enabled={remote_signing_enabled}, {data_access:?}");
+
+                assert!(
+                    table_config.creds.inner().is_empty(),
+                    "creds must be empty when no credential is vended, got {:?} ({context})",
+                    table_config.creds.inner()
+                );
+                assert!(
+                    table_config
+                        .storage_credentials(&"s3://bucket-name/path/to/table".parse().unwrap())
+                        .is_none(),
+                    "no storage-credentials entry may be emitted ({context})"
+                );
+                // The client still needs the qualifying properties to reach the storage itself and
+                // to encrypt its writes with the warehouse's key — they only lose the `creds` copy.
+                assert_eq!(
+                    table_config.config.get_prop_opt::<s3::Region>().as_deref(),
+                    Some("local"),
+                    "({context})"
+                );
+                assert!(
+                    table_config.config.get_prop_opt::<s3::Endpoint>().is_some(),
+                    "({context})"
+                );
+                assert_eq!(
+                    table_config.config.get_prop_opt::<s3::PathStyleAccess>(),
+                    Some(true),
+                    "({context})"
+                );
+                assert_eq!(
+                    table_config.config.get_prop_opt::<s3::SseType>().as_deref(),
+                    Some("kms"),
+                    "({context})"
+                );
+                assert_eq!(
+                    table_config.config.get_prop_opt::<s3::SseKey>().as_deref(),
+                    Some("arn:aws:kms:local:0:key/abcd-1234"),
+                    "({context})"
+                );
+                // Remote signing is unaffected: it needs no client-side credential.
+                let signs_remotely = matches!(data_access, DataAccessMode::ServerDelegated(_))
+                    && remote_signing_enabled;
+                assert_eq!(
+                    table_config
+                        .config
+                        .get_prop_opt::<s3::RemoteSigningEnabled>(),
+                    signs_remotely.then_some(true),
+                    "({context})"
+                );
+            }
+        }
+    }
+
+    /// The counterpart: a vended credential must travel *with* the properties that qualify it.
+    /// The credential-refresh response carries `creds` alone — no `config` — so a client that
+    /// refreshes loses region, endpoint and the SSE-KMS key unless they are mirrored here.
+    #[test]
+    fn test_vended_credential_carries_qualifying_properties() {
+        assert!(
+            CONFIG.cache.stc.enabled,
+            "test seeds the STC cache to keep STS out of a unit test"
+        );
+        let arn = "arn:aws:kms:us-east-1:123456789012:key/abcd-1234";
+        let profile = S3Profile::builder()
+            .bucket("bucket-name".to_string())
+            .region("us-east-1".to_string())
+            .endpoint("http://s3-compatible:8333".parse().unwrap())
+            .sts_enabled(true)
+            .sts_role_arn("arn:aws:iam::123456789012:role/lakekeeper".to_string())
+            .remote_signing_enabled(false)
+            .path_style_access(true)
+            .aws_kms_key_arn(arn.to_string())
+            .flavor(S3Flavor::S3Compat)
+            .build();
+
+        let warehouse_id = WarehouseId::new_random();
+        let tabular_info = crate::service::TableInfo::new_random(warehouse_id);
+        let table_location: Location = "s3://bucket-name/path/to/table".parse().unwrap();
+        let stc_request = ShortTermCredentialsRequest {
+            table_location: table_location.clone(),
+            storage_permissions: StoragePermissions::ReadWriteDelete,
+            warehouse_id,
+            tabular_id: tabular_info.tabular_id(),
+        };
+        let expires_at_ms = 1_900_000_000_000_i64;
+
+        let table_config = test_block_on(
+            async {
+                // Seed the STC cache under this request's key: the read-through loader only runs
+                // on a miss, so no STS call is made. Random ids keep the key unique in the
+                // process-wide cache.
+                S3_STC_CACHE
+                    .insert(
+                        STCCacheKey::new(stc_request.clone(), (&profile).into(), None),
+                        CachedStc::new(
+                            aws_sdk_sts::types::Credentials::builder()
+                                .access_key_id("AKIAEXAMPLE")
+                                .secret_access_key("secret")
+                                .session_token("token")
+                                .expiration(aws_sdk_sts::primitives::DateTime::from_millis(
+                                    expires_at_ms,
+                                ))
+                                .build()
+                                .unwrap(),
+                            Instant::now().checked_add(Duration::from_hours(1)),
+                        ),
+                    )
+                    .await;
+                profile
+                    .generate_table_config(
+                        DataAccessMode::ServerDelegated(DataAccess {
+                            vended_credentials: true,
+                            remote_signing: false,
+                        }),
+                        None,
+                        stc_request,
+                        &tabular_info,
+                        &RequestMetadata::new_unauthenticated(),
+                    )
+                    .await
+                    .expect("generate_table_config failed")
+            },
+            false,
+        );
+
+        let creds = &table_config.creds;
+        assert_eq!(
+            creds.get_prop_opt::<s3::AccessKeyId>().as_deref(),
+            Some("AKIAEXAMPLE")
+        );
+        assert_eq!(
+            creds.get_prop_opt::<s3::Region>().as_deref(),
+            Some("us-east-1")
+        );
+        assert!(creds.get_prop_opt::<s3::Endpoint>().is_some());
+        assert_eq!(creds.get_prop_opt::<s3::PathStyleAccess>(), Some(true));
+        assert_eq!(creds.get_prop_opt::<s3::SseType>().as_deref(), Some("kms"));
+        assert_eq!(creds.get_prop_opt::<s3::SseKey>().as_deref(), Some(arn));
+        assert_eq!(table_config.credentials_expiration_ms, Some(expires_at_ms));
+        assert_eq!(
+            table_config
+                .storage_credentials(&table_location)
+                .map(|c| c.len()),
+            Some(1)
+        );
     }
 
     #[test]
@@ -3044,7 +3234,6 @@ pub(crate) mod test {
             .aws_kms_key_arn(arn.to_string())
             .build();
         let config = client_managed_table_config(&profile);
-        // Emitted into both the load config and the credential-refresh properties.
         assert_eq!(
             config.config.get_prop_opt::<s3::SseType>(),
             Some("kms".to_string())
@@ -3053,14 +3242,8 @@ pub(crate) mod test {
             config.config.get_prop_opt::<s3::SseKey>(),
             Some(arn.to_string())
         );
-        assert_eq!(
-            config.creds.get_prop_opt::<s3::SseType>(),
-            Some("kms".to_string())
-        );
-        assert_eq!(
-            config.creds.get_prop_opt::<s3::SseKey>(),
-            Some(arn.to_string())
-        );
+        // This profile vends nothing, so the SSE properties get no `creds` copy.
+        assert!(config.creds.inner().is_empty());
     }
 
     #[test]

--- a/docs/docs/engines.md
+++ b/docs/docs/engines.md
@@ -71,6 +71,21 @@ duckdb.sql(f"""
 duckdb.sql("SELECT * FROM my_datalake.my_namespace.my_table").show()
 ```
 
+DuckDB requests vended credentials by default and does not support remote signing. If your warehouse has `sts-enabled: false`, add an S3 secret so DuckDB can reach the storage itself:
+
+```python
+duckdb.sql("""
+    CREATE SECRET storage_secret (
+        TYPE S3,
+        KEY_ID 'my-access-key',
+        SECRET 'my-secret-key',
+        ENDPOINT 'my-s3-endpoint:9000',
+        URL_STYLE 'path',
+        USE_SSL false
+    )
+""")
+```
+
 ## <img src="/assets/trino.svg" width="30"> Trino
 
 The following docker compose examples are available for trino:

--- a/docs/docs/engines.md
+++ b/docs/docs/engines.md
@@ -79,12 +79,13 @@ duckdb.sql("""
         TYPE S3,
         KEY_ID 'my-access-key',
         SECRET 'my-secret-key',
-        ENDPOINT 'my-s3-endpoint:9000',
-        URL_STYLE 'path',
-        USE_SSL false
+        ENDPOINT 's3.my-domain.com',
+        URL_STYLE 'path'
     )
 """)
 ```
+
+For a local or test storage that only serves plaintext HTTP, add `USE_SSL false` to the secret.
 
 ## <img src="/assets/trino.svg" width="30"> Trino
 

--- a/docs/docs/storage.md
+++ b/docs/docs/storage.md
@@ -183,6 +183,7 @@ When a client requests table configuration, Lakekeeper selects between remote si
 - If the header specifies `vended-credentials` or `remote-signing`, that method is used if enabled in the storage profile
 - If both methods are requested or neither is specified, Lakekeeper attempts to provide vended credentials first (if STS is enabled), then falls back to remote signing (if enabled)
 - If both methods are disabled at the storage profile level, no credentials are returned regardless of the header value
+- If the method Lakekeeper offers is not implemented by the client — DuckDB, for example, does not support remote signing — the client needs its own S3 credentials. Region, endpoint and path-style settings are still returned in the table `config`, but no `storage-credentials` are.
 
 For maximum client compatibility, we recommend enabling both STS and remote signing when your S3 storage supports it.
 

--- a/docs/docs/storage.md
+++ b/docs/docs/storage.md
@@ -183,7 +183,7 @@ When a client requests table configuration, Lakekeeper selects between remote si
 - If the header specifies `vended-credentials` or `remote-signing`, that method is used if enabled in the storage profile
 - If both methods are requested or neither is specified, Lakekeeper attempts to provide vended credentials first (if STS is enabled), then falls back to remote signing (if enabled)
 - If both methods are disabled at the storage profile level, no credentials are returned regardless of the header value
-- If the method Lakekeeper offers is not implemented by the client — DuckDB, for example, does not support remote signing — the client needs its own S3 credentials. Region, endpoint and path-style settings are still returned in the table `config`, but no `storage-credentials` are.
+- If the method Lakekeeper offers is not implemented by the client — DuckDB, for example, does not support remote signing — the client needs its own S3 credentials. Region, endpoint and path-style settings are still returned in the table `config`, but no `storage-credentials` entry is returned.
 
 For maximum client compatibility, we recommend enabling both STS and remote signing when your S3 storage supports it.
 


### PR DESCRIPTION
For S3 warehouses, `region`, `endpoint`, `path-style-access` and the SSE-KMS properties were mirrored into the credential-refresh properties before the vending branch ran. That map is what every caller checks to decide whether to emit a `storage-credentials` entry, so warehouses that vend nothing — STS disabled, and not Cloudflare R2 or Alibaba Cloud OSS — still returned an entry scoped to the table prefix carrying no credential at all.

Clients that honour access delegation (DuckDB's iceberg extension requests it by default) build a key-less, prefix-scoped secret from that entry and then send unsigned requests for every file below the table prefix, which the storage rejects with 403 — while the credentials the client already had would have worked. Files fetched outside that scope still succeeded, so the failure looked intermittent and file-specific. Independent of `remote-signing-enabled`: the remote-signing properties travel in the load config, not in the credentials.

Clear the credential-refresh properties when nothing was vended, document the "non-empty means a credential was vended" invariant on `TableConfig::creds`, and route the five call sites through a single `TableConfig::storage_credentials`.

Closes #1920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 credential handling during table creation and loading.
  * Omits `storage-credentials` when credentials are not issued, while retaining region, endpoint, path-style, and encryption settings.
  * Preserves remote-signing and vended-credential support across supported access modes.

* **Documentation**
  * Added guidance for DuckDB with STS-disabled warehouses.
  * Clarified requirements for clients that cannot use provided credentials or signing methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->