### PR TITLE
feat(authz-openfga): make manage_tags and tag_creator assignable and grantable

### DIFF
--- a/crates/authz-openfga/src/api.rs
+++ b/crates/authz-openfga/src/api.rs
@@ -3459,6 +3459,8 @@ mod tests {
                 .await
                 .unwrap();
 
+            let tag_creator =
+                ProjectAssignment::TagCreator(UserOrRole::User(user_id_assignee.clone()));
             checked_write(
                 authorizer.clone(),
                 &Actor::Principal(user_id_owner.clone()),
@@ -3466,6 +3468,7 @@ mod tests {
                     ProjectAssignment::Describe(UserOrRole::Role(role_id.into_api_assignee())),
                     ProjectAssignment::DataAdmin(UserOrRole::Role(role_id.into_api_assignee())),
                     ProjectAssignment::DataAdmin(UserOrRole::User(user_id_assignee.clone())),
+                    tag_creator.clone(),
                 ],
                 vec![],
                 &project_id.to_openfga(),
@@ -3477,7 +3480,9 @@ mod tests {
                 get_relations(authorizer.clone(), None, &project_id.to_openfga())
                     .await
                     .unwrap();
-            assert_eq!(relations.len(), 4);
+            // project_admin (seeded) + describe + 2x data_admin + tag_creator
+            assert_eq!(relations.len(), 5);
+            assert!(relations.contains(&tag_creator));
         }
 
         #[tokio::test]

--- a/crates/authz-openfga/src/relations.rs
+++ b/crates/authz-openfga/src/relations.rs
@@ -616,6 +616,7 @@ pub(super) enum APIProjectRelation {
     SecurityAdmin,
     DataAdmin,
     RoleCreator,
+    TagCreator,
     Describe,
     Select,
     Create,
@@ -634,6 +635,8 @@ pub(super) enum ProjectAssignment {
     DataAdmin(UserOrRole),
     #[cfg_attr(feature = "open-api", schema(title = "ProjectAssignmentRoleCreator"))]
     RoleCreator(UserOrRole),
+    #[cfg_attr(feature = "open-api", schema(title = "ProjectAssignmentTagCreator"))]
+    TagCreator(UserOrRole),
     #[cfg_attr(feature = "open-api", schema(title = "ProjectAssignmentDescribe"))]
     Describe(UserOrRole),
     #[cfg_attr(feature = "open-api", schema(title = "ProjectAssignmentSelect"))]
@@ -651,6 +654,7 @@ impl GrantableRelation for APIProjectRelation {
             APIProjectRelation::SecurityAdmin => ProjectRelation::CanGrantSecurityAdmin,
             APIProjectRelation::DataAdmin => ProjectRelation::CanGrantDataAdmin,
             APIProjectRelation::RoleCreator => ProjectRelation::CanGrantRoleCreator,
+            APIProjectRelation::TagCreator => ProjectRelation::CanGrantTagCreator,
             APIProjectRelation::Describe => ProjectRelation::CanGrantDescribe,
             APIProjectRelation::Select => ProjectRelation::CanGrantSelect,
             APIProjectRelation::Create => ProjectRelation::CanGrantCreate,
@@ -679,6 +683,9 @@ impl Assignment for ProjectAssignment {
             APIProjectRelation::RoleCreator => {
                 UserOrRole::parse_from_openfga(user).map(ProjectAssignment::RoleCreator)
             }
+            APIProjectRelation::TagCreator => {
+                UserOrRole::parse_from_openfga(user).map(ProjectAssignment::TagCreator)
+            }
             APIProjectRelation::Describe => {
                 UserOrRole::parse_from_openfga(user).map(ProjectAssignment::Describe)
             }
@@ -700,6 +707,7 @@ impl Assignment for ProjectAssignment {
             | ProjectAssignment::SecurityAdmin(user)
             | ProjectAssignment::DataAdmin(user)
             | ProjectAssignment::RoleCreator(user)
+            | ProjectAssignment::TagCreator(user)
             | ProjectAssignment::Describe(user)
             | ProjectAssignment::Select(user)
             | ProjectAssignment::Create(user)
@@ -713,6 +721,7 @@ impl Assignment for ProjectAssignment {
             ProjectAssignment::SecurityAdmin(_) => APIProjectRelation::SecurityAdmin,
             ProjectAssignment::DataAdmin(_) => APIProjectRelation::DataAdmin,
             ProjectAssignment::RoleCreator(_) => APIProjectRelation::RoleCreator,
+            ProjectAssignment::TagCreator(_) => APIProjectRelation::TagCreator,
             ProjectAssignment::Describe { .. } => APIProjectRelation::Describe,
             ProjectAssignment::Select { .. } => APIProjectRelation::Select,
             ProjectAssignment::Create { .. } => APIProjectRelation::Create,
@@ -735,6 +744,7 @@ pub(super) enum APIProjectAction {
     SearchRoles,
     ReadAssignments,
     GrantRoleCreator,
+    GrantTagCreator,
     GrantCreate,
     GrantDescribe,
     GrantModify,
@@ -751,6 +761,7 @@ pub(super) enum APIProjectAction {
 pub(super) enum OpenFGAProjectAction {
     ReadAssignments,
     GrantRoleCreator,
+    GrantTagCreator,
     GrantCreate,
     GrantDescribe,
     GrantModify,
@@ -769,6 +780,7 @@ impl ReducedRelation for APIProjectRelation {
             APIProjectRelation::SecurityAdmin => ProjectRelation::SecurityAdmin,
             APIProjectRelation::DataAdmin => ProjectRelation::DataAdmin,
             APIProjectRelation::RoleCreator => ProjectRelation::RoleCreator,
+            APIProjectRelation::TagCreator => ProjectRelation::TagCreator,
             APIProjectRelation::Describe => ProjectRelation::Describe,
             APIProjectRelation::Select => ProjectRelation::Select,
             APIProjectRelation::Create => ProjectRelation::Create,
@@ -791,6 +803,7 @@ impl ReducedRelation for APIProjectAction {
             APIProjectAction::SearchRoles => ProjectRelation::CanSearchRoles,
             APIProjectAction::ReadAssignments => ProjectRelation::CanReadAssignments,
             APIProjectAction::GrantRoleCreator => ProjectRelation::CanGrantRoleCreator,
+            APIProjectAction::GrantTagCreator => ProjectRelation::CanGrantTagCreator,
             APIProjectAction::GrantCreate => ProjectRelation::CanGrantCreate,
             APIProjectAction::GrantDescribe => ProjectRelation::CanGrantDescribe,
             APIProjectAction::GrantModify => ProjectRelation::CanGrantModify,
@@ -839,6 +852,7 @@ impl ReducedRelation for OpenFGAProjectAction {
         match self {
             OpenFGAProjectAction::ReadAssignments => ProjectRelation::CanReadAssignments,
             OpenFGAProjectAction::GrantRoleCreator => ProjectRelation::CanGrantRoleCreator,
+            OpenFGAProjectAction::GrantTagCreator => ProjectRelation::CanGrantTagCreator,
             OpenFGAProjectAction::GrantCreate => ProjectRelation::CanGrantCreate,
             OpenFGAProjectAction::GrantDescribe => ProjectRelation::CanGrantDescribe,
             OpenFGAProjectAction::GrantModify => ProjectRelation::CanGrantModify,
@@ -929,6 +943,7 @@ pub(super) enum APIWarehouseRelation {
     Select,
     Create,
     Modify,
+    ManageTags,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -952,6 +967,8 @@ pub(super) enum WarehouseAssignment {
     Create(UserOrRole),
     #[cfg_attr(feature = "open-api", schema(title = "WarehouseAssignmentModify"))]
     Modify(UserOrRole),
+    #[cfg_attr(feature = "open-api", schema(title = "WarehouseAssignmentManageTags"))]
+    ManageTags(UserOrRole),
 }
 
 impl GrantableRelation for APIWarehouseRelation {
@@ -964,6 +981,7 @@ impl GrantableRelation for APIWarehouseRelation {
             APIWarehouseRelation::Select => WarehouseRelation::CanGrantSelect,
             APIWarehouseRelation::Create => WarehouseRelation::CanGrantCreate,
             APIWarehouseRelation::Modify => WarehouseRelation::CanGrantModify,
+            APIWarehouseRelation::ManageTags => WarehouseRelation::CanGrantManageTags,
         }
     }
 }
@@ -997,6 +1015,9 @@ impl Assignment for WarehouseAssignment {
             APIWarehouseRelation::Modify => {
                 UserOrRole::parse_from_openfga(user).map(WarehouseAssignment::Modify)
             }
+            APIWarehouseRelation::ManageTags => {
+                UserOrRole::parse_from_openfga(user).map(WarehouseAssignment::ManageTags)
+            }
         }
     }
 
@@ -1008,7 +1029,8 @@ impl Assignment for WarehouseAssignment {
             | WarehouseAssignment::Select(user)
             | WarehouseAssignment::Create(user)
             | WarehouseAssignment::Modify(user)
-            | WarehouseAssignment::ManageGrants(user) => user.to_openfga(),
+            | WarehouseAssignment::ManageGrants(user)
+            | WarehouseAssignment::ManageTags(user) => user.to_openfga(),
         }
     }
 
@@ -1021,6 +1043,7 @@ impl Assignment for WarehouseAssignment {
             WarehouseAssignment::Select { .. } => APIWarehouseRelation::Select,
             WarehouseAssignment::Create { .. } => APIWarehouseRelation::Create,
             WarehouseAssignment::Modify { .. } => APIWarehouseRelation::Modify,
+            WarehouseAssignment::ManageTags { .. } => APIWarehouseRelation::ManageTags,
         }
     }
 }
@@ -1049,6 +1072,7 @@ pub(super) enum APIWarehouseAction {
     GrantSelect,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
     ChangeOwnership,
     GetAllTasks,
     ControlAllTasks,
@@ -1068,6 +1092,7 @@ pub(super) enum OpenFGAWarehouseAction {
     GrantSelect,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
     ChangeOwnership,
 }
 
@@ -1083,6 +1108,7 @@ impl ReducedRelation for APIWarehouseRelation {
             APIWarehouseRelation::Select => WarehouseRelation::Select,
             APIWarehouseRelation::Create => WarehouseRelation::Create,
             APIWarehouseRelation::Modify => WarehouseRelation::Modify,
+            APIWarehouseRelation::ManageTags => WarehouseRelation::ManageTags,
         }
     }
 }
@@ -1113,6 +1139,7 @@ impl ReducedRelation for APIWarehouseAction {
             APIWarehouseAction::GrantSelect => WarehouseRelation::CanGrantSelect,
             APIWarehouseAction::GrantPassGrants => WarehouseRelation::CanGrantPassGrants,
             APIWarehouseAction::GrantManageGrants => WarehouseRelation::CanGrantManageGrants,
+            APIWarehouseAction::GrantManageTags => WarehouseRelation::CanGrantManageTags,
             APIWarehouseAction::ChangeOwnership => WarehouseRelation::CanChangeOwnership,
             APIWarehouseAction::GetAllTasks => WarehouseRelation::CanGetAllTasks,
             APIWarehouseAction::ControlAllTasks => WarehouseRelation::CanControlAllTasks,
@@ -1178,6 +1205,7 @@ impl ReducedRelation for OpenFGAWarehouseAction {
             OpenFGAWarehouseAction::GrantSelect => WarehouseRelation::CanGrantSelect,
             OpenFGAWarehouseAction::GrantPassGrants => WarehouseRelation::CanGrantPassGrants,
             OpenFGAWarehouseAction::GrantManageGrants => WarehouseRelation::CanGrantManageGrants,
+            OpenFGAWarehouseAction::GrantManageTags => WarehouseRelation::CanGrantManageTags,
             OpenFGAWarehouseAction::ChangeOwnership => WarehouseRelation::CanChangeOwnership,
         }
     }
@@ -1261,6 +1289,7 @@ pub(super) enum APINamespaceRelation {
     Select,
     Create,
     Modify,
+    ManageTags,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -1284,6 +1313,8 @@ pub(super) enum NamespaceAssignment {
     Create(UserOrRole),
     #[cfg_attr(feature = "open-api", schema(title = "NamespaceAssignmentModify"))]
     Modify(UserOrRole),
+    #[cfg_attr(feature = "open-api", schema(title = "NamespaceAssignmentManageTags"))]
+    ManageTags(UserOrRole),
 }
 
 impl GrantableRelation for APINamespaceRelation {
@@ -1296,6 +1327,7 @@ impl GrantableRelation for APINamespaceRelation {
             APINamespaceRelation::Select => NamespaceRelation::CanGrantSelect,
             APINamespaceRelation::Create => NamespaceRelation::CanGrantCreate,
             APINamespaceRelation::Modify => NamespaceRelation::CanGrantModify,
+            APINamespaceRelation::ManageTags => NamespaceRelation::CanGrantManageTags,
         }
     }
 }
@@ -1329,6 +1361,9 @@ impl Assignment for NamespaceAssignment {
             APINamespaceRelation::Modify => {
                 UserOrRole::parse_from_openfga(user).map(NamespaceAssignment::Modify)
             }
+            APINamespaceRelation::ManageTags => {
+                UserOrRole::parse_from_openfga(user).map(NamespaceAssignment::ManageTags)
+            }
         }
     }
 
@@ -1340,7 +1375,8 @@ impl Assignment for NamespaceAssignment {
             | NamespaceAssignment::Describe(user)
             | NamespaceAssignment::Select(user)
             | NamespaceAssignment::Create(user)
-            | NamespaceAssignment::Modify(user) => user.to_openfga(),
+            | NamespaceAssignment::Modify(user)
+            | NamespaceAssignment::ManageTags(user) => user.to_openfga(),
         }
     }
 
@@ -1353,6 +1389,7 @@ impl Assignment for NamespaceAssignment {
             NamespaceAssignment::Select { .. } => APINamespaceRelation::Select,
             NamespaceAssignment::Create { .. } => APINamespaceRelation::Create,
             NamespaceAssignment::Modify { .. } => APINamespaceRelation::Modify,
+            NamespaceAssignment::ManageTags { .. } => APINamespaceRelation::ManageTags,
         }
     }
 }
@@ -1376,6 +1413,7 @@ pub(super) enum APINamespaceAction {
     GrantSelect,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
     SetProtection,
 }
 
@@ -1390,6 +1428,7 @@ pub(super) enum OpenFGANamespaceAction {
     GrantSelect,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
 }
 
 impl ReducedRelation for APINamespaceRelation {
@@ -1404,6 +1443,7 @@ impl ReducedRelation for APINamespaceRelation {
             APINamespaceRelation::Select => NamespaceRelation::Select,
             APINamespaceRelation::Create => NamespaceRelation::Create,
             APINamespaceRelation::Modify => NamespaceRelation::Modify,
+            APINamespaceRelation::ManageTags => NamespaceRelation::ManageTags,
         }
     }
 }
@@ -1427,6 +1467,7 @@ impl ReducedRelation for APINamespaceAction {
             APINamespaceAction::GrantSelect => NamespaceRelation::CanGrantSelect,
             APINamespaceAction::GrantPassGrants => NamespaceRelation::CanGrantPassGrants,
             APINamespaceAction::GrantManageGrants => NamespaceRelation::CanGrantManageGrants,
+            APINamespaceAction::GrantManageTags => NamespaceRelation::CanGrantManageTags,
             APINamespaceAction::SetProtection => NamespaceRelation::CanSetProtection,
         }
     }
@@ -1472,6 +1513,7 @@ impl ReducedRelation for OpenFGANamespaceAction {
             OpenFGANamespaceAction::GrantSelect => NamespaceRelation::CanGrantSelect,
             OpenFGANamespaceAction::GrantPassGrants => NamespaceRelation::CanGrantPassGrants,
             OpenFGANamespaceAction::GrantManageGrants => NamespaceRelation::CanGrantManageGrants,
+            OpenFGANamespaceAction::GrantManageTags => NamespaceRelation::CanGrantManageTags,
         }
     }
 }
@@ -1547,6 +1589,7 @@ pub(super) enum APITableRelation {
     Describe,
     Select,
     Modify,
+    ManageTags,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -1565,6 +1608,8 @@ pub(super) enum TableAssignment {
     Select(UserOrRole),
     #[cfg_attr(feature = "open-api", schema(title = "TableAssignmentModify"))]
     Modify(UserOrRole),
+    #[cfg_attr(feature = "open-api", schema(title = "TableAssignmentManageTags"))]
+    ManageTags(UserOrRole),
 }
 
 impl GrantableRelation for APITableRelation {
@@ -1576,6 +1621,7 @@ impl GrantableRelation for APITableRelation {
             APITableRelation::Describe => TableRelation::CanGrantDescribe,
             APITableRelation::Select => TableRelation::CanGrantSelect,
             APITableRelation::Modify => TableRelation::CanGrantModify,
+            APITableRelation::ManageTags => TableRelation::CanGrantManageTags,
         }
     }
 }
@@ -1606,6 +1652,9 @@ impl Assignment for TableAssignment {
             APITableRelation::Modify => {
                 UserOrRole::parse_from_openfga(user).map(TableAssignment::Modify)
             }
+            APITableRelation::ManageTags => {
+                UserOrRole::parse_from_openfga(user).map(TableAssignment::ManageTags)
+            }
         }
     }
 
@@ -1616,7 +1665,8 @@ impl Assignment for TableAssignment {
             | TableAssignment::ManageGrants(user)
             | TableAssignment::Describe(user)
             | TableAssignment::Select(user)
-            | TableAssignment::Modify(user) => user.to_openfga(),
+            | TableAssignment::Modify(user)
+            | TableAssignment::ManageTags(user) => user.to_openfga(),
         }
     }
 
