### PR TITLE
fix(catalog): key table ETags on the full response shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3349,7 +3349,6 @@ dependencies = [
  "utoipa",
  "uuid",
  "valuable",
- "xxhash-rust",
 ]
 
 [[package]]

--- a/crates/iceberg-ext/Cargo.toml
+++ b/crates/iceberg-ext/Cargo.toml
@@ -34,7 +34,6 @@ url = { workspace = true }
 utoipa = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }
 valuable = { workspace = true }
-xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/iceberg-ext/src/catalog/mod.rs
+++ b/crates/iceberg-ext/src/catalog/mod.rs
@@ -31,7 +31,7 @@ pub mod rest {
     pub use table::{
         CommitTableRequest, CommitTableResponse, CommitTransactionRequest, CreateTableRequest,
         ETag, ListTablesResponse, LoadCredentialsResponse, LoadTableResult, RegisterTableRequest,
-        RenameTableRequest, StorageCredential, TableETag, create_etag,
+        RenameTableRequest, StorageCredential,
     };
 
     mod view;

--- a/crates/iceberg-ext/src/catalog/rest/table.rs
+++ b/crates/iceberg-ext/src/catalog/rest/table.rs
@@ -7,7 +7,6 @@ use axum::{
 };
 use iceberg::spec::TableMetadataRef;
 use typed_builder::TypedBuilder;
-use xxhash_rust::xxh3::xxh3_64;
 
 #[cfg(feature = "axum")]
 use super::impl_into_response;
@@ -38,13 +37,15 @@ pub struct LoadTableResult {
     pub config: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_credentials: Option<Vec<StorageCredential>>,
-    /// Absolute time (epoch ms) until which a conditional request may be answered
-    /// with `304`, or `None` if the response vends no expiring credentials.
-    /// Computed from the credentials' actual expiry; not serialized — it is the
-    /// revalidation point embedded in the [`ETag`] (via [`Self::etag`]), so a 304
-    /// is never served once the client's credentials leave the serve window.
+    /// Validator for this exact body, emitted as the `ETag` header.
+    ///
+    /// Not serialized, and deliberately not derivable from this struct: the tag
+    /// must cover request inputs that never appear in the body, and the
+    /// conditional-request path has to compute it before a body exists. The
+    /// caller mints it; `None` means no validator, so a conditional request
+    /// reloads rather than risking a wrong `304`.
     #[serde(skip)]
-    pub credentials_revalidate_after_ms: Option<i64>,
+    pub etag: Option<ETag>,
 }
 
 impl LoadTableResult {
@@ -55,8 +56,7 @@ impl LoadTableResult {
 
     #[must_use]
     pub fn etag(&self) -> Option<ETag> {
-        let metadata_location = self.metadata_location.as_ref()?;
-        Some(TableETag::new(metadata_location, self.credentials_revalidate_after_ms).into_etag())
+        self.etag.clone()
     }
 }
 
@@ -119,12 +119,16 @@ pub struct CommitTableResponse {
     pub metadata_location: String,
     pub metadata: TableMetadataRef,
     pub config: Option<std::collections::HashMap<String, String>>,
+    /// Validator for this body, emitted as the `ETag` header. See
+    /// [`LoadTableResult::etag`] for why it is minted by the caller.
+    #[serde(skip)]
+    pub etag: Option<ETag>,
 }
 
 impl CommitTableResponse {
     #[must_use]
-    pub fn etag(&self) -> ETag {
-        create_etag(&self.metadata_location)
+    pub fn etag(&self) -> Option<ETag> {
+        self.etag.clone()
     }
 }
 
@@ -156,93 +160,13 @@ impl From<String> for ETag {
     }
 }
 
-/// Version prefix for structured `loadTable` [`ETag`]s. Anything not parsing
-/// under this prefix (pre-upgrade or future-version values) isn't matched, so
-/// the client reloads. Bump the suffix on incompatible encoding changes.
-const ETAG_PREFIX: &str = "lk1";
-
-/// Structured contents of a `loadTable` [`ETag`].
-///
-/// Wire form (inside the quotes): `lk1.<metadata_hash>`, or
-/// `lk1.<metadata_hash>.<revalidate_after_hex>` when credentials are vended
-/// (revalidate-after as epoch-ms in hex). `metadata_hash` is the xxh3-64 hex of
-/// the metadata location. Embedding the revalidation point lets the server
-/// decide, from the client-echoed [`ETag`] alone, whether the held credentials
-/// are still within their serve window — i.e. fresh enough for a 304.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TableETag {
-    metadata_hash: String,
-    revalidate_after_ms: Option<i64>,
-}
-
-impl TableETag {
-    #[must_use]
-    pub fn new(metadata_location: &str, revalidate_after_ms: Option<i64>) -> Self {
-        let hash = xxh3_64(metadata_location.as_bytes());
-        Self {
-            metadata_hash: format!("{hash:x}"),
-            // A non-positive value carries no information; drop it.
-            revalidate_after_ms: revalidate_after_ms.filter(|ms| *ms > 0),
-        }
-    }
-
-    #[must_use]
-    pub fn metadata_hash(&self) -> &str {
-        &self.metadata_hash
-    }
-
-    #[must_use]
-    pub fn revalidate_after_ms(&self) -> Option<i64> {
-        self.revalidate_after_ms
-    }
-
-    /// Parse a client-supplied [`ETag`] value (quotes already stripped). Returns
-    /// `None` for unrecognized values so callers can reload.
-    #[must_use]
-    pub fn parse(value: &str) -> Option<Self> {
-        let mut parts = value.split('.');
-        if parts.next()? != ETAG_PREFIX {
-            return None;
-        }
-        let metadata_hash = parts.next().filter(|s| !s.is_empty())?.to_string();
-        let revalidate_after_ms = parts
-            .next()
-            .map(|s| i64::from_str_radix(s, 16))
-            .transpose()
-            .ok()?;
-        // Reject trailing junk so an unexpected shape falls back to a reload.
-        if parts.next().is_some() {
-            return None;
-        }
-        Some(Self {
-            metadata_hash,
-            revalidate_after_ms,
-        })
-    }
-
-    /// Render the wire [`ETag`] value, quoted per HTTP `ETag` syntax.
-    #[must_use]
-    pub fn into_etag(self) -> ETag {
-        let inner = match self.revalidate_after_ms {
-            Some(ms) => format!("{ETAG_PREFIX}.{}.{ms:x}", self.metadata_hash),
-            None => format!("{ETAG_PREFIX}.{}", self.metadata_hash),
-        };
-        format!("\"{inner}\"").into()
-    }
-}
-
-#[must_use]
-pub fn create_etag(text: &str) -> ETag {
-    TableETag::new(text, None).into_etag()
-}
-
 #[cfg(feature = "axum")]
 impl IntoResponse for LoadTableResult {
     fn into_response(self) -> axum::http::Response<axum::body::Body> {
         let mut headers = HeaderMap::new();
         let body = axum::Json(&self);
 
-        let Some(ref etag) = self.etag() else {
+        let Some(ref etag) = self.etag else {
             return (headers, body).into_response();
         };
 
@@ -271,7 +195,10 @@ impl IntoResponse for CommitTableResponse {
         let mut headers = HeaderMap::new();
         let body = axum::Json(&self);
 
-        let etag = self.etag();
+        let Some(ref etag) = self.etag else {
+            return (headers, body).into_response();
+        };
+
         match etag.as_str().parse::<HeaderValue>() {
             Ok(header_value) => {
                 headers.insert(header::ETAG, header_value);
@@ -305,51 +232,6 @@ mod tests {
 
     #[test]
     #[cfg(feature = "axum")]
-    fn test_create_etag() {
-        let ETag(etag) = create_etag("Hello World");
-        assert_eq!(etag, "\"lk1.e34615aade2e6333\"");
-    }
-
-    #[test]
-    fn test_table_etag_round_trip_metadata_only() {
-        let etag = TableETag::new("s3://bucket/table/metadata.json", None);
-        let ETag(wire) = etag.clone().into_etag();
-        let parsed = TableETag::parse(wire.trim_matches('"')).unwrap();
-        assert_eq!(parsed, etag);
-        assert_eq!(parsed.revalidate_after_ms(), None);
-    }
-
-    #[test]
-    fn test_table_etag_round_trip_with_expiry() {
-        let etag = TableETag::new("s3://bucket/table/metadata.json", Some(1_750_000_000_123));
-        let ETag(wire) = etag.clone().into_etag();
-        let parsed = TableETag::parse(wire.trim_matches('"')).unwrap();
-        assert_eq!(parsed, etag);
-        assert_eq!(parsed.revalidate_after_ms(), Some(1_750_000_000_123));
-    }
-
-    #[test]
-    fn test_table_etag_metadata_hash_matches_legacy() {
-        // The metadata component must stay byte-identical to the legacy hash so
-        // a pre-upgrade client's echoed ETag still matches after upgrade.
-        let location = "s3://bucket/table/metadata.json";
-        let legacy_hash = format!("{:x}", xxh3_64(location.as_bytes()));
-        assert_eq!(TableETag::new(location, None).metadata_hash(), legacy_hash);
-    }
-
-    #[test]
-    fn test_table_etag_parse_rejects_legacy_and_junk() {
-        // Legacy bare hash → not the structured format.
-        assert!(TableETag::parse("e34615aade2e6333").is_none());
-        // Wrong prefix, empty hash, trailing junk, non-hex expiry.
-        assert!(TableETag::parse("lk2.abc").is_none());
-        assert!(TableETag::parse("lk1.").is_none());
-        assert!(TableETag::parse("lk1.abc.def.ghi").is_none());
-        assert!(TableETag::parse("lk1.abc.zzz").is_none());
-    }
-
-    #[test]
-    #[cfg(feature = "axum")]
     fn test_load_table_result_into_response_adds_etag_for_existing_tables() {
         let table_metadata = create_table_metadata_mock();
 
@@ -358,35 +240,33 @@ mod tests {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
-            credentials_revalidate_after_ms: None,
+            etag: Some(ETag::from("W/\"lk1.deadbeef\"")),
         };
 
         let response = load_table_result.into_response();
         let headers = response.headers();
 
-        let ETag(etag_expected) = create_etag("s3://bucket/table/metadata.json");
-        assert_eq!(headers.get(header::ETAG).unwrap(), &etag_expected);
+        assert_eq!(headers.get(header::ETAG).unwrap(), "W/\"lk1.deadbeef\"");
     }
 
     #[test]
     #[cfg(feature = "axum")]
-    fn test_load_table_result_etag_embeds_revalidate_after() {
-        let table_metadata = create_table_metadata_mock();
+    fn test_load_table_result_emits_the_caller_supplied_etag_verbatim() {
+        // The tag is minted by the caller, which is the only place that knows the
+        // request inputs it has to cover. This type must not reinterpret it.
         let load_table_result = LoadTableResult {
             metadata_location: Some("s3://bucket/table/metadata.json".to_string()),
-            metadata: table_metadata,
+            metadata: create_table_metadata_mock(),
             config: None,
             storage_credentials: None,
-            credentials_revalidate_after_ms: Some(1_750_000_000_123),
+            etag: Some(ETag::from("W/\"lk1.abc.199e1e0f9c3\"")),
         };
 
-        let ETag(etag) = load_table_result.etag().unwrap();
-        let expected =
-            TableETag::new("s3://bucket/table/metadata.json", Some(1_750_000_000_123)).into_etag();
-        assert_eq!(ETag(etag), expected);
-        // The revalidation point must round-trip out of the wire ETag.
-        let parsed = TableETag::parse(expected.as_str().trim_matches('"')).unwrap();
-        assert_eq!(parsed.revalidate_after_ms(), Some(1_750_000_000_123));
+        let response = load_table_result.into_response();
+        assert_eq!(
+            response.headers().get(header::ETAG).unwrap(),
+            "W/\"lk1.abc.199e1e0f9c3\""
+        );
     }
 
     #[test]
@@ -399,7 +279,8 @@ mod tests {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
-            credentials_revalidate_after_ms: None,
+            // Staged tables have no metadata location, so the caller mints no tag.
+            etag: None,
         };
 
         let response = load_table_result.into_response();
@@ -418,7 +299,7 @@ mod tests {
             metadata: table_metadata.clone(),
             config: None,
             storage_credentials: None,
-            credentials_revalidate_after_ms: None,
+            etag: Some(ETag::from("W/\"lk1.deadbeef\"")),
         };
 
         let response = load_table_result.clone().into_response();
@@ -428,7 +309,14 @@ mod tests {
         let deserialized: LoadTableResult =
             serde_json::from_slice(&body_bytes).expect("Failed to deserialize body");
 
-        assert_eq!(deserialized, load_table_result);
+        // `etag` is `#[serde(skip)]` — it travels in the header, not the body — so
+        // it cannot survive a round trip and must be excluded from the comparison.
+        assert_eq!(deserialized.etag, None);
+        let expected = LoadTableResult {
+            etag: None,
+            ..load_table_result
+        };
+        assert_eq!(deserialized, expected);
     }
 
     fn create_table_metadata_mock() -> Arc<TableMetadata> {

--- a/crates/lakekeeper-integration-tests/tests/server_load_table.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_load_table.rs
@@ -10,7 +10,14 @@ use iceberg::{
         SnapshotRetention, Summary, Type, UnboundPartitionSpec,
     },
 };
-use iceberg_ext::catalog::rest::{CreateTableRequest, LoadTableResult, create_etag};
+use iceberg_ext::catalog::rest::{CreateTableRequest, ETag, LoadTableResult};
+
+/// The shape a client echoes back in `If-None-Match`: what the HTTP layer's
+/// `parse_etags` yields from the wire value — weak marker and quotes stripped.
+/// These tests drive the handler directly, so they have to do it themselves.
+fn as_client_etag(etag: &ETag) -> ETag {
+    ETag::from(etag.as_str().trim_start_matches("W/").trim_matches('"'))
+}
 use lakekeeper::{
     api::{
         ApiContext,
@@ -18,8 +25,8 @@ use lakekeeper::{
             NamespaceParameters, TableParameters,
             namespace::NamespaceService as _,
             tables::{
-                DataAccess, LoadTableFilters, LoadTableRequest, LoadTableResultOrNotModified,
-                SnapshotsQuery, TablesService as _,
+                DataAccess, DataAccessMode, LoadTableFilters, LoadTableRequest,
+                LoadTableResultOrNotModified, SnapshotsQuery, TablesService as _,
             },
         },
         management::v1::warehouse::TabularDeleteProfile,
@@ -680,8 +687,10 @@ async fn test_load_table_returns_not_modified_with_single_matching_etag(pool: Pg
 
     let request_metadata = random_request_metadata();
 
-    let etag = create_etag(&table.metadata_location.unwrap());
-    let etags = vec![etag.as_str().trim_matches('"').into()];
+    // Taken from the response `create_table` produced, so these also pin that
+    // handler's ETag shape against what a default load matches.
+    let etag = table.etag().expect("created table should carry an ETag");
+    let etags = vec![as_client_etag(&etag)];
     let load_table_result = Box::pin(load_table(
         parameters,
         LoadTableRequest::builder().etags(etags).build(),
@@ -711,10 +720,12 @@ async fn test_load_table_returns_not_modified_when_given_multiple_etags_and_one_
 
     let request_metadata = random_request_metadata();
 
-    let etag = create_etag(&table.metadata_location.unwrap());
+    // Taken from the response `create_table` produced, so these also pin that
+    // handler's ETag shape against what a default load matches.
+    let etag = table.etag().expect("created table should carry an ETag");
     let etags = vec![
         "a4b2f6c1dd87".into(),
-        etag.as_str().trim_matches('"').into(),
+        as_client_etag(&etag),
         "b6f8c2d4a45f".into(),
     ];
     let load_table_result = Box::pin(load_table(
@@ -744,7 +755,9 @@ async fn test_load_table_returns_not_modified_when_given_wildcard(pool: PgPool) 
 
     let request_metadata = random_request_metadata();
 
-    let etag = create_etag(&table.metadata_location.unwrap());
+    // Taken from the response `create_table` produced, so these also pin that
+    // handler's ETag shape against what a default load matches.
+    let etag = table.etag().expect("created table should carry an ETag");
     let etags = vec!["*".into()];
     let load_table_result = Box::pin(load_table(
         parameters,
@@ -759,5 +772,171 @@ async fn test_load_table_returns_not_modified_when_given_wildcard(pool: PgPool) 
     assert_eq!(
         result,
         LoadTableResultOrNotModified::NotModifiedResponse(etag)
+    );
+}
+
+/// A conditional load must not be answered across snapshot filters.
+///
+/// Drives the `load_table` handler (not the HTTP layer): load with
+/// `snapshots=refs`, which drops the unreferenced snapshot 1, keep the returned
+/// ETag, then revalidate asking for `snapshots=all`. That must return a full
+/// body, not a 304 — otherwise the client keeps using the truncated snapshot
+/// list as if it were complete.
+#[sqlx::test]
+async fn test_load_table_does_not_return_not_modified_across_snapshot_filters(pool: PgPool) {
+    let (api_context, namespace_parameters, table_identifier, _) =
+        setup_table_with_snapshots(pool).await;
+    let parameters = TableParameters {
+        prefix: namespace_parameters.prefix.clone(),
+        table: table_identifier.clone(),
+    };
+
+    // Load with `refs` and keep the ETag the server handed out.
+    let refs_result = Box::pin(load_table(
+        parameters.clone(),
+        LoadTableRequest::builder()
+            .filters(LoadTableFilters {
+                snapshots: SnapshotsQuery::Refs,
+            })
+            .build(),
+        api_context.clone(),
+        random_request_metadata(),
+    ))
+    .await
+    .expect("refs load failed");
+
+    let LoadTableResultOrNotModified::LoadTableResult(refs_body) = refs_result else {
+        panic!("expected a full response for the priming load");
+    };
+    // Precondition: `refs` really did truncate the snapshot list.
+    let refs_snapshots: Vec<i64> = refs_body
+        .metadata
+        .snapshots()
+        .map(|s| s.snapshot_id())
+        .collect();
+    assert!(
+        !refs_snapshots.contains(&1),
+        "precondition failed: `refs` should have dropped the unreferenced snapshot"
+    );
+    let refs_etag = refs_body
+        .etag()
+        .expect("refs response should carry an ETag");
+
+    // Revalidate for `all` with the `refs` ETag -> must NOT be a 304.
+    let all_result = Box::pin(load_table(
+        parameters.clone(),
+        LoadTableRequest::builder()
+            .filters(LoadTableFilters {
+                snapshots: SnapshotsQuery::All,
+            })
+            .etags(vec![as_client_etag(&refs_etag)])
+            .build(),
+        api_context.clone(),
+        random_request_metadata(),
+    ))
+    .await
+    .expect("all load failed");
+
+    let LoadTableResultOrNotModified::LoadTableResult(all_body) = all_result else {
+        panic!(
+            "served 304 for `snapshots=all` from a `snapshots=refs` ETag: \
+             the client would reuse a truncated snapshot list"
+        );
+    };
+    let all_snapshots: Vec<i64> = all_body
+        .metadata
+        .snapshots()
+        .map(|s| s.snapshot_id())
+        .collect();
+    assert!(
+        all_snapshots.contains(&1),
+        "the `all` response must carry the unreferenced snapshot"
+    );
+
+    // The same ETag must still 304 against its own representation, so the fix
+    // narrows conditional requests rather than disabling them.
+    let refs_again = Box::pin(load_table(
+        parameters,
+        LoadTableRequest::builder()
+            .filters(LoadTableFilters {
+                snapshots: SnapshotsQuery::Refs,
+            })
+            .etags(vec![as_client_etag(&refs_etag)])
+            .build(),
+        api_context,
+        random_request_metadata(),
+    ))
+    .await
+    .expect("refs revalidation failed");
+    assert_eq!(
+        refs_again,
+        LoadTableResultOrNotModified::NotModifiedResponse(refs_etag),
+        "a `refs` ETag must still 304 a `refs` request"
+    );
+}
+
+/// A conditional load must not be answered across access-delegation modes.
+///
+/// Drives the `load_table` handler on the in-memory profile, which vends no
+/// expiring credentials — so the `vends_credentials` gate never fires and the
+/// response shape is the only thing preventing the 304.
+#[sqlx::test]
+async fn test_load_table_does_not_return_not_modified_across_delegation_modes(pool: PgPool) {
+    let (api_context, namespace_parameters, table_identifier, _) = setup_simple_table(pool).await;
+    let parameters = TableParameters {
+        prefix: namespace_parameters.prefix.clone(),
+        table: table_identifier.clone(),
+    };
+    let vended: DataAccessMode = DataAccess {
+        vended_credentials: true,
+        remote_signing: false,
+    }
+    .into();
+    let signing: DataAccessMode = DataAccess {
+        vended_credentials: false,
+        remote_signing: true,
+    }
+    .into();
+
+    let load = |data_access: DataAccessMode, etags: Vec<ETag>| {
+        let parameters = parameters.clone();
+        let api_context = api_context.clone();
+        async move {
+            Box::pin(load_table(
+                parameters,
+                LoadTableRequest::builder()
+                    .data_access(data_access)
+                    .etags(etags)
+                    .build(),
+                api_context,
+                random_request_metadata(),
+            ))
+            .await
+            .expect("load failed")
+        }
+    };
+
+    // Prime a cache entry under vended-credentials.
+    let LoadTableResultOrNotModified::LoadTableResult(body) = load(vended, vec![]).await else {
+        panic!("expected a full response for the priming load");
+    };
+    let etag = body.etag().expect("response should carry an ETag");
+    let echoed = vec![as_client_etag(&etag)];
+
+    // Revalidating under a different delegation must not 304.
+    assert!(
+        matches!(
+            load(signing, echoed.clone()).await,
+            LoadTableResultOrNotModified::LoadTableResult(_)
+        ),
+        "304'd a remote-signing request from a vended-credentials ETag: the client \
+         would reuse storage config it did not request"
+    );
+
+    // The same tag still 304s its own delegation, so conditional requests keep working.
+    assert_eq!(
+        load(vended, echoed).await,
+        LoadTableResultOrNotModified::NotModifiedResponse(etag),
+        "a vended-credentials ETag must still 304 a vended-credentials request"
     );
 }

--- a/crates/lakekeeper/src/api/iceberg/v1/tables.rs
+++ b/crates/lakekeeper/src/api/iceberg/v1/tables.rs
@@ -68,7 +68,7 @@ pub struct ListTablesQuery {
     pub return_protection_status: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum SnapshotsQuery {
     /// Load all snapshots
@@ -1175,7 +1175,7 @@ mod test {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
-            credentials_revalidate_after_ms: None,
+            etag: Some(ETag::from("W/\"lk1.deadbeef\"")),
         };
         let load_table_result_response_expected = load_table_result.clone().into_response();
 

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -23,6 +23,7 @@ use serde::Serialize;
 use uuid::Uuid;
 pub mod authorize_load;
 pub mod create_table;
+pub(crate) mod etag;
 pub mod load_table;
 mod rename_table;
 
@@ -51,7 +52,8 @@ use crate::{
                 ReferencingView, RegisterTableRequest, RenameTableRequest, Result, TableIdent,
                 TableParameters,
                 tables::{
-                    DataAccessMode, LoadTableCredentialsRequest, LoadTableFilters, LoadTableRequest,
+                    DataAccessMode, LoadTableCredentialsRequest, LoadTableFilters,
+                    LoadTableRequest, SnapshotsQuery,
                 },
             },
         },
@@ -165,6 +167,7 @@ async fn replay_commit_table<C: CatalogStore, A: Authorizer + Clone, S: SecretSt
         )
     })?;
     Ok(CommitTableResponse {
+        etag: Some(etag::commit_etag(&metadata_location)),
         metadata_location,
         metadata: r.metadata,
         config: None,
@@ -460,12 +463,16 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         )
         .await?;
 
+        // Bound once and reused for the ETag shape below: if register ever starts
+        // honouring the delegation header, the tag must follow the config.
+        let data_access: DataAccessMode = DataAccess::not_specified().into();
+        let storage_permissions = StoragePermissions::ReadWriteDelete;
         let config = storage_profile
             .generate_table_config(
-                DataAccess::not_specified().into(),
+                data_access,
                 storage_secret_ref,
                 &table_location,
-                StoragePermissions::ReadWriteDelete,
+                storage_permissions,
                 request_metadata,
                 &table_info,
             )
@@ -541,13 +548,32 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             Arc::new(metadata_location),
         );
 
+        // Full snapshot list from the metadata file, tagged with the delegation
+        // and permission scope the config above was built for. A read-only
+        // caller's later load is scoped narrower, so it gets a distinct tag
+        // rather than matching this one. Register never honours the delegation
+        // header, so a client that sent one misses this tag on its next load —
+        // a lost validator, not a wrong one.
+        let etag = etag::TableETag::new(
+            &metadata_location_str,
+            etag::TableResponseShape::new(
+                SnapshotsQuery::All,
+                etag::StorageAccess::Config {
+                    delegation: data_access,
+                    permissions: storage_permissions,
+                    warehouse_version: warehouse.version,
+                },
+            ),
+            None,
+        )
+        .into_etag();
+
         Ok(LoadTableResult {
             metadata_location: Some(metadata_location_str),
             metadata: table_metadata,
             config: Some(config.config.into()),
             storage_credentials: None,
-            // No credentials are vended in the register response.
-            credentials_revalidate_after_ms: None,
+            etag: Some(etag),
         })
     }
 
@@ -693,8 +719,10 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
                     "commit_table must return exactly one CommitContext"
                 );
 
+                let metadata_location = item.new_metadata_location.to_string();
                 Ok(CommitTableResponse {
-                    metadata_location: item.new_metadata_location.to_string(),
+                    etag: Some(etag::commit_etag(&metadata_location)),
+                    metadata_location,
                     metadata: item.new_metadata.clone(),
                     config: None,
                 })

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use super::{
     super::{io::write_file, require_warehouse_id},
+    etag::{StorageAccess, TableETag, TableResponseShape},
     validate_table_properties,
 };
 use crate::{
@@ -18,7 +19,8 @@ use crate::{
         endpoints::EndpointFlat,
         iceberg::v1::{
             ApiContext, CreateTableRequest, ErrorModel, LoadTableResult, NamespaceParameters,
-            Result, TableIdent, TableParameters, tables::DataAccessMode,
+            Result, TableIdent, TableParameters,
+            tables::{DataAccessMode, SnapshotsQuery},
         },
     },
     request_metadata::RequestMetadata,
@@ -323,12 +325,15 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
     // This requires the storage secret
     // because the table config might contain vended-credentials based
     // on the `data_access` parameter.
+    // Bound once and reused for the ETag shape below, so the tag can never
+    // describe a different access scope than the config it accompanies.
+    let storage_permissions = StoragePermissions::ReadWriteDelete;
     let config = storage_profile
         .generate_table_config(
             data_access,
             storage_secret_ref,
             &table_location,
-            StoragePermissions::ReadWriteDelete,
+            storage_permissions,
             &request_metadata,
             &table_info,
         )
@@ -338,13 +343,25 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
         .credentials_expiration_ms
         .map(credential_revalidate_after_ms);
     let storage_credentials = config.storage_credentials(&table_location);
+    // Full (empty) snapshot list, tagged with the delegation and permission
+    // scope the config above was generated for.
+    let shape = TableResponseShape::new(
+        SnapshotsQuery::All,
+        StorageAccess::Config {
+            delegation: data_access,
+            permissions: storage_permissions,
+            warehouse_version: warehouse.version,
+        },
+    );
 
     let load_table_result = LoadTableResult {
         metadata_location: metadata_location.as_ref().map(ToString::to_string),
         metadata: table_metadata.clone(),
         config: Some(config.config.into()),
         storage_credentials,
-        credentials_revalidate_after_ms,
+        etag: metadata_location.as_ref().map(|loc| {
+            TableETag::new(loc.as_str(), shape, credentials_revalidate_after_ms).into_etag()
+        }),
     };
 
     // Create table in authorizer

--- a/crates/lakekeeper/src/server/tables/etag.rs
+++ b/crates/lakekeeper/src/server/tables/etag.rs
@@ -1,0 +1,444 @@
+//! Construction of the `ETag` that lets a conditional `loadTable` be answered
+//! with `304 Not Modified`.
+//!
+//! This is Lakekeeper policy rather than Iceberg wire format — the `lk1.`
+//! encoding is ours, and the inputs include our authorization model — so it
+//! lives here and not in `iceberg-ext`. That crate keeps only the [`ETag`]
+//! newtype and emits whatever tag it is handed.
+
+use iceberg_ext::catalog::rest::ETag;
+use xxhash_rust::xxh3::Xxh3Default;
+
+use crate::{
+    api::iceberg::v1::tables::{DataAccessMode, LoadTableFilters, SnapshotsQuery},
+    service::{WarehouseVersion, storage::StoragePermissions},
+};
+
+/// Version prefix for structured `loadTable` [`ETag`]s. Anything not parsing
+/// under this prefix (pre-upgrade or future-version values) isn't matched, so
+/// the client reloads. Bump the suffix on incompatible encoding changes.
+const ETAG_PREFIX: &str = "lk1";
+
+/// One axis of a [`TableResponseShape`].
+///
+/// Implemented on the real domain types rather than on mirrors of them, so a
+/// new variant is a compile error here instead of a silently untagged value.
+///
+/// The tags are written out by hand, not derived. [`std::hash::Hash`] would be
+/// shorter but guarantees no stability across Rust releases, and these tags live
+/// in client caches across deploys — a toolchain upgrade must not silently
+/// change the wire format, and the pinned-value tests could not exist.
+trait EtagAxis {
+    /// Stable discriminant mixed into the hash. Changing an existing string
+    /// invalidates every [`ETag`] carrying it.
+    fn as_tag(&self) -> &'static str;
+}
+
+impl EtagAxis for SnapshotsQuery {
+    fn as_tag(&self) -> &'static str {
+        match self {
+            SnapshotsQuery::All => "all",
+            SnapshotsQuery::Refs => "refs",
+        }
+    }
+}
+
+impl EtagAxis for DataAccessMode {
+    fn as_tag(&self) -> &'static str {
+        match self {
+            DataAccessMode::ClientManaged => "cm",
+            DataAccessMode::ServerDelegated(access) => {
+                match (access.vended_credentials, access.remote_signing) {
+                    (false, false) => "d--",
+                    (true, false) => "dv-",
+                    (false, true) => "d-r",
+                    (true, true) => "dvr",
+                }
+            }
+        }
+    }
+}
+
+impl EtagAxis for StoragePermissions {
+    fn as_tag(&self) -> &'static str {
+        match self {
+            StoragePermissions::Read => "r",
+            StoragePermissions::ReadWrite => "rw",
+            StoragePermissions::ReadWriteDelete => "rwd",
+        }
+    }
+}
+
+/// The storage-config content of a response: either absent, or characterised by
+/// the per-request inputs that shape it.
+///
+/// A sum rather than parallel fields, so "no config" cannot be paired with a
+/// delegation or permission level that would mean nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StorageAccess {
+    /// No `config` in the body at all — a commit response, or a caller with no
+    /// storage access.
+    NoConfig,
+    /// Config present, scoped to this delegation and permission level, and
+    /// generated from this revision of the warehouse's storage profile.
+    ///
+    /// The revision belongs here rather than alongside `snapshots`: a warehouse
+    /// edit changes region, endpoint, KMS key or the STS toggle, none of which
+    /// can reach a body that carries no config at all.
+    Config {
+        delegation: DataAccessMode,
+        permissions: StoragePermissions,
+        warehouse_version: WarehouseVersion,
+    },
+}
+
+/// Identifies which response body a request would produce, at an unchanged
+/// table metadata version.
+///
+/// Covers the inputs that vary the body per request: the snapshot filter and
+/// the storage access the config was generated for. It is deliberately *not* a
+/// claim to cover everything — `request_metadata` also reaches the body through
+/// signer and credential-refresh URIs, which are bounded by the credential
+/// window rather than by the tag.
+///
+/// Predicted, never measured: the conditional-request check runs before the
+/// metadata is read and before any storage config is generated, so there is no
+/// body to inspect. The same value is then attached to the response that gets
+/// built, which is what keeps the two sides symmetric.
+///
+/// It is therefore an over-approximation. Two shapes may yield byte-identical
+/// bodies, which costs only a cache miss; the requirement runs the other way —
+/// one shape must never cover two different bodies. When adding an axis, prefer
+/// splitting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TableResponseShape {
+    snapshots: SnapshotsQuery,
+    storage: StorageAccess,
+}
+
+impl TableResponseShape {
+    pub(crate) fn new(snapshots: SnapshotsQuery, storage: StorageAccess) -> Self {
+        Self { snapshots, storage }
+    }
+
+    /// Shape of a `loadTable` response.
+    ///
+    /// `filters` is destructured on purpose: a new field on [`LoadTableFilters`]
+    /// must not compile until it has been considered here, since a body-affecting
+    /// filter missing from the tag reintroduces the cross-shape 304.
+    pub(crate) fn for_load(filters: &LoadTableFilters, storage: StorageAccess) -> Self {
+        let LoadTableFilters { snapshots } = filters;
+        Self::new(*snapshots, storage)
+    }
+
+    /// Shape of a response carrying the full metadata and no storage config.
+    ///
+    /// A commit response, and equally a load by a caller with no storage access —
+    /// those bodies are genuinely equivalent, so sharing a tag is correct.
+    pub(crate) fn no_storage_config() -> Self {
+        Self::new(SnapshotsQuery::All, StorageAccess::NoConfig)
+    }
+}
+
+/// Structured contents of a `loadTable` [`ETag`].
+///
+/// Wire form (inside the quotes): `lk1.<hash>`, or `lk1.<hash>.<revalidate_hex>`
+/// when credentials are vended (revalidate-after as epoch-ms in hex). Embedding
+/// the revalidation point lets the server decide, from the client-echoed tag
+/// alone, whether the held credentials are still within their serve window —
+/// i.e. fresh enough for a 304.
+///
+/// Emitted as a *weak* validator (`W/`): two responses sharing a tag are not
+/// byte-identical, since each vends freshly minted credentials.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableETag {
+    hash: String,
+    revalidate_after_ms: Option<i64>,
+}
+
+impl TableETag {
+    pub(crate) fn new(
+        metadata_location: &str,
+        shape: TableResponseShape,
+        revalidate_after_ms: Option<i64>,
+    ) -> Self {
+        // Destructured so a new axis cannot be added without being hashed here.
+        let TableResponseShape { snapshots, storage } = shape;
+
+        // NUL-separated: each axis occupies a fixed slot, so no combination of an
+        // arbitrary metadata location and the fixed tags can be re-split into a
+        // different combination that hashes the same.
+        let mut hasher = Xxh3Default::new();
+        hasher.update(metadata_location.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(snapshots.as_tag().as_bytes());
+        hasher.update(&[0]);
+        match storage {
+            StorageAccess::NoConfig => hasher.update(b"nc"),
+            StorageAccess::Config {
+                delegation,
+                permissions,
+                warehouse_version,
+            } => {
+                hasher.update(delegation.as_tag().as_bytes());
+                hasher.update(&[0]);
+                hasher.update(permissions.as_tag().as_bytes());
+                hasher.update(&[0]);
+                hasher.update(&warehouse_version.to_le_bytes());
+            }
+        }
+        let hash = hasher.digest();
+
+        Self {
+            hash: format!("{hash:x}"),
+            // A non-positive value carries no information; drop it.
+            revalidate_after_ms: revalidate_after_ms.filter(|ms| *ms > 0),
+        }
+    }
+
+    pub(crate) fn hash(&self) -> &str {
+        &self.hash
+    }
+
+    pub(crate) fn revalidate_after_ms(&self) -> Option<i64> {
+        self.revalidate_after_ms
+    }
+
+    /// Parse a client-supplied [`ETag`] value (quotes and any `W/` already
+    /// stripped by `parse_etags`). Returns `None` for unrecognized values so
+    /// callers reload.
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        let mut parts = value.split('.');
+        if parts.next()? != ETAG_PREFIX {
+            return None;
+        }
+        let hash = parts.next().filter(|s| !s.is_empty())?.to_string();
+        let revalidate_after_ms = parts
+            .next()
+            .map(|s| i64::from_str_radix(s, 16))
+            .transpose()
+            .ok()?;
+        // Reject trailing junk so an unexpected shape falls back to a reload.
+        if parts.next().is_some() {
+            return None;
+        }
+        Some(Self {
+            hash,
+            revalidate_after_ms,
+        })
+    }
+
+    /// Render the wire [`ETag`] value, quoted and weak per HTTP syntax.
+    pub(crate) fn into_etag(self) -> ETag {
+        let inner = match self.revalidate_after_ms {
+            Some(ms) => format!("{ETAG_PREFIX}.{}.{ms:x}", self.hash),
+            None => format!("{ETAG_PREFIX}.{}", self.hash),
+        };
+        format!("W/\"{inner}\"").into()
+    }
+}
+
+/// Mint the [`ETag`] for a commit response, which carries no storage config.
+pub(crate) fn commit_etag(metadata_location: &str) -> ETag {
+    TableETag::new(
+        metadata_location,
+        TableResponseShape::no_storage_config(),
+        None,
+    )
+    .into_etag()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+    use crate::api::iceberg::v1::tables::DataAccess;
+
+    const LOC: &str = "s3://bucket/table/metadata.json";
+    fn wv() -> WarehouseVersion {
+        WarehouseVersion::new(7)
+    }
+
+    fn delegated(vended_credentials: bool, remote_signing: bool) -> DataAccessMode {
+        DataAccessMode::ServerDelegated(DataAccess {
+            vended_credentials,
+            remote_signing,
+        })
+    }
+
+    /// Every shape the server can emit, for exhaustive distinctness checks.
+    fn all_shapes() -> Vec<TableResponseShape> {
+        let mut shapes = Vec::new();
+        for snapshots in [SnapshotsQuery::All, SnapshotsQuery::Refs] {
+            shapes.push(TableResponseShape::new(snapshots, StorageAccess::NoConfig));
+            for delegation in [
+                DataAccessMode::ClientManaged,
+                delegated(false, false),
+                delegated(true, false),
+                delegated(false, true),
+                delegated(true, true),
+            ] {
+                for permissions in [
+                    StoragePermissions::Read,
+                    StoragePermissions::ReadWrite,
+                    StoragePermissions::ReadWriteDelete,
+                ] {
+                    shapes.push(TableResponseShape::new(
+                        snapshots,
+                        StorageAccess::Config {
+                            delegation,
+                            permissions,
+                            warehouse_version: wv(),
+                        },
+                    ));
+                }
+            }
+        }
+        shapes
+    }
+
+    #[test]
+    fn every_shape_gets_a_distinct_etag() {
+        // The property the whole mechanism rests on, checked over the full
+        // product rather than one axis at a time: two bodies that differ must
+        // never share a tag. Catches a new variant copy-pasting an existing tag.
+        let shapes = all_shapes();
+        let mut seen = HashSet::new();
+        for shape in &shapes {
+            assert!(
+                seen.insert(TableETag::new(LOC, *shape, None).into_etag()),
+                "duplicate ETag for {shape:?}"
+            );
+        }
+        assert_eq!(seen.len(), shapes.len());
+        // 2 snapshot modes x (1 no-config + 5 delegations x 3 permission levels)
+        assert_eq!(shapes.len(), 32);
+    }
+
+    #[test]
+    fn warehouse_version_is_part_of_the_tag() {
+        // A storage-profile edit bumps the warehouse row's version, which changes
+        // region/endpoint/KMS key/STS toggle in the config body without touching
+        // the metadata location. Without this axis a client-managed caller — whose
+        // tag carries no revalidation point — would 304 onto the old config
+        // indefinitely.
+        let shape = |warehouse_version| {
+            TableResponseShape::new(
+                SnapshotsQuery::All,
+                StorageAccess::Config {
+                    delegation: delegated(false, false),
+                    permissions: StoragePermissions::ReadWriteDelete,
+                    warehouse_version,
+                },
+            )
+        };
+        assert_ne!(
+            TableETag::new(LOC, shape(WarehouseVersion::new(1)), None),
+            TableETag::new(LOC, shape(WarehouseVersion::new(2)), None)
+        );
+    }
+
+    #[test]
+    fn etag_round_trips_through_the_wire_form() {
+        for revalidate in [None, Some(1_750_000_000_123)] {
+            let etag = TableETag::new(LOC, all_shapes()[0], revalidate);
+            let wire = etag.clone().into_etag();
+            // `parse_etags` strips the quotes and the weak marker before we see it.
+            let bare = wire.as_str().trim_start_matches("W/").trim_matches('"');
+            assert_eq!(TableETag::parse(bare).as_ref(), Some(&etag));
+            assert_eq!(etag.revalidate_after_ms(), revalidate);
+        }
+    }
+
+    #[test]
+    fn etag_is_emitted_as_a_weak_validator() {
+        // Two responses sharing a tag are not byte-identical — each vends freshly
+        // minted credentials — so the tag is weak per RFC 9110 8.8.1.
+        let wire = TableETag::new(LOC, all_shapes()[0], None).into_etag();
+        assert!(wire.as_str().starts_with("W/\""), "{}", wire.as_str());
+        assert!(wire.as_str().ends_with('"'));
+    }
+
+    #[test]
+    fn parse_rejects_legacy_and_junk() {
+        // Legacy bare hash, wrong prefix, empty hash, trailing junk, non-hex expiry.
+        assert!(TableETag::parse("e34615aade2e6333").is_none());
+        assert!(TableETag::parse("lk2.abc").is_none());
+        assert!(TableETag::parse("lk1.").is_none());
+        assert!(TableETag::parse("lk1.abc.def.ghi").is_none());
+        assert!(TableETag::parse("lk1.abc.zzz").is_none());
+    }
+
+    #[test]
+    fn axis_tags_are_suffix_free_within_each_slot() {
+        // What makes the NUL separators load-bearing. Without them the hash input
+        // is a bare concatenation, and an arbitrary metadata location abutting a
+        // fixed tag can be re-split: location `X` + tag `abc` and location `Xa` +
+        // tag `bc` produce identical bytes. That needs one tag in the *same* slot
+        // to be a suffix of another; across slots it cannot happen. Fails on a
+        // future rename rather than silently allowing a collision.
+        let slots: [(&str, Vec<&'static str>); 3] = [
+            (
+                "snapshots",
+                vec![SnapshotsQuery::All.as_tag(), SnapshotsQuery::Refs.as_tag()],
+            ),
+            (
+                "storage",
+                vec![
+                    "nc",
+                    DataAccessMode::ClientManaged.as_tag(),
+                    delegated(false, false).as_tag(),
+                    delegated(true, false).as_tag(),
+                    delegated(false, true).as_tag(),
+                    delegated(true, true).as_tag(),
+                ],
+            ),
+            (
+                "permissions",
+                vec![
+                    StoragePermissions::Read.as_tag(),
+                    StoragePermissions::ReadWrite.as_tag(),
+                    StoragePermissions::ReadWriteDelete.as_tag(),
+                ],
+            ),
+        ];
+        for (slot, tags) in slots {
+            for (i, a) in tags.iter().enumerate() {
+                for (j, b) in tags.iter().enumerate() {
+                    assert!(
+                        i == j || !a.ends_with(b),
+                        "{slot} tag {a:?} ends with {b:?}; without the NUL \
+                         separators these could collide"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn commit_etag_matches_a_load_with_no_storage_access() {
+        // A commit body and a no-storage-access load body are both metadata with
+        // no config, so they are the same shape and sharing a tag is correct.
+        // Every config-bearing load differs and must not match.
+        let commit = commit_etag(LOC);
+        assert_eq!(
+            commit,
+            TableETag::new(LOC, TableResponseShape::no_storage_config(), None).into_etag()
+        );
+        let delegated_load = TableETag::new(
+            LOC,
+            TableResponseShape::new(
+                SnapshotsQuery::All,
+                StorageAccess::Config {
+                    delegation: delegated(false, false),
+                    permissions: StoragePermissions::ReadWriteDelete,
+                    warehouse_version: wv(),
+                },
+            ),
+            None,
+        )
+        .into_etag();
+        assert_ne!(commit, delegated_load);
+    }
+}

--- a/crates/lakekeeper/src/server/tables/etag.rs
+++ b/crates/lakekeeper/src/server/tables/etag.rs
@@ -316,6 +316,52 @@ mod tests {
         assert_eq!(shapes.len(), 32);
     }
 
+    /// Pins the wire format against literals rather than against another
+    /// generated tag, so a change to the framing, the field order, the axis
+    /// strings or the little-endian version encoding fails here even when it
+    /// keeps every shape distinct. Updating these values invalidates every
+    /// `ETag` in every client cache — bump [`ETAG_PREFIX`] when you do.
+    #[test]
+    fn etag_wire_format_is_pinned() {
+        let delegated_shape = TableResponseShape::new(
+            SnapshotsQuery::Refs,
+            StorageAccess::Config {
+                delegation: delegated(true, false),
+                permissions: StoragePermissions::Read,
+                warehouse_version: WarehouseVersion::new(1),
+            },
+        );
+
+        assert_eq!(
+            TableETag::new(LOC, delegated_shape, None)
+                .into_etag()
+                .as_str(),
+            "W/\"lk1.d6f45486df4c5bc3\""
+        );
+        // Same shape, next warehouse version: differs only in the trailing
+        // little-endian bytes, so a big-endian slip changes this value.
+        let next_version = TableResponseShape::new(
+            SnapshotsQuery::Refs,
+            StorageAccess::Config {
+                delegation: delegated(true, false),
+                permissions: StoragePermissions::Read,
+                warehouse_version: WarehouseVersion::new(2),
+            },
+        );
+        assert_eq!(
+            TableETag::new(LOC, next_version, None).into_etag().as_str(),
+            "W/\"lk1.ce4d3de4c470d7d0\""
+        );
+        // The `nc` branch skips the version entirely, and the revalidation
+        // point is appended as lower-case hex.
+        assert_eq!(
+            TableETag::new(LOC, TableResponseShape::no_storage_config(), Some(255))
+                .into_etag()
+                .as_str(),
+            "W/\"lk1.7ccceafed717f689.ff\""
+        );
+    }
+
     #[test]
     fn warehouse_version_is_part_of_the_tag() {
         // A storage-profile edit bumps the warehouse row's version, which changes

--- a/crates/lakekeeper/src/server/tables/load_table.rs
+++ b/crates/lakekeeper/src/server/tables/load_table.rs
@@ -108,25 +108,29 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
             .warehouse
             .storage_profile
             .vends_expiring_credentials(data_access);
-    // Built once and reused for the response below: the tag we would hand out
-    // must be the one we match against here, or the next conditional request
-    // never hits.
-    let shape = TableResponseShape::for_load(
-        &filters,
-        // Both per-request inputs to `generate_table_config`. Without storage
-        // access there is no `config` at all — a load made before access was
-        // granted must not answer one made after; and credentials are
-        // policy-scoped per permission level, so a read-scoped body must not
-        // answer a request from a caller who can now write.
-        match storage_permissions {
-            None => StorageAccess::NoConfig,
-            Some(permissions) => StorageAccess::Config {
-                delegation: data_access,
-                permissions,
-                warehouse_version: event_ctx.resolved().warehouse.version,
+    // The warehouse version is a parameter rather than read from `event_ctx`,
+    // because the two call sites see different versions: the 304 check below
+    // runs before the table is loaded, while the response tag must name the
+    // version the body was actually generated from — which the refetch further
+    // down may have advanced.
+    let shape_at = |warehouse_version| {
+        TableResponseShape::for_load(
+            &filters,
+            // Both per-request inputs to `generate_table_config`. Without storage
+            // access there is no `config` at all — a load made before access was
+            // granted must not answer one made after; and credentials are
+            // policy-scoped per permission level, so a read-scoped body must not
+            // answer a request from a caller who can now write.
+            match storage_permissions {
+                None => StorageAccess::NoConfig,
+                Some(permissions) => StorageAccess::Config {
+                    delegation: data_access,
+                    permissions,
+                    warehouse_version,
+                },
             },
-        },
-    );
+        )
+    };
     if let Some(etag) = match_not_modified(
         &etags,
         event_ctx
@@ -135,7 +139,7 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
             .metadata_location
             .as_ref()
             .map(lakekeeper_io::Location::as_str),
-        shape,
+        shape_at(event_ctx.resolved().warehouse.version),
         now_epoch_ms(),
         vends_credentials,
     ) {
@@ -176,6 +180,10 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
         event_ctx.resolved_mut().warehouse = fresh_warehouse;
     }
     let warehouse = &event_ctx.resolved().warehouse;
+    // Bound to the version `generate_table_config` below reads the profile from,
+    // which the refetch above may have advanced past the one the 304 check used.
+    // Reusing that earlier shape would let one tag stand for two different bodies.
+    let response_shape = shape_at(warehouse.version);
 
     let table_location =
         parse_location(table_metadata.location(), StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -219,10 +227,13 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
         metadata: metadata_ref,
         config: storage_config.map(|c| c.config.into()),
         storage_credentials,
-        // Same `shape` the 304 check above used, so the tag we hand out is the
-        // one the next equivalent request recomputes.
         etag: metadata_location_ref.as_ref().map(|loc| {
-            TableETag::new(loc.as_str(), shape, credentials_revalidate_after_ms).into_etag()
+            TableETag::new(
+                loc.as_str(),
+                response_shape,
+                credentials_revalidate_after_ms,
+            )
+            .into_etag()
         }),
     };
 

--- a/crates/lakekeeper/src/server/tables/load_table.rs
+++ b/crates/lakekeeper/src/server/tables/load_table.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use http::StatusCode;
-use iceberg_ext::catalog::rest::{ETag, TableETag};
+use iceberg_ext::catalog::rest::ETag;
 
 use crate::{
     WarehouseId,
@@ -13,7 +13,11 @@ use crate::{
     request_metadata::RequestMetadata,
     server::{
         maybe_get_secret, require_warehouse_id,
-        tables::{authorize_load_table, parse_location, validate_table_or_view_ident},
+        tables::{
+            authorize_load_table,
+            etag::{StorageAccess, TableETag, TableResponseShape},
+            parse_location, validate_table_or_view_ident,
+        },
     },
     service::{
         AuthZTableInfo as _, CachePolicy, CatalogStore, CatalogTableOps, CatalogWarehouseOps,
@@ -104,6 +108,25 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
             .warehouse
             .storage_profile
             .vends_expiring_credentials(data_access);
+    // Built once and reused for the response below: the tag we would hand out
+    // must be the one we match against here, or the next conditional request
+    // never hits.
+    let shape = TableResponseShape::for_load(
+        &filters,
+        // Both per-request inputs to `generate_table_config`. Without storage
+        // access there is no `config` at all — a load made before access was
+        // granted must not answer one made after; and credentials are
+        // policy-scoped per permission level, so a read-scoped body must not
+        // answer a request from a caller who can now write.
+        match storage_permissions {
+            None => StorageAccess::NoConfig,
+            Some(permissions) => StorageAccess::Config {
+                delegation: data_access,
+                permissions,
+                warehouse_version: event_ctx.resolved().warehouse.version,
+            },
+        },
+    );
     if let Some(etag) = match_not_modified(
         &etags,
         event_ctx
@@ -112,6 +135,7 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
             .metadata_location
             .as_ref()
             .map(lakekeeper_io::Location::as_str),
+        shape,
         now_epoch_ms(),
         vends_credentials,
     ) {
@@ -195,7 +219,11 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
         metadata: metadata_ref,
         config: storage_config.map(|c| c.config.into()),
         storage_credentials,
-        credentials_revalidate_after_ms,
+        // Same `shape` the 304 check above used, so the tag we hand out is the
+        // one the next equivalent request recomputes.
+        etag: metadata_location_ref.as_ref().map(|loc| {
+            TableETag::new(loc.as_str(), shape, credentials_revalidate_after_ms).into_etag()
+        }),
     };
 
     Ok(LoadTableResultOrNotModified::LoadTableResult(
@@ -268,14 +296,21 @@ fn require_not_staged<T>(
 /// load also vends no expiring credentials (`!vends_credentials`). Anything we
 /// can't parse isn't matched, so the client reloads — never a 304 with stale
 /// credentials.
+///
+/// `shape` describes the body *this* request would produce. It is folded into
+/// the comparison tag, so a client that cached one shape and revalidates for
+/// another — a different `snapshots` filter, or different access delegation —
+/// misses and gets a full response instead of a 304 for content it never
+/// received.
 fn match_not_modified(
     client_etags: &[ETag],
     metadata_location: Option<&str>,
+    shape: TableResponseShape,
     now_ms: i64,
     vends_credentials: bool,
 ) -> Option<ETag> {
     let metadata_location = metadata_location?;
-    let current = TableETag::new(metadata_location, None);
+    let current = TableETag::new(metadata_location, shape, None);
 
     for client in client_etags {
         let value = client.as_str();
@@ -292,7 +327,7 @@ fn match_not_modified(
         let Some(parsed) = TableETag::parse(value) else {
             continue;
         };
-        if parsed.metadata_hash() != current.metadata_hash() {
+        if parsed.hash() != current.hash() {
             continue;
         }
         match parsed.revalidate_after_ms() {
@@ -316,18 +351,87 @@ fn match_not_modified(
 #[cfg(test)]
 mod etag_tests {
     use super::*;
+    use crate::{
+        api::iceberg::v1::tables::{DataAccess, DataAccessMode, SnapshotsQuery},
+        service::{WarehouseVersion, storage::StoragePermissions},
+    };
 
     const LOC: &str = "s3://bucket/table/metadata.json";
     const NOW: i64 = 1_750_000_000_000;
-    /// Build a client-supplied `ETag` (quotes stripped, as `parse_etags` yields).
-    /// `revalidate_after` = `None` for a metadata-only cached response.
+    /// Default shape: all snapshots, default (unspecified) delegation.
+    fn wv() -> WarehouseVersion {
+        WarehouseVersion::new(7)
+    }
+
+    fn delegated(vended_credentials: bool, remote_signing: bool) -> DataAccessMode {
+        DataAccessMode::ServerDelegated(DataAccess {
+            vended_credentials,
+            remote_signing,
+        })
+    }
+
+    /// A config-bearing shape with the given snapshot filter.
+    fn shape_of(
+        snapshots: SnapshotsQuery,
+        delegation: DataAccessMode,
+        permissions: StoragePermissions,
+    ) -> TableResponseShape {
+        TableResponseShape::new(
+            snapshots,
+            StorageAccess::Config {
+                delegation,
+                permissions,
+                warehouse_version: wv(),
+            },
+        )
+    }
+
+    /// A default delegated load: all snapshots, unspecified delegation, writer.
+    fn all() -> TableResponseShape {
+        shape_of(
+            SnapshotsQuery::All,
+            delegated(false, false),
+            StoragePermissions::ReadWriteDelete,
+        )
+    }
+
+    /// The same, refs-filtered.
+    fn refs() -> TableResponseShape {
+        shape_of(
+            SnapshotsQuery::Refs,
+            delegated(false, false),
+            StoragePermissions::ReadWriteDelete,
+        )
+    }
+
+    /// Build a client-supplied `ETag` for a given shape, in the form
+    /// `parse_etags` yields. `revalidate_after` = `None` for a metadata-only
+    /// cached response.
+    fn client_etag_for(
+        loc: &str,
+        shape: TableResponseShape,
+        revalidate_after: Option<i64>,
+    ) -> ETag {
+        as_client_etag(&TableETag::new(loc, shape, revalidate_after).into_etag())
+    }
+
+    /// The shape a client echoes back: the wire value with the weak marker and
+    /// quotes stripped, exactly as the HTTP layer's `parse_etags` produces.
+    fn as_client_etag(etag: &ETag) -> ETag {
+        ETag::from(etag.as_str().trim_start_matches("W/").trim_matches('"'))
+    }
+
+    /// Default-shape client [`ETag`].
     fn client_etag(loc: &str, revalidate_after: Option<i64>) -> ETag {
-        let quoted = TableETag::new(loc, revalidate_after).into_etag();
-        ETag::from(quoted.as_str().trim_matches('"'))
+        client_etag_for(loc, all(), revalidate_after)
+    }
+
+    fn matches_repr(etags: &[ETag], shape: TableResponseShape, vends_credentials: bool) -> bool {
+        match_not_modified(etags, Some(LOC), shape, NOW, vends_credentials).is_some()
     }
 
     fn matches(etags: &[ETag], vends_credentials: bool) -> bool {
-        match_not_modified(etags, Some(LOC), NOW, vends_credentials).is_some()
+        matches_repr(etags, all(), vends_credentials)
     }
 
     #[test]
@@ -341,7 +445,7 @@ mod etag_tests {
     fn unparseable_etag_triggers_reload() {
         // A pre-upgrade bare-hash ETag (or any non-`lk1` value) can't be parsed,
         // so it never yields a 304. The client reloads once and re-primes.
-        let legacy = ETag::from(TableETag::new(LOC, None).metadata_hash());
+        let legacy = ETag::from(TableETag::new(LOC, all(), None).hash());
         assert!(!matches(&[legacy], false));
         assert!(!matches(&[ETag::from("not-our-etag")], false));
     }
@@ -355,7 +459,7 @@ mod etag_tests {
 
     #[test]
     fn no_match_when_metadata_location_absent() {
-        assert!(match_not_modified(&[ETag::from("*")], None, NOW, false).is_none());
+        assert!(match_not_modified(&[ETag::from("*")], None, all(), NOW, false).is_none());
     }
 
     #[test]
@@ -374,8 +478,14 @@ mod etag_tests {
             let etag = client_etag(LOC, Some(revalidate_after_at(expiry, vend_now)));
             for check_now in [expiry, expiry + 1, expiry + 60_000] {
                 assert!(
-                    match_not_modified(std::slice::from_ref(&etag), Some(LOC), check_now, true)
-                        .is_none(),
+                    match_not_modified(
+                        std::slice::from_ref(&etag),
+                        Some(LOC),
+                        all(),
+                        check_now,
+                        true
+                    )
+                    .is_none(),
                     "served a 304 at/after expiry (expiry={expiry}, check_now={check_now})"
                 );
             }
@@ -403,9 +513,171 @@ mod etag_tests {
     #[test]
     fn credential_load_rejects_unparseable_and_wildcard() {
         // Unparseable ETag and wildcard carry no revalidation point → reload.
-        let legacy = ETag::from(TableETag::new(LOC, None).metadata_hash());
+        let legacy = ETag::from(TableETag::new(LOC, all(), None).hash());
         assert!(!matches(&[legacy], true));
         assert!(!matches(&[ETag::from("*")], true));
+    }
+
+    #[test]
+    fn no_304_across_snapshot_representations() {
+        // A client caches `snapshots=refs` (a truncated snapshot list), then
+        // revalidates asking for `snapshots=all`. When both sides hashed only the
+        // metadata location this matched, and the client kept using the truncated
+        // body as if it were complete.
+        let cached_refs = client_etag_for(LOC, refs(), None);
+        assert!(
+            !matches_repr(std::slice::from_ref(&cached_refs), all(), false),
+            "304'd an `all` request from a `refs` ETag: client would reuse a truncated snapshot list"
+        );
+
+        // And the reverse: a full body cached, then a `refs` request.
+        let cached_all = client_etag_for(LOC, all(), None);
+        assert!(
+            !matches_repr(std::slice::from_ref(&cached_all), refs(), false),
+            "304'd a `refs` request from an `all` ETag"
+        );
+
+        // Each still 304s against its own representation — the fix must not
+        // disable conditional requests, only stop them crossing representations.
+        assert!(matches_repr(&[cached_refs], refs(), false));
+        assert!(matches_repr(&[cached_all], all(), false));
+    }
+
+    #[test]
+    fn no_304_across_delegation_modes() {
+        // Storage config depends on the delegation the client asked for, so a
+        // tag minted under one mode must not satisfy a request under another.
+        // These cases cover the revalidate-less branch, reachable when the load
+        // vends no expiring credentials — client-managed access, or the in-memory
+        // test profile. See `credential_load_rejects_cross_delegation_304` for
+        // the branch that real S3/GCS/ADLS traffic takes.
+        let signing = shape_of(
+            SnapshotsQuery::All,
+            delegated(false, true),
+            StoragePermissions::ReadWriteDelete,
+        );
+        let client_managed = shape_of(
+            SnapshotsQuery::All,
+            DataAccessMode::ClientManaged,
+            StoragePermissions::ReadWriteDelete,
+        );
+
+        let cached_signing = client_etag_for(LOC, signing, None);
+        assert!(
+            !matches_repr(std::slice::from_ref(&cached_signing), all(), false),
+            "304'd an unspecified-delegation request from a remote-signing ETag"
+        );
+        assert!(
+            !matches_repr(std::slice::from_ref(&cached_signing), client_managed, false),
+            "304'd a client-managed request from a remote-signing ETag"
+        );
+        // Still 304s its own shape.
+        assert!(matches_repr(&[cached_signing], signing, false));
+
+        // And the reverse direction: a plain cached body must not satisfy a
+        // request that asks for signing.
+        let cached_default = client_etag_for(LOC, all(), None);
+        assert!(
+            !matches_repr(std::slice::from_ref(&cached_default), signing, false),
+            "304'd a remote-signing request from an unspecified-delegation ETag: \
+             the client would get no signer config"
+        );
+    }
+
+    #[test]
+    fn credential_load_rejects_cross_delegation_304() {
+        // The branch real traffic takes. On S3/GCS/ADLS `vends_expiring_credentials`
+        // is true for *any* server-delegated request — it never inspects
+        // `remote_signing` — so a delegated load always carries a revalidation
+        // point and the `vends_credentials` gate cannot distinguish modes. Inside
+        // that window only the shape stops the 304.
+        let vended = shape_of(
+            SnapshotsQuery::All,
+            delegated(true, false),
+            StoragePermissions::ReadWriteDelete,
+        );
+        let signing = shape_of(
+            SnapshotsQuery::All,
+            delegated(false, true),
+            StoragePermissions::ReadWriteDelete,
+        );
+        // Cached a credential-bearing response, still well inside its window.
+        let cached = client_etag_for(LOC, vended, Some(NOW + 60_000));
+
+        assert!(
+            !matches_repr(std::slice::from_ref(&cached), signing, true),
+            "304'd a remote-signing request from a vended-credentials ETag while \
+             the credential window was still open"
+        );
+        // Its own shape still 304s inside the window — the gate is unchanged.
+        assert!(matches_repr(&[cached], vended, true));
+    }
+
+    #[test]
+    fn no_storage_access_is_its_own_shape() {
+        // A load the caller has no storage access for returns `config: null`.
+        // That body must not satisfy a later load made after access is granted.
+        let no_config = TableResponseShape::no_storage_config();
+        let cached = client_etag_for(LOC, no_config, None);
+        assert!(
+            !matches_repr(std::slice::from_ref(&cached), all(), false),
+            "304'd a config-bearing load from a config-less ETag"
+        );
+        assert!(matches_repr(&[cached], no_config, false));
+    }
+
+    #[test]
+    fn no_304_across_storage_permission_levels() {
+        // Vended credentials are policy-scoped per level, so a body built for a
+        // read-only caller must not answer a request from one who can now write.
+        // `create_table`/`register_table` always scope to ReadWriteDelete, so
+        // without this a read-only caller's load could match a create tag.
+        let read = shape_of(
+            SnapshotsQuery::All,
+            delegated(false, false),
+            StoragePermissions::Read,
+        );
+        let cached_read = client_etag_for(LOC, read, Some(NOW + 60_000));
+        assert!(
+            !matches_repr(std::slice::from_ref(&cached_read), all(), true),
+            "304'd a read-write-delete load from a read-scoped ETag: the client \
+             would keep credentials that cannot write"
+        );
+        assert!(matches_repr(&[cached_read], read, true));
+    }
+
+    #[test]
+    fn commit_etag_does_not_satisfy_a_delegated_load() {
+        // A commit response carries `config: None`, which no load reproduces, so
+        // its tag must not 304 a load that expects storage config.
+        let commit = as_client_etag(&super::super::etag::commit_etag(LOC));
+        assert!(!matches(std::slice::from_ref(&commit), false));
+        assert!(!matches_repr(&[commit], refs(), false));
+    }
+
+    #[test]
+    fn wildcard_echoes_the_requested_representation() {
+        // `If-None-Match: *` carries no representation, so the tag we echo must be
+        // the one for the body this request would have produced. Echoing the
+        // default here would hand the client an `all` tag for a `refs` body.
+        let echoed = match_not_modified(&[ETag::from("*")], Some(LOC), refs(), NOW, false)
+            .expect("wildcard should 304 when no credentials are vended");
+        // Compare against the quoted wire form — `client_etag_for` yields the
+        // unquoted shape a client echoes back, which is not what we emit.
+        assert_eq!(echoed, TableETag::new(LOC, refs(), None).into_etag());
+        assert_ne!(
+            echoed,
+            TableETag::new(LOC, all(), None).into_etag(),
+            "wildcard echoed the default representation instead of the requested one"
+        );
+        // That echoed tag must then be accepted for `refs` and rejected for `all`.
+        let echoed_bare = as_client_etag(&echoed);
+        assert!(matches_repr(
+            std::slice::from_ref(&echoed_bare),
+            refs(),
+            false
+        ));
+        assert!(!matches_repr(&[echoed_bare], all(), false));
     }
 
     #[test]


### PR DESCRIPTION
Table ETags hashed only the metadata location, so responses differing only by request inputs shared a tag and a conditional load could get a 304 for content the client never received.

Four inputs now feed the hash:

- `snapshots=refs` vs `all` — different snapshot lists (spec #15045)
- `X-Iceberg-Access-Delegation` — different storage config
- StoragePermissions — credentials are STS-policy-scoped per level
- warehouse version — profile edits change region/endpoint/KMS/STS toggle, unbounded staleness for client-managed access

The shape is derived from the request and the caller's authorization, not from the body: the conditional check runs before a body exists.

Tag construction moves from iceberg-ext to lakekeeper. The `lk1.` encoding is our policy, not Iceberg wire format, and keeping it in iceberg-ext forced four mirror enums across the crate boundary. Those are gone — the axes are implemented on the real domain types. iceberg-ext keeps the ETag newtype; the response types carry a precomputed tag and emit it verbatim.

Tags are now weak validators (`W/`) — two responses sharing a tag are not byte-identical, as each vends fresh credentials.

Behaviour changes:

- All existing ETags are invalidated: one extra full load per cached table, then re-primed.
- A commit ETag no longer satisfies a load expecting storage config (commit responses carry none). Gives up an optimisation spec #14760 permits; the Java client never caches commit ETags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added representation-aware ETags for table creation, loading, registration, and commit responses.
  * ETags now reflect snapshot filters, access settings, permissions, warehouse versions, and credential settings.
  * Conditional table requests return `304 Not Modified` only when the requested representation matches.

* **Bug Fixes**
  * Prevented stale or incorrectly reused ETags across different table views and access configurations.
  * Responses now omit ETag headers when no tag is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->