### PR TITLE
fix(catalog): advertise idempotency-key-lifetime as a top-level field

### DIFF
--- a/crates/iceberg-ext/src/catalog/rest/catalog_config.rs
+++ b/crates/iceberg-ext/src/catalog/rest/catalog_config.rs
@@ -10,6 +10,15 @@ pub struct CatalogConfig {
     /// Properties that should be used as default configuration; applied before client configuration.
     pub defaults: std::collections::HashMap<String, String>,
     pub endpoints: Vec<String>,
+    /// Client reuse window for an `Idempotency-Key`, as an ISO-8601 duration
+    /// (e.g. `PT30M`).
+    ///
+    /// Its presence is what tells a client the server supports
+    /// `Idempotency-Key` semantics at all; absent means the client must assume
+    /// it is unsupported. So this is skipped when serializing rather than sent
+    /// as `null`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotency_key_lifetime: Option<String>,
 }
 
 #[cfg(feature = "axum")]
@@ -29,5 +38,57 @@ mod test {
 
         let c: CatalogConfig = serde_json::from_value(j.clone()).unwrap();
         assert_eq!(serde_json::to_value(c).unwrap(), j);
+    }
+
+    /// A sibling of `overrides`/`defaults`, not an entry inside them — a client
+    /// looking for it in the property maps concludes idempotency is
+    /// unsupported, and one applying the maps wholesale gets an unrecognized
+    /// property injected into its own config.
+    #[test]
+    fn idempotency_key_lifetime_is_a_top_level_field() {
+        let config = CatalogConfig {
+            idempotency_key_lifetime: Some("PT30M".to_string()),
+            ..CatalogConfig::default()
+        };
+
+        let json = serde_json::to_value(config).unwrap();
+
+        assert_eq!(json["idempotency-key-lifetime"], "PT30M");
+        assert!(json["overrides"].as_object().unwrap().is_empty());
+        assert!(json["defaults"].as_object().unwrap().is_empty());
+    }
+
+    /// Absence is meaningful: it is how a client learns idempotency is not
+    /// supported, so the key must not appear at all rather than as `null`.
+    #[test]
+    fn idempotency_key_lifetime_is_omitted_when_unset() {
+        let json = serde_json::to_value(CatalogConfig::default()).unwrap();
+
+        assert!(
+            !json
+                .as_object()
+                .unwrap()
+                .contains_key("idempotency-key-lifetime"),
+            "{json}"
+        );
+    }
+
+    #[test]
+    fn idempotency_key_lifetime_round_trips() {
+        let json = serde_json::json!({
+            "overrides": {},
+            "defaults": {},
+            "endpoints": Vec::<String>::new(),
+            "idempotency-key-lifetime": "PT24H",
+        });
+
+        let config: CatalogConfig = serde_json::from_value(json.clone()).unwrap();
+
+        assert_eq!(
+            config.idempotency_key_lifetime.as_deref(),
+            Some("PT24H"),
+            "field did not deserialize"
+        );
+        assert_eq!(serde_json::to_value(config).unwrap(), json);
     }
 }