@@ -1628,6 +1678,7 @@ impl Assignment for TableAssignment {
             TableAssignment::Describe { .. } => APITableRelation::Describe,
             TableAssignment::Select { .. } => APITableRelation::Select,
             TableAssignment::Modify { .. } => APITableRelation::Modify,
+            TableAssignment::ManageTags { .. } => APITableRelation::ManageTags,
         }
     }
 }
@@ -1646,6 +1697,7 @@ pub(super) enum APITableAction {
     ReadAssignments,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
     GrantDescribe,
     GrantSelect,
     GrantModify,
@@ -1662,6 +1714,7 @@ pub(super) enum OpenFGATableAction {
     ReadAssignments,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
     GrantDescribe,
     GrantSelect,
     GrantModify,
@@ -1679,6 +1732,7 @@ impl ReducedRelation for APITableRelation {
             APITableRelation::Describe => TableRelation::Describe,
             APITableRelation::Select => TableRelation::Select,
             APITableRelation::Modify => TableRelation::Modify,
+            APITableRelation::ManageTags => TableRelation::ManageTags,
         }
     }
 }
@@ -1697,6 +1751,7 @@ impl ReducedRelation for APITableAction {
             APITableAction::ReadAssignments => TableRelation::CanReadAssignments,
             APITableAction::GrantPassGrants => TableRelation::CanGrantPassGrants,
             APITableAction::GrantManageGrants => TableRelation::CanGrantManageGrants,
+            APITableAction::GrantManageTags => TableRelation::CanGrantManageTags,
             APITableAction::GrantDescribe => TableRelation::CanGrantDescribe,
             APITableAction::GrantSelect => TableRelation::CanGrantSelect,
             APITableAction::GrantModify => TableRelation::CanGrantModify,
@@ -1737,6 +1792,7 @@ impl ReducedRelation for OpenFGATableAction {
             OpenFGATableAction::ReadAssignments => TableRelation::CanReadAssignments,
             OpenFGATableAction::GrantPassGrants => TableRelation::CanGrantPassGrants,
             OpenFGATableAction::GrantManageGrants => TableRelation::CanGrantManageGrants,
+            OpenFGATableAction::GrantManageTags => TableRelation::CanGrantManageTags,
             OpenFGATableAction::GrantDescribe => TableRelation::CanGrantDescribe,
             OpenFGATableAction::GrantSelect => TableRelation::CanGrantSelect,
             OpenFGATableAction::GrantModify => TableRelation::CanGrantModify,
@@ -1815,6 +1871,7 @@ pub(super) enum APIViewRelation {
     Describe,
     Select,
     Modify,
+    ManageTags,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -1833,6 +1890,8 @@ pub(super) enum ViewAssignment {
     Select(UserOrRole),
     #[cfg_attr(feature = "open-api", schema(title = "ViewAssignmentModify"))]
     Modify(UserOrRole),
+    #[cfg_attr(feature = "open-api", schema(title = "ViewAssignmentManageTags"))]
+    ManageTags(UserOrRole),
 }
 
 impl GrantableRelation for APIViewRelation {
@@ -1844,6 +1903,7 @@ impl GrantableRelation for APIViewRelation {
             APIViewRelation::Describe => ViewRelation::CanGrantDescribe,
             APIViewRelation::Select => ViewRelation::CanGrantSelect,
             APIViewRelation::Modify => ViewRelation::CanGrantModify,
+            APIViewRelation::ManageTags => ViewRelation::CanGrantManageTags,
         }
     }
 }
@@ -1874,6 +1934,9 @@ impl Assignment for ViewAssignment {
             APIViewRelation::Modify => {
                 UserOrRole::parse_from_openfga(user).map(ViewAssignment::Modify)
             }
+            APIViewRelation::ManageTags => {
+                UserOrRole::parse_from_openfga(user).map(ViewAssignment::ManageTags)
+            }
         }
     }
 
@@ -1884,7 +1947,8 @@ impl Assignment for ViewAssignment {
             | ViewAssignment::ManageGrants(user)
             | ViewAssignment::Describe(user)
             | ViewAssignment::Select(user)
-            | ViewAssignment::Modify(user) => user.to_openfga(),
+            | ViewAssignment::Modify(user)
+            | ViewAssignment::ManageTags(user) => user.to_openfga(),
         }
     }
 
