### PR TITLE
fix(kv2): treat Vault standby nodes as healthy

### DIFF
--- a/crates/lakekeeper-secrets-kv2/src/lib.rs
+++ b/crates/lakekeeper-secrets-kv2/src/lib.rs
@@ -7,6 +7,7 @@ use serde::{Serialize, de::DeserializeOwned};
 use tokio::{sync::RwLock, time::Sleep};
 use uuid::Uuid;
 use vaultrs::{
+    api::{exec_with_no_result, sys::requests::ReadHealthRequest},
     client::{Client, VaultClient},
     error::ClientError,
 };
@@ -230,7 +231,16 @@ impl HealthExt for SecretsState {
 
     async fn update_health(&self) {
         let handle = self.vault_client.read().await;
-        let t = vaultrs::sys::health(&*handle).await;
+        // Vault returns 429 for standby nodes and 473 for performance standbys.
+        // These nodes transparently forward requests to the active leader, so
+        // treat them as healthy by requesting standbyok/perfstandbyok.
+        // https://developer.hashicorp.com/vault/api-docs/system/health
+        let endpoint = ReadHealthRequest::builder()
+            .standbyok(true)
+            .perfstandbyok(true)
+            .build()
+            .expect("ReadHealthRequest has no required fields");
+        let t = exec_with_no_result(&*handle, endpoint).await;
         match t {
             Ok(_) => {
                 tracing::debug!("Vault is healthy");


### PR DESCRIPTION
Fixes #1929 

Fix the KV2 Vault health check to treat HA standby nodes as healthy. Currently we make a request to vaults /health endpoint with no parameters. 
In this case, Vault returns HTTP `429` for standby nodes and `473` for performance standbys, and since they are not 2xx responses, we wrongly interpret it as unhealthy.

This PR proposes to pass relevant parameters ([standbyok and perfstandbyok](https://developer.hashicorp.com/vault/api-docs/system/health#parameters) to properly flag these responses as healthy instead.

This way, Lakekeeper pods doesn't fail their liveness probe and doesn't restart unnecessarily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault health checks now recognize standby and performance-standby nodes as healthy.
  * Improved health-check compatibility for Vault deployments using standby forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->