### PR TITLE
feat(grants): pass the grantee to grant-authority checks

### DIFF
--- a/crates/authz-openfga/src/authorizer.rs
+++ b/crates/authz-openfga/src/authorizer.rs
@@ -18,10 +18,11 @@ use lakekeeper::{
             ActionOnGenericTable, ActionOnTable, ActionOnView, AddRoleAssignmentsError,
             AuthorizationBackendUnavailable, AuthorizationDecision, Authorizer,
             AuthzBackendErrorOrBadRequest, CannotInspectPermissions, CatalogProjectAction,
-            CatalogUserAction, GrantResource, IsAllowedActionError, ListProjectsResponse,
-            ListRoleAssignmentsError, ListRoleAssignmentsResultPage, MalformedRoleAssignment,
-            ManagesGrants, ManagesRoleAssignments, NamespaceParent, PrivilegeDescriptor,
-            ResourceType, RoleAssignmentFilter, RoleAssignmentRow, UserOrRole, UserOrRoleId,
+            CatalogUserAction, GrantAuthorityCheck, GrantResource, IsAllowedActionError,
+            ListProjectsResponse, ListRoleAssignmentsError, ListRoleAssignmentsResultPage,
+            MalformedRoleAssignment, ManagesGrants, ManagesRoleAssignments, NamespaceParent,
+            PrivilegeDescriptor, ResourceType, RoleAssignmentFilter, RoleAssignmentRow, UserOrRole,
+            UserOrRoleId,
         },
         events::context::authz_to_error_no_audit,
         health::Health,
@@ -1014,9 +1015,9 @@ impl Authorizer for OpenFGAAuthorizer {
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         resource: &GrantResource,
-        privileges: &[&str],
+        checks: &[GrantAuthorityCheck<'_>],
     ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
-        self.grant_authority(metadata, for_user, resource, privileges)
+        self.grant_authority(metadata, for_user, resource, checks)
             .await
     }
 }

--- a/crates/authz-openfga/src/grant.rs
+++ b/crates/authz-openfga/src/grant.rs
@@ -310,6 +310,39 @@ fn assumed_role_restriction(
     Ok(())
 }
 