--- a/crates/lakekeeper-integration-tests/tests/server_config.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_config.rs
@@ -1,5 +1,5 @@
 use lakekeeper::{
-    ProjectId,
+    CONFIG, ProjectId,
     api::{
         RequestMetadata,
         iceberg::v1::{
@@ -45,6 +45,53 @@ async fn test_get_config_visible_warehouse(pool: PgPool) {
         config.overrides.get("uri"),
         Some(&RequestMetadata::new_unauthenticated().base_uri_catalog())
     );
+}
+
+/// The spec defines `idempotency-key-lifetime` as a sibling of
+/// `overrides`/`defaults`, and its presence is the *only* signal that the
+/// server supports `Idempotency-Key` at all. Advertised inside `overrides`, a
+/// conformant client concludes idempotency is unsupported and additionally
+/// applies an unrecognized property to its own configuration.
+#[sqlx::test]
+async fn test_get_config_advertises_idempotency_at_the_top_level(pool: PgPool) {
+    let (ctx, warehouse) = setup(
+        pool,
+        memory_io_profile(),
+        None,
+        HidingAuthorizer::new(),
+        TabularDeleteProfile::Hard {},
+        None,
+        1,
+        None,
+    )
+    .await;
+
+    let config = CatalogServer::get_config(
+        config_query(&warehouse.project_id, &warehouse.warehouse_name),
+        ctx,
+        RequestMetadata::new_unauthenticated(),
+    )
+    .await
+    .unwrap();
+
+    // Idempotency is enabled by default, so the field must be populated. Whether
+    // the *value* honours the configuration is covered by unit tests on the
+    // mapping itself; what only an end-to-end run can show is where it lands in
+    // the JSON a client actually parses.
+    assert!(CONFIG.idempotency.enabled, "test presumes the default");
+    let json = serde_json::to_value(&config).unwrap();
+
+    assert_eq!(
+        json["idempotency-key-lifetime"],
+        serde_json::json!(CONFIG.idempotency.lifetime_iso8601())
+    );
+    for map in ["overrides", "defaults"] {
+        assert!(
+            json[map].get("idempotency-key-lifetime").is_none(),
+            "leaked into {map}: {}",
+            json[map]
+        );
+    }
 }
 
 /// A warehouse the caller cannot see must produce the *same* error as a

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -833,7 +833,10 @@ impl IdempotencyConfig {
     /// Returns the lifetime as an ISO-8601 duration string for advertising in getConfig.
     #[must_use]
     pub fn lifetime_iso8601(&self) -> String {
-        crate::utils::time_conversion::std_duration_to_iso_8601_string(&self.lifetime)
+        // Never the weeks form: this value is advertised in `GET /v1/config`,
+        // and the Iceberg Java client feeds it to `java.time.Duration.parse`,
+        // which rejects `P<n>W` and fails the entire config response with it.
+        crate::utils::time_conversion::std_duration_to_iso_8601_string_no_weeks(&self.lifetime)
     }
 
     /// Total retention duration (lifetime + grace).
@@ -2254,6 +2257,28 @@ mod test {
             );
             Ok(())
         });
+    }
+
+    /// A week-multiple lifetime must not go out as `P<n>W`. That form is legal
+    /// ISO 8601, but the Iceberg Java client runs this field through
+    /// `java.time.Duration.parse`, which rejects the weeks designator and fails
+    /// the *entire* `GET /v1/config` response — so every Java/Spark/Trino client
+    /// would die at `RESTCatalog.initialize()` rather than merely lose the field.
+    #[test]
+    fn test_idempotency_lifetime_never_advertises_weeks() {
+        for (configured, expected) in [
+            ("P7D", "P7D"),
+            ("P1W", "P7D"),
+            ("P14D", "P14D"),
+            ("PT168H", "P7D"),
+        ] {
+            figment::Jail::expect_with(|jail| {
+                jail.set_env("LAKEKEEPER_TEST__IDEMPOTENCY__LIFETIME", configured);
+                let advertised = get_config().idempotency.lifetime_iso8601();
+                assert_eq!(advertised, expected, "configured as {configured}");
+                Ok(())
+            });
+        }
     }
 
     #[test]

--- a/crates/lakekeeper/src/server/config.rs
+++ b/crates/lakekeeper/src/server/config.rs
@@ -10,7 +10,7 @@ use crate::{
         },
         management::v1::user::{UserLastUpdatedWith, parse_create_user_request},
     },
-    config::MaintenanceMode,
+    config::{IdempotencyConfig, MaintenanceMode},
     request_metadata::RequestMetadata,
     service::{
         CatalogStore, CatalogWarehouseOps, ProjectId, SecretStore, State, Transaction,
@@ -126,15 +126,24 @@ impl<A: Authorizer + Clone, C: CatalogStore, S: SecretStore>
             .overrides
             .insert("uri".to_string(), request_metadata_arc.base_uri_catalog());
 
-        if CONFIG.idempotency.enabled {
-            config.overrides.insert(
-                "idempotency-key-lifetime".to_string(),
-                CONFIG.idempotency.lifetime_iso8601(),
-            );
-        }
+        config.idempotency_key_lifetime = advertised_idempotency_lifetime(&CONFIG.idempotency);
 
         Ok(config)
     }
+}
+
+/// The `idempotency-key-lifetime` to advertise in `GET /v1/config`.
+///
+/// A top-level field, not an override: it announces a server capability rather
+/// than a property the client should apply to itself. `None` when idempotency
+/// is disabled — absence is precisely how a client learns it is unsupported, so
+/// advertising a lifetime here while the server ignores `Idempotency-Key` would
+/// invite clients to rely on a guarantee that does not hold.
+///
+/// Split out from the handler so it is reachable without a database or the
+/// global config.
+fn advertised_idempotency_lifetime(idempotency: &IdempotencyConfig) -> Option<String> {
+    idempotency.enabled.then(|| idempotency.lifetime_iso8601())
 }
 
 fn parse_warehouse_arg(arg: &str) -> (Option<ProjectId>, String) {
@@ -234,4 +243,38 @@ async fn maybe_register_user<D: CatalogStore>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn idempotency(enabled: bool, lifetime: Duration) -> IdempotencyConfig {
+        IdempotencyConfig {
+            enabled,
+            lifetime,
+            ..IdempotencyConfig::default()
+        }
+    }
+
+    /// Absence is the "unsupported" signal, so a disabled server must advertise
+    /// nothing rather than a lifetime it will not honor.
+    #[test]
+    fn disabled_idempotency_advertises_nothing() {
+        assert_eq!(
+            advertised_idempotency_lifetime(&idempotency(false, Duration::from_mins(30))),
+            None
+        );
+    }
+
+    /// A non-default lifetime, so this cannot pass by coinciding with the default.
+    #[test]
+    fn enabled_idempotency_advertises_the_configured_lifetime() {
+        assert_eq!(
+            advertised_idempotency_lifetime(&idempotency(true, Duration::from_hours(1))),
+            Some("PT1H".to_string())
+        );
+    }
 }

