### PR TITLE
fix(s3): sign ListObjectsV2 for prefixes inside a table location

### DIFF
--- a/crates/io/src/location.rs
+++ b/crates/io/src/location.rs
@@ -204,6 +204,21 @@ impl Location {
         self.to_string().starts_with(other_folder.as_str())
     }
 
+    /// Check if every location that starts with `self`, read as a key prefix, is a
+    /// sublocation of `other`.
+    ///
+    /// Unlike [`Self::is_sublocation_of`], `other` itself does not qualify: a key prefix is
+    /// matched as a raw string, so the prefix `s3://bucket/table` also matches the keys of a
+    /// sibling `s3://bucket/table_other/...`. Only a prefix that reaches past the separator -
+    /// `s3://bucket/table/` or deeper - is confined to `other`.
+    #[must_use]
+    pub fn is_prefix_within(&self, other: &Location) -> bool {
+        let mut other_folder = other.clone();
+        other_folder.with_trailing_slash();
+
+        self.as_str().starts_with(other_folder.as_str())
+    }
+
     #[must_use]
     pub fn partial_locations<'a>(&'a self) -> impl IntoIterator<Item = &'a str> {
         let scheme_index = self.scheme().len() + 3; // 3 for "://"
@@ -714,6 +729,35 @@ mod tests {
             assert_eq!(
                 result, expected,
                 "Parent: {parent}, Sublocation: {maybe_sublocation}, Expected: {expected}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_prefix_within() {
+        let cases = vec![
+            // A prefix that reaches past the separator is confined to the parent.
+            ("s3://bucket/foo", "s3://bucket/foo/", true),
+            ("s3://bucket/foo", "s3://bucket/foo/bar", true),
+            ("s3://bucket/foo/", "s3://bucket/foo/bar", true),
+            // The parent itself also matches siblings that extend its name.
+            ("s3://bucket/foo", "s3://bucket/foo", false),
+            ("s3://bucket/foo", "s3://bucket/foo-bar/baz", false),
+            // Parents of the parent, and unrelated locations.
+            ("s3://bucket/foo/bar", "s3://bucket/foo/", false),
+            ("s3://bucket/foo", "s3://bucket/baz/bar", false),
+            ("s3://bucket/foo", "s3://other-bucket/foo/bar", false),
+            // A parent stored with a trailing slash accepts its own directory.
+            ("s3://bucket/foo/", "s3://bucket/foo/", true),
+        ];
+
+        for (parent, prefix, expected) in cases {
+            let parent = Location::from_str(parent).unwrap();
+            let prefix = Location::from_str(prefix).unwrap();
+            let result = prefix.is_prefix_within(&parent);
+            assert_eq!(
+                result, expected,
+                "Parent: {parent}, Prefix: {prefix}, Expected: {expected}",
             );
         }
     }

--- a/crates/io/src/location.rs
+++ b/crates/io/src/location.rs
@@ -198,10 +198,7 @@ impl Location {
             return true;
         }
 
-        let mut other_folder = other.clone();
-        other_folder.with_trailing_slash();
-
-        self.to_string().starts_with(other_folder.as_str())
+        starts_with_folder(self.as_str(), other.as_str())
     }
 
     /// Check if every location that starts with `self`, read as a key prefix, is a