+/// The tuples to check for `checks`, and the item each check takes its answer from.
+///
+/// Keeps the request dense. A privilege this level cannot grant gets no tuple at all
+/// (`None`, answered as a deny), and equal privileges share one: the relation is a
+/// function of the privilege, so two checks differing only in their grantee ask the same
+/// question of the model.
+fn plan_authority_checks(
+    resource_type: ResourceType,
+    user: &str,
+    object: &str,
+    checks: &[GrantAuthorityCheck<'_>],
+) -> (Vec<CheckRequestTupleKey>, Vec<Option<usize>>) {
+    let mut item_of_privilege: HashMap<&str, usize> = HashMap::new();
+    let mut item_of_check = Vec::with_capacity(checks.len());
+    let mut items: Vec<CheckRequestTupleKey> = Vec::with_capacity(checks.len());
+    for check in checks {
+        let Some(relation) = authority_relation(resource_type, check.privilege) else {
+            item_of_check.push(None);
+            continue;
+        };
+        let item = *item_of_privilege.entry(check.privilege).or_insert_with(|| {
+            items.push(CheckRequestTupleKey {
+                user: user.to_string(),
+                relation,
+                object: object.to_string(),
+            });
+            items.len() - 1
+        });
+        item_of_check.push(Some(item));
+    }
+    (items, item_of_check)
+}
+
 impl OpenFGAAuthorizer {
     /// Which of `checks` the actor (or `for_user`) may grant and revoke on `resource`,
     /// in order.
@@ -337,26 +370,7 @@ impl OpenFGAAuthorizer {
             |u| u.api_user_or_role().to_openfga(),
         );
 
-        // Keep the request dense: unknown privileges get no check, and repeated
-        // privileges share one. Both are filled back in from `checked_item` afterwards.
-        let mut item_of_privilege: HashMap<&str, usize> = HashMap::new();
-        let mut checked_item = Vec::with_capacity(checks.len());
-        let mut items: Vec<CheckRequestTupleKey> = Vec::with_capacity(checks.len());
-        for check in checks {
-            let Some(relation) = authority_relation(resource_type, check.privilege) else {
-                checked_item.push(None);
-                continue;
-            };
-            let item = *item_of_privilege.entry(check.privilege).or_insert_with(|| {
-                items.push(CheckRequestTupleKey {
-                    user: user.clone(),
-                    relation,
-                    object: object.clone(),
-                });
-                items.len() - 1
-            });
-            checked_item.push(Some(item));
-        }
+        let (items, item_of_check) = plan_authority_checks(resource_type, &user, &object, checks);
 
         let guard_tuples = if for_user.is_some() {
             vec![CheckRequestTupleKey {
@@ -374,7 +388,7 @@ impl OpenFGAAuthorizer {
 
         // A check with no item is an unknown privilege; a missing result would be a bug
         // in the batch, and denying is the safe reading of both.
-        Ok(checked_item
+        Ok(item_of_check
             .into_iter()
             .map(|item| {
                 item.and_then(|item| checked.get(item).cloned())
@@ -610,6 +624,8 @@ fn tuple_timestamp(seconds_and_nanos: Option<(i64, i32)>) -> Option<chrono::Date
 
 #[cfg(test)]
 mod tests {
+    use lakekeeper::service::UserId;
+
     use super::*;
     use crate::FgaType;
 
@@ -659,6 +675,44 @@ mod tests {
         <ResourceType as strum::VariantArray>::VARIANTS
             .iter()
             .copied()
+    }
+
+    /// Equal privileges are one tuple however many grantees name them, and a privilege
+    /// this level cannot grant is no tuple at all. The decisions alone cannot show either:
+    /// a plan with one tuple per check answers identically, just more expensively.
+    #[test]
+    fn equal_privileges_share_one_tuple_whatever_the_grantee() {
+        let alice = UserOrRoleId::User(UserId::new_unchecked("oidc", "alice"));
+        let bob = UserOrRoleId::User(UserId::new_unchecked("oidc", "bob"));
+        let (items, item_of_check) = plan_authority_checks(
+            ResourceType::Warehouse,
+            "user:oidc~caller",
+            "warehouse:11111111-1111-1111-1111-111111111111",
+            &[
+                GrantAuthorityCheck::new("select", Some(&alice)),
+                GrantAuthorityCheck::new("select", Some(&bob)),
+                GrantAuthorityCheck::new("modify", Some(&alice)),
+                // A warehouse action, but not an assignable relation, so not grantable.
+                GrantAuthorityCheck::new("get_metadata", Some(&alice)),
+            ],
+        );
+
+        assert_eq!(item_of_check, vec![Some(0), Some(0), Some(1), None]);
+        assert_eq!(
+            items,
+            vec![
+                CheckRequestTupleKey {
+                    user: "user:oidc~caller".to_string(),
+                    relation: "can_grant_select".to_string(),
+                    object: "warehouse:11111111-1111-1111-1111-111111111111".to_string(),
+                },
+                CheckRequestTupleKey {
+                    user: "user:oidc~caller".to_string(),
+                    relation: "can_grant_modify".to_string(),
+                    object: "warehouse:11111111-1111-1111-1111-111111111111".to_string(),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/authz-openfga/src/grant.rs
+++ b/crates/authz-openfga/src/grant.rs
@@ -25,10 +25,10 @@ use lakekeeper::{
     service::authz::{
         AppliedGrants, ApplyGrantsError, AuthorizationDecision, CatalogGenericTableAction,
         CatalogNamespaceAction, CatalogProjectAction, CatalogServerAction, CatalogTableAction,
-        CatalogTagAction, CatalogViewAction, CatalogWarehouseAction, GrantFilter,
-        GrantListingNotImplemented, GrantNotSupported, GrantResource, GrantRow, GrantSpec,
-        IsAllowedActionError, ListGrantsError, ListGrantsResultPage, MalformedGrant, ManagesGrants,
-        PrivilegeDescriptor, ResourceType, UserOrRole, UserOrRoleId,
+        CatalogTagAction, CatalogViewAction, CatalogWarehouseAction, GrantAuthorityCheck,
+        GrantFilter, GrantListingNotImplemented, GrantNotSupported, GrantResource, GrantRow,
+        GrantSpec, IsAllowedActionError, ListGrantsError, ListGrantsResultPage, MalformedGrant,
+        ManagesGrants, PrivilegeDescriptor, ResourceType, UserOrRole, UserOrRoleId,
     },
 };
 use openfga_client::client::{
@@ -311,18 +311,24 @@ fn assumed_role_restriction(
 }
 
 impl OpenFGAAuthorizer {
-    /// Which of `privileges` the actor (or `for_user`) may grant and revoke on
-    /// `resource`, in order.
+    /// Which of `checks` the actor (or `for_user`) may grant and revoke on `resource`,
+    /// in order.
     ///
     /// A privilege outside this level's vocabulary is a deny, not an error: the name
     /// may come from another authorizer's vocabulary, and answering "not allowed" is
     /// both true and safe.
+    ///
+    /// The grantee is ignored. Every `can_grant_*` relation is a property of the actor,
+    /// the resource and the privilege — nothing in the model reads who receives the
+    /// privilege — so checks that differ only in their grantee collapse into one check
+    /// whose answer is repeated for each. A diff handing one privilege to a hundred
+    /// principals is a single check.
     pub(crate) async fn grant_authority(
         &self,
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
         resource: &GrantResource,
-        privileges: &[&str],
+        checks: &[GrantAuthorityCheck<'_>],
     ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         let resource_type = resource.resource_type();
         let object = grant_object(self, resource);
@@ -331,19 +337,25 @@ impl OpenFGAAuthorizer {
             |u| u.api_user_or_role().to_openfga(),
         );
 
-        // Keep the request dense: unknown privileges get no check and are filled back
-        // in as denials afterwards.
-        let mut checked_positions = Vec::with_capacity(privileges.len());
-        let mut items = Vec::with_capacity(privileges.len());
-        for (position, privilege) in privileges.iter().enumerate() {
-            if let Some(relation) = authority_relation(resource_type, privilege) {
-                checked_positions.push(position);
+        // Keep the request dense: unknown privileges get no check, and repeated
+        // privileges share one. Both are filled back in from `checked_item` afterwards.
+        let mut item_of_privilege: HashMap<&str, usize> = HashMap::new();
+        let mut checked_item = Vec::with_capacity(checks.len());
+        let mut items: Vec<CheckRequestTupleKey> = Vec::with_capacity(checks.len());
+        for check in checks {
+            let Some(relation) = authority_relation(resource_type, check.privilege) else {
+                checked_item.push(None);
+                continue;
+            };
+            let item = *item_of_privilege.entry(check.privilege).or_insert_with(|| {
                 items.push(CheckRequestTupleKey {
                     user: user.clone(),
                     relation,
                     object: object.clone(),
                 });
-            }
+                items.len() - 1
+            });
+            checked_item.push(Some(item));
         }
 
         let guard_tuples = if for_user.is_some() {
@@ -360,11 +372,15 @@ impl OpenFGAAuthorizer {
             .check_actions_with_permission_guard(metadata.actor(), items, guard_tuples)
             .await?;
 
-        let mut decisions = vec![AuthorizationDecision::deny(); privileges.len()];
-        for (position, decision) in checked_positions.into_iter().zip(checked) {
-            decisions[position] = decision;
-        }
-        Ok(decisions)
+        // A check with no item is an unknown privilege; a missing result would be a bug
+        // in the batch, and denying is the safe reading of both.
+        Ok(checked_item
+            .into_iter()
+            .map(|item| {
+                item.and_then(|item| checked.get(item).cloned())
+                    .unwrap_or_else(AuthorizationDecision::deny)
+            })
+            .collect())
     }
 }
 

--- a/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
@@ -39,7 +39,10 @@ mod grant {
             service::{
                 CatalogNamespaceOps as _, NamespaceId, State, UserId,
                 authn::Actor,
-                authz::{AuthZGrantOps as _, Authorizer as _, GrantResource, ResourceType},
+                authz::{
+                    AuthZGrantOps as _, Authorizer as _, GrantAuthorityCheck, GrantResource,
+                    ResourceType, UserOrRoleId,
+                },
             },
         };
         use lakekeeper_authz_openfga::{
@@ -84,6 +87,12 @@ mod grant {
                 privilege: privilege.to_string(),
                 principal: UserOrRole::User(user.clone()),
             }
+        }
+
+        /// A grant-authority question naming no grantee. The tests that name one build
+        /// the check directly.
+        fn check(privilege: &str) -> GrantAuthorityCheck<'_> {
+            GrantAuthorityCheck::new(privilege, None)
         }
 
         fn writes(entries: Vec<GrantEntry>) -> ApplyGrantsRequest {
@@ -273,7 +282,7 @@ mod grant {
                     &metadata(&admin, &project_id),
                     None,
                     &resource,
-                    &["select", "modify"],
+                    &[check("select"), check("modify")],
                 )
                 .await
                 .unwrap();
@@ -285,7 +294,7 @@ mod grant {
                     &metadata(&nobody, &project_id),
                     None,
                     &resource,
-                    &["select", "modify"],
+                    &[check("select"), check("modify")],
                 )
                 .await
                 .unwrap();
@@ -298,11 +307,74 @@ mod grant {
                     &metadata(&admin, &project_id),
                     None,
                     &resource,
-                    &["get_metadata"],
+                    &[check("get_metadata")],
                 )
                 .await
                 .unwrap();
             assert_eq!(unknown, vec![false]);
+        }
+
+        /// The grantee reaches the authorizer but does not change its answer: no
+        /// `can_grant_*` relation reads who receives the privilege, so this arm checks
+        /// each distinct privilege once and repeats the answer per check.
+        ///
+        /// Pins the fan-out, which is the part that can go wrong silently: one decision
+        /// per check, in the order asked, with repeated and unknown privileges mixed in.
+        #[sqlx::test]
+        async fn grant_authority_repeats_one_answer_per_grantee(pool: PgPool) {
+            let (ctx, admin, project_id, warehouse_id) = setup(pool).await;
+            let authorizer = &ctx.v1_state.authz;
+            let resource = GrantResource::Warehouse(warehouse_id);
+            let alice = UserOrRoleId::User(UserId::new_unchecked("oidc", "alice"));
+            let bob = UserOrRoleId::User(UserId::new_unchecked("oidc", "bob"));
+
+            let decisions = authorizer
+                .are_allowed_grants(
+                    &metadata(&admin, &project_id),
+                    None,
+                    &resource,
+                    &[
+                        GrantAuthorityCheck::new("select", Some(&alice)),
+                        GrantAuthorityCheck::new("select", Some(&bob)),
+                        GrantAuthorityCheck::new("modify", Some(&alice)),
+                    ],
+                )
+                .await
+                .unwrap();
+            assert_eq!(decisions, vec![true, true, true]);
+
+            // An unknown name is a deny wherever it sits, and does not shift the
+            // decisions of the checks around it.
+            let mixed = authorizer
+                .are_allowed_grants(
+                    &metadata(&admin, &project_id),
+                    None,
+                    &resource,
+                    &[
+                        GrantAuthorityCheck::new("get_metadata", Some(&alice)),
+                        GrantAuthorityCheck::new("select", Some(&alice)),
+                        GrantAuthorityCheck::new("get_metadata", Some(&bob)),
+                        GrantAuthorityCheck::new("select", Some(&bob)),
+                    ],
+                )
+                .await
+                .unwrap();
+            assert_eq!(mixed, vec![false, true, false, true]);
+
+            let nobody = UserId::new_unchecked("oidc", "nobody");
+            let as_nobody = authorizer
+                .are_allowed_grants(
+                    &metadata(&nobody, &project_id),
+                    None,
+                    &resource,
+                    &[
+                        GrantAuthorityCheck::new("select", Some(&alice)),
+                        GrantAuthorityCheck::new("select", Some(&bob)),
+                    ],
+                )
+                .await
+                .unwrap();
+            assert_eq!(as_nobody, vec![false, false]);
         }
 
         /// A principal holding only direct `manage_grants` on a warehouse can read
@@ -471,7 +543,7 @@ mod grant {
                     &as_instance_admin,
                     None,
                     &GrantResource::Warehouse(warehouse_id),
-                    &["select", "modify"],
+                    &[check("select"), check("modify")],
                 )
                 .await
                 .unwrap();
@@ -514,7 +586,7 @@ mod grant {
                     &metadata(&admin, &project_id),
                     Some(&for_bob),
                     &resource,
-                    &["select"],
+                    &[check("select")],
                 )
                 .await
                 .unwrap();
@@ -528,7 +600,7 @@ mod grant {
                     &metadata(&nobody, &project_id),
                     Some(&for_bob),
                     &resource,
-                    &["select"],
+                    &[check("select")],
                 )
                 .await
                 .unwrap_err();

--- a/crates/lakekeeper/src/api/management/v1/grant.rs
+++ b/crates/lakekeeper/src/api/management/v1/grant.rs
@@ -68,11 +68,12 @@ use crate::{
             ActionDescriptor, AuthZCannotSeeTag, AuthZCannotUseWarehouseId, AuthZError,
             AuthZGenericTableOps, AuthZGrantActionForbidden, AuthZGrantOps, AuthZProjectOps,
             AuthZServerOps, AuthZTableOps, AuthZTagActionForbidden, AuthZTagOps, AuthZViewOps,
-            Authorizer, AuthzNamespaceOps, AuthzWarehouseOps, CatalogGenericTableAction,
-            CatalogNamespaceAction, CatalogProjectAction, CatalogServerAction, CatalogTableAction,
-            CatalogTagAction, CatalogViewAction, CatalogWarehouseAction, GrantAuthorityCheck,
-            GrantFilter, GrantResource, GrantRow, GrantSpec, PrivilegeDescriptor,
-            RequireTagActionError, ResourceType, UserOrRole as AuthzUserOrRole, UserOrRoleId,
+            AuthorizationDecision, Authorizer, AuthzNamespaceOps, AuthzWarehouseOps,
+            CatalogGenericTableAction, CatalogNamespaceAction, CatalogProjectAction,
+            CatalogServerAction, CatalogTableAction, CatalogTagAction, CatalogViewAction,
+            CatalogWarehouseAction, GrantAuthorityCheck, GrantFilter, GrantResource, GrantRow,
+            GrantSpec, PrivilegeDescriptor, RequireTagActionError, ResourceType,
+            UserOrRole as AuthzUserOrRole, UserOrRoleId,
         },
         events::{
             APIEventContext, GrantsChangedEvent,
@@ -717,12 +718,11 @@ async fn validate_write_principals<C: CatalogRoleOps>(
 /// The distinct grant-authority questions a diff asks, in `writes`-then-`deletes` order:
 /// which privilege, destined for which principal.
 ///
-/// Deduplicated on the *pair*, and in first-seen order rather than sorted, so the error
-/// below lists refused privileges in the order the caller's request names them. A diff
-/// handing one privilege to a hundred principals asks a hundred questions: whether the
-/// grantee changes the answer belongs to the authorizer's model, so this layer cannot
-/// collapse them. Authorizers that resolve authority from the privilege alone collapse
-/// them internally instead, where doing so is sound.
+/// Deduplicated on the *pair*, in first-seen order. A diff handing one privilege to a
+/// hundred principals asks a hundred questions: whether the grantee changes the answer
+/// belongs to the authorizer's model, so this layer cannot collapse them. An authorizer
+/// that resolves authority from the privilege alone collapses them itself, where that is
+/// sound.
 fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str)> {
     let mut seen = std::collections::HashSet::new();
     request
@@ -734,6 +734,26 @@ fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str)
             )
         })
         .filter(|question| seen.insert(question.clone()))
+        .collect()
+}
+
+/// The privileges to name in a refusal: those `decisions` refused, named once each, in
+/// the order they were first refused.
+///
+/// `decisions` answer `questions` positionally. First-refusal order is not request order
+/// once an authorizer answers per grantee: a privilege allowed for the first principal
+/// that asks for it and refused for the second is named where the refusal is.
+fn refused_privileges<'a>(
+    questions: &[(UserOrRoleId, &'a str)],
+    decisions: &[AuthorizationDecision],
+) -> Vec<&'a str> {
+    let mut named = std::collections::HashSet::new();
+    questions
+        .iter()
+        .zip(decisions)
+        .filter(|(_, decision)| !decision.allowed)
+        .map(|((_, privilege), _)| *privilege)
+        .filter(|privilege| named.insert(*privilege))
         .collect()
 }
 
@@ -755,17 +775,9 @@ async fn require_grant_authority<A: Authorizer>(
     let decisions = authorizer
         .are_allowed_grants(metadata, None, resource, &checks)
         .await?;
-    // Every refused privilege is named, matching the validation errors above: one
-    // round trip should surface everything the caller must remove. Named once even when
-    // refused for several principals — the message speaks about privileges.
-    let mut named = std::collections::HashSet::new();
-    let refused: Vec<&str> = questions
-        .iter()
-        .zip(&decisions)
-        .filter(|(_, decision)| !decision.allowed)
-        .map(|((_, privilege), _)| *privilege)
-        .filter(|privilege| named.insert(*privilege))
-        .collect();
+    // Every refused privilege is named, matching the validation errors above: one round
+    // trip should surface everything the caller must remove.
+    let refused = refused_privileges(&questions, &decisions);
     if !refused.is_empty() {
         return Err(AuthZGrantActionForbidden::new(resource, refused).into());
     }
@@ -2750,6 +2762,46 @@ mod tests {
                 (UserOrRoleId::Role(role_id), "modify"),
                 (alice_id, "select"),
             ]
+        );
+    }
+
+    #[test]
+    fn a_refusal_names_each_privilege_once_in_first_refusal_order() {
+        // Mixed decisions, which no authorizer in this workspace produces: the answers are
+        // positional, so a pairing that slipped by one would name a privilege the
+        // authorizer allowed - and stay invisible to every all-deny or all-allow test.
+        let alice = UserOrRoleId::from(&alice());
+        let role = UserOrRoleId::Role(RoleId::new_random());
+        let questions = vec![
+            (alice.clone(), "select"),
+            (role, "select"),
+            (alice, "modify"),
+        ];
+
+        // `select` allowed for alice but refused for the role: named once, and from the
+        // position of the refusal rather than of the first request for it.
+        assert_eq!(
+            refused_privileges(
+                &questions,
+                &[
+                    AuthorizationDecision::allow(),
+                    AuthorizationDecision::deny(),
+                    AuthorizationDecision::deny(),
+                ]
+            ),
+            vec!["select", "modify"]
+        );
+        // Only the first question refused, so `modify` must not be named.
+        assert_eq!(
+            refused_privileges(
+                &questions,
+                &[
+                    AuthorizationDecision::deny(),
+                    AuthorizationDecision::allow(),
+                    AuthorizationDecision::allow(),
+                ]
+            ),
+            vec!["select"]
         );
     }
 

--- a/crates/lakekeeper/src/api/management/v1/grant.rs
+++ b/crates/lakekeeper/src/api/management/v1/grant.rs
@@ -70,9 +70,9 @@ use crate::{
             AuthZServerOps, AuthZTableOps, AuthZTagActionForbidden, AuthZTagOps, AuthZViewOps,
             Authorizer, AuthzNamespaceOps, AuthzWarehouseOps, CatalogGenericTableAction,
             CatalogNamespaceAction, CatalogProjectAction, CatalogServerAction, CatalogTableAction,
-            CatalogTagAction, CatalogViewAction, CatalogWarehouseAction, GrantFilter,
-            GrantResource, GrantRow, GrantSpec, PrivilegeDescriptor, RequireTagActionError,
-            ResourceType, UserOrRole as AuthzUserOrRole, UserOrRoleId,
+            CatalogTagAction, CatalogViewAction, CatalogWarehouseAction, GrantAuthorityCheck,
+            GrantFilter, GrantResource, GrantRow, GrantSpec, PrivilegeDescriptor,
+            RequireTagActionError, ResourceType, UserOrRole as AuthzUserOrRole, UserOrRoleId,
         },
         events::{
             APIEventContext, GrantsChangedEvent,
@@ -714,47 +714,57 @@ async fn validate_write_principals<C: CatalogRoleOps>(
 // Shared apply / list bodies
 // ---------------------------------------------------------------------------
 
-/// The privileges of a diff, in `writes`-then-`deletes` order — the order every
-/// per-entry decision is returned in.
-fn privileges_of(request: &ApplyGrantsRequest) -> Vec<&str> {
+/// The distinct grant-authority questions a diff asks, in `writes`-then-`deletes` order:
+/// which privilege, destined for which principal.
+///
+/// Deduplicated on the *pair*, and in first-seen order rather than sorted, so the error
+/// below lists refused privileges in the order the caller's request names them. A diff
+/// handing one privilege to a hundred principals asks a hundred questions: whether the
+/// grantee changes the answer belongs to the authorizer's model, so this layer cannot
+/// collapse them. Authorizers that resolve authority from the privilege alone collapse
+/// them internally instead, where doing so is sound.
+fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str)> {
+    let mut seen = std::collections::HashSet::new();
     request
         .entries()
-        .map(|entry| entry.privilege.as_str())
+        .map(|entry| {
+            (
+                UserOrRoleId::from(&entry.principal),
+                entry.privilege.as_str(),
+            )
+        })
+        .filter(|question| seen.insert(question.clone()))
         .collect()
 }
 
 /// Check grant authority for every entry of the diff, including the deletes:
 /// revoking a privilege requires the same authority as granting it.
-///
-/// Asked once per *distinct* privilege. The decision depends only on
-/// `(actor, resource, privilege)` — `are_allowed_grants` folds `for_user` to `None` here —
-/// so the principal each entry names cannot change the answer, and a diff handing one
-/// privilege to a hundred principals would otherwise ask the same question a hundred
-/// times. Under an authorizer that evaluates a graph per check, a bulk onboarding pass
-/// turns that into tens of thousands of evaluations where a few hundred suffice.
 async fn require_grant_authority<A: Authorizer>(
     authorizer: &A,
     metadata: &RequestMetadata,
     resource: &GrantResource,
     request: &ApplyGrantsRequest,
 ) -> std::result::Result<(), AuthZError> {
-    // Deduplicated in first-seen order, not sorted: the error below lists the refused
-    // privileges in the order the caller's request names them.
-    let mut seen = std::collections::HashSet::new();
-    let privileges: Vec<&str> = privileges_of(request)
-        .into_iter()
-        .filter(|privilege| seen.insert(*privilege))
+    // Materialized first so each check can borrow its grantee: the request carries the
+    // API principal type, and converting it to an id allocates.
+    let questions = authority_questions(request);
+    let checks: Vec<GrantAuthorityCheck<'_>> = questions
+        .iter()
+        .map(|(grantee, privilege)| GrantAuthorityCheck::new(privilege, Some(grantee)))
         .collect();
     let decisions = authorizer
-        .are_allowed_grants(metadata, None, resource, &privileges)
+        .are_allowed_grants(metadata, None, resource, &checks)
         .await?;
     // Every refused privilege is named, matching the validation errors above: one
-    // round trip should surface everything the caller must remove.
-    let refused: Vec<&str> = privileges
+    // round trip should surface everything the caller must remove. Named once even when
+    // refused for several principals — the message speaks about privileges.
+    let mut named = std::collections::HashSet::new();
+    let refused: Vec<&str> = questions
         .iter()
         .zip(&decisions)
         .filter(|(_, decision)| !decision.allowed)
-        .map(|(privilege, _)| *privilege)
+        .map(|((_, privilege), _)| *privilege)
+        .filter(|privilege| named.insert(*privilege))
         .collect();
     if !refused.is_empty() {
         return Err(AuthZGrantActionForbidden::new(resource, refused).into());
@@ -777,12 +787,15 @@ async fn allowed_privileges<A: Authorizer>(
     resource: &GrantResource,
 ) -> std::result::Result<Vec<GrantablePrivilege>, AuthZError> {
     let vocabulary = authorizer.grantable_privileges(resource.resource_type());
-    let names: Vec<&str> = vocabulary
+    // No grantee: this asks whether the subject has authority over each privilege here
+    // at all. Advisory - the apply path asks again per grantee - so an authorizer that
+    // distinguishes them need not enumerate anyone to answer.
+    let checks: Vec<GrantAuthorityCheck<'_>> = vocabulary
         .iter()
-        .map(|privilege| privilege.name.as_str())
+        .map(|privilege| GrantAuthorityCheck::new(privilege.name.as_str(), None))
         .collect();
     let decisions = authorizer
-        .are_allowed_grants(request_metadata, for_user.as_ref(), resource, &names)
+        .are_allowed_grants(request_metadata, for_user.as_ref(), resource, &checks)
         .await?;
     Ok(vocabulary
         .iter()
@@ -940,8 +953,8 @@ const TABULAR_FLAGS: TabularListFlags = TabularListFlags {
     include_deleted: true,
 };
 
-/// Event-action marker for a grant write. Grant authority is resolved per privilege
-/// by the authorizer rather than modelled as a `Catalog*Action`, so the audit event
+/// Event-action marker for a grant write. Grant authority is resolved by the authorizer
+/// from the privilege name rather than modelled as a `Catalog*Action`, so the audit event
 /// carries its own marker instead of borrowing a resource action.
 ///
 /// Carries what was asked for, because a *denied* apply emits no per-grant
@@ -2599,16 +2612,22 @@ mod tests {
         },
     };
 
+    fn alice() -> UserOrRole {
+        UserOrRole::User(UserId::try_from("oidc~alice").expect("valid test user id"))
+    }
+
+    fn entry(privilege: &str, principal: UserOrRole) -> GrantEntry {
+        GrantEntry {
+            privilege: privilege.to_string(),
+            principal,
+        }
+    }
+
     fn write_request(privileges: &[&str]) -> ApplyGrantsRequest {
         ApplyGrantsRequest {
             writes: privileges
                 .iter()
-                .map(|privilege| GrantEntry {
-                    privilege: (*privilege).to_string(),
-                    principal: UserOrRole::User(
-                        UserId::try_from("oidc~alice").expect("valid test user id"),
-                    ),
-                })
+                .map(|privilege| entry(privilege, alice()))
                 .collect(),
             deletes: Vec::new(),
         }
@@ -2695,6 +2714,66 @@ mod tests {
             &metadata,
             &resource,
             &write_request(&["provision_users", "list_users"]),
+        )
+        .await
+        .expect_err("a deny-all authorizer must not confer grant authority")
+        .into_error_model();
+
+        assert_eq!(
+            err.message,
+            "Granting or revoking `provision_users`, `list_users` on this server is forbidden"
+        );
+    }
+
+    #[test]
+    fn authority_questions_are_deduplicated_on_the_pair() {
+        // Not on the privilege alone: an authorizer may answer differently depending on
+        // who receives the privilege, so `modify` for alice and `modify` for a role are
+        // two questions. The same pair twice - here a grant and a revoke of `modify` for
+        // alice - is one, asked in the position the request first names it.
+        let role_id = RoleId::new_random();
+        let role = UserOrRole::Role(RoleAssignee::from_role(role_id));
+        let request = ApplyGrantsRequest {
+            writes: vec![
+                entry("modify", alice()),
+                entry("modify", role),
+                entry("select", alice()),
+            ],
+            deletes: vec![entry("modify", alice())],
+        };
+
+        let alice_id = UserOrRoleId::from(&alice());
+        assert_eq!(
+            authority_questions(&request),
+            vec![
+                (alice_id.clone(), "modify"),
+                (UserOrRoleId::Role(role_id), "modify"),
+                (alice_id, "select"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_write_gate_names_a_privilege_refused_for_several_principals_once() {
+        // The gate asks per pair, but the message speaks about privileges: one name
+        // refused for two principals is named once, and still in request order.
+        let authorizer = HidingAuthorizer::new();
+        let metadata = RequestMetadataTestBuilder::builder().build();
+        let resource = GrantResource::Server;
+        let role = UserOrRole::Role(RoleAssignee::from_role(RoleId::new_random()));
+
+        let err = require_grant_authority(
+            &authorizer,
+            &metadata,
+            &resource,
+            &ApplyGrantsRequest {
+                writes: vec![
+                    entry("provision_users", alice()),
+                    entry("provision_users", role),
+                    entry("list_users", alice()),
+                ],
+                deletes: Vec::new(),
+            },
         )
         .await
         .expect_err("a deny-all authorizer must not confer grant authority")

--- a/crates/lakekeeper/src/service/authz/grant.rs
+++ b/crates/lakekeeper/src/service/authz/grant.rs
@@ -541,25 +541,25 @@ impl AppliedGrants {
 /// One grant-authority question: may the subject grant and revoke `privilege` on the
 /// resource, to `grantee`?
 ///
-/// Extensible on purpose — construct with [`new`](Self::new). A question may grow a term
-/// (whether the entry is a grant or a revoke, say) without breaking authorizers that live
-/// outside this workspace.
+/// Extensible on purpose — construct with [`new`](Self::new) and read fields rather than
+/// destructuring, so a new term costs no out-of-workspace authorizer a compile error.
+/// Compiling is not honoring: a term that changes what may be authorized (grant versus
+/// revoke, say) belongs in a change its implementors cannot silently ignore.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub struct GrantAuthorityCheck<'a> {
-    /// A name from the authorizer's own vocabulary. An unrecognized name is a deny, not
-    /// an error: it may belong to a different authorizer's vocabulary.
+    /// A name from the authorizer's own vocabulary. An unrecognized name is answered
+    /// rather than rejected — it may belong to a different authorizer's vocabulary — and
+    /// an authorizer that enforces its own vocabulary answers it with a deny.
     pub privilege: &'a str,
-    /// Who would come to hold the privilege — or lose it, for a revoke.
+    /// Who would come to hold the privilege — or lose it, for a revoke. An authorizer
+    /// whose authority does not depend on the recipient ignores it.
     ///
     /// `None` leaves the grantee out of the question: the grantable-privileges endpoint
     /// asks whether the subject has authority over the privilege here at all. That
-    /// answer is advisory, since the apply path asks again for each grantee, so an
-    /// authorizer that does distinguish grantees may still answer this form from the
-    /// privilege alone.
-    ///
-    /// An authorizer whose grant authority never depends on who receives the privilege
-    /// ignores this field and answers the same either way.
+    /// answer is advisory, since the apply path asks again for each grantee, so even an
+    /// authorizer that does distinguish grantees may answer this form from the privilege
+    /// alone.
     pub grantee: Option<&'a UserOrRoleId>,
 }
 

--- a/crates/lakekeeper/src/service/authz/grant.rs
+++ b/crates/lakekeeper/src/service/authz/grant.rs
@@ -538,13 +538,45 @@ impl AppliedGrants {
     }
 }
 
+/// One grant-authority question: may the subject grant and revoke `privilege` on the
+/// resource, to `grantee`?
+///
+/// Extensible on purpose — construct with [`new`](Self::new). A question may grow a term
+/// (whether the entry is a grant or a revoke, say) without breaking authorizers that live
+/// outside this workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub struct GrantAuthorityCheck<'a> {
+    /// A name from the authorizer's own vocabulary. An unrecognized name is a deny, not
+    /// an error: it may belong to a different authorizer's vocabulary.
+    pub privilege: &'a str,
+    /// Who would come to hold the privilege — or lose it, for a revoke.
+    ///
+    /// `None` leaves the grantee out of the question: the grantable-privileges endpoint
+    /// asks whether the subject has authority over the privilege here at all. That
+    /// answer is advisory, since the apply path asks again for each grantee, so an
+    /// authorizer that does distinguish grantees may still answer this form from the
+    /// privilege alone.
+    ///
+    /// An authorizer whose grant authority never depends on who receives the privilege
+    /// ignores this field and answers the same either way.
+    pub grantee: Option<&'a UserOrRoleId>,
+}
+
+impl<'a> GrantAuthorityCheck<'a> {
+    #[must_use]
+    pub fn new(privilege: &'a str, grantee: Option<&'a UserOrRoleId>) -> Self {
+        Self { privilege, grantee }
+    }
+}
+
 /// The checked entry point to grant authority. Blanket-implemented, so an authorizer
 /// cannot replace it and lose the guards — implement
 /// [`are_allowed_grants_impl`](Authorizer::are_allowed_grants_impl) instead.
 #[async_trait::async_trait]
 pub trait AuthZGrantOps: Authorizer {
-    /// May the actor (or `for_user`, when given) grant and revoke each of `privileges`
-    /// on `resource`? Returns exactly one decision per privilege, in order.
+    /// May the actor (or `for_user`, when given) grant and revoke each of `checks` on
+    /// `resource`? Returns exactly one decision per check, in order.
     ///
     /// Grant *authority* is resolved here rather than modelled as a `Catalog*Action`
     /// because the privilege is a name from this authorizer's own vocabulary: it cannot
@@ -559,7 +591,7 @@ pub trait AuthZGrantOps: Authorizer {
         metadata: &RequestMetadata,
         mut for_user: Option<&UserOrRole>,
         resource: &GrantResource,
-        privileges: &[&str],
+        checks: &[GrantAuthorityCheck<'_>],
     ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         // Naming yourself asks the same question as naming nobody, so it must not trip
         // the read-assignments guard that answering for someone else requires.
@@ -573,17 +605,14 @@ pub trait AuthZGrantOps: Authorizer {
         // by writing the very records its own permission API refuses them. Instance
         // admins provision; they do not administer permissions.
         let decisions = self
-            .are_allowed_grants_impl(metadata, for_user, resource, privileges)
+            .are_allowed_grants_impl(metadata, for_user, resource, checks)
             .await?;
-        // Callers zip decisions against privileges, and `zip` stops at the shorter side —
+        // Callers zip decisions against the checks, and `zip` stops at the shorter side —
         // a short vector would silently authorize the tail rather than deny it.
-        if decisions.len() != privileges.len() {
-            return Err(AuthorizationCountMismatch::new(
-                privileges.len(),
-                decisions.len(),
-                "grant",
-            )
-            .into());
+        if decisions.len() != checks.len() {
+            return Err(
+                AuthorizationCountMismatch::new(checks.len(), decisions.len(), "grant").into(),
+            );
         }
         Ok(decisions)
     }

--- a/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
+++ b/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
@@ -21,8 +21,8 @@ use crate::{
             AuthzBackendErrorOrBadRequest, CatalogAction, CatalogGenericTableAction,
             CatalogNamespaceAction, CatalogProjectAction, CatalogRoleAction, CatalogServerAction,
             CatalogTableAction, CatalogTagAction, CatalogUserAction, CatalogViewAction,
-            CatalogWarehouseAction, GrantResource, IsAllowedActionError, ListProjectsResponse,
-            NamespaceParent, PrivilegeDescriptor, ResourceType, UserOrRole,
+            CatalogWarehouseAction, GrantAuthorityCheck, GrantResource, IsAllowedActionError,
+            ListProjectsResponse, NamespaceParent, PrivilegeDescriptor, ResourceType, UserOrRole,
         },
         health::{Health, HealthExt},
     },
@@ -287,9 +287,9 @@ impl Authorizer for AllowAllAuthorizer {
         _metadata: &RequestMetadata,
         _for_user: Option<&UserOrRole>,
         _resource: &GrantResource,
-        privileges: &[&str],
+        checks: &[GrantAuthorityCheck<'_>],
     ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
-        Ok(vec![AuthorizationDecision::allow(); privileges.len()])
+        Ok(vec![AuthorizationDecision::allow(); checks.len()])
     }
 
     async fn delete_user(&self, _metadata: &RequestMetadata, _user_id: UserId) -> Result<()> {
@@ -453,7 +453,7 @@ fn build_vocabulary(resource_type: ResourceType) -> Vec<PrivilegeDescriptor> {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::super::{AuthZGrantOps, InvalidGrantPrivilege},
+        super::super::{AuthZGrantOps, InvalidGrantPrivilege, UserOrRoleId},
         *,
     };
 
@@ -545,12 +545,16 @@ mod tests {
     async fn grant_authority_is_allowed_for_every_privilege() {
         let authorizer = AllowAllAuthorizer::default();
         let resource = GrantResource::Warehouse(WarehouseId::new_random());
+        let bob = UserOrRoleId::User(UserId::new_unchecked("oidc", "bob"));
         let decisions = authorizer
             .are_allowed_grants(
                 &RequestMetadata::new_unauthenticated(),
                 None,
                 &resource,
-                &["get_metadata", "not_a_privilege"],
+                &[
+                    GrantAuthorityCheck::new("get_metadata", Some(&bob)),
+                    GrantAuthorityCheck::new("not_a_privilege", None),
+                ],
             )
             .await
             .expect("allow-all never fails a grant-authority check");

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -2020,10 +2020,8 @@ where
     /// check to fold in here. Callers document what that discloses.
     ///
     /// Each check names a privilege and, where the caller knows it, the grantee it is
-    /// destined for. Whether the answer depends on the grantee belongs to the
-    /// authorizer's model: one that resolves authority from the privilege alone should
-    /// answer equal privileges with one lookup and repeat its decision, and must still
-    /// return one decision per check, in order.
+    /// destined for. Whether the grantee changes the answer is the authorizer's business;
+    /// either way, return one decision per check, in order.
     ///
     /// The default denies everything.
     async fn are_allowed_grants_impl(

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -2019,15 +2019,21 @@ where
     /// warehouse's grants without being able to read it — so there is no visibility
     /// check to fold in here. Callers document what that discloses.
     ///
+    /// Each check names a privilege and, where the caller knows it, the grantee it is
+    /// destined for. Whether the answer depends on the grantee belongs to the
+    /// authorizer's model: one that resolves authority from the privilege alone should
+    /// answer equal privileges with one lookup and repeat its decision, and must still
+    /// return one decision per check, in order.
+    ///
     /// The default denies everything.
     async fn are_allowed_grants_impl(
         &self,
         _metadata: &RequestMetadata,
         _for_user: Option<&UserOrRole>,
         _resource: &GrantResource,
-        privileges: &[&str],
+        checks: &[GrantAuthorityCheck<'_>],
     ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
-        Ok(vec![AuthorizationDecision::deny(); privileges.len()])
+        Ok(vec![AuthorizationDecision::deny(); checks.len()])
     }
 
     /// Hook that is called when a new project is created.
@@ -2158,7 +2164,7 @@ pub mod tests {
     #[test]
     fn read_grants_action_exists_at_every_grantable_level() {
         // `read_grants` gates listing grants on a resource. Grant *authority* is not an
-        // action - it is resolved per privilege by `Authorizer::are_allowed_grants`.
+        // action - `Authorizer::are_allowed_grants` resolves it from the privilege name.
         assert_eq!(
             CatalogWarehouseAction::ReadGrants
                 .action_descriptor()
@@ -2197,8 +2203,17 @@ pub mod tests {
                 privilege: "select".to_string(),
             })
         );
+        let alice = UserOrRoleId::User(UserId::new_unchecked("oidc", "alice"));
         let decisions = authz
-            .are_allowed_grants(&md, None, &GrantResource::Server, &["admin", "select"])
+            .are_allowed_grants(
+                &md,
+                None,
+                &GrantResource::Server,
+                &[
+                    GrantAuthorityCheck::new("admin", None),
+                    GrantAuthorityCheck::new("select", Some(&alice)),
+                ],
+            )
             .await
             .unwrap();
         assert_eq!(decisions, vec![false, false]);


### PR DESCRIPTION
`are_allowed_grants` took a list of privilege names, so an authorizer could not see who a privilege was destined for — the grantee arrived on the wire and was dropped one line before the check. Rules every permission system is asked for ("nobody may grant to themselves", "you may only grant within your team") were unexpressible, and the call site documented grantee-independence as an invariant.

Checks are now `GrantAuthorityCheck { privilege, grantee }`, non-exhaustive and built through a constructor so a later term (grant vs. revoke) stays additive for out-of-tree authorizers. The apply gate deduplicates on the pair; the grantable-privileges endpoint names no grantee, and that form is documented as advisory since the apply path asks again per grantee.

No behavior change. The OpenFGA arm resolves authority from the privilege alone, so it collapses checks that differ only in their grantee and repeats the answer — the same batch of tuples as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grant authorization checks can now target specific users or roles.
  * Authorization decisions remain aligned with each requested privilege and grantee.
* **Bug Fixes**
  * Repeated checks are handled correctly without losing individual decisions.
  * Unknown privileges and missing authorization results are denied safely.
  * Refused privileges are reported consistently and in request order.
  * Authorization results now preserve the order of requested checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->