@@ -1896,6 +1960,7 @@ impl Assignment for ViewAssignment {
             ViewAssignment::Describe { .. } => APIViewRelation::Describe,
             ViewAssignment::Select { .. } => APIViewRelation::Select,
             ViewAssignment::Modify { .. } => APIViewRelation::Modify,
+            ViewAssignment::ManageTags { .. } => APIViewRelation::ManageTags,
         }
     }
 }
@@ -1913,6 +1978,7 @@ pub(super) enum APIViewAction {
     ReadAssignments,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
     GrantDescribe,
     GrantSelect,
     GrantModify,
@@ -1929,6 +1995,7 @@ pub(super) enum OpenFGAViewAction {
     ReadAssignments,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
     GrantDescribe,
     GrantSelect,
     GrantModify,
@@ -1946,6 +2013,7 @@ impl ReducedRelation for APIViewRelation {
             APIViewRelation::Describe => ViewRelation::Describe,
             APIViewRelation::Select => ViewRelation::Select,
             APIViewRelation::Modify => ViewRelation::Modify,
+            APIViewRelation::ManageTags => ViewRelation::ManageTags,
         }
     }
 }
@@ -1963,6 +2031,7 @@ impl ReducedRelation for APIViewAction {
             APIViewAction::ReadAssignments => ViewRelation::CanReadAssignments,
             APIViewAction::GrantPassGrants => ViewRelation::CanGrantPassGrants,
             APIViewAction::GrantManageGrants => ViewRelation::CanGrantManageGrants,
+            APIViewAction::GrantManageTags => ViewRelation::CanGrantManageTags,
             APIViewAction::GrantDescribe => ViewRelation::CanGrantDescribe,
             APIViewAction::GrantSelect => ViewRelation::CanGrantSelect,
             APIViewAction::GrantModify => ViewRelation::CanGrantModify,
@@ -2002,6 +2071,7 @@ impl ReducedRelation for OpenFGAViewAction {
             OpenFGAViewAction::ReadAssignments => ViewRelation::CanReadAssignments,
             OpenFGAViewAction::GrantPassGrants => ViewRelation::CanGrantPassGrants,
             OpenFGAViewAction::GrantManageGrants => ViewRelation::CanGrantManageGrants,
+            OpenFGAViewAction::GrantManageTags => ViewRelation::CanGrantManageTags,
             OpenFGAViewAction::GrantDescribe => ViewRelation::CanGrantDescribe,
             OpenFGAViewAction::GrantSelect => ViewRelation::CanGrantSelect,
             OpenFGAViewAction::GrantModify => ViewRelation::CanGrantModify,
@@ -2105,6 +2175,7 @@ pub(super) enum APIGenericTableRelation {
     Describe,
     Select,
     Modify,
+    ManageTags,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -2132,6 +2203,11 @@ pub(super) enum GenericTableAssignment {
     Select(UserOrRole),
     #[cfg_attr(feature = "open-api", schema(title = "GenericTableAssignmentModify"))]
     Modify(UserOrRole),
+    #[cfg_attr(
+        feature = "open-api",
+        schema(title = "GenericTableAssignmentManageTags")
+    )]
+    ManageTags(UserOrRole),
 }
 
 impl GrantableRelation for APIGenericTableRelation {
@@ -2143,6 +2219,7 @@ impl GrantableRelation for APIGenericTableRelation {
             APIGenericTableRelation::Describe => GenericTableRelation::CanGrantDescribe,
             APIGenericTableRelation::Select => GenericTableRelation::CanGrantSelect,
             APIGenericTableRelation::Modify => GenericTableRelation::CanGrantModify,
+            APIGenericTableRelation::ManageTags => GenericTableRelation::CanGrantManageTags,
         }
     }
 }
