### PR TITLE
fix(catalog): enforce the format-version policy on registerTable

### DIFF
--- a/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
@@ -30,8 +30,11 @@ use lakekeeper::{
             },
         },
         management::v1::{
-            ApiServer as ManagementApiServer, table::TableManagementService,
-            warehouse::TabularDeleteProfile,
+            ApiServer as ManagementApiServer,
+            table::TableManagementService,
+            warehouse::{
+                Service as _, TabularDeleteProfile, UpdateWarehouseFormatVersionPolicyRequest,
+            },
         },
     },
     server::{
@@ -2711,4 +2714,99 @@ async fn test_reuse_table_ids_soft_delete(pool: PgPool) {
         .unwrap()
         .expect("table and metadata should still exist");
     }
+}
+
+/// `registerTable` is the only way a table enters a warehouse without going
+/// through `createTable`, so it has to honour the format-version policy too.
+/// Otherwise the setting is advisory: a warehouse restricted to v1/v2 quietly
+/// acquires a v3 table, and the failure surfaces later in whichever engine
+/// cannot read it.
+#[sqlx::test]
+async fn test_register_table_enforces_the_format_version_policy(pg_pool: PgPool) {
+    let (ctx, ns, ns_params, _) = table_test_setup(pg_pool).await;
+    let warehouse_id: WarehouseId = ns_params
+        .prefix
+        .as_ref()
+        .unwrap()
+        .as_str()
+        .parse::<Uuid>()
+        .unwrap()
+        .into();
+
+    // All three versions are allowed by default, so both tables can be created
+    // before the policy is tightened underneath them.
+    let mut metadata_locations = HashMap::new();
+    for (name, version) in [
+        ("v3_table", FormatVersion::V3),
+        ("v2_table", FormatVersion::V2),
+    ] {
+        let table = CatalogServer::create_table(
+            ns_params.clone(),
+            create_table_request_with_format(name, Some(version)),
+            DataAccess::not_specified(),
+            ctx.clone(),
+            RequestMetadata::new_unauthenticated(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(table.metadata.format_version(), version);
+
+        // Registering reuses the metadata file, so the original table has to go
+        // first — two tables cannot share one table UUID. Keep the data.
+        CatalogServer::drop_table(
+            TableParameters {
+                prefix: ns_params.prefix.clone(),
+                table: TableIdent {
+                    namespace: ns.namespace.clone(),
+                    name: name.to_string(),
+                },
+            },
+            DropParams {
+                purge_requested: false,
+                force: false,
+            },
+            ctx.clone(),
+            RequestMetadata::new_unauthenticated(),
+        )
+        .await
+        .unwrap();
+
+        metadata_locations.insert(version, table.metadata_location.clone().unwrap());
+    }
+
+    ManagementApiServer::update_warehouse_format_version_policy(
+        warehouse_id,
+        UpdateWarehouseFormatVersionPolicyRequest {
+            allowed_format_versions: vec![FormatVersion::V1, FormatVersion::V2],
+            default_format_version: None,
+        },
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+
+    let register = |name: &str, version: FormatVersion| {
+        let request = iceberg_ext::catalog::rest::RegisterTableRequest::builder()
+            .name(name.to_string())
+            .metadata_location(metadata_locations[&version].clone())
+            .build();
+        CatalogServer::register_table(
+            ns_params.clone(),
+            request,
+            ctx.clone(),
+            RequestMetadata::new_unauthenticated(),
+        )
+    };
+
+    let err = register("registered_v3", FormatVersion::V3)
+        .await
+        .expect_err("a v3 file must not register into a v1/v2 warehouse");
+    assert_eq!(err.error.r#type, "FormatVersionNotAllowed");
+    assert_eq!(err.error.code, StatusCode::BAD_REQUEST.as_u16());
+
+    // A permitted version still registers, so the gate is not a blanket refusal.
+    register("registered_v2", FormatVersion::V2)
+        .await
+        .expect("a v2 file is allowed by the policy");
 }

--- a/crates/lakekeeper-integration-tests/tests/warehouse_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/warehouse_ops.rs
@@ -1359,9 +1359,8 @@ async fn test_update_format_version_policy(pool: PgPool) {
     );
     assert_eq!(response.default_format_version, Some(FormatVersion::V3));
 
-    // Give the async event handler time to update the cache.
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
+    // No sleep: the policy write invalidates this replica's cache before it
+    // returns, so the next read cannot observe the pre-update policy.
     let after = PostgresBackend::get_warehouse_by_id(
         warehouse_resp.warehouse_id,
         WarehouseStatus::active(),
@@ -1453,8 +1452,6 @@ async fn test_managed_by_locks_spec_via_handlers(pool: PgPool) {
     .await
     .unwrap();
     assert_eq!(resp.managed_by, ManagedBy::InstanceAdmin);
-    // Let the managed-by-set event update the warehouse cache.
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // Spec mutation by a non-admin is now locked, despite AllowAll passing authz.
     let err =

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -60,6 +60,7 @@ use crate::{
         tasks::{
             CancelTasksFilter, TaskQueueName, tabular_expiration_queue::TabularExpirationTask,
         },
+        warehouse_cache::warehouse_cache_invalidate,
     },
 };
 
@@ -1088,6 +1089,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         .map_err(|e| spec_lock_to_error(&event_ctx, e))?;
         C::delete_warehouse(warehouse_id, query, transaction.transaction()).await?;
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         // Post-commit: best-effort authz cleanup (see `delete_project`).
         authorizer
@@ -1157,6 +1159,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let resolved_warehouse =
             C::set_warehouse_protected(warehouse_id, protection, transaction.transaction()).await?;
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         event_ctx.emit_warehouse_protection_set(protection, resolved_warehouse.clone());
 
@@ -1203,6 +1206,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         )
         .await?;
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         event_ctx.emit_warehouse_managed_by_set(request.managed_by, updated_warehouse.clone());
 
@@ -1266,6 +1270,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             C::rename_warehouse(warehouse_id, &request.new_name, transaction.transaction()).await?;
 
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         event_ctx.emit_warehouse_renamed(Arc::new(request), updated_warehouse.clone());
 
@@ -1325,6 +1330,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         )
         .await?;
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         event_ctx
             .emit_warehouse_delete_profile_updated(Arc::new(request), updated_warehouse.clone());
@@ -1395,6 +1401,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         )
         .await?;
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         event_ctx.emit_warehouse_format_version_policy_updated(
             Arc::new(request),
@@ -1463,6 +1470,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         .await?;
 
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         Ok(())
     }
@@ -1521,6 +1529,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         .await?;
 
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         Ok(())
     }
@@ -1615,6 +1624,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         .await?;
 
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         event_ctx.emit_warehouse_storage_updated(request_for_event, updated_warehouse.clone());
 
@@ -1720,6 +1730,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         .await?;
 
         transaction.commit().await?;
+        warehouse_cache_invalidate(warehouse_id).await;
 
         event_ctx.emit_warehouse_storage_credential_updated(
             request_for_event,

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -349,6 +349,14 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         let table_location = parse_location(table_metadata.location(), StatusCode::BAD_REQUEST)?;
         validate_table_properties(table_metadata.properties().keys())?;
         storage_profile.require_allowed_location(&table_location)?;
+        // Register is the only way a table enters the warehouse without going
+        // through `createTable`, so without this the format-version policy is
+        // advisory: a v3 file could be registered into a v1/v2-only warehouse
+        // and only fail later, in whichever engine cannot read it.
+        create_table::ensure_format_version_allowed(
+            table_metadata.format_version(),
+            &warehouse.allowed_format_versions,
+        )?;
 
         let action = CatalogNamespaceAction::CreateTable {
             name: Some(request.name.clone()),

--- a/crates/lakekeeper/src/service/catalog_store/warehouse_cache.rs
+++ b/crates/lakekeeper/src/service/catalog_store/warehouse_cache.rs
@@ -105,8 +105,17 @@ pub struct CachedWarehouse {
     pub warehouse: Arc<ResolvedWarehouse>,
 }
 
-#[allow(dead_code)] // Not required for all features
-async fn warehouse_cache_invalidate(warehouse_id: WarehouseId) {
+/// Drop a warehouse from this replica's cache.
+///
+/// Call this *after* the mutating transaction commits, never before: the write
+/// methods hand back the updated warehouse while the transaction is still open,
+/// so publishing it earlier would cache a value a rollback discards.
+///
+/// Dropping rather than replacing with the updated row is deliberate. It costs
+/// one reload on the next access — warehouse mutations are rare — and in
+/// exchange it also clears the `(project, name) -> id` index via the eviction
+/// listener, which a rename would otherwise leave resolving the old name.
+pub async fn warehouse_cache_invalidate(warehouse_id: WarehouseId) {
     if CONFIG.cache.warehouse.enabled {
         tracing::debug!("Invalidating warehouse id {warehouse_id} from cache");
         // Remove via the loader's per-key compute lock (`Op::Remove`), not a bare


### PR DESCRIPTION
register is the only way a table enters a warehouse without going through createTable, so allowed_format_versions was advisory there: a v3 file could be registered into a v1/v2-only warehouse. Reuse the existing gate so both paths reject identically.

The test for it failed with the gate in place: the warehouse cache is refreshed by a listener in a task spawned by emit_*, so a write returns 200 before the refresh runs and register still read the old policy. Call warehouse_cache_invalidate — present but never wired up — right after commit in all ten warehouse-state mutations, and drop the two test sleeps that papered over the window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Warehouse format-version policies are now enforced when registering tables.
  * Table registration supports configured version restrictions, allowing approved versions and rejecting unsupported ones.

* **Bug Fixes**
  * Warehouse changes, including policy, activation, naming, and storage settings, are now reflected immediately without stale cached information.
  * Improved reliability of warehouse management operations and table registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->