@@ -213,10 +210,7 @@ impl Location {
     /// `s3://bucket/table/` or deeper - is confined to `other`.
     #[must_use]
     pub fn is_prefix_within(&self, other: &Location) -> bool {
-        let mut other_folder = other.clone();
-        other_folder.with_trailing_slash();
-
-        self.as_str().starts_with(other_folder.as_str())
+        starts_with_folder(self.as_str(), other.as_str())
     }
 
     #[must_use]
@@ -343,6 +337,19 @@ fn is_format_or_invisible(c: char) -> bool {
 /// (object keys with literal `/./`/`/../`/`//`) for one rule that can be
 /// audited without a per-scheme matrix; matches the same trade-off made
 /// for `check_host` on Azure trailing-dot.
+/// `true` if `location` starts with `folder` as a directory, i.e. `folder` with a single
+/// trailing separator appended. Kept allocation-free because callers run it once per location
+/// of a request, and a bulk delete carries up to a thousand of them.
+fn starts_with_folder(location: &str, folder: &str) -> bool {
+    if folder.ends_with('/') {
+        return location.starts_with(folder);
+    }
+
+    location
+        .strip_prefix(folder)
+        .is_some_and(|rest| rest.starts_with('/'))
+}
+
 fn check_path_segments(authority_and_path: &str) -> Result<(), String> {
     let Some((_authority, path)) = authority_and_path.split_once('/') else {
         return Ok(()); // No path — just authority.
@@ -720,6 +727,8 @@ mod tests {
             ("s3://bucket/foo", "s3://bucket/foo/bar", true),
             ("s3://bucket/foo", "s3://bucket/baz/bar", false),
             ("s3://bucket/foo", "s3://bucket/foo-bar", false),
+            // A parent stored with a trailing separator still needs one in the sublocation.
+            ("s3://bucket/foo/", "s3://bucket/foobar", false),
         ];
 
         for (parent, maybe_sublocation, expected) in cases {

--- a/crates/lakekeeper-integration-tests/tests/server_generic_table_signing.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_generic_table_signing.rs
@@ -302,6 +302,23 @@ fn batch_delete_request(keys: &[String]) -> S3SignRequest {
     )
 }
 
+/// The S3 `ListObjectsV2` request prefix listing issues: `GET /{bucket}?list-type=2` with
+/// the directory to walk in the `prefix` query parameter instead of in the path.
+fn list_prefix_request(prefix: &str) -> S3SignRequest {
+    sign_request(
+        Method::GET,
+        format!("{ENDPOINT}/{BUCKET}?list-type=2&prefix={prefix}")
+            .parse()
+            .unwrap(),
+    )
+}
+
+/// The bucket-relative key of `base_location` as a directory prefix, which is what
+/// Iceberg's `FileSystemWalker` lists.
+fn dir_key_of(base_location: &str) -> String {
+    key_under(base_location, "")
+}
+
 /// The bucket-relative S3 key of `suffix` under `base_location`.
 fn key_under(base_location: &str, suffix: &str) -> String {
     let prefix = format!("s3://{BUCKET}/");
@@ -553,6 +570,146 @@ async fn test_sign_generic_table_batch_delete_rejects_foreign_key(pool: PgPool) 
         .expect_err("a bulk delete touching another location must fail");
 
     assert_eq!(err.error.code, StatusCode::BAD_REQUEST, "{err:?}");
+    assert_eq!(err.error.r#type, "RequestUriMismatch", "{err:?}");
+}
+
+/// Prefix listing (`SupportsPrefixOperations`, used by Spark's `remove_orphan_files` with
+/// `prefix_listing => true`) reaches the signer as a bucket-level `ListObjectsV2`. The table
+/// is identified by the `prefix` query parameter, and listing is authorized as a read.
+#[sqlx::test]
+async fn test_sign_generic_table_list_prefix(pool: PgPool) {
+    let authz = HidingAuthorizer::new();
+    let (ctx, namespace_name, warehouse_id) = setup(pool, authz.clone()).await;
+    let base_location =
+        create_generic_table(&ctx, &namespace_name, warehouse_id, GENERIC_TABLE).await;
+
+    for prefix in [
+        // The table's own directory, and a subdirectory of it.
+        dir_key_of(&base_location),
+        key_under(&base_location, "data/"),
+        // The AWS SDKs url-encode the prefix.
+        dir_key_of(&base_location).replace('/', "%2F"),
+    ] {
+        let request = list_prefix_request(&prefix);
+        let response = sign_warehouse_scoped_request(&ctx, warehouse_id, request.clone())
+            .await
+            .unwrap_or_else(|e| panic!("listing `{prefix}` must be signed: {e:?}"));
+        assert_signed(&response);
+        // Signing must leave the URI byte-identical: the client sends back what it gets, and
+        // any change to the query would list something other than what was authorized.
+        assert_eq!(
+            response.uri, request.uri,
+            "signing must not rewrite the request URI"
+        );
+    }
+
+    authz.block_action(format!("generic_table:{:?}", CatalogGenericTableAction::ReadData).as_str());
+    let err = sign_warehouse_scoped_request(
+        &ctx,
+        warehouse_id,
+        list_prefix_request(&dir_key_of(&base_location)),
+    )
+    .await
+    .expect_err("a list must be rejected without read_data");
+    assert_forbidden(&err);
+}
+
+/// S3 matches list prefixes as raw strings, so the bare table location also returns the keys
+/// of a sibling table whose location starts with the same string. Only a prefix that reaches
+/// past the table's path separator is confined to the table.
+#[sqlx::test]
+async fn test_sign_list_prefix_requires_a_directory_prefix(pool: PgPool) {
+    let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
+    let (_table_id, location) =
+        create_catalog_table(&ctx, &namespace_name, warehouse_id, "my_table").await;
+    let location = location.to_string();
+    // A sibling that the bare prefix `…/my_table` would list along with `…/my_table` itself.
+    create_catalog_table(&ctx, &namespace_name, warehouse_id, "my_table_secret").await;
+
+    let bare_key = dir_key_of(&location).trim_end_matches('/').to_string();
+    let err = sign_warehouse_scoped_request(&ctx, warehouse_id, list_prefix_request(&bare_key))
+        .await
+        .expect_err("a prefix that stops at the table location must not be signed");
+    assert_eq!(err.error.code, StatusCode::BAD_REQUEST, "{err:?}");
+    assert_eq!(err.error.r#type, "RequestUriMismatch", "{err:?}");
+
+    // The directory form of the very same location is signable.
+    let response = sign_warehouse_scoped_request(
+        &ctx,
+        warehouse_id,
+        list_prefix_request(&dir_key_of(&location)),
+    )
+    .await
+    .expect("the table's directory must be signable");
+    assert_signed(&response);
+}
+
+/// A list that is not scoped to a prefix would walk the whole bucket, and one scoped above
+/// the table resolves no table at all.
+#[sqlx::test]
+async fn test_sign_list_prefix_rejects_unscoped_and_foreign_prefixes(pool: PgPool) {
+    let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
+    create_generic_table(&ctx, &namespace_name, warehouse_id, GENERIC_TABLE).await;
+
+    let err = sign_warehouse_scoped_request(
+        &ctx,
+        warehouse_id,
+        sign_request(
+            Method::GET,
+            format!("{ENDPOINT}/{BUCKET}?list-type=2").parse().unwrap(),
+        ),
+    )
+    .await
+    .expect_err("a bucket-wide list must not be signed");
+    assert_eq!(err.error.code, StatusCode::BAD_REQUEST, "{err:?}");
+    assert_eq!(err.error.r#type, "ListWithoutPrefix", "{err:?}");
+
+    // The namespace directory above the table belongs to no tabular.
+    let err = sign_warehouse_scoped_request(
+        &ctx,
+        warehouse_id,
+        list_prefix_request(&format!("{namespace_name}/")),
+    )
+    .await
+    .expect_err("a list above the table location must not be signed");
+    assert_eq!(err.error.r#type, "NoSuchTableLocationException", "{err:?}");
+}
+
+/// Iceberg tables share the list-prefix path with generic tables, on both signer routes.
+#[sqlx::test]
+async fn test_sign_iceberg_table_list_prefix(pool: PgPool) {
+    let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
+    let (table_id, location) =
+        create_catalog_table(&ctx, &namespace_name, warehouse_id, "my_table").await;
+    let prefix = dir_key_of(location.as_ref());
+
+    let response = sign_warehouse_scoped_request(&ctx, warehouse_id, list_prefix_request(&prefix))
+        .await
+        .expect("warehouse-scoped signer must sign list requests for iceberg tables");
+    assert_signed(&response);
+
+    let response = CatalogServer::sign(
+        Some(Prefix(warehouse_id.to_string())),
+        Some(*table_id),
+        list_prefix_request(&prefix),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .expect("table-scoped signer must sign list requests for iceberg tables");
+    assert_signed(&response);
+
+    // The table-scoped route validates the URI twice - once to decide whether the id in the
+    // path owns it, then again after authorization. Both must apply the directory rule.
+    let err = CatalogServer::sign(
+        Some(Prefix(warehouse_id.to_string())),
+        Some(*table_id),
+        list_prefix_request(prefix.trim_end_matches('/')),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .expect_err("table-scoped signer must reject a prefix that stops at the table location");
     assert_eq!(err.error.r#type, "RequestUriMismatch", "{err:?}");
 }
 

--- a/crates/lakekeeper/src/server/s3_signer/sign.rs
+++ b/crates/lakekeeper/src/server/s3_signer/sign.rs
@@ -611,16 +611,22 @@ fn validate_uri(
     };
 
     for url_location in &parsed_url.locations {
-        if !(url_location
-            .location()
-            .is_sublocation_of(table_location.location())
-            || normalized_table_location
-                .as_ref()
-                .is_some_and(|normalized| {
-                    url_location
-                        .location()
-                        .is_sublocation_of(normalized.location())
-                }))
+        let is_within = |table_location: &S3Location| {
+            // S3 matches list prefixes as raw strings, so a prefix that stops at the table
+            // location would also return the keys of same-prefixed siblings.
+            if parsed_url.locations_are_list_prefixes {
+                url_location
+                    .location()
+                    .is_prefix_within(table_location.location())
+            } else {
+                url_location
+                    .location()
+                    .is_sublocation_of(table_location.location())
+            }
+        };
+
+        if !(is_within(&table_location)
+            || normalized_table_location.as_ref().is_some_and(is_within))
         {
             return Err(SignError::RequestUriMismatch {
                 request_uri: parsed_url.url.to_string(),
@@ -642,10 +648,19 @@ pub(super) mod s3_utils {
     use super::{ErrorModel, Operation, Result};
     use crate::service::storage::{ValidationError, s3::S3UrlStyleDetectionMode};
 
+    /// Query parameter that identifies a `ListObjectsV2` request, and its only valid value.
+    const LIST_TYPE_QUERY_PARAM: &str = "list-type";
+    const LIST_TYPE_V2: &str = "2";
+    /// Query parameter carrying the key prefix a list request is scoped to.
+    const PREFIX_QUERY_PARAM: &str = "prefix";
+
     #[derive(Debug, Clone)]
     pub(super) struct ParsedSignRequest {
         pub(super) url: url::Url,
         pub(super) locations: Vec<S3Location>,
+        /// `true` if `locations` are S3 list prefixes rather than object keys. S3 matches
+        /// list prefixes by raw string, so they require a stricter containment check.
+        pub(super) locations_are_list_prefixes: bool,
         // Used endpoint without the bucket
         #[allow(dead_code)]
         pub(super) endpoint: String,
@@ -751,16 +766,19 @@ pub(super) mod s3_utils {
             }
         };
 
+        // `DeleteObjects` and `ListObjectsV2` address the bucket instead of a single object.
+        // The keys that identify the table live in the request body resp. the query string.
+        let is_list_operation = *method == http::Method::GET && is_list_objects_v2(uri);
+        let allow_no_key = is_post_delete_operation || is_list_operation;
+
         // Parse the base URL
         let mut parsed_request = match s3_url_style_detection {
-            S3UrlStyleDetectionMode::VirtualHost => {
-                virtual_host_style(uri, is_post_delete_operation, true)?
-            }
-            S3UrlStyleDetectionMode::Path => path_style(uri, is_post_delete_operation)?,
+            S3UrlStyleDetectionMode::VirtualHost => virtual_host_style(uri, allow_no_key, true)?,
+            S3UrlStyleDetectionMode::Path => path_style(uri, allow_no_key)?,
             S3UrlStyleDetectionMode::Auto => {
-                if let Ok(parsed) = virtual_host_style(uri, is_post_delete_operation, false) {
+                if let Ok(parsed) = virtual_host_style(uri, allow_no_key, false) {
                     parsed
-                } else if let Ok(parsed) = path_style(uri, is_post_delete_operation) {
+                } else if let Ok(parsed) = path_style(uri, allow_no_key) {
                     parsed
                 } else {
                     return Err(err("UriNotS3", "URI does not match S3 host or path style").into());
@@ -771,20 +789,8 @@ pub(super) mod s3_utils {
         // For DeleteObjects operation, parse the XML body for object keys
         if is_post_delete_operation {
             if let Some(xml_body) = body {
-                // Get bucket from the original parsed URL
-                let bucket = parsed_request
-                    .locations
-                    .first()
-                    .ok_or_else(|| {
-                        // Should not happen, as both virtual & path style set a location
-                        ErrorModel::internal(
-                            "URI to sign does not have a location",
-                            "UriNoLocation",
-                            None,
-                        )
-                    })?
-                    .bucket_name()
-                    .to_string();
+                let bucket = bucket_of(&parsed_request)?;
+                require_bucket_addressed(&parsed_request, &bucket)?;
 
                 // Parse XML body to get deletion keys
                 let keys = parse_s3_delete_xml(xml_body)
@@ -804,9 +810,141 @@ pub(super) mod s3_utils {
             } else {
                 return Err(err("DeleteWithoutBody", "Delete requests require a body").into());
             }
+        } else if is_list_operation {
+            // The URI path is just the bucket - the table is identified by the `prefix`.
+            let bucket = bucket_of(&parsed_request)?;
+            require_bucket_addressed(&parsed_request, &bucket)?;
+            require_known_list_parameters(uri)?;
+            parsed_request.locations = vec![list_prefix_location(uri, &bucket)?];
+            parsed_request.locations_are_list_prefixes = true;
         }
 
         Ok((parsed_request, operation))
+    }
+
+    /// `GET /{bucket}?list-type=2` - the `ListObjectsV2` API. Other bucket-level `GET`
+    /// sub-resources (`?versions`, `?uploads`, `?location`) stay unsignable: they carry no
+    /// prefix that could be authorized against a table location.
+    fn is_list_objects_v2(uri: &url::Url) -> bool {
+        uri.query_pairs()
+            .any(|(key, value)| key == LIST_TYPE_QUERY_PARAM && value == LIST_TYPE_V2)
+    }
+
+    /// Requests whose locations are taken from the body or the query string must address the
+    /// bucket itself. The URI is signed as received, and S3 dispatches on the path: a key in
+    /// the path would turn the signed request into an object operation that ignores the
+    /// parameters this authorization is based on.
+    fn require_bucket_addressed(parsed_request: &ParsedSignRequest, bucket: &str) -> Result<()> {
+        let addresses_bucket = parsed_request.locations.first().is_some_and(|location| {
+            location.location().as_str().trim_end_matches('/') == format!("s3://{bucket}")
+        });
+
+        if !addresses_bucket {
+            return Err(ErrorModel::bad_request(
+                "Bucket-level requests must not address an object",
+                "UriNotBucket",
+                None,
+            )
+            .into());
+        }
+
+        Ok(())
+    }
+
+    /// Parameters of the `ListObjectsV2` API, plus the `x-id` telemetry parameter that some
+    /// AWS SDKs append. None of them widens the set of keys `prefix` selects.
+    const LIST_QUERY_PARAMS: &[&str] = &[
+        LIST_TYPE_QUERY_PARAM,
+        PREFIX_QUERY_PARAM,
+        "continuation-token",
+        "delimiter",
+        "encoding-type",
+        "fetch-owner",
+        "max-keys",
+        "start-after",
+        "x-id",
+    ];
+
+    /// Rejects list requests that carry any other parameter, or one of them twice.
+    ///
+    /// S3 dispatches on the query string, so a bucket sub-resource (`?policy`, `?versioning`,
+    /// `?uploads`, …) alongside the list parameters would make the signed request return
+    /// something else entirely - something no table location can authorize. Which of two
+    /// values for the same parameter S3 applies is implementation defined, so only one of
+    /// them could be authorized.
+    fn require_known_list_parameters(uri: &url::Url) -> Result<()> {
+        let mut seen: Vec<std::borrow::Cow<'_, str>> = Vec::new();
+
+        for (key, _) in uri.query_pairs() {
+            if !LIST_QUERY_PARAMS.contains(&key.as_ref()) {
+                return Err(ErrorModel::bad_request(
+                    format!("Unsupported query parameter for a list request: `{key}`"),
+                    "UnsupportedListParameter",
+                    None,
+                )
+                .into());
+            }
+
+            if seen.contains(&key) {
+                return Err(ErrorModel::bad_request(
+                    format!("Repeated query parameter in a list request: `{key}`"),
+                    "RepeatedListParameter",
+                    None,
+                )
+                .into());
+            }
+
+            seen.push(key);
+        }
+
+        Ok(())
+    }
+
+    fn bucket_of(parsed_request: &ParsedSignRequest) -> Result<String> {
+        Ok(parsed_request
+            .locations
+            .first()
+            .ok_or_else(|| {
+                // Should not happen, as both virtual & path style set a location
+                ErrorModel::internal(
+                    "URI to sign does not have a location",
+                    "UriNoLocation",
+                    None,
+                )
+            })?
+            .bucket_name()
+            .to_string())
+    }
+
+    /// The location a `ListObjectsV2` request is scoped to: `s3://{bucket}/{prefix}`.
+    ///
+    /// Sigv4 covers the canonical query string, so the client cannot widen the `prefix`
+    /// after signing. Parsing the location from the concatenated string rather than from
+    /// segments is what makes the check trustworthy: the authorized location is the exact
+    /// string S3 matches keys against, and prefixes that a `Location` would not round-trip
+    /// (empty segments, `.`/`..`, unsafe characters) are rejected instead of normalized.
+    fn list_prefix_location(uri: &url::Url, bucket: &str) -> Result<S3Location> {
+        let prefix = uri
+            .query_pairs()
+            .find(|(key, _)| key == PREFIX_QUERY_PARAM)
+            .map(|(_, value)| value)
+            .filter(|prefix| !prefix.is_empty())
+            .ok_or_else(|| {
+                ErrorModel::bad_request(
+                    "List requests must be scoped to a prefix inside a table location",
+                    "ListWithoutPrefix",
+                    None,
+                )
+            })?;
+
+        S3Location::try_from_str(&format!("s3://{bucket}/{prefix}"), false).map_err(|e| {
+            ErrorModel::bad_request(
+                format!("Invalid list prefix: {e}"),
+                "InvalidListPrefix",
+                Some(Box::new(e)),
+            )
+            .into()
+        })
     }
 
     fn virtual_host_style(
@@ -853,6 +991,7 @@ pub(super) mod s3_utils {
                 )
                 .map_err(ValidationError::from)?,
             ],
+            locations_are_list_prefixes: false,
             endpoint: used_endpoint.to_string(),
             port,
         })
@@ -900,6 +1039,7 @@ pub(super) mod s3_utils {
                 )
                 .map_err(ValidationError::from)?,
             ],
+            locations_are_list_prefixes: false,
             endpoint: uri
                 .host_str()
                 .ok_or_else(|| {
@@ -1361,6 +1501,269 @@ mod test {
 
         for tc in cases {
             run_validate_uri_test(&tc);
+        }
+    }
+
+    fn parse_list(uri: &str, mode: S3UrlStyleDetectionMode) -> s3_utils::ParsedSignRequest {
+        let (parsed, operation) = parse_s3_url(
+            &url::Url::parse(uri).unwrap(),
+            mode,
+            &http::Method::GET,
+            None,
+        )
+        .unwrap_or_else(|e| panic!("Failed to parse {uri}: {e:?}"));
+        // Listing reveals the keys under a prefix, which is a read.
+        assert_eq!(operation, Operation::Read);
+        assert!(parsed.locations_are_list_prefixes);
+        parsed
+    }
+
+    fn parse_list_err(uri: &str, mode: S3UrlStyleDetectionMode) -> String {
+        parse_s3_url(
+            &url::Url::parse(uri).unwrap(),
+            mode,
+            &http::Method::GET,
+            None,
+        )
+        .map(|(parsed, _)| parsed)
+        .expect_err(&format!("{uri} must not be signable"))
+        .error
+        .r#type
+    }
+
+    /// `ListObjectsV2` addresses the bucket, so the location that identifies the table
+    /// comes from the `prefix` query parameter, in both URL styles.
+    #[test]
+    fn test_parse_s3_url_list_objects_v2() {
+        let cases = vec![
+            // Path style, no key in the path at all.
+            (
+                "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::Auto,
+            ),
+            (
+                "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::Path,
+            ),
+            // Path style with the trailing slash some SDKs append to the bucket.
+            (
+                "http://s3.example.com:8333/bucket/?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::Auto,
+            ),
+            // Virtual host style.
+            (
+                "https://bucket.s3.my-region.amazonaws.com/?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::Auto,
+            ),
+            (
+                "https://bucket.s3.my-region.amazonaws.com?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::VirtualHost,
+            ),
+            // The prefix is url-encoded by the AWS SDKs.
+            (
+                "http://s3.example.com:8333/bucket?list-type=2&prefix=ns%2Ftbl%2F",
+                S3UrlStyleDetectionMode::Auto,
+            ),
+            // Trailing separators collapse. S3 then matches a subset of the authorized
+            // directory, so this is signable rather than rejected.
+            (
+                "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl//",
+                S3UrlStyleDetectionMode::Auto,
+            ),
+            // Pagination and other list parameters only narrow the result set.
+            (
+                "https://bucket.s3.my-region.amazonaws.com/?list-type=2&prefix=ns/tbl/&continuation-token=abc&max-keys=1000&encoding-type=url",
+                S3UrlStyleDetectionMode::Auto,
+            ),
+        ];
+
+        for (uri, mode) in cases {
+            let parsed = parse_list(uri, mode);
+            assert_eq!(
+                parsed
+                    .locations
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect_vec(),
+                vec!["s3://bucket/ns/tbl/"],
+                "Test case: {uri}"
+            );
+        }
+    }
+
+    /// Without a prefix the request would list the whole bucket, which no table can
+    /// authorize.
+    #[test]
+    fn test_parse_s3_url_list_requires_prefix() {
+        for uri in [
+            "http://s3.example.com:8333/bucket?list-type=2",
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=",
+            "https://bucket.s3.my-region.amazonaws.com/?list-type=2",
+        ] {
+            assert_eq!(
+                parse_list_err(uri, S3UrlStyleDetectionMode::Auto),
+                "ListWithoutPrefix",
+                "Test case: {uri}"
+            );
+        }
+    }
+
+    /// A prefix that a location would not round-trip cannot be authorized: the string S3
+    /// matches keys against would differ from the one that was checked. `ns//tbl/` is the
+    /// case that matters - its keys lie outside the `ns/tbl/` directory it normalizes to.
+    #[test]
+    fn test_parse_s3_url_list_rejects_prefix_that_is_not_a_location() {
+        for uri in [
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns//tbl/",
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=/ns/tbl/",
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/../other/",
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/%00/",
+        ] {
+            assert_eq!(
+                parse_list_err(uri, S3UrlStyleDetectionMode::Auto),
+                "InvalidListPrefix",
+                "Test case: {uri}"
+            );
+        }
+    }
+
+    /// Which of two values for the same parameter S3 applies is implementation defined, so
+    /// only one of them could be authorized.
+    #[test]
+    fn test_parse_s3_url_list_rejects_repeated_parameters() {
+        for uri in [
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/&prefix=other/",
+            "http://s3.example.com:8333/bucket?list-type=2&list-type=2&prefix=ns/tbl/",
+            "http://s3.example.com:8333/bucket?list-type=1&list-type=2&prefix=ns/tbl/",
+        ] {
+            assert_eq!(
+                parse_list_err(uri, S3UrlStyleDetectionMode::Auto),
+                "RepeatedListParameter",
+                "Test case: {uri}"
+            );
+        }
+    }
+
+    /// Only `ListObjectsV2` gains the keyless path - all other bucket-level requests carry
+    /// no prefix that could be authorized against a table location.
+    #[test]
+    fn test_parse_s3_url_other_bucket_requests_stay_unsignable() {
+        for uri in [
+            "http://s3.example.com:8333/bucket",
+            "http://s3.example.com:8333/bucket?versions&prefix=ns/tbl/",
+            "http://s3.example.com:8333/bucket?uploads&prefix=ns/tbl/",
+            "http://s3.example.com:8333/bucket?location",
+            // List Objects V1 is not implemented.
+            "http://s3.example.com:8333/bucket?prefix=ns/tbl/",
+        ] {
+            assert_eq!(
+                parse_list_err(uri, S3UrlStyleDetectionMode::Path),
+                "UriNotS3",
+                "Test case: {uri}"
+            );
+        }
+    }
+
+    /// The signed URI is the one that was received, and S3 dispatches on its path: a key in
+    /// the path makes the signed request a `GetObject` for that key, which ignores the
+    /// `prefix` this request was authorized against.
+    #[test]
+    fn test_parse_s3_url_list_must_address_the_bucket() {
+        for (uri, mode) in [
+            (
+                "http://s3.example.com:8333/bucket/other-ns/other-tbl/metadata/v1.json?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::Auto,
+            ),
+            (
+                "http://s3.example.com:8333/bucket/other-ns/other-tbl/metadata/v1.json?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::Path,
+            ),
+            (
+                "https://bucket.s3.my-region.amazonaws.com/other-ns/other-tbl/metadata/v1.json?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::Auto,
+            ),
+            (
+                "https://bucket.s3.my-region.amazonaws.com/other-ns/other-tbl/metadata/v1.json?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::VirtualHost,
+            ),
+        ] {
+            assert_eq!(
+                parse_list_err(uri, mode),
+                "UriNotBucket",
+                "Test case: {uri}"
+            );
+        }
+
+        // The same holds for the bulk delete that takes its keys from the body.
+        let body = "<Delete><Object><Key>ns/tbl/data/a.parquet</Key></Object></Delete>";
+        let err = parse_s3_url(
+            &url::Url::parse("http://s3.example.com:8333/bucket/other-ns/other-tbl/x.json?delete")
+                .unwrap(),
+            S3UrlStyleDetectionMode::Auto,
+            &http::Method::POST,
+            Some(body),
+        )
+        .map(|(parsed, _)| parsed)
+        .expect_err("a bulk delete addressing an object must not be signable");
+        assert_eq!(err.error.r#type, "UriNotBucket", "{err:?}");
+    }
+
+    /// S3 dispatches on the query string too: a bucket sub-resource next to the list
+    /// parameters returns something else entirely, which no table location authorizes.
+    #[test]
+    fn test_parse_s3_url_list_rejects_unknown_parameters() {
+        for uri in [
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/&policy",
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/&acl",
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/&versions",
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/&uploads",
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl/&location",
+        ] {
+            assert_eq!(
+                parse_list_err(uri, S3UrlStyleDetectionMode::Auto),
+                "UnsupportedListParameter",
+                "Test case: {uri}"
+            );
+        }
+    }
+
+    /// A list prefix must reach past the table's own path separator: S3 matches prefixes as
+    /// raw strings, so the bare table location also returns keys of same-prefixed siblings.
+    #[test]
+    fn test_validate_uri_list_prefix() {
+        let cases = vec![
+            // The directory listing Iceberg's `FileSystemWalker` issues.
+            ("ns/tbl/", "s3://bucket/ns/tbl", true),
+            // Subdirectories of the table.
+            ("ns/tbl/data/", "s3://bucket/ns/tbl", true),
+            ("ns/tbl/metadata", "s3://bucket/ns/tbl", true),
+            // Table locations may be stored with a trailing slash.
+            ("ns/tbl/", "s3://bucket/ns/tbl/", true),
+            // `s3a` and `s3n` table locations are normalized to `s3`.
+            ("ns/tbl/", "s3a://bucket/ns/tbl", true),
+            ("ns/tbl/", "s3n://bucket/ns/tbl", true),
+            // The bare table location matches siblings like `s3://bucket/ns/tbl_secret/…`.
+            ("ns/tbl", "s3://bucket/ns/tbl", false),
+            // Siblings, whether or not they share a string prefix with the table.
+            ("ns/tbl_secret/", "s3://bucket/ns/tbl", false),
+            ("ns/other/", "s3://bucket/ns/tbl", false),
+            // Parents of the table.
+            ("ns/", "s3://bucket/ns/tbl", false),
+            // Another bucket.
+            ("ns/tbl/", "s3://other-bucket/ns/tbl", false),
+        ];
+
+        for (prefix, table_location, expected_outcome) in cases {
+            let parsed = parse_list(
+                &format!("http://s3.example.com:8333/bucket?list-type=2&prefix={prefix}"),
+                S3UrlStyleDetectionMode::Auto,
+            );
+            let result = validate_uri(&parsed, &Location::from_str(table_location).unwrap());
+            assert_eq!(
+                result.is_ok(),
+                expected_outcome,
+                "prefix `{prefix}` against table location `{table_location}`: {result:?}"
+            );
         }
     }
 

--- a/crates/lakekeeper/src/server/s3_signer/sign.rs
+++ b/crates/lakekeeper/src/server/s3_signer/sign.rs
@@ -160,11 +160,10 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             method: request_method,
             headers: request_headers,
             body: request_body,
-        } = request.clone();
+        } = request;
 
-        let decoded_url = urldecode_uri_path_segments(&request_url)?;
         let (parsed_url, operation) = s3_utils::parse_s3_url(
-            &decoded_url,
+            &s3_utils::SignRequestUri::new(request_url.clone())?,
             s3_url_style_detection(&warehouse)?,
             &request_method,
             request_body.as_deref(),
@@ -491,7 +490,7 @@ async fn resolve_signable_by_id<C: CatalogStore, A: Authorizer + Clone, S: Secre
         tracing::warn!(
             "Received a tabular specific sign request for tabular {tabular_id} with a location {} that does not match the request URI {}. Falling back to location based lookup. This is a bug in the query engine. When using PyIceberg, please update to versions > 0.9.1",
             signable.location(),
-            parsed_url.url
+            parsed_url.uri.received()
         );
     }
 
@@ -629,7 +628,7 @@ fn validate_uri(
             || normalized_table_location.as_ref().is_some_and(is_within))
         {
             return Err(SignError::RequestUriMismatch {
-                request_uri: parsed_url.url.to_string(),
+                request_uri: parsed_url.uri.received().to_string(),
                 expected_location: table_location.to_string(),
                 actual_location: url_location.to_string(),
             }
@@ -654,9 +653,44 @@ pub(super) mod s3_utils {
     /// Query parameter carrying the key prefix a list request is scoped to.
     const PREFIX_QUERY_PARAM: &str = "prefix";
 
+    /// The URI of a request to sign, both as received and with its path segments url-decoded.
+    ///
+    /// The signature covers the request as received, so anything that constrains the *shape*
+    /// of the request has to look at [`Self::received`]. Locations are derived from
+    /// [`Self::decoded`], because clients url-encode object keys. Decoding can change what a
+    /// path addresses - a `%2F` hides separators from the url parser, which then collapses the
+    /// `.`/`..` behind them - so the two are kept together rather than passed around as two
+    /// look-alike arguments.
+    #[derive(Debug, Clone)]
+    pub(super) struct SignRequestUri {
+        received: url::Url,
+        decoded: url::Url,
+    }
+
+    impl SignRequestUri {
+        pub(super) fn new(received: url::Url) -> Result<Self> {
+            let decoded = super::urldecode_uri_path_segments(&received)?;
+            Ok(Self { received, decoded })
+        }
+
+        pub(super) fn received(&self) -> &url::Url {
+            &self.received
+        }
+
+        pub(super) fn decoded(&self) -> &url::Url {
+            &self.decoded
+        }
+
+        /// `false` if url-decoding changed the path, i.e. the locations derived from
+        /// [`Self::decoded`] may not describe what the signed request addresses.
+        fn path_survived_decoding(&self) -> bool {
+            self.received.path() == self.decoded.path()
+        }
+    }
+
     #[derive(Debug, Clone)]
     pub(super) struct ParsedSignRequest {
-        pub(super) url: url::Url,
+        pub(super) uri: SignRequestUri,
         pub(super) locations: Vec<S3Location>,
         /// `true` if `locations` are S3 list prefixes rather than object keys. S3 matches
         /// list prefixes by raw string, so they require a stricter containment check.
@@ -726,8 +760,9 @@ pub(super) mod s3_utils {
         Ok(keys)
     }
 
+    /// Determine the locations a request touches.
     pub(super) fn parse_s3_url(
-        uri: &url::Url,
+        uri: &SignRequestUri,
         s3_url_style_detection: S3UrlStyleDetectionMode,
         method: &http::Method,
         body: Option<&str>,
@@ -735,7 +770,7 @@ pub(super) mod s3_utils {
         let err = |t: &str, m: &str| ErrorModel::bad_request(m, t, None);
 
         // Require https or http
-        if !matches!(uri.scheme(), "https" | "http") {
+        if !matches!(uri.received().scheme(), "https" | "http") {
             return Err(err(
                 "UriSchemeNotSupported",
                 "URI to sign does not have a supported scheme. Expected https or http",
@@ -748,7 +783,8 @@ pub(super) mod s3_utils {
             http::Method::GET | http::Method::HEAD => (Operation::Read, false),
             http::Method::POST | http::Method::PUT => {
                 // Handle special case: DeleteObjects operation (POST with ?delete and XML body)
-                if method == http::Method::POST && uri.query().is_some_and(|q| q.contains("delete"))
+                if method == http::Method::POST
+                    && uri.received().query().is_some_and(|q| q.contains("delete"))
                 {
                     (Operation::Delete, true)
                 } else {
@@ -768,7 +804,7 @@ pub(super) mod s3_utils {
 
         // `DeleteObjects` and `ListObjectsV2` address the bucket instead of a single object.
         // The keys that identify the table live in the request body resp. the query string.
-        let is_list_operation = *method == http::Method::GET && is_list_objects_v2(uri);
+        let is_list_operation = *method == http::Method::GET && is_list_objects_v2(uri.received());
         let allow_no_key = is_post_delete_operation || is_list_operation;
 
         // Parse the base URL
@@ -814,8 +850,8 @@ pub(super) mod s3_utils {
             // The URI path is just the bucket - the table is identified by the `prefix`.
             let bucket = bucket_of(&parsed_request)?;
             require_bucket_addressed(&parsed_request, &bucket)?;
-            require_known_list_parameters(uri)?;
-            parsed_request.locations = vec![list_prefix_location(uri, &bucket)?];
+            require_known_list_parameters(uri.received())?;
+            parsed_request.locations = vec![list_prefix_location(uri.received(), &bucket)?];
             parsed_request.locations_are_list_prefixes = true;
         }
 
@@ -831,15 +867,21 @@ pub(super) mod s3_utils {
     }
 
     /// Requests whose locations are taken from the body or the query string must address the
-    /// bucket itself. The URI is signed as received, and S3 dispatches on the path: a key in
-    /// the path would turn the signed request into an object operation that ignores the
-    /// parameters this authorization is based on.
+    /// bucket itself. S3 dispatches on the path: a key in the path would turn the signed
+    /// request into an object operation that ignores the parameters this authorization is
+    /// based on.
     fn require_bucket_addressed(parsed_request: &ParsedSignRequest, bucket: &str) -> Result<()> {
+        // The location the path resolves to is the bucket itself, in either url style ...
         let addresses_bucket = parsed_request.locations.first().is_some_and(|location| {
             location.location().as_str().trim_end_matches('/') == format!("s3://{bucket}")
         });
 
-        if !addresses_bucket {
+        // ... and url-decoding did not change the path, which would mean the bytes that get
+        // signed address something else than what was just checked: `%2F` hides separators
+        // from the url parser, which then collapses the `.`/`..` behind them.
+        let path_survived_decoding = parsed_request.uri.path_survived_decoding();
+
+        if !(addresses_bucket && path_survived_decoding) {
             return Err(ErrorModel::bad_request(
                 "Bucket-level requests must not address an object",
                 "UriNotBucket",
@@ -948,15 +990,15 @@ pub(super) mod s3_utils {
     }
 
     fn virtual_host_style(
-        uri: &url::Url,
+        uri: &SignRequestUri,
         allow_no_key: bool,
         is_known: bool,
     ) -> Result<ParsedSignRequest> {
-        let host = uri.host().ok_or_else(|| {
+        let host = uri.decoded().host().ok_or_else(|| {
             ErrorModel::bad_request("URI to sign does not have a host", "UriNoHost", None)
         })?;
-        let path_segments = get_path_segments(uri, allow_no_key)?;
-        let port = uri.port_or_known_default().unwrap_or(443);
+        let path_segments = get_path_segments(uri.decoded(), allow_no_key)?;
+        let port = uri.decoded().port_or_known_default().unwrap_or(443);
 
         let host_str = host.to_string();
 
@@ -982,7 +1024,7 @@ pub(super) mod s3_utils {
             .into());
         };
         Ok(ParsedSignRequest {
-            url: uri.clone(),
+            uri: uri.clone(),
             locations: vec![
                 S3Location::new(
                     bucket,
@@ -1009,8 +1051,8 @@ pub(super) mod s3_utils {
         Ok((bucket, endpoint))
     }
 
-    fn path_style(uri: &url::Url, allow_no_key: bool) -> Result<ParsedSignRequest> {
-        let path_segments = get_path_segments(uri, allow_no_key)?;
+    fn path_style(uri: &SignRequestUri, allow_no_key: bool) -> Result<ParsedSignRequest> {
+        let path_segments = get_path_segments(uri.decoded(), allow_no_key)?;
 
         let min_path_segments = if allow_no_key { 1 } else { 2 };
 
@@ -1026,7 +1068,7 @@ pub(super) mod s3_utils {
         let path_segments_borrowed: Vec<&str> = path_segments.iter().map(String::as_str).collect();
 
         Ok(ParsedSignRequest {
-            url: uri.clone(),
+            uri: uri.clone(),
             locations: vec![
                 S3Location::new(
                     path_segments_borrowed[0],
@@ -1041,12 +1083,13 @@ pub(super) mod s3_utils {
             ],
             locations_are_list_prefixes: false,
             endpoint: uri
+                .decoded()
                 .host_str()
                 .ok_or_else(|| {
                     ErrorModel::bad_request("URI to sign does not have a host", "UriNoHost", None)
                 })?
                 .to_string(),
-            port: uri.port_or_known_default().unwrap_or(443),
+            port: uri.decoded().port_or_known_default().unwrap_or(443),
         })
     }
 
@@ -1179,7 +1222,7 @@ mod test {
     use itertools::Itertools as _;
 
     use super::*;
-    use crate::{server::s3_signer::sign::s3_utils::parse_s3_url, service::storage::S3Flavor};
+    use crate::service::storage::S3Flavor;
 
     #[derive(Debug)]
     struct TC {
@@ -1190,9 +1233,23 @@ mod test {
         expected_outcome: bool,
     }
 
+    fn parse_uri(
+        uri: &url::Url,
+        mode: S3UrlStyleDetectionMode,
+        method: &http::Method,
+        body: Option<&str>,
+    ) -> Result<(s3_utils::ParsedSignRequest, Operation)> {
+        s3_utils::parse_s3_url(
+            &s3_utils::SignRequestUri::new(uri.clone())?,
+            mode,
+            method,
+            body,
+        )
+    }
+
     fn run_validate_uri_test(test_case: &TC) {
         let request_uri = url::Url::parse(test_case.request_uri).unwrap();
-        let (request_uri, _operation) = s3_utils::parse_s3_url(
+        let (request_uri, _operation) = parse_uri(
             &request_uri,
             S3UrlStyleDetectionMode::Auto,
             &http::Method::GET,
@@ -1210,7 +1267,7 @@ mod test {
 
     #[test]
     fn test_parse_s3_url_config_path_style() {
-        let (parsed, _operation) = parse_s3_url(
+        let (parsed, _operation) = parse_uri(
             &url::Url::parse("https://not-a-bucket.s3.region.amazonaws.com/bucket/key").unwrap(),
             S3UrlStyleDetectionMode::Path,
             &http::Method::GET,
@@ -1222,7 +1279,7 @@ mod test {
 
     #[test]
     fn test_parse_s3_url_config_virtual_style() {
-        let (parsed, _operation) = parse_s3_url(
+        let (parsed, _operation) = parse_uri(
             &url::Url::parse("https://bucket.s3.region.amazonaws.com/key").unwrap(),
             S3UrlStyleDetectionMode::VirtualHost,
             &http::Method::GET,
@@ -1234,7 +1291,7 @@ mod test {
 
     #[test]
     fn test_parse_s3_url_config_virtual_style_minimal() {
-        let (parsed, _operation) = parse_s3_url(
+        let (parsed, _operation) = parse_uri(
             &url::Url::parse("https://bucket.s3-service/key").unwrap(),
             S3UrlStyleDetectionMode::VirtualHost,
             &http::Method::GET,
@@ -1328,7 +1385,7 @@ mod test {
 
         for (uri, expected) in cases {
             let uri = url::Url::parse(uri).unwrap();
-            let (parsed, _operation) = parse_s3_url(
+            let (parsed, _operation) = parse_uri(
                 &uri,
                 S3UrlStyleDetectionMode::Auto,
                 &http::Method::GET,
@@ -1368,7 +1425,7 @@ mod test {
 
         for (uri, body, expected) in cases {
             let uri = url::Url::parse(uri).unwrap();
-            let (parsed, operation) = parse_s3_url(
+            let (parsed, operation) = parse_uri(
                 &uri,
                 S3UrlStyleDetectionMode::Auto,
                 &http::Method::POST,
@@ -1505,7 +1562,7 @@ mod test {
     }
 
     fn parse_list(uri: &str, mode: S3UrlStyleDetectionMode) -> s3_utils::ParsedSignRequest {
-        let (parsed, operation) = parse_s3_url(
+        let (parsed, operation) = parse_uri(
             &url::Url::parse(uri).unwrap(),
             mode,
             &http::Method::GET,
@@ -1519,7 +1576,7 @@ mod test {
     }
 
     fn parse_list_err(uri: &str, mode: S3UrlStyleDetectionMode) -> String {
-        parse_s3_url(
+        parse_uri(
             &url::Url::parse(uri).unwrap(),
             mode,
             &http::Method::GET,
@@ -1686,6 +1743,11 @@ mod test {
                 "https://bucket.s3.my-region.amazonaws.com/other-ns/other-tbl/metadata/v1.json?list-type=2&prefix=ns/tbl/",
                 S3UrlStyleDetectionMode::VirtualHost,
             ),
+            // Virtual-host style, where the key happens to be named like the bucket.
+            (
+                "https://bucket.s3.my-region.amazonaws.com/bucket?list-type=2&prefix=ns/tbl/",
+                S3UrlStyleDetectionMode::VirtualHost,
+            ),
         ] {
             assert_eq!(
                 parse_list_err(uri, mode),
@@ -1696,7 +1758,7 @@ mod test {
 
         // The same holds for the bulk delete that takes its keys from the body.
         let body = "<Delete><Object><Key>ns/tbl/data/a.parquet</Key></Object></Delete>";
-        let err = parse_s3_url(
+        let err = parse_uri(
             &url::Url::parse("http://s3.example.com:8333/bucket/other-ns/other-tbl/x.json?delete")
                 .unwrap(),
             S3UrlStyleDetectionMode::Auto,
@@ -1706,6 +1768,64 @@ mod test {
         .map(|(parsed, _)| parsed)
         .expect_err("a bulk delete addressing an object must not be signable");
         assert_eq!(err.error.r#type, "UriNotBucket", "{err:?}");
+    }
+
+    /// Url-decoding the path reveals separators hidden in `%2F` and lets the url parser
+    /// collapse the `.`/`..` behind them, so a path that addresses a key can decode to the
+    /// bare bucket. The guard has to reject it, because the key is what gets signed.
+    #[test]
+    fn test_parse_s3_url_list_must_address_the_bucket_before_decoding() {
+        let received = url::Url::parse(
+            "http://s3.example.com:8333/bucket%2Fns%2Ftbl%2F%2E%2E%2F%2E%2E?list-type=2&prefix=ns/tbl/",
+        )
+        .unwrap();
+        let uri = s3_utils::SignRequestUri::new(received).unwrap();
+        assert_eq!(
+            uri.decoded().path(),
+            "/bucket/",
+            "decoding must collapse to the bucket for this test to mean anything"
+        );
+
+        let err = s3_utils::parse_s3_url(
+            &uri,
+            S3UrlStyleDetectionMode::Auto,
+            &http::Method::GET,
+            None,
+        )
+        .map(|(parsed, _)| parsed)
+        .expect_err("a path that only decodes to the bucket must not be signable");
+        assert_eq!(err.error.r#type, "UriNotBucket", "{err:?}");
+    }
+
+    /// `+` in a query value is form-decoded to a space, by S3 as well as by the parameter
+    /// reader here, so the prefix that is authorized is the one S3 matches keys against.
+    #[test]
+    fn test_parse_s3_url_list_prefix_plus_is_a_space() {
+        let parsed = parse_list(
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl+dir/",
+            S3UrlStyleDetectionMode::Auto,
+        );
+        assert_eq!(
+            parsed
+                .locations
+                .iter()
+                .map(ToString::to_string)
+                .collect_vec(),
+            vec!["s3://bucket/ns/tbl dir/"]
+        );
+
+        let parsed = parse_list(
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns/tbl%2Bdir/",
+            S3UrlStyleDetectionMode::Auto,
+        );
+        assert_eq!(
+            parsed
+                .locations
+                .iter()
+                .map(ToString::to_string)
+                .collect_vec(),
+            vec!["s3://bucket/ns/tbl+dir/"]
+        );
     }
 
     /// S3 dispatches on the query string too: a bucket sub-resource next to the list
@@ -1769,7 +1889,7 @@ mod test {
 
     #[test]
     fn test_uri_bucket_missing() {
-        parse_s3_url(
+        parse_uri(
             &url::Url::parse("https://s3.my-region.amazonaws.com/key").unwrap(),
             S3UrlStyleDetectionMode::Auto,
             &http::Method::GET,

--- a/crates/lakekeeper/src/server/s3_signer/sign.rs
+++ b/crates/lakekeeper/src/server/s3_signer/sign.rs
@@ -642,6 +642,7 @@ fn validate_uri(
 pub(super) mod s3_utils {
     use lakekeeper_io::s3::S3Location;
     use lazy_regex::regex;
+    use percent_encoding::{AsciiSet, utf8_percent_encode};
     use serde::{Deserialize, Serialize};
 
     use super::{ErrorModel, Operation, Result};
@@ -652,6 +653,19 @@ pub(super) mod s3_utils {
     const LIST_TYPE_V2: &str = "2";
     /// Query parameter carrying the key prefix a list request is scoped to.
     const PREFIX_QUERY_PARAM: &str = "prefix";
+
+    /// The url path percent-encode set, which is what a `Location` built from an object key
+    /// carries. `/` is not part of it - it separates segments in both representations.
+    const LIST_PREFIX_ENCODE_SET: &AsciiSet = &AsciiSet::EMPTY
+        .add(b' ')
+        .add(b'"')
+        .add(b'#')
+        .add(b'<')
+        .add(b'>')
+        .add(b'?')
+        .add(b'`')
+        .add(b'{')
+        .add(b'}');
 
     /// The URI of a request to sign, both as received and with its path segments url-decoded.
     ///
@@ -978,6 +992,16 @@ pub(super) mod s3_utils {
                     None,
                 )
             })?;
+
+        // The prefix arrives url-decoded, so it has to be encoded again to become a location.
+        // Object keys reach their location through `urldecode_uri_path_segments`, which
+        // re-encodes with the url path percent-encode set, so the same key has to end up as
+        // the same string here - otherwise a table whose location contains one of these
+        // characters can be read file by file but never listed. `%` and control characters
+        // are deliberately not encoded: the parser below must keep rejecting a prefix that
+        // does not round-trip - an empty segment, `.`/`..`, a control character - instead of
+        // it disappearing behind an encoding of ours.
+        let prefix = utf8_percent_encode(&prefix, LIST_PREFIX_ENCODE_SET);
 
         S3Location::try_from_str(&format!("s3://{bucket}/{prefix}"), false).map_err(|e| {
             ErrorModel::bad_request(
@@ -1665,6 +1689,43 @@ mod test {
         }
     }
 
+    /// A key must reach the same location whether it arrives as an object key in the path or
+    /// as a list prefix in the query. Otherwise a table whose location contains one of these
+    /// characters can be read file by file but never listed - and for `#` and `?` the prefix
+    /// would not even parse, because they start a fragment resp. a query string.
+    #[test]
+    fn test_list_prefix_and_object_key_encode_alike() {
+        for encoded in [
+            "%20", "%22", "%23", "%3C", "%3E", "%3F", "%60", "%7B", "%7D",    // path-encoded
+            "%C3%A9", // non-ascii
+            "%25", "%2B", "%3A", "%40", // left as-is by both
+        ] {
+            let (object, _) = parse_uri(
+                &url::Url::parse(&format!(
+                    "http://s3.example.com:8333/bucket/ns/tbl{encoded}a/f.parquet"
+                ))
+                .unwrap(),
+                S3UrlStyleDetectionMode::Auto,
+                &http::Method::GET,
+                None,
+            )
+            .unwrap_or_else(|e| panic!("object key `{encoded}` must parse: {e:?}"));
+
+            let list = parse_list(
+                &format!(
+                    "http://s3.example.com:8333/bucket?list-type=2&prefix=ns%2Ftbl{encoded}a%2F"
+                ),
+                S3UrlStyleDetectionMode::Auto,
+            );
+
+            assert_eq!(
+                object.locations[0].to_string(),
+                format!("{}f.parquet", list.locations[0]),
+                "object key and list prefix must encode `{encoded}` the same way"
+            );
+        }
+    }
+
     /// A prefix that a location would not round-trip cannot be authorized: the string S3
     /// matches keys against would differ from the one that was checked. `ns//tbl/` is the
     /// case that matters - its keys lie outside the `ns/tbl/` directory it normalizes to.
@@ -1811,7 +1872,7 @@ mod test {
                 .iter()
                 .map(ToString::to_string)
                 .collect_vec(),
-            vec!["s3://bucket/ns/tbl dir/"]
+            vec!["s3://bucket/ns/tbl%20dir/"]
         );
 
         let parsed = parse_list(
@@ -1859,6 +1920,10 @@ mod test {
             ("ns/tbl/metadata", "s3://bucket/ns/tbl", true),
             // Table locations may be stored with a trailing slash.
             ("ns/tbl/", "s3://bucket/ns/tbl/", true),
+            // A table whose location holds an encoded `#`, addressed by the decoded prefix
+            // the client sends.
+            ("ns/tbl%23a/", "s3://bucket/ns/tbl%23a", true),
+            ("ns/tbl%23a/", "s3://bucket/ns/tbl", false),
             // `s3a` and `s3n` table locations are normalized to `s3`.
             ("ns/tbl/", "s3a://bucket/ns/tbl", true),
             ("ns/tbl/", "s3n://bucket/ns/tbl", true),

--- a/crates/lakekeeper/src/server/s3_signer/sign.rs
+++ b/crates/lakekeeper/src/server/s3_signer/sign.rs
@@ -655,7 +655,10 @@ pub(super) mod s3_utils {
     const PREFIX_QUERY_PARAM: &str = "prefix";
 
     /// The url path percent-encode set, which is what a `Location` built from an object key
-    /// carries. `/` is not part of it - it separates segments in both representations.
+    /// carries. `/` is not part of it - it separates segments in both representations. `\` is
+    /// not either, and there the two representations genuinely disagree: `url` treats it as a
+    /// second separator for http but not for `s3`, so an object key loses it while a list
+    /// prefix keeps the byte S3 matches against. Keeping the byte is the sound half.
     const LIST_PREFIX_ENCODE_SET: &AsciiSet = &AsciiSet::EMPTY
         .add(b' ')
         .add(b'"')
@@ -992,6 +995,21 @@ pub(super) mod s3_utils {
                     None,
                 )
             })?;
+
+        // `query_pairs` decodes lossily - a byte sequence that is not valid utf-8 becomes
+        // U+FFFD. The location built from it would describe a different key range than the
+        // one S3 matches against the bytes that get signed, so such a prefix is refused. A
+        // literal U+FFFD is refused with it, because the two are indistinguishable here -
+        // stricter than the object key path, which errors on malformed input but accepts the
+        // literal character.
+        if prefix.contains(char::REPLACEMENT_CHARACTER) {
+            return Err(ErrorModel::bad_request(
+                "List prefix is not valid utf-8",
+                "InvalidListPrefix",
+                None,
+            )
+            .into());
+        }
 
         // The prefix arrives url-decoded, so it has to be encoded again to become a location.
         // Object keys reach their location through `urldecode_uri_path_segments`, which
@@ -1690,17 +1708,30 @@ mod test {
     }
 
     /// A key must reach the same location whether it arrives as an object key in the path or
-    /// as a list prefix in the query. Otherwise a table whose location contains one of these
-    /// characters can be read file by file but never listed - and for `#` and `?` the prefix
-    /// would not even parse, because they start a fragment resp. a query string.
+    /// as a list prefix in the query. Otherwise a table whose location contains the character
+    /// can be read file by file but never listed - and for `#` and `?` the prefix would not
+    /// even parse, because they start a fragment resp. a query string.
+    ///
+    /// Swept over every byte, so a change to either representation cannot pull them apart
+    /// unnoticed. One of the two rejecting is fine - it just refuses to sign - so only the
+    /// cases where both produce a location are compared. `\` is the one disagreement, see
+    /// [`test_list_prefix_keeps_a_backslash_that_an_object_key_loses`].
     #[test]
     fn test_list_prefix_and_object_key_encode_alike() {
-        for encoded in [
-            "%20", "%22", "%23", "%3C", "%3E", "%3F", "%60", "%7B", "%7D",    // path-encoded
-            "%C3%A9", // non-ascii
-            "%25", "%2B", "%3A", "%40", // left as-is by both
-        ] {
-            let (object, _) = parse_uri(
+        let escapes = (0x00..=0xFF).map(|byte: u8| format!("%{byte:02X}")).chain([
+            "%C3%A9".to_string(),
+            "%2525".to_string(),
+            "%2f".to_string(),
+        ]);
+
+        let mut compared = 0;
+
+        for encoded in escapes {
+            if encoded == "%5C" {
+                continue;
+            }
+
+            let object = parse_uri(
                 &url::Url::parse(&format!(
                     "http://s3.example.com:8333/bucket/ns/tbl{encoded}a/f.parquet"
                 ))
@@ -1708,20 +1739,71 @@ mod test {
                 S3UrlStyleDetectionMode::Auto,
                 &http::Method::GET,
                 None,
-            )
-            .unwrap_or_else(|e| panic!("object key `{encoded}` must parse: {e:?}"));
-
-            let list = parse_list(
-                &format!(
-                    "http://s3.example.com:8333/bucket?list-type=2&prefix=ns%2Ftbl{encoded}a%2F"
-                ),
-                S3UrlStyleDetectionMode::Auto,
             );
 
+            let list = parse_uri(
+                &url::Url::parse(&format!(
+                    "http://s3.example.com:8333/bucket?list-type=2&prefix=ns%2Ftbl{encoded}a%2F"
+                ))
+                .unwrap(),
+                S3UrlStyleDetectionMode::Auto,
+                &http::Method::GET,
+                None,
+            );
+
+            if let (Ok((object, _)), Ok((list, _))) = (object, list) {
+                assert_eq!(
+                    object.locations[0].to_string(),
+                    format!("{}f.parquet", list.locations[0]),
+                    "object key and list prefix must encode `{encoded}` the same way"
+                );
+                compared += 1;
+            }
+        }
+
+        // Both rejecting is the trivially passing case, so make sure the sweep did compare the
+        // printable range rather than run empty.
+        assert_eq!(compared, 97, "the sweep must not go vacuous");
+    }
+
+    /// `\` is the one character the two representations disagree on: `url` treats it as a
+    /// second path separator for http, so the object key loses it, while the list prefix keeps
+    /// the byte S3 matches keys against. Keeping it is the sound half - the authorized string
+    /// is what gets listed - so this pins the list behaviour rather than the agreement.
+    #[test]
+    fn test_list_prefix_keeps_a_backslash_that_an_object_key_loses() {
+        let list = parse_list(
+            "http://s3.example.com:8333/bucket?list-type=2&prefix=ns%2Ftbl%5Ca%2F",
+            S3UrlStyleDetectionMode::Auto,
+        );
+        assert_eq!(list.locations[0].to_string(), "s3://bucket/ns/tbl\\a/");
+
+        let (object, _) = parse_uri(
+            &url::Url::parse("http://s3.example.com:8333/bucket/ns/tbl%5Ca/f.parquet").unwrap(),
+            S3UrlStyleDetectionMode::Auto,
+            &http::Method::GET,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            object.locations[0].to_string(),
+            "s3://bucket/ns/tbl/a/f.parquet"
+        );
+    }
+
+    /// A prefix whose bytes are not valid utf-8 cannot be authorized: `query_pairs` decodes it
+    /// lossily, so the location built from it describes a different key range than the one S3
+    /// matches against the bytes that get signed.
+    #[test]
+    fn test_parse_s3_url_list_rejects_malformed_prefix_encoding() {
+        for prefix in ["ns%2Ftbl%FF%FEa%2F", "ns%2Ftbl%C3%28a%2F", "ns%2Ftbl%80%2F"] {
             assert_eq!(
-                object.locations[0].to_string(),
-                format!("{}f.parquet", list.locations[0]),
-                "object key and list prefix must encode `{encoded}` the same way"
+                parse_list_err(
+                    &format!("http://s3.example.com:8333/bucket?list-type=2&prefix={prefix}"),
+                    S3UrlStyleDetectionMode::Auto
+                ),
+                "InvalidListPrefix",
+                "Test case: {prefix}"
             );
         }
     }

--- a/docs/docs/storage.md
+++ b/docs/docs/storage.md
@@ -189,6 +189,8 @@ For maximum client compatibility, we recommend enabling both STS and remote sign
 
 Remote signing applies to [Generic Tables](./generic-tables.md) as well as Iceberg tables — see [Remote signing for generic tables](./generic-tables.md#remote-signing-s3-without-sts).
 
+Remote signing also covers prefix listings (`ListObjectsV2`), which clients use for maintenance operations such as Spark's `remove_orphan_files` with `prefix_listing => true` (requires `iceberg-spark-runtime` 1.10 or newer). The `prefix` must address a directory inside the table's location, i.e. it has to end with a `/` when listing the table location itself. S3 matches list prefixes as raw strings, so the prefix `warehouse/ns/table` would also return the keys of a sibling `warehouse/ns/table_other`, and is rejected. Iceberg's `FileSystemWalker` appends the `/` before listing; clients that don't are expected to normalize their prefix.
+
 For some older remote signing clients that cannot handle table-specific remote signing endpoint locations, Lakekeeper needs to identifying a table by its location in the storage. Since there are multiple canonical ways to specify S3 resources (virtual-host & path), Lakekeeper warehouses by default use a heuristic to determine which style is used. For some setups these heuristics may not work, or you may want to enforce a specific style. In this case, you can set the `remote-signing-url-style` field to either `path` or `virtual-host` in your storage profile. `path` will always use the first path segment as the bucket name. `virtual-host` will use the first subdomain if it is followed by `.s3` or `.s3-`. The default mode is `auto` which first tries `virtual-host` and falls back to `path` if it fails.
 
 ### Configuration Parameters


### PR DESCRIPTION
The signer rejected bucket-level ListObjectsV2, so any Iceberg client walking a prefix through S3FileIO failed - concretely Spark's `remove_orphan_files` with `prefix_listing => true`, the only route for remote-signing users. The parser allowed a keyless bucket path for DeleteObjects only, and the location was derived from the URI path, never from the `prefix` that identifies the table.

Listing is now signable when `prefix` addresses a directory inside the table location. Sigv4 covers the query string, so the signed prefix cannot be widened afterwards. The prefix must reach past the table's path separator: S3 matches prefixes as raw strings, so `warehouse/ns/table` would also return the keys of a sibling `warehouse/ns/table_other`. Adds `Location::is_prefix_within`, since `is_sublocation_of` accepts the parent itself.

The URI is signed as received and S3 dispatches on both path and query, so bucket-level requests must not address a key (this also hardens the pre-existing DeleteObjects path), and only ListObjectsV2 parameters are accepted, each at most once. Requests carrying no prefix (`?versions`, `?uploads`, `?location`, List Objects V1) stay unsignable.

Closes #1917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure signing for S3 prefix-based listings of Iceberg and generic tables.
  * Added support for directory-scoped prefixes across supported signing routes.

* **Bug Fixes**
  * Improved validation for ambiguous, unauthorized, or incorrectly scoped listings.
  * Strengthened safeguards against bucket-level listing requests and bulk deletes.
  * Improved handling of encoded request paths and folder boundaries during validation.

* **Documentation**
  * Documented requirements and restrictions for S3 prefix listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->