@@ -2173,6 +2250,9 @@ impl Assignment for GenericTableAssignment {
             APIGenericTableRelation::Modify => {
                 UserOrRole::parse_from_openfga(user).map(GenericTableAssignment::Modify)
             }
+            APIGenericTableRelation::ManageTags => {
+                UserOrRole::parse_from_openfga(user).map(GenericTableAssignment::ManageTags)
+            }
         }
     }
 
@@ -2183,7 +2263,8 @@ impl Assignment for GenericTableAssignment {
             | GenericTableAssignment::ManageGrants(user)
             | GenericTableAssignment::Describe(user)
             | GenericTableAssignment::Select(user)
-            | GenericTableAssignment::Modify(user) => user.to_openfga(),
+            | GenericTableAssignment::Modify(user)
+            | GenericTableAssignment::ManageTags(user) => user.to_openfga(),
         }
     }
 
@@ -2195,6 +2276,7 @@ impl Assignment for GenericTableAssignment {
             GenericTableAssignment::Describe(_) => APIGenericTableRelation::Describe,
             GenericTableAssignment::Select(_) => APIGenericTableRelation::Select,
             GenericTableAssignment::Modify(_) => APIGenericTableRelation::Modify,
+            GenericTableAssignment::ManageTags(_) => APIGenericTableRelation::ManageTags,
         }
     }
 }