--- a/crates/lakekeeper/src/service/storage/az/mod.rs
+++ b/crates/lakekeeper/src/service/storage/az/mod.rs
@@ -415,6 +415,7 @@ pub(super) fn adls_catalog_config() -> CatalogConfig {
         defaults: HashMap::default(),
         overrides: HashMap::default(),
         endpoints: supported_endpoints().to_vec(),
+        idempotency_key_lifetime: None,
     }
 }
 

--- a/crates/lakekeeper/src/service/storage/gcs/mod.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/mod.rs
@@ -269,6 +269,7 @@ impl GcsProfile {
             defaults: HashMap::with_capacity(0),
             overrides: HashMap::with_capacity(0),
             endpoints: supported_endpoints().to_vec(),
+            idempotency_key_lifetime: None,
         }
     }
 

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -239,6 +239,7 @@ impl StorageProfile {
                 overrides: std::collections::HashMap::new(),
                 defaults: std::collections::HashMap::new(),
                 endpoints: crate::api::iceberg::supported_endpoints().to_vec(),
+                idempotency_key_lifetime: None,
             },
         }
     }

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -437,6 +437,7 @@ impl S3Profile {
             defaults,
             overrides: HashMap::new(),
             endpoints: supported_endpoints().to_vec(),
+            idempotency_key_lifetime: None,
         }
     }
 

--- a/crates/lakekeeper/src/utils/time_conversion.rs
+++ b/crates/lakekeeper/src/utils/time_conversion.rs
@@ -148,10 +148,15 @@ pub fn iso_8601_duration_to_std(
 
 /// Converts a `std::time::Duration` to an ISO 8601 duration string.
 ///
+/// A duration that is a whole number of weeks is rendered with the weeks
+/// designator (`P<n>W`). That form is valid ISO 8601 but is **not** accepted by
+/// `java.time.Duration.parse`, so use
+/// [`std_duration_to_iso_8601_string_no_weeks`] for any value handed to an
+/// Iceberg REST client.
+///
 /// `std::time::Duration` is always non-negative, so this cannot fail for that reason.
 #[must_use]
 pub fn std_duration_to_iso_8601_string(duration: &std::time::Duration) -> String {
-    use std::fmt::Write;
     let total_secs = duration.as_secs();
     let millis = duration.subsec_millis();
 
@@ -160,6 +165,23 @@ pub fn std_duration_to_iso_8601_string(duration: &std::time::Duration) -> String
         let weeks = total_secs / (7 * 24 * 3600);
         return format!("P{weeks}W");
     }
+
+    std_duration_to_iso_8601_string_no_weeks(duration)
+}
+
+/// Converts a `std::time::Duration` to an ISO 8601 duration string, never using
+/// the weeks designator.
+///
+/// `java.time.Duration.parse` — which the Iceberg Java client applies to
+/// duration-typed fields of the `GET /v1/config` response — rejects `P<n>W`
+/// outright and fails the whole response, so a seven-day value has to go out as
+/// `P7D`. Prefer this over [`std_duration_to_iso_8601_string`] whenever the
+/// result crosses the catalog API.
+#[must_use]
+pub fn std_duration_to_iso_8601_string_no_weeks(duration: &std::time::Duration) -> String {
+    use std::fmt::Write;
+    let total_secs = duration.as_secs();
+    let millis = duration.subsec_millis();
 
     let days = total_secs / 86400;
     let hours = (total_secs % 86400) / 3600;


### PR DESCRIPTION
The spec defines idempotency-key-lifetime as a sibling of overrides/defaults on CatalogConfig, and its presence is the only signal that the server supports Idempotency-Key. We put it in the overrides map, so RESTSessionCatalog's null check never fired and the Java client silently disabled idempotency against a server that fully implements it. The feature has worked since 0.13.0; it was invisible.

Emitting it top-level also routes it into java.time.Duration.parse, which rejects the weeks designator — so a P7D lifetime, previously an opaque string in overrides, would now fail the entire config response and kill RESTCatalog.initialize(). Advertise via a formatter that never produces P<n>W. The shared formatter keeps the weeks form, which other Lakekeeper APIs emit.

Extract the enabled/disabled mapping so it is testable without a database: the disabled path had no coverage, and advertising a lifetime the server won't honor is the inverse of the signal clients need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The configuration endpoint now reports the configured idempotency-key lifetime as a top-level catalog setting.
  * The setting is omitted when idempotency support is disabled or no lifetime is configured.
* **Bug Fixes**
  * Duration values are now serialized in a format compatible with Java parsers, including week-based durations represented as days.
* **Tests**
  * Added coverage for configuration placement, omission, round-trip serialization, disabled settings, and duration formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->