@@ -2206,6 +2288,7 @@ pub(super) enum OpenFGAGenericTableAction {
     ReadAssignments,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
     GrantDescribe,
     GrantSelect,
     GrantModify,
@@ -2223,6 +2306,7 @@ impl ReducedRelation for APIGenericTableRelation {
             APIGenericTableRelation::Describe => GenericTableRelation::Describe,
             APIGenericTableRelation::Select => GenericTableRelation::Select,
             APIGenericTableRelation::Modify => GenericTableRelation::Modify,
+            APIGenericTableRelation::ManageTags => GenericTableRelation::ManageTags,
         }
     }
 }
@@ -2237,6 +2321,7 @@ impl ReducedRelation for OpenFGAGenericTableAction {
             OpenFGAGenericTableAction::GrantManageGrants => {
                 GenericTableRelation::CanGrantManageGrants
             }
+            OpenFGAGenericTableAction::GrantManageTags => GenericTableRelation::CanGrantManageTags,
             OpenFGAGenericTableAction::GrantDescribe => GenericTableRelation::CanGrantDescribe,
             OpenFGAGenericTableAction::GrantSelect => GenericTableRelation::CanGrantSelect,
             OpenFGAGenericTableAction::GrantModify => GenericTableRelation::CanGrantModify,
@@ -2265,6 +2350,7 @@ pub(super) enum APIGenericTableAction {
     ReadAssignments,
     GrantPassGrants,
     GrantManageGrants,
+    GrantManageTags,
     GrantDescribe,
     GrantSelect,
     GrantModify,
@@ -2289,6 +2375,7 @@ impl ReducedRelation for APIGenericTableAction {
             APIGenericTableAction::ReadAssignments => GenericTableRelation::CanReadAssignments,
             APIGenericTableAction::GrantPassGrants => GenericTableRelation::CanGrantPassGrants,
             APIGenericTableAction::GrantManageGrants => GenericTableRelation::CanGrantManageGrants,
+            APIGenericTableAction::GrantManageTags => GenericTableRelation::CanGrantManageTags,
             APIGenericTableAction::GrantDescribe => GenericTableRelation::CanGrantDescribe,
             APIGenericTableAction::GrantSelect => GenericTableRelation::CanGrantSelect,
             APIGenericTableAction::GrantModify => GenericTableRelation::CanGrantModify,
@@ -2326,6 +2413,94 @@ pub(crate) mod test {
         assert_eq!(
             expected,
             serde_json::from_str::<serde_json::Value>(&serialized).unwrap()
+        );
+    }
+
+    // `manage_tags` must map to its OWN grant/stored relations at every object
+    // level — never to `manage_grants`'. The compiler cannot catch such a
+    // copy-paste (both sides are the same relation enum), so pin it here.
+    #[test]
+    fn manage_tags_maps_to_its_own_grant_and_stored_relations() {
+        assert_eq!(
+            APIWarehouseRelation::ManageTags.grant_relation(),
+            WarehouseRelation::CanGrantManageTags
+        );
+        assert_eq!(
+            APIWarehouseRelation::ManageTags.to_openfga(),
+            WarehouseRelation::ManageTags
+        );
+        assert_eq!(
+            APINamespaceRelation::ManageTags.grant_relation(),
+            NamespaceRelation::CanGrantManageTags
+        );
+        assert_eq!(
+            APINamespaceRelation::ManageTags.to_openfga(),
+            NamespaceRelation::ManageTags
+        );
+        assert_eq!(
+            APITableRelation::ManageTags.grant_relation(),
+            TableRelation::CanGrantManageTags
+        );
+        assert_eq!(
+            APITableRelation::ManageTags.to_openfga(),
+            TableRelation::ManageTags
+        );
+        assert_eq!(
+            APIViewRelation::ManageTags.grant_relation(),
+            ViewRelation::CanGrantManageTags
+        );
+        assert_eq!(
+            APIViewRelation::ManageTags.to_openfga(),
+            ViewRelation::ManageTags
+        );
+        assert_eq!(
+            APIGenericTableRelation::ManageTags.grant_relation(),
+            GenericTableRelation::CanGrantManageTags
+        );
+        assert_eq!(
+            APIGenericTableRelation::ManageTags.to_openfga(),
+            GenericTableRelation::ManageTags
+        );
+    }
+
+    #[test]
+    fn tag_creator_maps_to_its_own_grant_and_stored_relations() {
+        assert_eq!(
+            APIProjectRelation::TagCreator.grant_relation(),
+            ProjectRelation::CanGrantTagCreator
+        );
+        assert_eq!(
+            APIProjectRelation::TagCreator.to_openfga(),
+            ProjectRelation::TagCreator
+        );
+    }
+
+    #[test]
+    fn manage_tags_and_tag_creator_assignments_round_trip_to_their_relations() {
+        let u = || UserOrRole::User(UserId::new_unchecked("oidc", "u"));
+        assert_eq!(
+            WarehouseAssignment::ManageTags(u()).relation(),
+            APIWarehouseRelation::ManageTags
+        );
+        assert_eq!(
+            NamespaceAssignment::ManageTags(u()).relation(),
+            APINamespaceRelation::ManageTags
+        );
+        assert_eq!(
+            TableAssignment::ManageTags(u()).relation(),
+            APITableRelation::ManageTags
+        );
+        assert_eq!(
+            ViewAssignment::ManageTags(u()).relation(),
+            APIViewRelation::ManageTags
+        );
+        assert_eq!(
+            GenericTableAssignment::ManageTags(u()).relation(),
+            APIGenericTableRelation::ManageTags
+        );
+        assert_eq!(
+            ProjectAssignment::TagCreator(u()).relation(),
+            APIProjectRelation::TagCreator
         );
     }
 }

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -6874,6 +6874,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -6946,6 +6947,17 @@ components:
                   enum:
                     - modify
           title: GenericTableAssignmentModify
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - manage_tags
+          title: GenericTableAssignmentManageTags
     GenericTableRelation:
       type: string
       enum:
@@ -6955,6 +6967,7 @@ components:
         - describe
         - select
         - modify
+        - manage_tags
     GetEndpointStatisticsRequest:
       type: object
       required:
@@ -9538,6 +9551,7 @@ components:
         - grant_select
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - set_protection
     NamespaceAssignment:
       oneOf:
@@ -9618,6 +9632,17 @@ components:
                   enum:
                     - modify
           title: NamespaceAssignmentModify
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - manage_tags
+          title: NamespaceAssignmentManageTags
     NamespaceIdentOrUuid:
       oneOf:
         - type: object
@@ -9654,6 +9679,7 @@ components:
         - select
         - create
         - modify
+        - manage_tags
     OneLakeProfile:
       type: object
       description: |-
@@ -9717,6 +9743,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -9731,11 +9758,13 @@ components:
         - grant_select
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
     OpenFGAProjectAction:
       type: string
       enum:
         - read_assignments
         - grant_role_creator
+        - grant_tag_creator
         - grant_create
         - grant_describe
         - grant_modify
@@ -9761,6 +9790,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -9771,6 +9801,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -9785,6 +9816,7 @@ components:
         - grant_select
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - change_ownership
     ProjectAction:
       type: string
@@ -9798,6 +9830,7 @@ components:
         - search_roles
         - read_assignments
         - grant_role_creator
+        - grant_tag_creator
         - grant_create
         - grant_describe
         - grant_modify
@@ -9861,6 +9894,17 @@ components:
                 type:
                   type: string
                   enum:
+                    - tag_creator
+          title: ProjectAssignmentTagCreator
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
                     - describe
           title: ProjectAssignmentDescribe
         - allOf:
@@ -9903,6 +9947,7 @@ components:
         - security_admin
         - data_admin
         - role_creator
+        - tag_creator
         - describe
         - select
         - create
@@ -11171,6 +11216,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -11246,6 +11292,17 @@ components:
                   enum:
                     - modify
           title: TableAssignmentModify
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - manage_tags
+          title: TableAssignmentManageTags
     TableRelation:
       type: string
       enum:
@@ -11255,6 +11312,7 @@ components:
         - describe
         - select
         - modify
+        - manage_tags
     TableUpdateKind:
       type: string
       description: |-
@@ -12285,6 +12343,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -12360,6 +12419,17 @@ components:
                   enum:
                     - modify
           title: ViewAssignmentModify
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - manage_tags
+          title: ViewAssignmentManageTags
     ViewRelation:
       type: string
       enum:
@@ -12369,6 +12439,7 @@ components:
         - describe
         - select
         - modify
+        - manage_tags
     WarehouseAction:
       type: string
       enum:
@@ -12391,6 +12462,7 @@ components:
         - grant_select
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - change_ownership
         - get_all_tasks
         - control_all_tasks
@@ -12476,6 +12548,17 @@ components:
                   enum:
                     - modify
           title: WarehouseAssignmentModify
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - manage_tags
+          title: WarehouseAssignmentManageTags
     WarehouseFilter:
       oneOf:
         - type: object
@@ -12519,6 +12602,7 @@ components:
         - select
         - create
         - modify
+        - manage_tags
     WarehouseStatistics:
       type: object
       required:


### PR DESCRIPTION
The v4.8 model defined `manage_tags` (warehouse, namespace, table, view, generic table) and `tag_creator` (project) as directly-assignable relations, but no API could write those tuples: the API-facing relation/assignment enums omitted them, and the grant vocabulary derives from the same enums. The only way to hold `manage_tags` was to be a project security-admin (via rule) — so a data steward who classifies objects could not be granted that right without full security-admin, defeating the separation-of-duties the relations exist for.

Wire both into the API surface as peers of `manage_grants`/`role_creator`:
- add the variant to each `API*Relation` and `*Assignment` (with schema title), plus the `Assignment` (try_from_user / openfga_user / relation), `GrantableRelation` (→ `can_grant_manage_tags` / `can_grant_tag_creator`), and `ReducedRelation` arms;
- add the `grant_*` peer to each `API*Action` / `OpenFGA*Action` and their maps, so the check and authorizer-action endpoints expose them too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-level `Tag Creator` permissions.
  * Added `Manage Tags` permissions for warehouses, namespaces, tables, views, and generic tables.
  * Updated permission assignments, actions, and relation mappings to support tag management.
* **Documentation**
  * Updated the API reference to include the new tag-related permissions and assignment options.
* **Tests**
  * Added coverage verifying tag creator assignments, relation counts, and permission mapping round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->