### PR TITLE
feat(grants): record ownership when a resource is created

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4024,6 +4024,7 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "async-channel 2.5.0",
+ "async-trait",
  "aws-sdk-s3",
  "bytes",
  "chrono",

--- a/crates/authz-openfga/src/authorizer.rs
+++ b/crates/authz-openfga/src/authorizer.rs
@@ -18,7 +18,7 @@ use lakekeeper::{
             ActionOnGenericTable, ActionOnTable, ActionOnView, AddRoleAssignmentsError,
             AuthorizationBackendUnavailable, AuthorizationDecision, Authorizer,
             AuthzBackendErrorOrBadRequest, CannotInspectPermissions, CatalogProjectAction,
-            CatalogUserAction, GrantAuthorityCheck, GrantResource, IsAllowedActionError,
+            CatalogUserAction, GrantAuthorityCheck, GrantTarget, IsAllowedActionError,
             ListProjectsResponse, ListRoleAssignmentsError, ListRoleAssignmentsResultPage,
             MalformedRoleAssignment, ManagesGrants, ManagesRoleAssignments, NamespaceParent,
             PrivilegeDescriptor, ResourceType, RoleAssignmentFilter, RoleAssignmentRow, UserOrRole,
@@ -1014,10 +1014,13 @@ impl Authorizer for OpenFGAAuthorizer {
         &self,
         metadata: &RequestMetadata,
         for_user: Option<&UserOrRole>,
-        resource: &GrantResource,
+        target: &GrantTarget<'_>,
         checks: &[GrantAuthorityCheck<'_>],
     ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
-        self.grant_authority(metadata, for_user, resource, checks)
+        // Only the ids are used: the resolved ancestry the target carries is for
+        // authorizers that resolve inheritance themselves, and this one reads it from its
+        // own tuples instead.
+        self.grant_authority(metadata, for_user, &target.resource(), checks)
             .await
     }
 }

--- a/crates/authz-openfga/src/grant.rs
+++ b/crates/authz-openfga/src/grant.rs
@@ -624,7 +624,7 @@ fn tuple_timestamp(seconds_and_nanos: Option<(i64, i32)>) -> Option<chrono::Date
 
 #[cfg(test)]
 mod tests {
-    use lakekeeper::service::UserId;
+    use lakekeeper::service::{UserId, authz::GrantOp};
 
     use super::*;
     use crate::FgaType;
@@ -677,11 +677,12 @@ mod tests {
             .copied()
     }
 
-    /// Equal privileges are one tuple however many grantees name them, and a privilege
-    /// this level cannot grant is no tuple at all. The decisions alone cannot show either:
-    /// a plan with one tuple per check answers identically, just more expensively.
+    /// Equal privileges are one tuple however many grantees name them and whichever way
+    /// they move, and a privilege this level cannot grant is no tuple at all. The decisions
+    /// alone cannot show either: a plan with one tuple per check answers identically, just
+    /// more expensively.
     #[test]
-    fn equal_privileges_share_one_tuple_whatever_the_grantee() {
+    fn equal_privileges_share_one_tuple_whatever_the_grantee_or_direction() {
         let alice = UserOrRoleId::User(UserId::new_unchecked("oidc", "alice"));
         let bob = UserOrRoleId::User(UserId::new_unchecked("oidc", "bob"));
         let (items, item_of_check) = plan_authority_checks(
@@ -689,15 +690,21 @@ mod tests {
             "user:oidc~caller",
             "warehouse:11111111-1111-1111-1111-111111111111",
             &[
-                GrantAuthorityCheck::new("select", Some(&alice)),
-                GrantAuthorityCheck::new("select", Some(&bob)),
-                GrantAuthorityCheck::new("modify", Some(&alice)),
+                GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Grant)),
+                GrantAuthorityCheck::new("select", Some(&bob), Some(GrantOp::Grant)),
+                GrantAuthorityCheck::new("modify", Some(&alice), Some(GrantOp::Grant)),
+                // Taking `select` back asks the same relation as handing it out: this
+                // model has one relation per privilege and nothing to say about direction.
+                GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Revoke)),
                 // A warehouse action, but not an assignable relation, so not grantable.
-                GrantAuthorityCheck::new("get_metadata", Some(&alice)),
+                GrantAuthorityCheck::new("get_metadata", Some(&alice), Some(GrantOp::Grant)),
             ],
         );
 
-        assert_eq!(item_of_check, vec![Some(0), Some(0), Some(1), None]);
+        assert_eq!(
+            item_of_check,
+            vec![Some(0), Some(0), Some(1), Some(0), None]
+        );
         assert_eq!(
             items,
             vec![

--- a/crates/authz-openfga/src/grant.rs
+++ b/crates/authz-openfga/src/grant.rs
@@ -685,21 +685,21 @@ mod tests {
     /// more expensively.
     #[test]
     fn equal_privileges_share_one_tuple_whatever_the_grantee_or_direction() {
-        let alice = UserOrRoleId::User(UserId::new_unchecked("oidc", "alice"));
-        let bob = UserOrRoleId::User(UserId::new_unchecked("oidc", "bob"));
+        let alice = UserOrRole::User(UserId::new_unchecked("oidc", "alice"));
+        let bob = UserOrRole::User(UserId::new_unchecked("oidc", "bob"));
         let (items, item_of_check) = plan_authority_checks(
             ResourceType::Warehouse,
             "user:oidc~caller",
             "warehouse:11111111-1111-1111-1111-111111111111",
             &[
-                GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
-                GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
-                GrantAuthorityCheck::entry("modify", &alice, GrantOp::Grant),
+                GrantAuthorityCheck::entry("select", Some(&alice), GrantOp::Grant),
+                GrantAuthorityCheck::entry("select", Some(&bob), GrantOp::Grant),
+                GrantAuthorityCheck::entry("modify", Some(&alice), GrantOp::Grant),
                 // Taking `select` back asks the same relation as handing it out: this
                 // model has one relation per privilege and nothing to say about direction.
-                GrantAuthorityCheck::entry("select", &alice, GrantOp::Revoke),
+                GrantAuthorityCheck::entry("select", Some(&alice), GrantOp::Revoke),
                 // A warehouse action, but not an assignable relation, so not grantable.
-                GrantAuthorityCheck::entry("get_metadata", &alice, GrantOp::Grant),
+                GrantAuthorityCheck::entry("get_metadata", Some(&alice), GrantOp::Grant),
             ],
         );
 

--- a/crates/authz-openfga/src/grant.rs
+++ b/crates/authz-openfga/src/grant.rs
@@ -313,9 +313,10 @@ fn assumed_role_restriction(
 /// The tuples to check for `checks`, and the item each check takes its answer from.
 ///
 /// Keeps the request dense. A privilege this level cannot grant gets no tuple at all
-/// (`None`, answered as a deny), and equal privileges share one: the relation is a
-/// function of the privilege, so two checks differing only in their grantee ask the same
-/// question of the model.
+/// (`None`, answered as a deny), and equal privileges share one: the relation is a function
+/// of the privilege alone, so two checks differing only in their grantee or in which way
+/// the privilege would move ask the same question of the model. A relation that ever became
+/// sensitive to either would have to key this map on it too.
 fn plan_authority_checks(
     resource_type: ResourceType,
     user: &str,
@@ -351,11 +352,12 @@ impl OpenFGAAuthorizer {
     /// may come from another authorizer's vocabulary, and answering "not allowed" is
     /// both true and safe.
     ///
-    /// The grantee is ignored. Every `can_grant_*` relation is a property of the actor,
-    /// the resource and the privilege — nothing in the model reads who receives the
-    /// privilege — so checks that differ only in their grantee collapse into one check
-    /// whose answer is repeated for each. A diff handing one privilege to a hundred
-    /// principals is a single check.
+    /// The grantee and the direction are both ignored. Every `can_grant_*` relation is a
+    /// property of the actor, the resource and the privilege — nothing in the model reads
+    /// who receives the privilege, and holding the relation covers taking the privilege
+    /// back as much as handing it out — so checks that differ only in either collapse into
+    /// one check whose answer is repeated for each. A diff handing one privilege to a
+    /// hundred principals is a single check.
     pub(crate) async fn grant_authority(
         &self,
         metadata: &RequestMetadata,
@@ -690,14 +692,14 @@ mod tests {
             "user:oidc~caller",
             "warehouse:11111111-1111-1111-1111-111111111111",
             &[
-                GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Grant)),
-                GrantAuthorityCheck::new("select", Some(&bob), Some(GrantOp::Grant)),
-                GrantAuthorityCheck::new("modify", Some(&alice), Some(GrantOp::Grant)),
+                GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
+                GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
+                GrantAuthorityCheck::entry("modify", &alice, GrantOp::Grant),
                 // Taking `select` back asks the same relation as handing it out: this
                 // model has one relation per privilege and nothing to say about direction.
-                GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Revoke)),
+                GrantAuthorityCheck::entry("select", &alice, GrantOp::Revoke),
                 // A warehouse action, but not an assignable relation, so not grantable.
-                GrantAuthorityCheck::new("get_metadata", Some(&alice), Some(GrantOp::Grant)),
+                GrantAuthorityCheck::entry("get_metadata", &alice, GrantOp::Grant),
             ],
         );
 

--- a/crates/lakekeeper-integration-tests/Cargo.toml
+++ b/crates/lakekeeper-integration-tests/Cargo.toml
@@ -27,6 +27,7 @@ open-api = [
 [dependencies]
 anyhow = { workspace = true }
 async-channel = { workspace = true }
+async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 http = { workspace = true }

--- a/crates/lakekeeper-integration-tests/tests/grant_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/grant_ops.rs
@@ -2717,6 +2717,7 @@ async fn re_registering_a_table_that_keeps_its_id_keeps_its_owner(pool: PgPool) 
             .metadata_location(created.metadata_location.clone().unwrap())
             .overwrite(true)
             .build(),
+        DataAccess::not_specified(),
         ctx.clone(),
         metadata.clone(),
     )

--- a/crates/lakekeeper-integration-tests/tests/grant_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/grant_ops.rs
@@ -18,6 +18,7 @@ use lakekeeper::{
                 CreateNamespaceRequest, NamespaceParameters, PageToken, PaginationQuery,
                 namespace::NamespaceService as _,
                 tables::{DataAccess, TablesService as _},
+                views::ViewService as _,
             },
         },
         management::v1::{
@@ -42,10 +43,12 @@ use lakekeeper::{
             AllowAllAuthorizer, GrantFilter, GrantResource, GrantSpec, ResourceType, UserOrRoleId,
             tests::HidingAuthorizer,
         },
+        events::{EventListener, GrantsChangedEvent},
     },
 };
 use lakekeeper_integration_tests::{
-    SetupTestCatalog, create_generic_table, create_view, memory_io_profile, random_request_metadata,
+    SetupTestCatalog, create_generic_table, create_view, create_view_request, memory_io_profile,
+    random_request_metadata,
 };
 use lakekeeper_storage_postgres::{PostgresBackend, SecretsState};
 use sqlx::PgPool;
@@ -2430,6 +2433,15 @@ async fn grantable_privileges_for_yourself_need_no_read_gate(pool: PgPool) {
 // `HidingAuthorizer` opts in here — `AllowAllAuthorizer` deliberately does not, so no
 // other test in this file gains rows it did not ask for.
 
+/// What every test in this section declares: ownership at four levels, and deliberately
+/// nothing on projects, so the tests can tell a declaration apart from a blanket rule.
+const OWNS_FOUR_LEVELS: &[(ResourceType, &[&str])] = &[
+    (ResourceType::Warehouse, &["ownership"]),
+    (ResourceType::Namespace, &["ownership"]),
+    (ResourceType::Table, &["ownership"]),
+    (ResourceType::View, &["ownership"]),
+];
+
 /// Creating a resource writes the declared grants for the creating identity, at every
 /// level, in the transaction that creates it.
 #[sqlx::test]
@@ -2440,7 +2452,7 @@ async fn creating_a_resource_grants_ownership_to_its_creator(pool: PgPool) {
     let (ctx, warehouse) = SetupTestCatalog::builder()
         .pool(pool.clone())
         .storage_profile(memory_io_profile())
-        .authorizer(HidingAuthorizer::new().with_bootstrap_grants(&["ownership"]))
+        .authorizer(HidingAuthorizer::new().with_bootstrap_grants(OWNS_FOUR_LEVELS))
         .user_id(Some(alice.clone()))
         .number_of_warehouses(1)
         .build()
@@ -2522,7 +2534,7 @@ async fn creating_a_resource_grants_ownership_to_its_creator(pool: PgPool) {
     let created = CatalogServer::create_table(
         NamespaceParameters {
             namespace: NamespaceIdent::new("owned_ns".to_string()),
-            prefix: Some(prefix),
+            prefix: Some(prefix.clone()),
         },
         CreateTableRequest {
             name: "owned_table".to_string(),
@@ -2545,7 +2557,7 @@ async fn creating_a_resource_grants_ownership_to_its_creator(pool: PgPool) {
         warehouse_id,
         table_id,
         ctx.clone(),
-        metadata,
+        metadata.clone(),
         ListGrantsQuery::default(),
         no_pagination(),
     )
@@ -2558,6 +2570,53 @@ async fn creating_a_resource_grants_ownership_to_its_creator(pool: PgPool) {
             table_id
         })]
     );
+
+    // Views store their grants under the same shape as tables, discriminated only by the
+    // kind the store checks before writing: naming the wrong one here would fail the
+    // create rather than quietly file the row under a table.
+    let view = CatalogServer::create_view(
+        NamespaceParameters {
+            namespace: NamespaceIdent::new("owned_ns".to_string()),
+            prefix: Some(prefix),
+        },
+        create_view_request(Some("owned_view"), None),
+        ctx.clone(),
+        DataAccess::not_specified(),
+        metadata.clone(),
+    )
+    .await
+    .unwrap();
+    let view_id: lakekeeper::service::ViewId = view.metadata.uuid().into();
+
+    let page = DenyServer::list_view_grants(
+        warehouse_id,
+        view_id,
+        ctx.clone(),
+        metadata,
+        ListGrantsQuery::default(),
+        no_pagination(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        listed_grants(page.grants),
+        vec![owned(GrantResourceResponse::View {
+            warehouse_id,
+            view_id
+        })]
+    );
+
+    // Projects are absent from the declaration, and the project this all lives in was
+    // created by the same user in the same run: a declaration confers on the types it
+    // names, not on creation as such.
+    let page = PostgresBackend::list_grants(
+        &GrantFilter::on(GrantResource::Project(project_id), None),
+        no_pagination(),
+        ctx.v1_state.catalog.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(page.grants, Vec::new());
 }
 
 /// The default is off: an authorizer that declares nothing writes nothing, so upgrading
@@ -2585,6 +2644,252 @@ async fn creating_a_resource_writes_nothing_without_a_declaration(pool: PgPool) 
     .await
     .unwrap();
     assert_eq!(page.grants, Vec::new());
+}
+
+/// Re-registering a table that keeps its id runs no create hook, and the drop inside that
+/// same transaction cascades the old rows away — so unless the write sits outside the hook
+/// branches, the table comes back with no owner at all.
+#[sqlx::test]
+async fn re_registering_a_table_that_keeps_its_id_keeps_its_owner(pool: PgPool) {
+    let alice = UserId::try_from("oidc~alice").unwrap();
+    let (ctx, warehouse) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(memory_io_profile())
+        .authorizer(HidingAuthorizer::new().with_bootstrap_grants(OWNS_FOUR_LEVELS))
+        .user_id(Some(alice.clone()))
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+    let warehouse_id = warehouse.warehouse_id;
+    let metadata = as_principal(&alice, &warehouse.project_id);
+    let prefix: Prefix = warehouse_id.to_string().into();
+    let namespace = NamespaceIdent::new("reg_ns".to_string());
+
+    CatalogServer::create_namespace(
+        Some(prefix.clone()),
+        CreateNamespaceRequest {
+            namespace: namespace.clone(),
+            properties: None,
+        },
+        ctx.clone(),
+        metadata.clone(),
+    )
+    .await
+    .unwrap();
+
+    let ns_params = NamespaceParameters {
+        namespace,
+        prefix: Some(prefix),
+    };
+    let schema = Schema::builder()
+        .with_fields(vec![
+            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+        ])
+        .build()
+        .unwrap();
+    let created = CatalogServer::create_table(
+        ns_params.clone(),
+        CreateTableRequest {
+            name: "reg_table".to_string(),
+            location: None,
+            schema,
+            partition_spec: Some(UnboundPartitionSpec::builder().build()),
+            write_order: None,
+            stage_create: Some(false),
+            properties: None,
+        },
+        DataAccess::not_specified(),
+        ctx.clone(),
+        metadata.clone(),
+    )
+    .await
+    .unwrap();
+    let table_id: lakekeeper::service::TableId = created.metadata.uuid().into();
+
+    // Its own metadata, over its own name: the registered table is the same table, so no
+    // create hook fires.
+    let registered = CatalogServer::register_table(
+        ns_params,
+        iceberg_ext::catalog::rest::RegisterTableRequest::builder()
+            .name("reg_table".to_string())
+            .metadata_location(created.metadata_location.clone().unwrap())
+            .overwrite(true)
+            .build(),
+        ctx.clone(),
+        metadata.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        lakekeeper::service::TableId::from(registered.metadata.uuid()),
+        table_id,
+        "the registration has to keep the id for this to exercise the arm it is about"
+    );
+
+    let page = DenyServer::list_table_grants(
+        warehouse_id,
+        table_id,
+        ctx.clone(),
+        metadata,
+        ListGrantsQuery::default(),
+        no_pagination(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        listed_grants(page.grants),
+        vec![(
+            UserOrRole::User(alice),
+            "ownership".to_string(),
+            GrantResourceResponse::Table {
+                warehouse_id,
+                table_id
+            }
+        )]
+    );
+}
+
+/// Records the grant events a request produced, so a test can assert what a create
+/// announced rather than only what it stored.
+#[derive(Debug)]
+struct GrantEventCapture(tokio::sync::mpsc::UnboundedSender<GrantsChangedEvent>);
+
+impl std::fmt::Display for GrantEventCapture {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GrantEventCapture")
+    }
+}
+
+#[async_trait::async_trait]
+impl EventListener for GrantEventCapture {
+    async fn grants_changed(&self, event: GrantsChangedEvent) -> anyhow::Result<()> {
+        let _ = self.0.send(event);
+        Ok(())
+    }
+}
+
+/// The rows a resource is born with are announced too. The audit backend derives its
+/// per-grant records from grant events alone, so a create that stored ownership without
+/// announcing it would leave no trace of who may act on the resource.
+#[sqlx::test]
+async fn creating_a_resource_announces_the_grants_it_wrote(pool: PgPool) {
+    let alice = UserId::try_from("oidc~alice").unwrap();
+    let (ctx, warehouse) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(memory_io_profile())
+        .authorizer(HidingAuthorizer::new().with_bootstrap_grants(OWNS_FOUR_LEVELS))
+        .user_id(Some(alice.clone()))
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+    let warehouse_id = warehouse.warehouse_id;
+
+    let (sender, mut events) = tokio::sync::mpsc::unbounded_channel();
+    ctx.v1_state
+        .events
+        .append(std::sync::Arc::new(GrantEventCapture(sender)))
+        .await;
+
+    CatalogServer::create_namespace(
+        Some(warehouse_id.to_string().into()),
+        CreateNamespaceRequest {
+            namespace: NamespaceIdent::new("announced_ns".to_string()),
+            properties: None,
+        },
+        ctx.clone(),
+        as_principal(&alice, &warehouse.project_id),
+    )
+    .await
+    .unwrap();
+    let namespace_id = PostgresBackend::get_namespace(
+        warehouse_id,
+        NamespaceIdent::new("announced_ns".to_string()),
+        ctx.v1_state.catalog.clone(),
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .namespace_id();
+
+    // Announcing is fire-and-forget, so the warehouse the setup created may still be
+    // announcing itself. Wait for the namespace's own event; never receiving it is the
+    // failure this test is about, and the timeout reports it.
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let event: GrantsChangedEvent =
+                events.recv().await.expect("the capture outlives dispatch");
+            if event
+                .created
+                .iter()
+                .any(|spec| matches!(spec.resource, GrantResource::Namespace { .. }))
+            {
+                break event;
+            }
+        }
+    })
+    .await
+    .expect("the create announced the grants it wrote");
+    assert_eq!(event.removed, Vec::new());
+    assert_eq!(
+        event.created,
+        vec![GrantSpec {
+            principal: UserOrRoleId::User(alice.clone()),
+            resource: GrantResource::Namespace {
+                warehouse_id,
+                namespace_id,
+            },
+            privilege: "ownership".to_string(),
+        }]
+    );
+    assert_eq!(event.request_metadata.actor(), &Actor::Principal(alice));
+}
+
+/// Declaring a privilege commits to the creator being able to hold it. A principal the
+/// catalog has no user record for cannot, and the create fails saying so rather than
+/// committing a resource nobody owns.
+#[sqlx::test]
+async fn a_creator_without_a_user_record_is_refused(pool: PgPool) {
+    let alice = UserId::try_from("oidc~alice").unwrap();
+    let (ctx, warehouse) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(memory_io_profile())
+        .authorizer(HidingAuthorizer::new().with_bootstrap_grants(OWNS_FOUR_LEVELS))
+        .user_id(Some(alice))
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+
+    // Authorized by this authorizer, but never registered as a user: no `/config` call,
+    // no bootstrap, no create-user request.
+    let stranger = UserId::try_from("oidc~stranger").unwrap();
+    let err = CatalogServer::create_namespace(
+        Some(warehouse.warehouse_id.to_string().into()),
+        CreateNamespaceRequest {
+            namespace: NamespaceIdent::new("unowned_ns".to_string()),
+            properties: None,
+        },
+        ctx.clone(),
+        as_principal(&stranger, &warehouse.project_id),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.error.code, 400);
+    assert_eq!(err.error.r#type, "GrantUserNotFound");
+
+    // And the namespace it would have owned is not there either.
+    assert_eq!(
+        PostgresBackend::get_namespace(
+            warehouse.warehouse_id,
+            NamespaceIdent::new("unowned_ns".to_string()),
+            ctx.v1_state.catalog.clone(),
+        )
+        .await
+        .unwrap(),
+        None
+    );
 }
 
 /// The three fields a bootstrap row is about, so a mismatch names what differs.

--- a/crates/lakekeeper-integration-tests/tests/grant_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/grant_ops.rs
@@ -1748,9 +1748,10 @@ async fn an_authorizer_without_a_vocabulary_refuses_writes_but_allows_revokes(po
     .unwrap_err();
     assert_eq!(err.error.code, 403);
     assert_eq!(err.error.r#type, "GrantActionForbidden");
+    // A deletes-only diff, so the refusal is about revoking and says so.
     assert_eq!(
         err.error.message,
-        "Granting or revoking `get_metadata` on this warehouse is forbidden"
+        "Revoking `get_metadata` on this warehouse is forbidden"
     );
 }
 

--- a/crates/lakekeeper-integration-tests/tests/grant_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/grant_ops.rs
@@ -2421,3 +2421,178 @@ async fn grantable_privileges_for_yourself_need_no_read_gate(pool: PgPool) {
     .expect("naming yourself is still a self-read");
     assert_eq!(explicit.privileges.len(), 0);
 }
+
+// ---------------------------------------------------------------------------
+// Ownership bootstrap
+// ---------------------------------------------------------------------------
+//
+// An authorizer that stores grants in the catalog can declare what creation confers.
+// `HidingAuthorizer` opts in here — `AllowAllAuthorizer` deliberately does not, so no
+// other test in this file gains rows it did not ask for.
+
+/// Creating a resource writes the declared grants for the creating identity, at every
+/// level, in the transaction that creates it.
+#[sqlx::test]
+async fn creating_a_resource_grants_ownership_to_its_creator(pool: PgPool) {
+    let alice = UserId::try_from("oidc~alice").unwrap();
+    // The setup helper creates the warehouse through the API as this user, so the
+    // warehouse row below comes from the real create path, not from a seeded row.
+    let (ctx, warehouse) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(memory_io_profile())
+        .authorizer(HidingAuthorizer::new().with_bootstrap_grants(&["ownership"]))
+        .user_id(Some(alice.clone()))
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+    let warehouse_id = warehouse.warehouse_id;
+    let project_id = (*warehouse.project_id).clone();
+    let metadata = as_principal(&alice, &project_id);
+
+    let owned = |resource: GrantResourceResponse| {
+        (
+            UserOrRole::User(alice.clone()),
+            "ownership".to_string(),
+            resource,
+        )
+    };
+
+    let page = DenyServer::list_warehouse_grants(
+        warehouse_id,
+        ctx.clone(),
+        metadata.clone(),
+        ListGrantsQuery::default(),
+        no_pagination(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        listed_grants(page.grants),
+        vec![owned(GrantResourceResponse::Warehouse { warehouse_id })]
+    );
+
+    // A namespace and a table created by the same user, through their own endpoints.
+    let prefix: Prefix = warehouse_id.to_string().into();
+    CatalogServer::create_namespace(
+        Some(prefix.clone()),
+        CreateNamespaceRequest {
+            namespace: NamespaceIdent::new("owned_ns".to_string()),
+            properties: None,
+        },
+        ctx.clone(),
+        metadata.clone(),
+    )
+    .await
+    .unwrap();
+    let namespace_id = PostgresBackend::get_namespace(
+        warehouse_id,
+        NamespaceIdent::new("owned_ns".to_string()),
+        ctx.v1_state.catalog.clone(),
+    )
+    .await
+    .unwrap()
+    .unwrap()
+    .namespace_id();
+
+    let page = DenyServer::list_namespace_grants(
+        warehouse_id,
+        namespace_id,
+        ctx.clone(),
+        metadata.clone(),
+        ListGrantsQuery::default(),
+        no_pagination(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        listed_grants(page.grants),
+        vec![owned(GrantResourceResponse::Namespace {
+            warehouse_id,
+            namespace_id
+        })]
+    );
+
+    let schema = Schema::builder()
+        .with_fields(vec![
+            NestedField::required(1, "id", Type::Primitive(PrimitiveType::Long)).into(),
+        ])
+        .build()
+        .unwrap();
+    let created = CatalogServer::create_table(
+        NamespaceParameters {
+            namespace: NamespaceIdent::new("owned_ns".to_string()),
+            prefix: Some(prefix),
+        },
+        CreateTableRequest {
+            name: "owned_table".to_string(),
+            location: None,
+            schema,
+            partition_spec: Some(UnboundPartitionSpec::builder().build()),
+            write_order: None,
+            stage_create: Some(false),
+            properties: None,
+        },
+        DataAccess::not_specified(),
+        ctx.clone(),
+        metadata.clone(),
+    )
+    .await
+    .unwrap();
+    let table_id: lakekeeper::service::TableId = created.metadata.uuid().into();
+
+    let page = DenyServer::list_table_grants(
+        warehouse_id,
+        table_id,
+        ctx.clone(),
+        metadata,
+        ListGrantsQuery::default(),
+        no_pagination(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        listed_grants(page.grants),
+        vec![owned(GrantResourceResponse::Table {
+            warehouse_id,
+            table_id
+        })]
+    );
+}
+
+/// The default is off: an authorizer that declares nothing writes nothing, so upgrading
+/// does not silently start recording ownership.
+#[sqlx::test]
+async fn creating_a_resource_writes_nothing_without_a_declaration(pool: PgPool) {
+    let alice = UserId::try_from("oidc~alice").unwrap();
+    let (ctx, warehouse) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(memory_io_profile())
+        .authorizer(HidingAuthorizer::new())
+        .user_id(Some(alice.clone()))
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+
+    let page = DenyServer::list_warehouse_grants(
+        warehouse.warehouse_id,
+        ctx.clone(),
+        as_principal(&alice, &warehouse.project_id),
+        ListGrantsQuery::default(),
+        no_pagination(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(page.grants, Vec::new());
+}
+
+/// The three fields a bootstrap row is about, so a mismatch names what differs.
+fn listed_grants(
+    grants: Vec<lakekeeper::api::management::v1::grant::GrantResponse>,
+) -> Vec<(UserOrRole, String, GrantResourceResponse)> {
+    grants
+        .into_iter()
+        .map(|grant| (grant.principal, grant.privilege, grant.resource))
+        .collect()
+}

--- a/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
@@ -40,8 +40,8 @@ mod grant {
                 CatalogNamespaceOps as _, NamespaceId, State, UserId,
                 authn::Actor,
                 authz::{
-                    AuthZGrantOps as _, Authorizer as _, GrantAuthorityCheck, GrantResource,
-                    ResourceType, UserOrRoleId,
+                    AuthZGrantOps as _, Authorizer as _, GrantAuthorityCheck, GrantOp,
+                    GrantResource, ResourceType, UserOrRoleId,
                 },
             },
         };
@@ -89,10 +89,11 @@ mod grant {
             }
         }
 
-        /// A grant-authority question naming no grantee. The tests that name one build
-        /// the check directly.
+        /// A grant-authority question naming neither grantee nor direction, as the
+        /// grantable-privileges endpoint asks it. The tests that name either build the
+        /// check directly.
         fn check(privilege: &str) -> GrantAuthorityCheck<'_> {
-            GrantAuthorityCheck::new(privilege, None)
+            GrantAuthorityCheck::new(privilege, None, None)
         }
 
         fn writes(entries: Vec<GrantEntry>) -> ApplyGrantsRequest {
@@ -334,9 +335,9 @@ mod grant {
                     None,
                     &resource,
                     &[
-                        GrantAuthorityCheck::new("select", Some(&alice)),
-                        GrantAuthorityCheck::new("select", Some(&bob)),
-                        GrantAuthorityCheck::new("modify", Some(&alice)),
+                        GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Grant)),
+                        GrantAuthorityCheck::new("select", Some(&bob), Some(GrantOp::Grant)),
+                        GrantAuthorityCheck::new("modify", Some(&alice), Some(GrantOp::Grant)),
                     ],
                 )
                 .await
@@ -351,10 +352,14 @@ mod grant {
                     None,
                     &resource,
                     &[
-                        GrantAuthorityCheck::new("get_metadata", Some(&alice)),
-                        GrantAuthorityCheck::new("select", Some(&alice)),
-                        GrantAuthorityCheck::new("get_metadata", Some(&bob)),
-                        GrantAuthorityCheck::new("select", Some(&bob)),
+                        GrantAuthorityCheck::new(
+                            "get_metadata",
+                            Some(&alice),
+                            Some(GrantOp::Grant),
+                        ),
+                        GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Grant)),
+                        GrantAuthorityCheck::new("get_metadata", Some(&bob), Some(GrantOp::Grant)),
+                        GrantAuthorityCheck::new("select", Some(&bob), Some(GrantOp::Grant)),
                     ],
                 )
                 .await
@@ -368,8 +373,8 @@ mod grant {
                     None,
                     &resource,
                     &[
-                        GrantAuthorityCheck::new("select", Some(&alice)),
-                        GrantAuthorityCheck::new("select", Some(&bob)),
+                        GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Grant)),
+                        GrantAuthorityCheck::new("select", Some(&bob), Some(GrantOp::Grant)),
                     ],
                 )
                 .await

--- a/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
@@ -37,11 +37,12 @@ mod grant {
             },
             server::CatalogServer,
             service::{
-                CatalogNamespaceOps as _, NamespaceId, State, UserId,
+                CatalogNamespaceOps as _, CatalogWarehouseOps as _, NamespaceId, ResolvedWarehouse,
+                State, UserId,
                 authn::Actor,
                 authz::{
                     AuthZGrantOps as _, Authorizer as _, GrantAuthorityCheck, GrantOp,
-                    GrantResource, ResourceType, UserOrRoleId,
+                    GrantResource, GrantTarget, ResourceType, UserOrRoleId,
                 },
             },
         };
@@ -73,6 +74,17 @@ mod grant {
                 .setup()
                 .await;
             (ctx, admin, warehouse.project_id, warehouse.warehouse_id)
+        }
+
+        /// The warehouse as the handlers resolve it before the gate: a grant target carries
+        /// the resource's ancestry, not its id, so an authorizer that resolves inheritance
+        /// itself can place it. This one reads inheritance from its own tuples and uses only
+        /// the id, which is why every test here can share one target.
+        async fn warehouse_target(ctx: &Ctx, warehouse_id: WarehouseId) -> Arc<ResolvedWarehouse> {
+            PostgresBackend::get_active_warehouse_by_id(warehouse_id, ctx.v1_state.catalog.clone())
+                .await
+                .expect("the setup's warehouse resolves")
+                .expect("the setup's warehouse is active")
         }
 
         fn metadata(user_id: &UserId, project_id: &ProjectId) -> RequestMetadata {
@@ -276,13 +288,14 @@ mod grant {
         async fn grant_authority_comes_from_the_can_grant_relations(pool: PgPool) {
             let (ctx, admin, project_id, warehouse_id) = setup(pool).await;
             let authorizer = &ctx.v1_state.authz;
-            let resource = GrantResource::Warehouse(warehouse_id);
+            let warehouse = warehouse_target(&ctx, warehouse_id).await;
+            let target = GrantTarget::Warehouse(&warehouse);
 
             let as_admin = authorizer
                 .are_allowed_grants(
                     &metadata(&admin, &project_id),
                     None,
-                    &resource,
+                    &target,
                     &[check("select"), check("modify")],
                 )
                 .await
@@ -294,7 +307,7 @@ mod grant {
                 .are_allowed_grants(
                     &metadata(&nobody, &project_id),
                     None,
-                    &resource,
+                    &target,
                     &[check("select"), check("modify")],
                 )
                 .await
@@ -307,7 +320,7 @@ mod grant {
                 .are_allowed_grants(
                     &metadata(&admin, &project_id),
                     None,
-                    &resource,
+                    &target,
                     &[check("get_metadata")],
                 )
                 .await
@@ -325,7 +338,8 @@ mod grant {
         async fn grant_authority_repeats_one_answer_per_grantee(pool: PgPool) {
             let (ctx, admin, project_id, warehouse_id) = setup(pool).await;
             let authorizer = &ctx.v1_state.authz;
-            let resource = GrantResource::Warehouse(warehouse_id);
+            let warehouse = warehouse_target(&ctx, warehouse_id).await;
+            let target = GrantTarget::Warehouse(&warehouse);
             let alice = UserOrRoleId::User(UserId::new_unchecked("oidc", "alice"));
             let bob = UserOrRoleId::User(UserId::new_unchecked("oidc", "bob"));
 
@@ -333,7 +347,7 @@ mod grant {
                 .are_allowed_grants(
                     &metadata(&admin, &project_id),
                     None,
-                    &resource,
+                    &target,
                     &[
                         GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
                         GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
@@ -350,7 +364,7 @@ mod grant {
                 .are_allowed_grants(
                     &metadata(&admin, &project_id),
                     None,
-                    &resource,
+                    &target,
                     &[
                         GrantAuthorityCheck::entry("get_metadata", &alice, GrantOp::Grant),
                         GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
@@ -367,7 +381,7 @@ mod grant {
                 .are_allowed_grants(
                     &metadata(&nobody, &project_id),
                     None,
-                    &resource,
+                    &target,
                     &[
                         GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
                         GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
@@ -537,13 +551,14 @@ mod grant {
 
             // The authority check itself denies rather than allowing wholesale, so the
             // vocabulary endpoint reports what an instance admin may really grant: nothing.
+            let warehouse = warehouse_target(&ctx, warehouse_id).await;
             let decisions = ctx
                 .v1_state
                 .authz
                 .are_allowed_grants(
                     &as_instance_admin,
                     None,
-                    &GrantResource::Warehouse(warehouse_id),
+                    &GrantTarget::Warehouse(&warehouse),
                     &[check("select"), check("modify")],
                 )
                 .await
@@ -577,7 +592,8 @@ mod grant {
         async fn answering_for_another_principal_needs_the_read_gate(pool: PgPool) {
             let (ctx, admin, project_id, warehouse_id) = setup(pool).await;
             let authorizer = &ctx.v1_state.authz;
-            let resource = GrantResource::Warehouse(warehouse_id);
+            let warehouse = warehouse_target(&ctx, warehouse_id).await;
+            let target = GrantTarget::Warehouse(&warehouse);
             let bob = UserId::new_unchecked("oidc", "bob");
             let for_bob = lakekeeper::service::authz::UserOrRole::User(bob.clone());
 
@@ -586,7 +602,7 @@ mod grant {
                 .are_allowed_grants(
                     &metadata(&admin, &project_id),
                     Some(&for_bob),
-                    &resource,
+                    &target,
                     &[check("select")],
                 )
                 .await
@@ -600,7 +616,7 @@ mod grant {
                 .are_allowed_grants(
                     &metadata(&nobody, &project_id),
                     Some(&for_bob),
-                    &resource,
+                    &target,
                     &[check("select")],
                 )
                 .await

--- a/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
@@ -93,7 +93,7 @@ mod grant {
         /// grantable-privileges endpoint asks it. The tests that name either build the
         /// check directly.
         fn check(privilege: &str) -> GrantAuthorityCheck<'_> {
-            GrantAuthorityCheck::new(privilege, None, None)
+            GrantAuthorityCheck::any(privilege)
         }
 
         fn writes(entries: Vec<GrantEntry>) -> ApplyGrantsRequest {
@@ -335,9 +335,9 @@ mod grant {
                     None,
                     &resource,
                     &[
-                        GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Grant)),
-                        GrantAuthorityCheck::new("select", Some(&bob), Some(GrantOp::Grant)),
-                        GrantAuthorityCheck::new("modify", Some(&alice), Some(GrantOp::Grant)),
+                        GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
+                        GrantAuthorityCheck::entry("modify", &alice, GrantOp::Grant),
                     ],
                 )
                 .await
@@ -352,14 +352,10 @@ mod grant {
                     None,
                     &resource,
                     &[
-                        GrantAuthorityCheck::new(
-                            "get_metadata",
-                            Some(&alice),
-                            Some(GrantOp::Grant),
-                        ),
-                        GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Grant)),
-                        GrantAuthorityCheck::new("get_metadata", Some(&bob), Some(GrantOp::Grant)),
-                        GrantAuthorityCheck::new("select", Some(&bob), Some(GrantOp::Grant)),
+                        GrantAuthorityCheck::entry("get_metadata", &alice, GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
+                        GrantAuthorityCheck::entry("get_metadata", &bob, GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
                     ],
                 )
                 .await
@@ -373,8 +369,8 @@ mod grant {
                     None,
                     &resource,
                     &[
-                        GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Grant)),
-                        GrantAuthorityCheck::new("select", Some(&bob), Some(GrantOp::Grant)),
+                        GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
                     ],
                 )
                 .await

--- a/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/openfga_grant_ops.rs
@@ -42,7 +42,7 @@ mod grant {
                 authn::Actor,
                 authz::{
                     AuthZGrantOps as _, Authorizer as _, GrantAuthorityCheck, GrantOp,
-                    GrantResource, GrantTarget, ResourceType, UserOrRoleId,
+                    GrantResource, GrantTarget, ResourceType, UserOrRole as AuthzUserOrRole,
                 },
             },
         };
@@ -101,11 +101,10 @@ mod grant {
             }
         }
 
-        /// A grant-authority question naming neither grantee nor direction, as the
-        /// grantable-privileges endpoint asks it. The tests that name either build the
-        /// check directly.
+        /// A grant-authority question naming no grantee, as the grantable-privileges
+        /// endpoint asks it. The tests that name one build the check directly.
         fn check(privilege: &str) -> GrantAuthorityCheck<'_> {
-            GrantAuthorityCheck::any(privilege)
+            GrantAuthorityCheck::grantable(privilege)
         }
 
         fn writes(entries: Vec<GrantEntry>) -> ApplyGrantsRequest {
@@ -340,8 +339,8 @@ mod grant {
             let authorizer = &ctx.v1_state.authz;
             let warehouse = warehouse_target(&ctx, warehouse_id).await;
             let target = GrantTarget::Warehouse(&warehouse);
-            let alice = UserOrRoleId::User(UserId::new_unchecked("oidc", "alice"));
-            let bob = UserOrRoleId::User(UserId::new_unchecked("oidc", "bob"));
+            let alice = AuthzUserOrRole::User(UserId::new_unchecked("oidc", "alice"));
+            let bob = AuthzUserOrRole::User(UserId::new_unchecked("oidc", "bob"));
 
             let decisions = authorizer
                 .are_allowed_grants(
@@ -349,9 +348,9 @@ mod grant {
                     None,
                     &target,
                     &[
-                        GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
-                        GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
-                        GrantAuthorityCheck::entry("modify", &alice, GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", Some(&alice), GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", Some(&bob), GrantOp::Grant),
+                        GrantAuthorityCheck::entry("modify", Some(&alice), GrantOp::Grant),
                     ],
                 )
                 .await
@@ -366,10 +365,10 @@ mod grant {
                     None,
                     &target,
                     &[
-                        GrantAuthorityCheck::entry("get_metadata", &alice, GrantOp::Grant),
-                        GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
-                        GrantAuthorityCheck::entry("get_metadata", &bob, GrantOp::Grant),
-                        GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
+                        GrantAuthorityCheck::entry("get_metadata", Some(&alice), GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", Some(&alice), GrantOp::Grant),
+                        GrantAuthorityCheck::entry("get_metadata", Some(&bob), GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", Some(&bob), GrantOp::Grant),
                     ],
                 )
                 .await
@@ -383,8 +382,8 @@ mod grant {
                     None,
                     &target,
                     &[
-                        GrantAuthorityCheck::entry("select", &alice, GrantOp::Grant),
-                        GrantAuthorityCheck::entry("select", &bob, GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", Some(&alice), GrantOp::Grant),
+                        GrantAuthorityCheck::entry("select", Some(&bob), GrantOp::Grant),
                     ],
                 )
                 .await

--- a/crates/lakekeeper-storage-postgres/src/catalog.rs
+++ b/crates/lakekeeper-storage-postgres/src/catalog.rs
@@ -80,7 +80,8 @@ use super::{
     CatalogState, PostgresTransaction,
     bootstrap::{bootstrap, get_validation_data, reopen_for_bootstrap},
     grant::{
-        apply_grants, delete_grants_for_user, insert_grants, list_grants, list_grants_on_resources,
+        apply_grants, delete_grants_for_user, insert_grants_bounded, list_grants,
+        list_grants_on_resources,
     },
     namespace::{create_namespace, drop_namespace, list_namespaces, update_namespace_properties},
     role::{create_roles, delete_roles, list_roles, list_roles_by_idents, update_role},
@@ -417,11 +418,11 @@ impl CatalogStore for super::PostgresBackend {
         apply_grants(writes, deletes, transaction).await
     }
 
-    async fn bootstrap_grants_impl<'a>(
+    async fn insert_grants_impl<'a>(
         writes: &[GrantSpec],
         transaction: <Self::Transaction as Transaction<CatalogState>>::Transaction<'a>,
     ) -> Result<Vec<GrantSpec>, ApplyGrantsStoreError> {
-        insert_grants(writes, transaction).await
+        insert_grants_bounded(writes, transaction).await
     }
 
     async fn delete_grants_for_user_impl<'a>(

--- a/crates/lakekeeper-storage-postgres/src/catalog.rs
+++ b/crates/lakekeeper-storage-postgres/src/catalog.rs
@@ -79,7 +79,9 @@ use lakekeeper_io::Location;
 use super::{
     CatalogState, PostgresTransaction,
     bootstrap::{bootstrap, get_validation_data, reopen_for_bootstrap},
-    grant::{apply_grants, delete_grants_for_user, list_grants, list_grants_on_resources},
+    grant::{
+        apply_grants, delete_grants_for_user, insert_grants, list_grants, list_grants_on_resources,
+    },
     namespace::{create_namespace, drop_namespace, list_namespaces, update_namespace_properties},
     role::{create_roles, delete_roles, list_roles, list_roles_by_idents, update_role},
     tabular::table::load_tables,
@@ -413,6 +415,13 @@ impl CatalogStore for super::PostgresBackend {
         transaction: <Self::Transaction as Transaction<CatalogState>>::Transaction<'a>,
     ) -> Result<AppliedGrants, ApplyGrantsStoreError> {
         apply_grants(writes, deletes, transaction).await
+    }
+
+    async fn bootstrap_grants_impl<'a>(
+        writes: &[GrantSpec],
+        transaction: <Self::Transaction as Transaction<CatalogState>>::Transaction<'a>,
+    ) -> Result<Vec<GrantSpec>, ApplyGrantsStoreError> {
+        insert_grants(writes, transaction).await
     }
 
     async fn delete_grants_for_user_impl<'a>(

--- a/crates/lakekeeper-storage-postgres/src/grant.rs
+++ b/crates/lakekeeper-storage-postgres/src/grant.rs
@@ -603,17 +603,14 @@ fn rows_into_specs(
         .collect()
 }
 
-/// Insert grants into a transaction the caller opened for something else — the rows a
-/// resource is born with, written next to the resource itself.
+/// Insert grants into a transaction the caller opened for other work.
 ///
-/// Takes no advisory lock: that serialization exists for diffs that cross, and an insert
-/// with no delete side cannot cross one. It does bound the wait, because the insert's
-/// foreign keys take `FOR KEY SHARE` on the resource's parents — the warehouse, the
-/// tabular, the principal — and those conflict with any `FOR UPDATE` another handler holds
-/// on them across a network call. Unbounded, a create would queue behind such a handler
-/// holding a write-pool connection for as long as it runs; bounded, it fails with a typed
-/// retriable error. The reset keeps the bound off the caller's remaining statements, and
-/// on the error path the caller's transaction is doomed anyway.
+/// Takes no advisory lock: that serializes diffs which cross — each revoking what the
+/// other adds — and an insert with no delete side has nothing to cross. It does bound its
+/// wait, because the foreign keys take `FOR KEY SHARE` on the grant's resource and
+/// principal, and another handler may hold `FOR UPDATE` there across a network call;
+/// unbounded, the caller would queue behind it holding its own connection. The bound is
+/// reset so it governs nothing but this insert.
 pub(crate) async fn insert_grants_bounded(
     specs: &[GrantSpec],
     transaction: &mut Transaction<'_, Postgres>,

--- a/crates/lakekeeper-storage-postgres/src/grant.rs
+++ b/crates/lakekeeper-storage-postgres/src/grant.rs
@@ -603,6 +603,36 @@ fn rows_into_specs(
         .collect()
 }
 
+/// Insert grants into a transaction the caller opened for something else — the rows a
+/// resource is born with, written next to the resource itself.
+///
+/// Takes no advisory lock: that serialization exists for diffs that cross, and an insert
+/// with no delete side cannot cross one. It does bound the wait, because the insert's
+/// foreign keys take `FOR KEY SHARE` on the resource's parents — the warehouse, the
+/// tabular, the principal — and those conflict with any `FOR UPDATE` another handler holds
+/// on them across a network call. Unbounded, a create would queue behind such a handler
+/// holding a write-pool connection for as long as it runs; bounded, it fails with a typed
+/// retriable error. The reset keeps the bound off the caller's remaining statements, and
+/// on the error path the caller's transaction is doomed anyway.
+pub(crate) async fn insert_grants_bounded(
+    specs: &[GrantSpec],
+    transaction: &mut Transaction<'_, Postgres>,
+) -> Result<Vec<GrantSpec>, ApplyGrantsStoreError> {
+    if specs.is_empty() {
+        return Ok(Vec::new());
+    }
+    sqlx::query("SET LOCAL lock_timeout = '3s'")
+        .execute(&mut **transaction)
+        .await
+        .map_err(DBErrorHandler::into_catalog_backend_error)?;
+    let created = insert_grants(specs, transaction).await?;
+    sqlx::query("SET LOCAL lock_timeout = DEFAULT")
+        .execute(&mut **transaction)
+        .await
+        .map_err(DBErrorHandler::into_catalog_backend_error)?;
+    Ok(created)
+}
+
 /// Insert `specs`, ignoring grants that already exist. Returns the grants actually
 /// created.
 pub(crate) async fn insert_grants(
@@ -1889,10 +1919,10 @@ mod tests {
         }
     }
 
-    /// The bootstrap write shares its transaction with a resource create, so it must
-    /// leave that transaction's settings alone. The diff path sets a transaction-local
-    /// `lock_timeout` — asserted here as the contrast — which every create would
-    /// otherwise inherit for the rest of its work.
+    /// The bootstrap write shares its transaction with a resource create, so the bound it
+    /// needs for its own foreign-key waits must not outlive it. The diff path sets the
+    /// same transaction-local `lock_timeout` and deliberately keeps it — asserted here as
+    /// the contrast.
     #[sqlx::test]
     async fn bootstrapping_grants_leaves_the_transaction_settings_alone(pool: PgPool) {
         let state = CatalogState::from_pools(pool.clone(), pool.clone());
@@ -1901,7 +1931,7 @@ mod tests {
         let spec = user_spec(&user, GrantResource::Warehouse(warehouse_id), "ownership");
 
         let mut txn = pool.begin().await.unwrap();
-        let created = insert_grants(std::slice::from_ref(&spec), &mut txn)
+        let created = insert_grants_bounded(std::slice::from_ref(&spec), &mut txn)
             .await
             .unwrap();
         assert_eq!(created, vec![spec.clone()]);
@@ -1913,7 +1943,7 @@ mod tests {
 
         // Re-running the same bootstrap creates nothing: a replayed create, or a
         // re-registered table that kept its id, must not double-grant.
-        let again = insert_grants(std::slice::from_ref(&spec), &mut txn)
+        let again = insert_grants_bounded(std::slice::from_ref(&spec), &mut txn)
             .await
             .unwrap();
         assert_eq!(again, Vec::new());

--- a/crates/lakekeeper-storage-postgres/src/grant.rs
+++ b/crates/lakekeeper-storage-postgres/src/grant.rs
@@ -1889,6 +1889,61 @@ mod tests {
         }
     }
 
+    /// The bootstrap write shares its transaction with a resource create, so it must
+    /// leave that transaction's settings alone. The diff path sets a transaction-local
+    /// `lock_timeout` — asserted here as the contrast — which every create would
+    /// otherwise inherit for the rest of its work.
+    #[sqlx::test]
+    async fn bootstrapping_grants_leaves_the_transaction_settings_alone(pool: PgPool) {
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
+        let (_, warehouse_id) = initialize_warehouse(state.clone(), None, None, None, true).await;
+        let user = seed_user(&pool, "oidc~alice").await;
+        let spec = user_spec(&user, GrantResource::Warehouse(warehouse_id), "ownership");
+
+        let mut txn = pool.begin().await.unwrap();
+        let created = insert_grants(std::slice::from_ref(&spec), &mut txn)
+            .await
+            .unwrap();
+        assert_eq!(created, vec![spec.clone()]);
+        let timeout: String = sqlx::query_scalar("SHOW lock_timeout")
+            .fetch_one(&mut *txn)
+            .await
+            .unwrap();
+        assert_eq!(timeout, "0");
+
+        // Re-running the same bootstrap creates nothing: a replayed create, or a
+        // re-registered table that kept its id, must not double-grant.
+        let again = insert_grants(std::slice::from_ref(&spec), &mut txn)
+            .await
+            .unwrap();
+        assert_eq!(again, Vec::new());
+
+        apply_grants(std::slice::from_ref(&spec), &[], &mut txn)
+            .await
+            .unwrap();
+        let timeout: String = sqlx::query_scalar("SHOW lock_timeout")
+            .fetch_one(&mut *txn)
+            .await
+            .unwrap();
+        assert_eq!(timeout, "3s");
+        txn.commit().await.unwrap();
+
+        let page = list_grants(
+            &GrantFilter::on(GrantResource::Warehouse(warehouse_id), None),
+            no_pagination(),
+            &pool,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            page.grants
+                .iter()
+                .map(|row| row.privilege.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ownership"]
+        );
+    }
+
     #[sqlx::test]
     async fn a_diff_that_revokes_and_regrants_ends_granted(pool: PgPool) {
         // Deletes run before inserts, so the same privilege appearing on both sides

--- a/crates/lakekeeper/src/api/management/mod.rs
+++ b/crates/lakekeeper/src/api/management/mod.rs
@@ -3347,7 +3347,7 @@ pub mod v1 {
     /// This API may change in a backward-incompatible way in a future release.
     ///
     /// Every privilege this server publishes, each marked with whether the caller may
-    /// grant and revoke it here. Not filtered: a picker needs to show the ones it
+    /// administer it here. Not filtered: a picker needs to show the ones it
     /// cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
     /// another principal's behalf, which requires authority to read this server's
     /// grants.
@@ -3374,7 +3374,7 @@ pub mod v1 {
     /// This API may change in a backward-incompatible way in a future release.
     ///
     /// Every privilege this project publishes, each marked with whether the caller may
-    /// grant and revoke it here. Not filtered: a picker needs to show the ones it
+    /// administer it here. Not filtered: a picker needs to show the ones it
     /// cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
     /// another principal's behalf, which requires authority to read this project's
     /// grants.
@@ -3401,7 +3401,7 @@ pub mod v1 {
     /// This API may change in a backward-incompatible way in a future release.
     ///
     /// Every privilege this warehouse publishes, each marked with whether the caller may
-    /// grant and revoke it here. Not filtered: a picker needs to show the ones it
+    /// administer it here. Not filtered: a picker needs to show the ones it
     /// cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
     /// another principal's behalf, which requires authority to read this warehouse's
     /// grants.
@@ -3435,7 +3435,7 @@ pub mod v1 {
     /// This API may change in a backward-incompatible way in a future release.
     ///
     /// Every privilege this namespace publishes, each marked with whether the caller may
-    /// grant and revoke it here. Not filtered: a picker needs to show the ones it
+    /// administer it here. Not filtered: a picker needs to show the ones it
     /// cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
     /// another principal's behalf, which requires authority to read this namespace's
     /// grants.
@@ -3470,7 +3470,7 @@ pub mod v1 {
     /// This API may change in a backward-incompatible way in a future release.
     ///
     /// Every privilege this table publishes, each marked with whether the caller may
-    /// grant and revoke it here. Not filtered: a picker needs to show the ones it
+    /// administer it here. Not filtered: a picker needs to show the ones it
     /// cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
     /// another principal's behalf, which requires authority to read this table's
     /// grants.
@@ -3505,7 +3505,7 @@ pub mod v1 {
     /// This API may change in a backward-incompatible way in a future release.
     ///
     /// Every privilege this view publishes, each marked with whether the caller may
-    /// grant and revoke it here. Not filtered: a picker needs to show the ones it
+    /// administer it here. Not filtered: a picker needs to show the ones it
     /// cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
     /// another principal's behalf, which requires authority to read this view's
     /// grants.
@@ -3540,7 +3540,7 @@ pub mod v1 {
     /// This API may change in a backward-incompatible way in a future release.
     ///
     /// Every privilege this generic table publishes, each marked with whether the caller may
-    /// grant and revoke it here. Not filtered: a picker needs to show the ones it
+    /// administer it here. Not filtered: a picker needs to show the ones it
     /// cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
     /// another principal's behalf, which requires authority to read this generic table's
     /// grants.
@@ -3579,7 +3579,7 @@ pub mod v1 {
     /// This API may change in a backward-incompatible way in a future release.
     ///
     /// Every privilege this tag definition publishes, each marked with whether the caller may
-    /// grant and revoke it here. Not filtered: a picker needs to show the ones it
+    /// administer it here. Not filtered: a picker needs to show the ones it
     /// cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
     /// another principal's behalf, which requires authority to read this tag definition's
     /// grants.

--- a/crates/lakekeeper/src/api/management/v1/grant.rs
+++ b/crates/lakekeeper/src/api/management/v1/grant.rs
@@ -71,8 +71,8 @@ use crate::{
             AuthorizationDecision, Authorizer, AuthzNamespaceOps, AuthzWarehouseOps,
             CatalogGenericTableAction, CatalogNamespaceAction, CatalogProjectAction,
             CatalogServerAction, CatalogTableAction, CatalogTagAction, CatalogViewAction,
-            CatalogWarehouseAction, GrantAuthorityCheck, GrantFilter, GrantResource, GrantRow,
-            GrantSpec, PrivilegeDescriptor, RequireTagActionError, ResourceType,
+            CatalogWarehouseAction, GrantAuthorityCheck, GrantFilter, GrantOp, GrantResource,
+            GrantRow, GrantSpec, PrivilegeDescriptor, RequireTagActionError, ResourceType,
             UserOrRole as AuthzUserOrRole, UserOrRoleId,
         },
         events::{
@@ -359,7 +359,9 @@ pub struct GrantablePrivilege {
     /// distinct — and so a new descriptor field can never collide with `allowed`.
     #[cfg_attr(feature = "open-api", schema(value_type = PrivilegeDescriptor))]
     pub privilege: &'static PrivilegeDescriptor,
-    /// Whether the principal may grant and revoke this privilege on this resource.
+    /// Whether the principal has authority over this privilege on this resource. Asked
+    /// without a direction, so an authorizer that separates granting from revoking may
+    /// answer for either; an apply is checked per entry.
     pub allowed: bool,
 }
 
@@ -716,22 +718,30 @@ async fn validate_write_principals<C: CatalogRoleOps>(
 // ---------------------------------------------------------------------------
 
 /// The distinct grant-authority questions a diff asks, in `writes`-then-`deletes` order:
-/// which privilege, destined for which principal.
+/// which privilege, destined for which principal, moving which way.
 ///
-/// Deduplicated on the *pair*, in first-seen order. A diff handing one privilege to a
-/// hundred principals asks a hundred questions: whether the grantee changes the answer
-/// belongs to the authorizer's model, so this layer cannot collapse them. An authorizer
-/// that resolves authority from the privilege alone collapses them itself, where that is
-/// sound.
-fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str)> {
+/// Deduplicated on the *triple*, in first-seen order. A diff handing one privilege to a
+/// hundred principals asks a hundred questions, and handing one to a principal while
+/// taking it from another asks two: whether the grantee or the direction changes the
+/// answer belongs to the authorizer's model, so this layer cannot collapse them. An
+/// authorizer that resolves authority from the privilege alone collapses them itself,
+/// where that is sound.
+fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str, GrantOp)> {
     let mut seen = std::collections::HashSet::new();
-    request
-        .entries()
-        .map(|entry| {
-            (
-                UserOrRoleId::from(&entry.principal),
-                entry.privilege.as_str(),
-            )
+    let sides = [
+        (request.writes.iter(), GrantOp::Grant),
+        (request.deletes.iter(), GrantOp::Revoke),
+    ];
+    sides
+        .into_iter()
+        .flat_map(|(entries, op)| {
+            entries.map(move |entry| {
+                (
+                    UserOrRoleId::from(&entry.principal),
+                    entry.privilege.as_str(),
+                    op,
+                )
+            })
         })
         .filter(|question| seen.insert(question.clone()))
         .collect()
@@ -744,7 +754,7 @@ fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str)
 /// once an authorizer answers per grantee: a privilege allowed for the first principal
 /// that asks for it and refused for the second is named where the refusal is.
 fn refused_privileges<'a>(
-    questions: &[(UserOrRoleId, &'a str)],
+    questions: &[(UserOrRoleId, &'a str, GrantOp)],
     decisions: &[AuthorizationDecision],
 ) -> Vec<&'a str> {
     let mut named = std::collections::HashSet::new();
@@ -752,13 +762,14 @@ fn refused_privileges<'a>(
         .iter()
         .zip(decisions)
         .filter(|(_, decision)| !decision.allowed)
-        .map(|((_, privilege), _)| *privilege)
+        .map(|((_, privilege, _), _)| *privilege)
         .filter(|privilege| named.insert(*privilege))
         .collect()
 }
 
-/// Check grant authority for every entry of the diff, including the deletes:
-/// revoking a privilege requires the same authority as granting it.
+/// Check grant authority for every entry of the diff, including the deletes: taking a
+/// privilege away is administering it too, so it is asked rather than assumed. Whether an
+/// authorizer answers the two directions alike is its own business.
 async fn require_grant_authority<A: Authorizer>(
     authorizer: &A,
     metadata: &RequestMetadata,
@@ -770,7 +781,9 @@ async fn require_grant_authority<A: Authorizer>(
     let questions = authority_questions(request);
     let checks: Vec<GrantAuthorityCheck<'_>> = questions
         .iter()
-        .map(|(grantee, privilege)| GrantAuthorityCheck::new(privilege, Some(grantee)))
+        .map(|(grantee, privilege, op)| {
+            GrantAuthorityCheck::new(privilege, Some(grantee), Some(*op))
+        })
         .collect();
     let decisions = authorizer
         .are_allowed_grants(metadata, None, resource, &checks)
@@ -799,12 +812,12 @@ async fn allowed_privileges<A: Authorizer>(
     resource: &GrantResource,
 ) -> std::result::Result<Vec<GrantablePrivilege>, AuthZError> {
     let vocabulary = authorizer.grantable_privileges(resource.resource_type());
-    // No grantee: this asks whether the subject has authority over each privilege here
-    // at all. Advisory - the apply path asks again per grantee - so an authorizer that
-    // distinguishes them need not enumerate anyone to answer.
+    // Neither grantee nor direction: this asks whether the subject has authority over each
+    // privilege here at all. Advisory - the apply path asks again per entry - so an
+    // authorizer that distinguishes them need not enumerate anyone to answer.
     let checks: Vec<GrantAuthorityCheck<'_>> = vocabulary
         .iter()
-        .map(|privilege| GrantAuthorityCheck::new(privilege.name.as_str(), None))
+        .map(|privilege| GrantAuthorityCheck::new(privilege.name.as_str(), None, None))
         .collect();
     let decisions = authorizer
         .are_allowed_grants(request_metadata, for_user.as_ref(), resource, &checks)
@@ -2738,11 +2751,14 @@ mod tests {
     }
 
     #[test]
-    fn authority_questions_are_deduplicated_on_the_pair() {
+    fn authority_questions_are_deduplicated_on_the_triple() {
         // Not on the privilege alone: an authorizer may answer differently depending on
-        // who receives the privilege, so `modify` for alice and `modify` for a role are
-        // two questions. The same pair twice - here a grant and a revoke of `modify` for
-        // alice - is one, asked in the position the request first names it.
+        // who receives the privilege and on which way it moves. So `modify` for alice,
+        // `modify` for a role, and taking `modify` back from alice are three questions —
+        // the last one is what lets a revoke-only role exist. A repeat of the whole
+        // triple is one question, asked where the request first names it; the request
+        // validator rejects a repeat within one side, but it compares the principal as
+        // written, and two spellings can name the same principal.
         let role_id = RoleId::new_random();
         let role = UserOrRole::Role(RoleAssignee::from_role(role_id));
         let request = ApplyGrantsRequest {
@@ -2750,6 +2766,7 @@ mod tests {
                 entry("modify", alice()),
                 entry("modify", role),
                 entry("select", alice()),
+                entry("modify", alice()),
             ],
             deletes: vec![entry("modify", alice())],
         };
@@ -2758,9 +2775,10 @@ mod tests {
         assert_eq!(
             authority_questions(&request),
             vec![
-                (alice_id.clone(), "modify"),
-                (UserOrRoleId::Role(role_id), "modify"),
-                (alice_id, "select"),
+                (alice_id.clone(), "modify", GrantOp::Grant),
+                (UserOrRoleId::Role(role_id), "modify", GrantOp::Grant),
+                (alice_id.clone(), "select", GrantOp::Grant),
+                (alice_id, "modify", GrantOp::Revoke),
             ]
         );
     }
@@ -2773,9 +2791,9 @@ mod tests {
         let alice = UserOrRoleId::from(&alice());
         let role = UserOrRoleId::Role(RoleId::new_random());
         let questions = vec![
-            (alice.clone(), "select"),
-            (role, "select"),
-            (alice, "modify"),
+            (alice.clone(), "select", GrantOp::Grant),
+            (role, "select", GrantOp::Grant),
+            (alice, "modify", GrantOp::Revoke),
         ];
 
         // `select` allowed for alice but refused for the role: named once, and from the

--- a/crates/lakekeeper/src/api/management/v1/grant.rs
+++ b/crates/lakekeeper/src/api/management/v1/grant.rs
@@ -72,8 +72,8 @@ use crate::{
             CatalogGenericTableAction, CatalogNamespaceAction, CatalogProjectAction,
             CatalogServerAction, CatalogTableAction, CatalogTagAction, CatalogViewAction,
             CatalogWarehouseAction, GrantAuthorityCheck, GrantFilter, GrantOp, GrantResource,
-            GrantRow, GrantSpec, PrivilegeDescriptor, RequireTagActionError, ResourceType,
-            UserOrRole as AuthzUserOrRole, UserOrRoleId,
+            GrantRow, GrantSpec, GrantTarget, PrivilegeDescriptor, RequireTagActionError,
+            ResourceType, UserOrRole as AuthzUserOrRole, UserOrRoleId,
         },
         events::{
             APIEventContext, GrantsChangedEvent,
@@ -348,7 +348,7 @@ impl axum::response::IntoResponse for GrantablePrivilegesResponse {
     }
 }
 
-/// One privilege of a resource's vocabulary, and whether the principal may grant it.
+/// One privilege of a resource's vocabulary, and whether the principal may administer it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[cfg_attr(feature = "open-api", derive(utoipa::ToSchema))]
 #[serde(rename_all = "kebab-case")]
@@ -365,7 +365,7 @@ pub struct GrantablePrivilege {
 }
 
 /// This resource's whole vocabulary, each entry marked with whether the principal may
-/// grant it.
+/// administer it — grant it, revoke it, or both.
 ///
 /// The deployment-wide vocabulary answers "what does this server understand"; this
 /// answers "what may I do here", which is the question a grant dialog asks. Grant
@@ -477,13 +477,13 @@ fn principal_from_params(
 #[cfg_attr(feature = "open-api", derive(utoipa::IntoParams))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct GetGrantAccessQuery {
-    /// Report which privileges this user may grant, instead of the caller. Requires
+    /// Report which privileges this user may administer, instead of the caller. Requires
     /// authority to read the resource's grants, since it discloses another principal's
     /// access. Mutually exclusive with `principalRole`.
     #[serde(default)]
     #[cfg_attr(feature = "open-api", param(required = false, value_type = Option<String>))]
     pub principal_user: Option<UserId>,
-    /// Report which privileges this role may grant, instead of the caller. Same
+    /// Report which privileges this role may administer, instead of the caller. Same
     /// authority requirement as `principalUser`, and mutually exclusive with it.
     #[serde(default)]
     #[cfg_attr(feature = "open-api", param(required = false, value_type = Option<uuid::Uuid>))]
@@ -776,7 +776,7 @@ fn refused_privileges<'a>(
 async fn require_grant_authority<A: Authorizer>(
     authorizer: &A,
     metadata: &RequestMetadata,
-    resource: &GrantResource,
+    target: &GrantTarget<'_>,
     request: &ApplyGrantsRequest,
 ) -> std::result::Result<(), AuthZError> {
     // Materialized first so each check can borrow its grantee: the request carries the
@@ -787,18 +787,18 @@ async fn require_grant_authority<A: Authorizer>(
         .map(|(grantee, privilege, op)| GrantAuthorityCheck::entry(privilege, grantee, *op))
         .collect();
     let decisions = authorizer
-        .are_allowed_grants(metadata, None, resource, &checks)
+        .are_allowed_grants(metadata, None, target, &checks)
         .await?;
     // Every refused privilege is named, matching the validation errors above: one round
     // trip should surface everything the caller must remove.
     let refused = refused_privileges(&questions, &decisions);
     if !refused.is_empty() {
-        return Err(AuthZGrantActionForbidden::new(resource, refused).into());
+        return Err(AuthZGrantActionForbidden::new(&target.resource(), refused).into());
     }
     Ok(())
 }
 
-/// The vocabulary entries the principal may grant on `resource`.
+/// The vocabulary entries the principal may administer on `target`.
 ///
 /// One batch call, so eight or nine privileges cost one round trip to the authorizer.
 ///
@@ -810,9 +810,9 @@ async fn allowed_privileges<A: Authorizer>(
     authorizer: &A,
     request_metadata: &RequestMetadata,
     for_user: Option<AuthzUserOrRole>,
-    resource: &GrantResource,
+    target: &GrantTarget<'_>,
 ) -> std::result::Result<Vec<GrantablePrivilege>, AuthZError> {
-    let vocabulary = authorizer.grantable_privileges(resource.resource_type());
+    let vocabulary = authorizer.grantable_privileges(target.resource_type());
     // Neither grantee nor direction: this asks whether the subject has authority over each
     // privilege here at all. Advisory - the apply path asks again per entry - so an
     // authorizer that distinguishes them need not enumerate anyone to answer.
@@ -821,7 +821,7 @@ async fn allowed_privileges<A: Authorizer>(
         .map(|privilege| GrantAuthorityCheck::any(privilege.name.as_str()))
         .collect();
     let decisions = authorizer
-        .are_allowed_grants(request_metadata, for_user.as_ref(), resource, &checks)
+        .are_allowed_grants(request_metadata, for_user.as_ref(), target, &checks)
         .await?;
     Ok(vocabulary
         .iter()
@@ -1273,7 +1273,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let authz_result = require_grant_authority(
             &authorizer,
             event_ctx.request_metadata(),
-            &resource,
+            &GrantTarget::Server,
             &request,
         )
         .await;
@@ -1355,7 +1355,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let authz_result = require_grant_authority(
             &authorizer,
             event_ctx.request_metadata(),
-            &resource,
+            &GrantTarget::Project(&project_id),
             &request,
         )
         .await;
@@ -1475,12 +1475,16 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 )
             );
             let warehouse = authorizer.require_warehouse_presence(warehouse_id, warehouse)?;
-            authorizer.require_namespace_presence(warehouse_id, namespace_id, namespace)?;
+            let namespace =
+                authorizer.require_namespace_presence(warehouse_id, namespace_id, namespace)?;
             ensure_warehouse_in_project(warehouse_id, &warehouse.project_id, &project_id)?;
             require_grant_authority(
                 &authorizer,
                 event_ctx.request_metadata(),
-                &resource,
+                &GrantTarget::Namespace {
+                    warehouse: &warehouse,
+                    namespace: &namespace,
+                },
                 &request,
             )
             .await
@@ -1607,11 +1611,11 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let authz_result = async {
             let definition =
                 C::get_tag_definition(&project_id, tag_definition_id, catalog_state.clone()).await;
-            authorizer.require_tag_presence(tag_definition_id, definition)?;
+            let definition = authorizer.require_tag_presence(tag_definition_id, definition)?;
             require_grant_authority(
                 &authorizer,
                 event_ctx.request_metadata(),
-                &resource,
+                &GrantTarget::Tag(&definition),
                 &request,
             )
             .await
@@ -1724,7 +1728,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let authz_result = async {
             // Presence only, as at every other level: grant authority is its own
             // right, so requiring a table action too would be a second, wrong gate.
-            let (warehouse, _, _) =
+            let (warehouse, namespace, table) =
                 crate::service::authz::fetch_warehouse_namespace_table_by_id::<C, A>(
                     &authorizer,
                     warehouse_id,
@@ -1737,7 +1741,11 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             require_grant_authority(
                 &authorizer,
                 event_ctx.request_metadata(),
-                &resource,
+                &GrantTarget::Table {
+                    warehouse: &warehouse,
+                    namespace: &namespace,
+                    table: &table,
+                },
                 &request,
             )
             .await
@@ -1848,7 +1856,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             ApplyGrants::of(&request),
         );
         let authz_result = async {
-            let (warehouse, _, _) =
+            let (warehouse, namespace, view) =
                 crate::service::authz::fetch_warehouse_namespace_view_by_id::<C, A>(
                     &authorizer,
                     warehouse_id,
@@ -1861,7 +1869,11 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             require_grant_authority(
                 &authorizer,
                 event_ctx.request_metadata(),
-                &resource,
+                &GrantTarget::View {
+                    warehouse: &warehouse,
+                    namespace: &namespace,
+                    view: &view,
+                },
                 &request,
             )
             .await
@@ -1972,7 +1984,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             ApplyGrants::of(&request),
         );
         let authz_result = async {
-            let (warehouse, _, _) =
+            let (warehouse, namespace, generic_table) =
                 crate::service::authz::fetch_warehouse_namespace_generic_table_by_id::<C, A>(
                     &authorizer,
                     warehouse_id,
@@ -1985,7 +1997,11 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             require_grant_authority(
                 &authorizer,
                 event_ctx.request_metadata(),
-                &resource,
+                &GrantTarget::GenericTable {
+                    warehouse: &warehouse,
+                    namespace: &namespace,
+                    generic_table: &generic_table,
+                },
                 &request,
             )
             .await
@@ -2051,7 +2067,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             require_grant_authority(
                 &authorizer,
                 event_ctx.request_metadata(),
-                &resource,
+                &GrantTarget::Warehouse(&resolved),
                 &request,
             )
             .await
@@ -2076,7 +2092,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         )
         .await
     }
-    /// Which server privileges the caller may grant.
+    /// Which server privileges the caller may administer.
     async fn get_server_grantable_privileges(
         context: ApiContext<State<A, C, S>>,
         request_metadata: RequestMetadata,
@@ -2085,7 +2101,6 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let for_user_api = query.try_principal()?;
         let authorizer = context.v1_state.authz;
         let catalog_state = context.v1_state.catalog;
-        let resource = GrantResource::Server;
 
         let mut event_ctx = APIEventContext::for_server(
             request_metadata.into(),
@@ -2111,7 +2126,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 &authorizer,
                 event_ctx.request_metadata(),
                 for_user,
-                &resource,
+                &GrantTarget::Server,
             )
             .await
         }
@@ -2122,7 +2137,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         })
     }
 
-    /// Which project privileges the caller may grant in the request's project.
+    /// Which project privileges the caller may administer in the request's project.
     async fn get_project_grantable_privileges(
         context: ApiContext<State<A, C, S>>,
         request_metadata: RequestMetadata,
@@ -2132,7 +2147,6 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let for_user_api = query.try_principal()?;
         let authorizer = context.v1_state.authz;
         let catalog_state = context.v1_state.catalog;
-        let resource = GrantResource::Project((*project_id).clone());
 
         let mut event_ctx = APIEventContext::for_project(
             request_metadata.into(),
@@ -2158,7 +2172,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 &authorizer,
                 event_ctx.request_metadata(),
                 for_user,
-                &resource,
+                &GrantTarget::Project(&project_id),
             )
             .await
         }
@@ -2169,7 +2183,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         })
     }
 
-    /// Which warehouse privileges the caller may grant on a warehouse.
+    /// Which warehouse privileges the caller may administer on a warehouse.
     async fn get_warehouse_grantable_privileges(
         warehouse_id: WarehouseId,
         context: ApiContext<State<A, C, S>>,
@@ -2180,7 +2194,6 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let for_user_api = query.try_principal()?;
         let authorizer = context.v1_state.authz;
         let catalog_state = context.v1_state.catalog;
-        let resource = GrantResource::Warehouse(warehouse_id);
 
         let mut event_ctx = APIEventContext::for_warehouse(
             request_metadata.into(),
@@ -2208,7 +2221,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                     .require_warehouse_action(
                         event_ctx.request_metadata(),
                         warehouse_id,
-                        Ok(Some(resolved)),
+                        Ok(Some(resolved.clone())),
                         CatalogWarehouseAction::ReadGrants,
                     )
                     .await?;
@@ -2217,7 +2230,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 &authorizer,
                 event_ctx.request_metadata(),
                 for_user,
-                &resource,
+                &GrantTarget::Warehouse(&resolved),
             )
             .await
         }
@@ -2228,7 +2241,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         })
     }
 
-    /// Which namespace privileges the caller may grant on a namespace.
+    /// Which namespace privileges the caller may administer on a namespace.
     async fn get_namespace_grantable_privileges(
         warehouse_id: WarehouseId,
         namespace_id: NamespaceId,
@@ -2240,10 +2253,6 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let for_user_api = query.try_principal()?;
         let authorizer = context.v1_state.authz;
         let catalog_state = context.v1_state.catalog;
-        let resource = GrantResource::Namespace {
-            warehouse_id,
-            namespace_id,
-        };
 
         let mut event_ctx = APIEventContext::for_namespace(
             request_metadata.into(),
@@ -2266,7 +2275,8 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 )
             );
             let warehouse = authorizer.require_warehouse_presence(warehouse_id, warehouse)?;
-            authorizer.require_namespace_presence(warehouse_id, namespace_id, namespace)?;
+            let namespace =
+                authorizer.require_namespace_presence(warehouse_id, namespace_id, namespace)?;
             ensure_warehouse_in_project(warehouse_id, &warehouse.project_id, &project_id)?;
             let for_user = resolve_principal::<C>(for_user_api, catalog_state.clone()).await?;
             if grant_read_is_delegated(for_user.as_ref(), event_ctx.request_metadata()) {
@@ -2284,7 +2294,10 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 &authorizer,
                 event_ctx.request_metadata(),
                 for_user,
-                &resource,
+                &GrantTarget::Namespace {
+                    warehouse: &warehouse,
+                    namespace: &namespace,
+                },
             )
             .await
         }
@@ -2295,7 +2308,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         })
     }
 
-    /// Which table privileges the caller may grant on a table.
+    /// Which table privileges the caller may administer on a table.
     async fn get_table_grantable_privileges(
         warehouse_id: WarehouseId,
         table_id: TableId,
@@ -2307,10 +2320,6 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let for_user_api = query.try_principal()?;
         let authorizer = context.v1_state.authz;
         let catalog_state = context.v1_state.catalog;
-        let resource = GrantResource::Table {
-            warehouse_id,
-            table_id,
-        };
 
         let mut event_ctx = APIEventContext::for_table(
             request_metadata.into(),
@@ -2323,7 +2332,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let event_ctx = event_ctx;
 
         let authz_result = async {
-            let (warehouse, _, _) =
+            let (warehouse, namespace, table) =
                 crate::service::authz::fetch_warehouse_namespace_table_by_id::<C, A>(
                     &authorizer,
                     warehouse_id,
@@ -2349,7 +2358,11 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 &authorizer,
                 event_ctx.request_metadata(),
                 for_user,
-                &resource,
+                &GrantTarget::Table {
+                    warehouse: &warehouse,
+                    namespace: &namespace,
+                    table: &table,
+                },
             )
             .await
         }
@@ -2360,7 +2373,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         })
     }
 
-    /// Which view privileges the caller may grant on a view.
+    /// Which view privileges the caller may administer on a view.
     async fn get_view_grantable_privileges(
         warehouse_id: WarehouseId,
         view_id: ViewId,
@@ -2372,10 +2385,6 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let for_user_api = query.try_principal()?;
         let authorizer = context.v1_state.authz;
         let catalog_state = context.v1_state.catalog;
-        let resource = GrantResource::View {
-            warehouse_id,
-            view_id,
-        };
 
         let mut event_ctx = APIEventContext::for_view(
             request_metadata.into(),
@@ -2388,7 +2397,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let event_ctx = event_ctx;
 
         let authz_result = async {
-            let (warehouse, _, _) =
+            let (warehouse, namespace, view) =
                 crate::service::authz::fetch_warehouse_namespace_view_by_id::<C, A>(
                     &authorizer,
                     warehouse_id,
@@ -2414,7 +2423,11 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 &authorizer,
                 event_ctx.request_metadata(),
                 for_user,
-                &resource,
+                &GrantTarget::View {
+                    warehouse: &warehouse,
+                    namespace: &namespace,
+                    view: &view,
+                },
             )
             .await
         }
@@ -2425,7 +2438,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         })
     }
 
-    /// Which generic-table privileges the caller may grant on a generic table.
+    /// Which generic-table privileges the caller may administer on a generic table.
     async fn get_generic_table_grantable_privileges(
         warehouse_id: WarehouseId,
         generic_table_id: GenericTableId,
@@ -2437,10 +2450,6 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let for_user_api = query.try_principal()?;
         let authorizer = context.v1_state.authz;
         let catalog_state = context.v1_state.catalog;
-        let resource = GrantResource::GenericTable {
-            warehouse_id,
-            generic_table_id,
-        };
 
         let mut event_ctx = APIEventContext::for_generic_table(
             request_metadata.into(),
@@ -2453,7 +2462,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let event_ctx = event_ctx;
 
         let authz_result = async {
-            let (warehouse, _, _) =
+            let (warehouse, namespace, generic_table) =
                 crate::service::authz::fetch_warehouse_namespace_generic_table_by_id::<C, A>(
                     &authorizer,
                     warehouse_id,
@@ -2479,7 +2488,11 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 &authorizer,
                 event_ctx.request_metadata(),
                 for_user,
-                &resource,
+                &GrantTarget::GenericTable {
+                    warehouse: &warehouse,
+                    namespace: &namespace,
+                    generic_table: &generic_table,
+                },
             )
             .await
         }
@@ -2490,7 +2503,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         })
     }
 
-    /// Which tag privileges the caller may grant on a tag definition.
+    /// Which tag privileges the caller may administer on a tag definition.
     async fn get_tag_grantable_privileges(
         tag_definition_id: TagDefinitionId,
         context: ApiContext<State<A, C, S>>,
@@ -2501,7 +2514,6 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let for_user_api = query.try_principal()?;
         let authorizer = context.v1_state.authz;
         let catalog_state = context.v1_state.catalog;
-        let resource = GrantResource::Tag(tag_definition_id);
 
         let mut event_ctx = APIEventContext::for_tag(
             request_metadata.into(),
@@ -2522,7 +2534,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                     .require_tag_action(
                         event_ctx.request_metadata(),
                         tag_definition_id,
-                        Ok(Some(definition)),
+                        Ok(Some(definition.clone())),
                         CatalogTagAction::ReadGrants,
                     )
                     .await?;
@@ -2531,7 +2543,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 &authorizer,
                 event_ctx.request_metadata(),
                 for_user,
-                &resource,
+                &GrantTarget::Tag(&definition),
             )
             .await
         }
@@ -2706,12 +2718,12 @@ mod tests {
         // the grant surface, so `are_allowed_grants` takes the fail-closed default.
         let authorizer = HidingAuthorizer::new();
         let metadata = RequestMetadataTestBuilder::builder().build();
-        let resource = GrantResource::Warehouse(WarehouseId::new_random());
+        let warehouse = crate::service::ResolvedWarehouse::new_random();
 
         let err = require_grant_authority(
             &authorizer,
             &metadata,
-            &resource,
+            &GrantTarget::Warehouse(&warehouse),
             &write_request(&["get_metadata"]),
         )
         .await
@@ -2733,12 +2745,11 @@ mod tests {
         // everything the caller must remove — matching the validation errors.
         let authorizer = HidingAuthorizer::new();
         let metadata = RequestMetadataTestBuilder::builder().build();
-        let resource = GrantResource::Server;
 
         let err = require_grant_authority(
             &authorizer,
             &metadata,
-            &resource,
+            &GrantTarget::Server,
             &write_request(&["provision_users", "list_users"]),
         )
         .await
@@ -2789,7 +2800,7 @@ mod tests {
             deletes: vec![entry("modify", alice())],
         };
 
-        let err = require_grant_authority(&authorizer, &metadata, &GrantResource::Server, &request)
+        let err = require_grant_authority(&authorizer, &metadata, &GrantTarget::Server, &request)
             .await
             .expect_err("granting is not this authorizer's to allow")
             .into_error_model();
@@ -2843,13 +2854,12 @@ mod tests {
         // refused for two principals is named once, and still in request order.
         let authorizer = HidingAuthorizer::new();
         let metadata = RequestMetadataTestBuilder::builder().build();
-        let resource = GrantResource::Server;
         let role = UserOrRole::Role(RoleAssignee::from_role(RoleId::new_random()));
 
         let err = require_grant_authority(
             &authorizer,
             &metadata,
-            &resource,
+            &GrantTarget::Server,
             &ApplyGrantsRequest {
                 writes: vec![
                     entry("provision_users", alice()),
@@ -2874,12 +2884,12 @@ mod tests {
         // The control case: the same gate, the same request, an allow-all authorizer.
         let authorizer = AllowAllAuthorizer::default();
         let metadata = RequestMetadataTestBuilder::builder().build();
-        let resource = GrantResource::Warehouse(WarehouseId::new_random());
+        let warehouse = crate::service::ResolvedWarehouse::new_random();
 
         require_grant_authority(
             &authorizer,
             &metadata,
-            &resource,
+            &GrantTarget::Warehouse(&warehouse),
             &write_request(&["get_metadata", "list_namespaces"]),
         )
         .await

--- a/crates/lakekeeper/src/api/management/v1/grant.rs
+++ b/crates/lakekeeper/src/api/management/v1/grant.rs
@@ -43,7 +43,7 @@
 //! (resolution, can-see action, event context). A ninth level is the trigger to
 //! revisit.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use iceberg_ext::catalog::rest::ErrorModel;
 use serde::{Deserialize, Serialize};
@@ -59,9 +59,9 @@ use crate::{
         },
     },
     service::{
-        CachePolicy, CatalogGrantOps, CatalogNamespaceOps, CatalogRoleOps, CatalogStore,
+        ArcRole, CachePolicy, CatalogGrantOps, CatalogNamespaceOps, CatalogRoleOps, CatalogStore,
         CatalogTagOps, CatalogWarehouseOps, GenericTableId, NamespaceId, NamespaceIdentOrId,
-        ProjectId, SecretStore, State, TableId, TabularListFlags, TagDefinitionId, ViewId,
+        ProjectId, RoleId, SecretStore, State, TableId, TabularListFlags, TagDefinitionId, ViewId,
         WarehouseId, WarehouseStatus,
         authn::UserId,
         authz::{
@@ -73,7 +73,8 @@ use crate::{
             CatalogServerAction, CatalogTableAction, CatalogTagAction, CatalogViewAction,
             CatalogWarehouseAction, GrantAuthorityCheck, GrantFilter, GrantOp, GrantResource,
             GrantRow, GrantSpec, GrantTarget, PrivilegeDescriptor, RequireTagActionError,
-            ResourceType, UserOrRole as AuthzUserOrRole, UserOrRoleId,
+            ResourceType, RoleAssignee as AuthzRoleAssignee, UserOrRole as AuthzUserOrRole,
+            UserOrRoleId,
         },
         events::{
             APIEventContext, GrantsChangedEvent,
@@ -661,33 +662,39 @@ fn validate_write_privileges<A: Authorizer>(
     Err(model.into())
 }
 
-/// Roles are project-scoped while their ids are global, so a caller could otherwise
-/// grant a privilege to a role from a different project. Checked on writes only, for
-/// the same reason as the privilege vocabulary: a grant to a role that has since
-/// moved or vanished must stay revocable.
-async fn validate_write_principals<C: CatalogRoleOps>(
+/// Every role named as a grantee anywhere in the diff, resolved to the role itself.
+///
+/// The authority check carries resolved grantees, so an authorizer can read a grantee
+/// role's identity and attributes instead of a `RoleId` it has no way to look up. One
+/// listing covers both sides of the diff.
+///
+/// Across projects, not within the request's: the server level has no project to scope to,
+/// and scoping here would make a cross-project role indistinguishable from a missing one,
+/// which is [`validate_write_principals`]'s distinction to draw. Nothing is refused here —
+/// a role that does not resolve is simply absent, and the check then asks without a
+/// grantee, which narrows nothing.
+///
+/// Runs before the authority gate, which is safe only because it cannot fail: the
+/// project-membership *judgement* stays after the gate, so an unauthorized caller still
+/// cannot use it to learn which roles exist.
+async fn resolve_grantee_roles<C: CatalogRoleOps>(
     request: &ApplyGrantsRequest,
-    project_id: &crate::service::ArcProjectId,
     catalog_state: C::State,
-) -> Result<()> {
+) -> Result<HashMap<RoleId, ArcRole>> {
     let mut role_ids: Vec<_> = request
-        .writes
-        .iter()
+        .entries()
         .filter_map(|entry| match &entry.principal {
             UserOrRole::Role(assignee) => Some(assignee.role_id()),
             UserOrRole::User(_) => None,
         })
         .collect();
     if role_ids.is_empty() {
-        return Ok(());
+        return Ok(HashMap::new());
     }
     role_ids.sort_unstable();
     role_ids.dedup();
 
-    // The listing is project-scoped, so a role from another project simply does not
-    // come back.
-    let found = C::list_roles(
-        project_id.clone(),
+    let found = C::list_roles_across_projects(
         crate::service::CatalogListRolesByIdFilter::builder()
             .role_ids(Some(role_ids.as_slice()))
             .build(),
@@ -699,10 +706,36 @@ async fn validate_write_principals<C: CatalogRoleOps>(
     )
     .await?
     .roles;
-    if let Some(missing) = role_ids
+    Ok(found.into_iter().map(|role| (role.id(), role)).collect())
+}
+
+/// Roles are project-scoped while their ids are global, so a caller could otherwise
+/// grant a privilege to a role from a different project. Checked on writes only, for
+/// the same reason as the privilege vocabulary: a grant to a role that has since
+/// moved or vanished must stay revocable.
+///
+/// Reads the resolution [`resolve_grantee_roles`] already performed rather than querying
+/// again — a role from another project resolves but reports a different project, which is
+/// the same answer a project-scoped listing gave by omitting it.
+fn validate_write_principals(
+    request: &ApplyGrantsRequest,
+    project_id: &ProjectId,
+    grantee_roles: &HashMap<RoleId, ArcRole>,
+) -> Result<()> {
+    let missing = request
+        .writes
         .iter()
-        .find(|role_id| !found.iter().any(|role| role.id() == **role_id))
-    {
+        .find_map(|entry| match &entry.principal {
+            UserOrRole::Role(assignee) => {
+                let role_id = assignee.role_id();
+                match grantee_roles.get(&role_id) {
+                    Some(role) if role.project_id() == project_id => None,
+                    _ => Some(role_id),
+                }
+            }
+            UserOrRole::User(_) => None,
+        });
+    if let Some(missing) = missing {
         return Err(bad_request(
             format!("Role `{missing}` does not exist in this project"),
             "GrantRoleNotInProject",
@@ -731,7 +764,10 @@ async fn validate_write_principals<C: CatalogRoleOps>(
 /// Nothing is deduplicated here because nothing can repeat: [`validate_request_shape`]
 /// rejects an entry repeated within a side and an entry appearing on both sides, and the
 /// side is what fixes the direction.
-fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str, GrantOp)> {
+fn authority_questions<'a>(
+    request: &'a ApplyGrantsRequest,
+    grantee_roles: &HashMap<RoleId, ArcRole>,
+) -> Vec<(Option<AuthzUserOrRole>, &'a str, GrantOp)> {
     let sides = [
         (request.writes.iter(), GrantOp::Grant),
         (request.deletes.iter(), GrantOp::Revoke),
@@ -740,11 +776,16 @@ fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str,
         .into_iter()
         .flat_map(|(entries, op)| {
             entries.map(move |entry| {
-                (
-                    UserOrRoleId::from(&entry.principal),
-                    entry.privilege.as_str(),
-                    op,
-                )
+                let grantee = match &entry.principal {
+                    UserOrRole::User(user_id) => Some(AuthzUserOrRole::User(user_id.clone())),
+                    // Absent when the role does not resolve; see `resolve_grantee_roles`.
+                    UserOrRole::Role(assignee) => {
+                        grantee_roles.get(&assignee.role_id()).map(|role| {
+                            AuthzUserOrRole::Role(AuthzRoleAssignee::from_role(role.clone()))
+                        })
+                    }
+                };
+                (grantee, entry.privilege.as_str(), op)
             })
         })
         .collect()
@@ -759,7 +800,7 @@ fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str,
 /// in — naming each privilege once is the error's own presentation choice, and it needs
 /// every refused direction to say which were refused.
 fn refused_privileges<'a>(
-    questions: &[(UserOrRoleId, &'a str, GrantOp)],
+    questions: &[(Option<AuthzUserOrRole>, &'a str, GrantOp)],
     decisions: &[AuthorizationDecision],
 ) -> Vec<(GrantOp, &'a str)> {
     questions
@@ -778,13 +819,16 @@ async fn require_grant_authority<A: Authorizer>(
     metadata: &RequestMetadata,
     target: &GrantTarget<'_>,
     request: &ApplyGrantsRequest,
+    grantee_roles: &HashMap<RoleId, ArcRole>,
 ) -> std::result::Result<(), AuthZError> {
     // Materialized first so each check can borrow its grantee: the request carries the
-    // API principal type, and converting it to an id allocates.
-    let questions = authority_questions(request);
+    // API principal type, and resolving it allocates.
+    let questions = authority_questions(request, grantee_roles);
     let checks: Vec<GrantAuthorityCheck<'_>> = questions
         .iter()
-        .map(|(grantee, privilege, op)| GrantAuthorityCheck::entry(privilege, grantee, *op))
+        .map(|(grantee, privilege, op)| {
+            GrantAuthorityCheck::entry(privilege, grantee.as_ref(), *op)
+        })
         .collect();
     let decisions = authorizer
         .are_allowed_grants(metadata, None, target, &checks)
@@ -813,12 +857,13 @@ async fn allowed_privileges<A: Authorizer>(
     target: &GrantTarget<'_>,
 ) -> std::result::Result<Vec<GrantablePrivilege>, AuthZError> {
     let vocabulary = authorizer.grantable_privileges(target.resource_type());
-    // Neither grantee nor direction: this asks whether the subject has authority over each
-    // privilege here at all. Advisory - the apply path asks again per entry - so an
-    // authorizer that distinguishes them need not enumerate anyone to answer.
+    // Asks about granting, with no grantee: may the subject hand each privilege out here
+    // at all? Advisory - the apply path asks again per entry, naming grantee and
+    // direction - so an authorizer that distinguishes grantees need not enumerate anyone
+    // to answer.
     let checks: Vec<GrantAuthorityCheck<'_>> = vocabulary
         .iter()
-        .map(|privilege| GrantAuthorityCheck::any(privilege.name.as_str()))
+        .map(|privilege| GrantAuthorityCheck::grantable(privilege.name.as_str()))
         .collect();
     let decisions = authorizer
         .are_allowed_grants(request_metadata, for_user.as_ref(), target, &checks)
@@ -1259,6 +1304,9 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         validate_request_shape(&request)?;
         validate_write_privileges(&authorizer, ResourceType::Server, &request)?;
+        // Before the gate, and deliberately cannot fail: the authority check carries
+        // resolved grantees. See `resolve_grantee_roles`.
+        let grantee_roles = resolve_grantee_roles::<C>(&request, catalog_state.clone()).await?;
         // No principal validation: roles are project-scoped and the server is not in a
         // project, so there is no project to resolve a role against. Role principals
         // stay allowed because the assignment API already grants server relations to
@@ -1275,6 +1323,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             event_ctx.request_metadata(),
             &GrantTarget::Server,
             &request,
+            &grantee_roles,
         )
         .await;
         let (event_ctx, ()) = event_ctx.emit_authz(authz_result)?;
@@ -1346,6 +1395,9 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         validate_request_shape(&request)?;
         validate_write_privileges(&authorizer, ResourceType::Project, &request)?;
+        // Before the gate, and deliberately cannot fail: the authority check carries
+        // resolved grantees. See `resolve_grantee_roles`.
+        let grantee_roles = resolve_grantee_roles::<C>(&request, catalog_state.clone()).await?;
         let event_ctx = APIEventContext::for_project(
             request_metadata.into(),
             events.clone(),
@@ -1357,6 +1409,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             event_ctx.request_metadata(),
             &GrantTarget::Project(&project_id),
             &request,
+            &grantee_roles,
         )
         .await;
         let (event_ctx, ()) = event_ctx.emit_authz(authz_result)?;
@@ -1364,7 +1417,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // After the gate: before it, the role lookup let an unauthorized caller probe
         // which roles exist in a project, and a catalog failure swallowed the
         // authorization event entirely. Still a 400, not an authorization failure.
-        validate_write_principals::<C>(&request, &project_id, catalog_state.clone()).await?;
+        validate_write_principals(&request, &project_id, &grantee_roles)?;
 
         apply_and_emit::<A, C>(
             &authorizer,
@@ -1456,6 +1509,9 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         validate_request_shape(&request)?;
         validate_write_privileges(&authorizer, ResourceType::Namespace, &request)?;
+        // Before the gate, and deliberately cannot fail: the authority check carries
+        // resolved grantees. See `resolve_grantee_roles`.
+        let grantee_roles = resolve_grantee_roles::<C>(&request, catalog_state.clone()).await?;
         let event_ctx = APIEventContext::for_namespace(
             request_metadata.into(),
             events.clone(),
@@ -1486,6 +1542,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                     namespace: &namespace,
                 },
                 &request,
+                &grantee_roles,
             )
             .await
         }
@@ -1495,7 +1552,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // After the gate: before it, the role lookup let an unauthorized caller probe
         // which roles exist in a project, and a catalog failure swallowed the
         // authorization event entirely. Still a 400, not an authorization failure.
-        validate_write_principals::<C>(&request, &project_id, catalog_state.clone()).await?;
+        validate_write_principals(&request, &project_id, &grantee_roles)?;
 
         apply_and_emit::<A, C>(
             &authorizer,
@@ -1602,6 +1659,9 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         validate_request_shape(&request)?;
         validate_write_privileges(&authorizer, ResourceType::Tag, &request)?;
+        // Before the gate, and deliberately cannot fail: the authority check carries
+        // resolved grantees. See `resolve_grantee_roles`.
+        let grantee_roles = resolve_grantee_roles::<C>(&request, catalog_state.clone()).await?;
         let event_ctx = APIEventContext::for_tag(
             request_metadata.into(),
             events.clone(),
@@ -1617,6 +1677,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 event_ctx.request_metadata(),
                 &GrantTarget::Tag(&definition),
                 &request,
+                &grantee_roles,
             )
             .await
         }
@@ -1626,7 +1687,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // After the gate: before it, the role lookup let an unauthorized caller probe
         // which roles exist in a project, and a catalog failure swallowed the
         // authorization event entirely. Still a 400, not an authorization failure.
-        validate_write_principals::<C>(&request, &project_id, catalog_state.clone()).await?;
+        validate_write_principals(&request, &project_id, &grantee_roles)?;
 
         apply_and_emit::<A, C>(
             &authorizer,
@@ -1718,6 +1779,9 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         validate_request_shape(&request)?;
         validate_write_privileges(&authorizer, ResourceType::Table, &request)?;
+        // Before the gate, and deliberately cannot fail: the authority check carries
+        // resolved grantees. See `resolve_grantee_roles`.
+        let grantee_roles = resolve_grantee_roles::<C>(&request, catalog_state.clone()).await?;
         let event_ctx = APIEventContext::for_table(
             request_metadata.into(),
             events.clone(),
@@ -1747,6 +1811,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                     table: &table,
                 },
                 &request,
+                &grantee_roles,
             )
             .await
         }
@@ -1756,7 +1821,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // After the gate: before it, the role lookup let an unauthorized caller probe
         // which roles exist in a project, and a catalog failure swallowed the
         // authorization event entirely. Still a 400, not an authorization failure.
-        validate_write_principals::<C>(&request, &project_id, catalog_state.clone()).await?;
+        validate_write_principals(&request, &project_id, &grantee_roles)?;
 
         apply_and_emit::<A, C>(
             &authorizer,
@@ -1848,6 +1913,9 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         validate_request_shape(&request)?;
         validate_write_privileges(&authorizer, ResourceType::View, &request)?;
+        // Before the gate, and deliberately cannot fail: the authority check carries
+        // resolved grantees. See `resolve_grantee_roles`.
+        let grantee_roles = resolve_grantee_roles::<C>(&request, catalog_state.clone()).await?;
         let event_ctx = APIEventContext::for_view(
             request_metadata.into(),
             events.clone(),
@@ -1875,6 +1943,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                     view: &view,
                 },
                 &request,
+                &grantee_roles,
             )
             .await
         }
@@ -1884,7 +1953,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // After the gate: before it, the role lookup let an unauthorized caller probe
         // which roles exist in a project, and a catalog failure swallowed the
         // authorization event entirely. Still a 400, not an authorization failure.
-        validate_write_principals::<C>(&request, &project_id, catalog_state.clone()).await?;
+        validate_write_principals(&request, &project_id, &grantee_roles)?;
 
         apply_and_emit::<A, C>(
             &authorizer,
@@ -1976,6 +2045,9 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         validate_request_shape(&request)?;
         validate_write_privileges(&authorizer, ResourceType::GenericTable, &request)?;
+        // Before the gate, and deliberately cannot fail: the authority check carries
+        // resolved grantees. See `resolve_grantee_roles`.
+        let grantee_roles = resolve_grantee_roles::<C>(&request, catalog_state.clone()).await?;
         let event_ctx = APIEventContext::for_generic_table(
             request_metadata.into(),
             events.clone(),
@@ -2003,6 +2075,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                     generic_table: &generic_table,
                 },
                 &request,
+                &grantee_roles,
             )
             .await
         }
@@ -2012,7 +2085,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // After the gate: before it, the role lookup let an unauthorized caller probe
         // which roles exist in a project, and a catalog failure swallowed the
         // authorization event entirely. Still a 400, not an authorization failure.
-        validate_write_principals::<C>(&request, &project_id, catalog_state.clone()).await?;
+        validate_write_principals(&request, &project_id, &grantee_roles)?;
 
         apply_and_emit::<A, C>(
             &authorizer,
@@ -2041,6 +2114,9 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // (1) Request validation: a malformed diff is a 400, never a denial.
         validate_request_shape(&request)?;
         validate_write_privileges(&authorizer, ResourceType::Warehouse, &request)?;
+        // Before the gate, and deliberately cannot fail: the authority check carries
+        // resolved grantees. See `resolve_grantee_roles`.
+        let grantee_roles = resolve_grantee_roles::<C>(&request, catalog_state.clone()).await?;
         // (2) Authorization, folded into one result so the audit event is faithful.
         let event_ctx = APIEventContext::for_warehouse(
             request_metadata.into(),
@@ -2069,6 +2145,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 event_ctx.request_metadata(),
                 &GrantTarget::Warehouse(&resolved),
                 &request,
+                &grantee_roles,
             )
             .await
         }
@@ -2078,7 +2155,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // After the gate: before it, the role lookup let an unauthorized caller probe
         // which roles exist in a project, and a catalog failure swallowed the
         // authorization event entirely. Still a 400, not an authorization failure.
-        validate_write_principals::<C>(&request, &project_id, catalog_state.clone()).await?;
+        validate_write_principals(&request, &project_id, &grantee_roles)?;
 
         // (3)+(4) Write, then emit — after the authorization event, so a storage
         // failure is not recorded as a denial.
@@ -2725,6 +2802,7 @@ mod tests {
             &metadata,
             &GrantTarget::Warehouse(&warehouse),
             &write_request(&["get_metadata"]),
+            &HashMap::new(),
         )
         .await
         .expect_err("a deny-all authorizer must not confer grant authority");
@@ -2751,6 +2829,7 @@ mod tests {
             &metadata,
             &GrantTarget::Server,
             &write_request(&["provision_users", "list_users"]),
+            &HashMap::new(),
         )
         .await
         .expect_err("a deny-all authorizer must not confer grant authority")
@@ -2767,20 +2846,43 @@ mod tests {
         // One question per entry, writes first, each carrying the direction its side
         // implies. Nothing collapses: an authorizer may answer differently depending on who
         // receives the privilege and on which way it moves.
-        let role_id = RoleId::new_random();
-        let role = UserOrRole::Role(RoleAssignee::from_role(role_id));
+        //
+        // A role grantee arrives resolved, so an authorizer can read its identity rather
+        // than an id it cannot look up. The second role is deliberately left out of the
+        // resolution: an unresolvable grantee asks without one rather than inventing a
+        // role, and a write naming it is refused after the gate.
+        let resolved = Arc::new(crate::service::Role::new_random());
+        let resolved_id = resolved.id();
+        let unresolved_id = RoleId::new_random();
         let request = ApplyGrantsRequest {
-            writes: vec![entry("modify", alice()), entry("select", alice())],
-            deletes: vec![entry("modify", role)],
+            writes: vec![
+                entry("modify", alice()),
+                entry(
+                    "select",
+                    UserOrRole::Role(RoleAssignee::from_role(unresolved_id)),
+                ),
+            ],
+            deletes: vec![entry(
+                "modify",
+                UserOrRole::Role(RoleAssignee::from_role(resolved_id)),
+            )],
         };
+        let grantee_roles = HashMap::from([(resolved_id, resolved.clone())]);
 
-        let alice_id = UserOrRoleId::from(&alice());
+        let alice_grantee =
+            AuthzUserOrRole::User(UserId::try_from("oidc~alice").expect("valid test user id"));
         assert_eq!(
-            authority_questions(&request),
+            authority_questions(&request, &grantee_roles),
             vec![
-                (alice_id.clone(), "modify", GrantOp::Grant),
-                (alice_id, "select", GrantOp::Grant),
-                (UserOrRoleId::Role(role_id), "modify", GrantOp::Revoke),
+                (Some(alice_grantee), "modify", GrantOp::Grant),
+                (None, "select", GrantOp::Grant),
+                (
+                    Some(AuthzUserOrRole::Role(AuthzRoleAssignee::from_role(
+                        resolved
+                    ))),
+                    "modify",
+                    GrantOp::Revoke
+                ),
             ]
         );
     }
@@ -2800,10 +2902,16 @@ mod tests {
             deletes: vec![entry("modify", alice())],
         };
 
-        let err = require_grant_authority(&authorizer, &metadata, &GrantTarget::Server, &request)
-            .await
-            .expect_err("granting is not this authorizer's to allow")
-            .into_error_model();
+        let err = require_grant_authority(
+            &authorizer,
+            &metadata,
+            &GrantTarget::Server,
+            &request,
+            &HashMap::new(),
+        )
+        .await
+        .expect_err("granting is not this authorizer's to allow")
+        .into_error_model();
         assert_eq!(err.message, "Granting `select` on this server is forbidden");
     }
 
@@ -2812,12 +2920,15 @@ mod tests {
         // Mixed decisions, which no authorizer in this workspace produces: the answers are
         // positional, so a pairing that slipped by one would report a question the
         // authorizer allowed - and stay invisible to every all-deny or all-allow test.
-        let alice = UserOrRoleId::from(&alice());
-        let role = UserOrRoleId::Role(RoleId::new_random());
+        let alice =
+            AuthzUserOrRole::User(UserId::try_from("oidc~alice").expect("valid test user id"));
+        let role = AuthzUserOrRole::Role(AuthzRoleAssignee::from_role(Arc::new(
+            crate::service::Role::new_random(),
+        )));
         let questions = vec![
-            (alice.clone(), "select", GrantOp::Grant),
-            (role, "select", GrantOp::Grant),
-            (alice, "modify", GrantOp::Revoke),
+            (Some(alice.clone()), "select", GrantOp::Grant),
+            (Some(role), "select", GrantOp::Grant),
+            (Some(alice), "modify", GrantOp::Revoke),
         ];
 
         // `select` allowed for alice but refused for the role: reported from the position
@@ -2868,6 +2979,7 @@ mod tests {
                 ],
                 deletes: Vec::new(),
             },
+            &HashMap::new(),
         )
         .await
         .expect_err("a deny-all authorizer must not confer grant authority")
@@ -2891,6 +3003,7 @@ mod tests {
             &metadata,
             &GrantTarget::Warehouse(&warehouse),
             &write_request(&["get_metadata", "list_namespaces"]),
+            &HashMap::new(),
         )
         .await
         .expect("allow-all confers grant authority on every privilege");

--- a/crates/lakekeeper/src/api/management/v1/grant.rs
+++ b/crates/lakekeeper/src/api/management/v1/grant.rs
@@ -359,9 +359,8 @@ pub struct GrantablePrivilege {
     /// distinct — and so a new descriptor field can never collide with `allowed`.
     #[cfg_attr(feature = "open-api", schema(value_type = PrivilegeDescriptor))]
     pub privilege: &'static PrivilegeDescriptor,
-    /// Whether the principal has authority over this privilege on this resource. Asked
-    /// without a direction, so an authorizer that separates granting from revoking may
-    /// answer for either; an apply is checked per entry.
+    /// Whether the principal may administer this privilege here — grant it, revoke it, or
+    /// both. Advisory: an apply checks each of its entries on its own.
     pub allowed: bool,
 }
 
@@ -717,17 +716,22 @@ async fn validate_write_principals<C: CatalogRoleOps>(
 // Shared apply / list bodies
 // ---------------------------------------------------------------------------
 
-/// The distinct grant-authority questions a diff asks, in `writes`-then-`deletes` order:
-/// which privilege, destined for which principal, moving which way.
+/// The grant-authority questions a diff asks, one per entry, in `writes`-then-`deletes`
+/// order: which privilege, destined for which principal, moving which way.
 ///
-/// Deduplicated on the *triple*, in first-seen order. A diff handing one privilege to a
-/// hundred principals asks a hundred questions, and handing one to a principal while
-/// taking it from another asks two: whether the grantee or the direction changes the
-/// answer belongs to the authorizer's model, so this layer cannot collapse them. An
-/// authorizer that resolves authority from the privilege alone collapses them itself,
-/// where that is sound.
+/// One question per entry rather than one per privilege: a diff handing one privilege to a
+/// hundred principals asks a hundred questions. Whether the grantee or the direction
+/// changes the answer belongs to the authorizer's model, so this layer collapses neither.
+/// An authorizer that resolves authority from the privilege alone collapses them itself,
+/// where that is sound — the tuple-based one does.
+///
+/// The direction each question carries is what lets an authorizer hold a principal to
+/// taking access away without letting it hand access out.
+///
+/// Nothing is deduplicated here because nothing can repeat: [`validate_request_shape`]
+/// rejects an entry repeated within a side and an entry appearing on both sides, and the
+/// side is what fixes the direction.
 fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str, GrantOp)> {
-    let mut seen = std::collections::HashSet::new();
     let sides = [
         (request.writes.iter(), GrantOp::Grant),
         (request.deletes.iter(), GrantOp::Revoke),
@@ -743,27 +747,26 @@ fn authority_questions(request: &ApplyGrantsRequest) -> Vec<(UserOrRoleId, &str,
                 )
             })
         })
-        .filter(|question| seen.insert(question.clone()))
         .collect()
 }
 
-/// The privileges to name in a refusal: those `decisions` refused, named once each, in
-/// the order they were first refused.
+/// What a refusal is about: every question `decisions` refused, with the direction it
+/// asked about, in the order they were refused.
 ///
-/// `decisions` answer `questions` positionally. First-refusal order is not request order
-/// once an authorizer answers per grantee: a privilege allowed for the first principal
-/// that asks for it and refused for the second is named where the refusal is.
+/// `decisions` answer `questions` positionally. Refusal order is not request order once an
+/// authorizer answers per grantee: a privilege allowed for the first principal that asks
+/// for it and refused for the second is reported where the refusal is. Repeats are left
+/// in — naming each privilege once is the error's own presentation choice, and it needs
+/// every refused direction to say which were refused.
 fn refused_privileges<'a>(
     questions: &[(UserOrRoleId, &'a str, GrantOp)],
     decisions: &[AuthorizationDecision],
-) -> Vec<&'a str> {
-    let mut named = std::collections::HashSet::new();
+) -> Vec<(GrantOp, &'a str)> {
     questions
         .iter()
         .zip(decisions)
         .filter(|(_, decision)| !decision.allowed)
-        .map(|((_, privilege, _), _)| *privilege)
-        .filter(|privilege| named.insert(*privilege))
+        .map(|((_, privilege, op), _)| (*op, *privilege))
         .collect()
 }
 
@@ -781,9 +784,7 @@ async fn require_grant_authority<A: Authorizer>(
     let questions = authority_questions(request);
     let checks: Vec<GrantAuthorityCheck<'_>> = questions
         .iter()
-        .map(|(grantee, privilege, op)| {
-            GrantAuthorityCheck::new(privilege, Some(grantee), Some(*op))
-        })
+        .map(|(grantee, privilege, op)| GrantAuthorityCheck::entry(privilege, grantee, *op))
         .collect();
     let decisions = authorizer
         .are_allowed_grants(metadata, None, resource, &checks)
@@ -817,7 +818,7 @@ async fn allowed_privileges<A: Authorizer>(
     // authorizer that distinguishes them need not enumerate anyone to answer.
     let checks: Vec<GrantAuthorityCheck<'_>> = vocabulary
         .iter()
-        .map(|privilege| GrantAuthorityCheck::new(privilege.name.as_str(), None, None))
+        .map(|privilege| GrantAuthorityCheck::any(privilege.name.as_str()))
         .collect();
     let decisions = authorizer
         .are_allowed_grants(request_metadata, for_user.as_ref(), resource, &checks)
@@ -2721,7 +2722,7 @@ mod tests {
         assert_eq!(err.r#type, "GrantActionForbidden");
         assert_eq!(
             err.message,
-            "Granting or revoking `get_metadata` on this warehouse is forbidden"
+            "Granting `get_metadata` on this warehouse is forbidden"
         );
     }
 
@@ -2746,29 +2747,20 @@ mod tests {
 
         assert_eq!(
             err.message,
-            "Granting or revoking `provision_users`, `list_users` on this server is forbidden"
+            "Granting `provision_users`, `list_users` on this server is forbidden"
         );
     }
 
     #[test]
-    fn authority_questions_are_deduplicated_on_the_triple() {
-        // Not on the privilege alone: an authorizer may answer differently depending on
-        // who receives the privilege and on which way it moves. So `modify` for alice,
-        // `modify` for a role, and taking `modify` back from alice are three questions —
-        // the last one is what lets a revoke-only role exist. A repeat of the whole
-        // triple is one question, asked where the request first names it; the request
-        // validator rejects a repeat within one side, but it compares the principal as
-        // written, and two spellings can name the same principal.
+    fn every_entry_asks_its_own_question_tagged_with_its_side() {
+        // One question per entry, writes first, each carrying the direction its side
+        // implies. Nothing collapses: an authorizer may answer differently depending on who
+        // receives the privilege and on which way it moves.
         let role_id = RoleId::new_random();
         let role = UserOrRole::Role(RoleAssignee::from_role(role_id));
         let request = ApplyGrantsRequest {
-            writes: vec![
-                entry("modify", alice()),
-                entry("modify", role),
-                entry("select", alice()),
-                entry("modify", alice()),
-            ],
-            deletes: vec![entry("modify", alice())],
+            writes: vec![entry("modify", alice()), entry("select", alice())],
+            deletes: vec![entry("modify", role)],
         };
 
         let alice_id = UserOrRoleId::from(&alice());
@@ -2776,17 +2768,38 @@ mod tests {
             authority_questions(&request),
             vec![
                 (alice_id.clone(), "modify", GrantOp::Grant),
-                (UserOrRoleId::Role(role_id), "modify", GrantOp::Grant),
-                (alice_id.clone(), "select", GrantOp::Grant),
-                (alice_id, "modify", GrantOp::Revoke),
+                (alice_id, "select", GrantOp::Grant),
+                (UserOrRoleId::Role(role_id), "modify", GrantOp::Revoke),
             ]
         );
     }
 
+    /// The direction has to reach the authorizer, or separating the two is a fiction: this
+    /// authorizer has authority over revokes only, so the grant in the same diff is the one
+    /// refused — and the refusal says which.
+    ///
+    /// Fails if the apply path stopped passing the direction (both entries would be
+    /// refused), or if the sides were tagged the wrong way round (the revoke would be).
+    #[tokio::test]
+    async fn the_gate_asks_with_the_direction_each_entry_moves() {
+        let authorizer = HidingAuthorizer::new().with_grant_authority(&[GrantOp::Revoke]);
+        let metadata = RequestMetadataTestBuilder::builder().build();
+        let request = ApplyGrantsRequest {
+            writes: vec![entry("select", alice())],
+            deletes: vec![entry("modify", alice())],
+        };
+
+        let err = require_grant_authority(&authorizer, &metadata, &GrantResource::Server, &request)
+            .await
+            .expect_err("granting is not this authorizer's to allow")
+            .into_error_model();
+        assert_eq!(err.message, "Granting `select` on this server is forbidden");
+    }
+
     #[test]
-    fn a_refusal_names_each_privilege_once_in_first_refusal_order() {
+    fn a_refusal_reports_every_refused_question_with_its_direction() {
         // Mixed decisions, which no authorizer in this workspace produces: the answers are
-        // positional, so a pairing that slipped by one would name a privilege the
+        // positional, so a pairing that slipped by one would report a question the
         // authorizer allowed - and stay invisible to every all-deny or all-allow test.
         let alice = UserOrRoleId::from(&alice());
         let role = UserOrRoleId::Role(RoleId::new_random());
@@ -2796,8 +2809,9 @@ mod tests {
             (alice, "modify", GrantOp::Revoke),
         ];
 
-        // `select` allowed for alice but refused for the role: named once, and from the
-        // position of the refusal rather than of the first request for it.
+        // `select` allowed for alice but refused for the role: reported from the position
+        // of the refusal rather than of the first request for it, and the revoke of
+        // `modify` keeps its direction so the message can name it.
         assert_eq!(
             refused_privileges(
                 &questions,
@@ -2807,9 +2821,9 @@ mod tests {
                     AuthorizationDecision::deny(),
                 ]
             ),
-            vec!["select", "modify"]
+            vec![(GrantOp::Grant, "select"), (GrantOp::Revoke, "modify")]
         );
-        // Only the first question refused, so `modify` must not be named.
+        // Only the first question refused, so `modify` must not be reported.
         assert_eq!(
             refused_privileges(
                 &questions,
@@ -2819,7 +2833,7 @@ mod tests {
                     AuthorizationDecision::allow(),
                 ]
             ),
-            vec!["select"]
+            vec![(GrantOp::Grant, "select")]
         );
     }
 
@@ -2851,7 +2865,7 @@ mod tests {
 
         assert_eq!(
             err.message,
-            "Granting or revoking `provision_users`, `list_users` on this server is forbidden"
+            "Granting `provision_users`, `list_users` on this server is forbidden"
         );
     }
 

--- a/crates/lakekeeper/src/api/management/v1/project.rs
+++ b/crates/lakekeeper/src/api/management/v1/project.rs
@@ -30,9 +30,10 @@ use crate::{
         ArcProjectId, CatalogStore, CatalogWarehouseOps, State, Transaction,
         authz::{
             AuthZProjectOps, AuthZServerOps, Authorizer, AuthzWarehouseOps, CatalogProjectAction,
-            CatalogServerAction, CatalogWarehouseAction,
+            CatalogServerAction, CatalogWarehouseAction, GrantResource,
             ListProjectsResponse as AuthZListProjectsResponse,
         },
+        emit_bootstrap_grants,
         events::{
             APIEventContext,
             context::{ServerActionListProjects, authz_to_error_no_audit},
@@ -43,6 +44,7 @@ use crate::{
             ScheduleTaskMetadata, TaskEntity, TaskQueueName,
             task_log_cleanup_queue::{self, TaskLogCleanupPayload, TaskLogCleanupTask},
         },
+        write_bootstrap_grants,
     },
 };
 
@@ -147,6 +149,14 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             .create_project(event_ctx.request_metadata(), &project_id)
             .await?;
 
+        let bootstrap_grants = write_bootstrap_grants::<A, C>(
+            &authorizer,
+            event_ctx.request_metadata(),
+            &GrantResource::Project((*project_id).clone()),
+            t.transaction(),
+        )
+        .await?;
+
         TaskLogCleanupTask::schedule_task::<C>(
             ScheduleTaskMetadata {
                 project_id: project_id.clone(),
@@ -166,6 +176,13 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         })?;
 
         t.commit().await?;
+
+        emit_bootstrap_grants(
+            event_ctx.dispatcher(),
+            event_ctx.request_metadata_arc(),
+            bootstrap_grants,
+        )
+        .await;
 
         // Emit success event
         let () = event_ctx.emit_project_created(project_id.clone(), project_name.clone());

--- a/crates/lakekeeper/src/api/management/v1/project.rs
+++ b/crates/lakekeeper/src/api/management/v1/project.rs
@@ -176,8 +176,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         t.commit().await?;
 
-        // Held across the create event below, which consumes the context: the grants are
-        // announced after the project they are on.
+        // Held across the create event below, which consumes the context.
         let grant_dispatcher = event_ctx.dispatcher().clone();
         let grant_request_metadata = event_ctx.request_metadata_arc();
 

--- a/crates/lakekeeper/src/api/management/v1/project.rs
+++ b/crates/lakekeeper/src/api/management/v1/project.rs
@@ -31,9 +31,9 @@ use crate::{
         authz::{
             AuthZProjectOps, AuthZServerOps, Authorizer, AuthzWarehouseOps, CatalogProjectAction,
             CatalogServerAction, CatalogWarehouseAction, GrantResource,
-            ListProjectsResponse as AuthZListProjectsResponse,
+            ListProjectsResponse as AuthZListProjectsResponse, emit_bootstrap_grants_async,
+            write_bootstrap_grants,
         },
-        emit_bootstrap_grants,
         events::{
             APIEventContext,
             context::{ServerActionListProjects, authz_to_error_no_audit},
@@ -44,7 +44,6 @@ use crate::{
             ScheduleTaskMetadata, TaskEntity, TaskQueueName,
             task_log_cleanup_queue::{self, TaskLogCleanupPayload, TaskLogCleanupTask},
         },
-        write_bootstrap_grants,
     },
 };
 
@@ -149,7 +148,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             .create_project(event_ctx.request_metadata(), &project_id)
             .await?;
 
-        let bootstrap_grants = write_bootstrap_grants::<A, C>(
+        let bootstrap_grants = write_bootstrap_grants::<C, A>(
             &authorizer,
             event_ctx.request_metadata(),
             &GrantResource::Project((*project_id).clone()),
@@ -177,15 +176,15 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         t.commit().await?;
 
-        emit_bootstrap_grants(
-            event_ctx.dispatcher(),
-            event_ctx.request_metadata_arc(),
-            bootstrap_grants,
-        )
-        .await;
+        // Held across the create event below, which consumes the context: the grants are
+        // announced after the project they are on.
+        let grant_dispatcher = event_ctx.dispatcher().clone();
+        let grant_request_metadata = event_ctx.request_metadata_arc();
 
         // Emit success event
         let () = event_ctx.emit_project_created(project_id.clone(), project_name.clone());
+
+        emit_bootstrap_grants_async(&grant_dispatcher, grant_request_metadata, bootstrap_grants);
 
         Ok(CreateProjectResponse { project_id })
     }

--- a/crates/lakekeeper/src/api/management/v1/server.rs
+++ b/crates/lakekeeper/src/api/management/v1/server.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use iceberg_ext::catalog::rest::ErrorModel;
 use serde::{Deserialize, Serialize};
@@ -10,11 +12,13 @@ use crate::{
     request_metadata::RequestMetadata,
     service::{
         Actor, ArcProjectId, CatalogStore, Result, SecretStore, State, Transaction, UserUpsertMode,
-        authz::Authorizer,
+        authz::{Authorizer, GrantResource},
+        emit_bootstrap_grants,
         tasks::{
             ScheduleTaskMetadata, TaskEntity,
             task_log_cleanup_queue::{self, TaskLogCleanupPayload, TaskLogCleanupTask},
         },
+        write_bootstrap_grants,
     },
 };
 
@@ -183,6 +187,7 @@ impl<C: CatalogStore, A: Authorizer, S: SecretStore> Service<C, A, S> for ApiSer
 
 #[async_trait::async_trait]
 pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
+    #[allow(clippy::too_many_lines)]
     async fn bootstrap(
         state: ApiContext<State<A, C, S>>,
         request_metadata: RequestMetadata,
@@ -294,7 +299,23 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 authorizer
                     .create_project(&request_metadata, default_project_id)
                     .await?;
+                // Bootstrapping without authentication has no acting identity, so the
+                // default project starts with no owner. The helper answers that.
+                let bootstrap_grants = write_bootstrap_grants::<A, C>(
+                    &authorizer,
+                    &request_metadata,
+                    &GrantResource::Project((**default_project_id).clone()),
+                    t.transaction(),
+                )
+                .await?;
                 t.commit().await?;
+
+                emit_bootstrap_grants(
+                    &state.v1_state.events,
+                    Arc::new(request_metadata.clone()),
+                    bootstrap_grants,
+                )
+                .await;
             }
         }
 

--- a/crates/lakekeeper/src/api/management/v1/server.rs
+++ b/crates/lakekeeper/src/api/management/v1/server.rs
@@ -12,13 +12,11 @@ use crate::{
     request_metadata::RequestMetadata,
     service::{
         Actor, ArcProjectId, CatalogStore, Result, SecretStore, State, Transaction, UserUpsertMode,
-        authz::{Authorizer, GrantResource},
-        emit_bootstrap_grants,
+        authz::{Authorizer, GrantResource, emit_bootstrap_grants_async, write_bootstrap_grants},
         tasks::{
             ScheduleTaskMetadata, TaskEntity,
             task_log_cleanup_queue::{self, TaskLogCleanupPayload, TaskLogCleanupTask},
         },
-        write_bootstrap_grants,
     },
 };
 
@@ -266,7 +264,23 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         }
 
         authorizer.bootstrap(&request_metadata, is_operator).await?;
+
+        // The one grant resource nothing creates: the server comes into existence here,
+        // in this transaction, and the bootstrapping user's row is written above it.
+        let server_grants = write_bootstrap_grants::<C, A>(
+            &authorizer,
+            &request_metadata,
+            &GrantResource::Server,
+            t.transaction(),
+        )
+        .await?;
         t.commit().await?;
+
+        emit_bootstrap_grants_async(
+            &state.v1_state.events,
+            Arc::new(request_metadata.clone()),
+            server_grants,
+        );
 
         // If default project is specified, and the project does not exist, create it
         if let Some(default_project_id) = DEFAULT_PROJECT_ID.as_ref() {
@@ -301,7 +315,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                     .await?;
                 // Bootstrapping without authentication has no acting identity, so the
                 // default project starts with no owner. The helper answers that.
-                let bootstrap_grants = write_bootstrap_grants::<A, C>(
+                let bootstrap_grants = write_bootstrap_grants::<C, A>(
                     &authorizer,
                     &request_metadata,
                     &GrantResource::Project((**default_project_id).clone()),
@@ -310,12 +324,11 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 .await?;
                 t.commit().await?;
 
-                emit_bootstrap_grants(
+                emit_bootstrap_grants_async(
                     &state.v1_state.events,
                     Arc::new(request_metadata.clone()),
                     bootstrap_grants,
-                )
-                .await;
+                );
             }
         }
 

--- a/crates/lakekeeper/src/api/management/v1/tag.rs
+++ b/crates/lakekeeper/src/api/management/v1/tag.rs
@@ -614,8 +614,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         )
         .await;
         let (event_ctx, (tag_definition, bootstrap_grants)) = event_ctx.emit_authz(authz_result)?;
-        // Held across the create event below, which consumes the context: the grants are
-        // announced after the definition they are on.
+        // Held across the create event below, which consumes the context.
         let grant_dispatcher = event_ctx.dispatcher().clone();
         let grant_request_metadata = event_ctx.request_metadata_arc();
         let event_ctx = event_ctx.resolve(tag_definition);

--- a/crates/lakekeeper/src/api/management/v1/tag.rs
+++ b/crates/lakekeeper/src/api/management/v1/tag.rs
@@ -30,9 +30,9 @@ use crate::{
             AuthZViewOps, Authorizer, AuthzNamespaceOps, AuthzWarehouseOps,
             CatalogGenericTableAction, CatalogNamespaceAction, CatalogProjectAction,
             CatalogTableAction, CatalogTagAction, CatalogViewAction, CatalogWarehouseAction,
-            GrantResource, GrantSpec, RequireTagActionError,
+            GrantResource, GrantSpec, RequireTagActionError, emit_bootstrap_grants_async,
+            write_bootstrap_grants,
         },
-        emit_bootstrap_grants,
         events::{
             APIEventContext,
             context::{
@@ -41,7 +41,7 @@ use crate::{
             },
         },
         is_reserved_tag_name, validate_scope_widening, validate_tag_name, validate_tag_scope,
-        validate_tag_value, validate_tag_value_chars, write_bootstrap_grants,
+        validate_tag_value, validate_tag_value_chars,
     },
 };
 
@@ -614,12 +614,10 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         )
         .await;
         let (event_ctx, (tag_definition, bootstrap_grants)) = event_ctx.emit_authz(authz_result)?;
-        emit_bootstrap_grants(
-            event_ctx.dispatcher(),
-            event_ctx.request_metadata_arc(),
-            bootstrap_grants,
-        )
-        .await;
+        // Held across the create event below, which consumes the context: the grants are
+        // announced after the definition they are on.
+        let grant_dispatcher = event_ctx.dispatcher().clone();
+        let grant_request_metadata = event_ctx.request_metadata_arc();
         let event_ctx = event_ctx.resolve(tag_definition);
         let mut result: TagDefinition = (**event_ctx.resolved()).clone().into();
         // Echo the validated allowed values, sorted, so create and get agree on order.
@@ -630,6 +628,9 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             });
         }
         event_ctx.emit_tag_definition_created();
+
+        emit_bootstrap_grants_async(&grant_dispatcher, grant_request_metadata, bootstrap_grants);
+
         Ok(result)
     }
 
@@ -1567,16 +1568,15 @@ async fn authorize_create_tag_definition<A: Authorizer, C: CatalogStore>(
         .map_err::<CreateTagDefinitionError, _>(|e| {
             CatalogBackendError::new_unexpected(e.error).into()
         })?;
-    let bootstrap_grants = write_bootstrap_grants::<A, C>(
+    // Kept typed rather than folded into a backend error: a missing user row is the
+    // caller's 400 and a lock conflict their retriable 409, not "the catalog is down".
+    let bootstrap_grants = write_bootstrap_grants::<C, A>(
         &authorizer,
         request_metadata,
         &GrantResource::Tag(tag_definition_id),
         t.transaction(),
     )
-    .await
-    .map_err::<CreateTagDefinitionError, _>(|e| {
-        CatalogBackendError::new_unexpected(ErrorModel::from(e)).into()
-    })?;
+    .await?;
     t.commit()
         .await
         .map_err::<CreateTagDefinitionError, _>(|e| {

--- a/crates/lakekeeper/src/api/management/v1/tag.rs
+++ b/crates/lakekeeper/src/api/management/v1/tag.rs
@@ -30,8 +30,9 @@ use crate::{
             AuthZViewOps, Authorizer, AuthzNamespaceOps, AuthzWarehouseOps,
             CatalogGenericTableAction, CatalogNamespaceAction, CatalogProjectAction,
             CatalogTableAction, CatalogTagAction, CatalogViewAction, CatalogWarehouseAction,
-            RequireTagActionError,
+            GrantResource, GrantSpec, RequireTagActionError,
         },
+        emit_bootstrap_grants,
         events::{
             APIEventContext,
             context::{
@@ -40,7 +41,7 @@ use crate::{
             },
         },
         is_reserved_tag_name, validate_scope_widening, validate_tag_name, validate_tag_scope,
-        validate_tag_value, validate_tag_value_chars,
+        validate_tag_value, validate_tag_value_chars, write_bootstrap_grants,
     },
 };
 
@@ -612,7 +613,13 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             &request,
         )
         .await;
-        let (event_ctx, tag_definition) = event_ctx.emit_authz(authz_result)?;
+        let (event_ctx, (tag_definition, bootstrap_grants)) = event_ctx.emit_authz(authz_result)?;
+        emit_bootstrap_grants(
+            event_ctx.dispatcher(),
+            event_ctx.request_metadata_arc(),
+            bootstrap_grants,
+        )
+        .await;
         let event_ctx = event_ctx.resolve(tag_definition);
         let mut result: TagDefinition = (**event_ctx.resolved()).clone().into();
         // Echo the validated allowed values, sorted, so create and get agree on order.
@@ -1507,12 +1514,14 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
     }
 }
 
+/// Also returns the grants the definition was born with, for the caller to announce once
+/// the transaction has committed.
 async fn authorize_create_tag_definition<A: Authorizer, C: CatalogStore>(
     authorizer: A,
     catalog_state: C::State,
     event_ctx: &APIEventContext<ProjectId, Unresolved, CatalogProjectAction>,
     request: &CreateTagDefinitionRequest,
-) -> Result<Arc<crate::service::TagDefinition>, AuthZError> {
+) -> Result<(Arc<crate::service::TagDefinition>, Vec<GrantSpec>), AuthZError> {
     let project_id = event_ctx.user_provided_entity_arc_ref();
     let request_metadata = event_ctx.request_metadata();
     let action = event_ctx.action();
@@ -1558,12 +1567,22 @@ async fn authorize_create_tag_definition<A: Authorizer, C: CatalogStore>(
         .map_err::<CreateTagDefinitionError, _>(|e| {
             CatalogBackendError::new_unexpected(e.error).into()
         })?;
+    let bootstrap_grants = write_bootstrap_grants::<A, C>(
+        &authorizer,
+        request_metadata,
+        &GrantResource::Tag(tag_definition_id),
+        t.transaction(),
+    )
+    .await
+    .map_err::<CreateTagDefinitionError, _>(|e| {
+        CatalogBackendError::new_unexpected(ErrorModel::from(e)).into()
+    })?;
     t.commit()
         .await
         .map_err::<CreateTagDefinitionError, _>(|e| {
             CatalogBackendError::new_unexpected(e.error).into()
         })?;
-    Ok(Arc::new(tag_definition))
+    Ok((Arc::new(tag_definition), bootstrap_grants))
 }
 
 async fn authorize_list_tag_definitions<A: Authorizer, C: CatalogStore>(

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -44,9 +44,9 @@ use crate::{
             AuthZProjectOps, AuthZTableOps, Authorizer, AuthzNamespaceOps, AuthzWarehouseOps,
             CatalogGenericTableAction, CatalogNamespaceAction, CatalogProjectAction,
             CatalogTableAction, CatalogViewAction, CatalogWarehouseAction, GrantResource,
-            InstanceAdminAction, InstanceAdminAuthorizer,
+            InstanceAdminAction, InstanceAdminAuthorizer, emit_bootstrap_grants_async,
+            write_bootstrap_grants,
         },
-        emit_bootstrap_grants,
         events::{
             APIEventContext,
             context::{
@@ -62,7 +62,6 @@ use crate::{
             CancelTasksFilter, TaskQueueName, tabular_expiration_queue::TabularExpirationTask,
         },
         warehouse_cache::warehouse_cache_invalidate,
-        write_bootstrap_grants,
     },
 };
 
@@ -551,7 +550,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             )
             .await?;
 
-        let bootstrap_grants = write_bootstrap_grants::<A, C>(
+        let bootstrap_grants = write_bootstrap_grants::<C, A>(
             &authorizer,
             request_metadata,
             &GrantResource::Warehouse(resolved_warehouse.warehouse_id),
@@ -561,14 +560,14 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         transaction.commit().await?;
 
-        emit_bootstrap_grants(
-            event_ctx.dispatcher(),
-            event_ctx.request_metadata_arc(),
-            bootstrap_grants,
-        )
-        .await;
+        // Held across the create event below, which consumes the context: the grants are
+        // announced after the warehouse they are on.
+        let grant_dispatcher = event_ctx.dispatcher().clone();
+        let grant_request_metadata = event_ctx.request_metadata_arc();
 
         event_ctx.emit_warehouse_created(resolved_warehouse.clone());
+
+        emit_bootstrap_grants_async(&grant_dispatcher, grant_request_metadata, bootstrap_grants);
 
         let response =
             GetWarehouseResponse::from_resolved((*resolved_warehouse).clone(), credential_type);

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -43,9 +43,10 @@ use crate::{
         authz::{
             AuthZProjectOps, AuthZTableOps, Authorizer, AuthzNamespaceOps, AuthzWarehouseOps,
             CatalogGenericTableAction, CatalogNamespaceAction, CatalogProjectAction,
-            CatalogTableAction, CatalogViewAction, CatalogWarehouseAction, InstanceAdminAction,
-            InstanceAdminAuthorizer,
+            CatalogTableAction, CatalogViewAction, CatalogWarehouseAction, GrantResource,
+            InstanceAdminAction, InstanceAdminAuthorizer,
         },
+        emit_bootstrap_grants,
         events::{
             APIEventContext,
             context::{
@@ -61,6 +62,7 @@ use crate::{
             CancelTasksFilter, TaskQueueName, tabular_expiration_queue::TabularExpirationTask,
         },
         warehouse_cache::warehouse_cache_invalidate,
+        write_bootstrap_grants,
     },
 };
 
@@ -435,6 +437,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore> Service<C, A, S>
 
 #[async_trait::async_trait]
 pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
+    #[allow(clippy::too_many_lines)]
     async fn create_warehouse(
         request: CreateWarehouseRequest,
         context: ApiContext<State<A, C, S>>,
@@ -548,7 +551,22 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             )
             .await?;
 
+        let bootstrap_grants = write_bootstrap_grants::<A, C>(
+            &authorizer,
+            request_metadata,
+            &GrantResource::Warehouse(resolved_warehouse.warehouse_id),
+            transaction.transaction(),
+        )
+        .await?;
+
         transaction.commit().await?;
+
+        emit_bootstrap_grants(
+            event_ctx.dispatcher(),
+            event_ctx.request_metadata_arc(),
+            bootstrap_grants,
+        )
+        .await;
 
         event_ctx.emit_warehouse_created(resolved_warehouse.clone());
 

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -560,8 +560,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         transaction.commit().await?;
 
-        // Held across the create event below, which consumes the context: the grants are
-        // announced after the warehouse they are on.
+        // Held across the create event below, which consumes the context.
         let grant_dispatcher = event_ctx.dispatcher().clone();
         let grant_request_metadata = event_ctx.request_metadata_arc();
 

--- a/crates/lakekeeper/src/server/generic_tables/create.rs
+++ b/crates/lakekeeper/src/server/generic_tables/create.rs
@@ -20,12 +20,14 @@ use crate::{
         CachePolicy, CatalogGenericTableOps, CatalogIdempotencyOps, CatalogStore,
         GenericTableCreation, GenericTableId, Result, SecretStore, State, TabularId, Transaction,
         WarehouseId,
-        authz::{Authorizer, AuthzNamespaceOps, CatalogNamespaceAction},
+        authz::{Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, GrantResource},
+        emit_bootstrap_grants,
         events::{
             APIEventContext,
             context::{ResolvedNamespace, UserProvidedNamespace},
         },
         idempotency::IdempotencyInfo,
+        write_bootstrap_grants,
     },
 };
 
@@ -288,6 +290,17 @@ async fn create_generic_table_inner<C: CatalogStore, A: Authorizer + Clone, S: S
         .await?;
     guard.mark_authorizer_created();
 
+    let bootstrap_grants = write_bootstrap_grants::<A, C>(
+        authorizer,
+        request_metadata,
+        &GrantResource::GenericTable {
+            warehouse_id,
+            generic_table_id: info.generic_table_id,
+        },
+        t.transaction(),
+    )
+    .await?;
+
     // Insert idempotency key in the same transaction.
     if let Some(key) = idempotency_key
         && !C::try_insert_idempotency_key(
@@ -309,6 +322,13 @@ async fn create_generic_table_inner<C: CatalogStore, A: Authorizer + Clone, S: S
     }
 
     t.commit().await?;
+
+    emit_bootstrap_grants(
+        event_ctx.dispatcher(),
+        event_ctx.request_metadata_arc(),
+        bootstrap_grants,
+    )
+    .await;
 
     let info = Arc::new(info);
     let response = LoadGenericTableResponse {

--- a/crates/lakekeeper/src/server/generic_tables/create.rs
+++ b/crates/lakekeeper/src/server/generic_tables/create.rs
@@ -20,14 +20,15 @@ use crate::{
         CachePolicy, CatalogGenericTableOps, CatalogIdempotencyOps, CatalogStore,
         GenericTableCreation, GenericTableId, Result, SecretStore, State, TabularId, Transaction,
         WarehouseId,
-        authz::{Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, GrantResource},
-        emit_bootstrap_grants,
+        authz::{
+            Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, GrantResource,
+            emit_bootstrap_grants_async, write_bootstrap_grants,
+        },
         events::{
             APIEventContext,
             context::{ResolvedNamespace, UserProvidedNamespace},
         },
         idempotency::IdempotencyInfo,
-        write_bootstrap_grants,
     },
 };
 
@@ -290,7 +291,7 @@ async fn create_generic_table_inner<C: CatalogStore, A: Authorizer + Clone, S: S
         .await?;
     guard.mark_authorizer_created();
 
-    let bootstrap_grants = write_bootstrap_grants::<A, C>(
+    let bootstrap_grants = write_bootstrap_grants::<C, A>(
         authorizer,
         request_metadata,
         &GrantResource::GenericTable {
@@ -323,12 +324,10 @@ async fn create_generic_table_inner<C: CatalogStore, A: Authorizer + Clone, S: S
 
     t.commit().await?;
 
-    emit_bootstrap_grants(
-        event_ctx.dispatcher(),
-        event_ctx.request_metadata_arc(),
-        bootstrap_grants,
-    )
-    .await;
+    // Held across the create event below, which consumes the context: the grants are
+    // announced after the table they are on.
+    let grant_dispatcher = event_ctx.dispatcher().clone();
+    let grant_request_metadata = event_ctx.request_metadata_arc();
 
     let info = Arc::new(info);
     let response = LoadGenericTableResponse {
@@ -347,6 +346,8 @@ async fn create_generic_table_inner<C: CatalogStore, A: Authorizer + Clone, S: S
     };
 
     event_ctx.emit_generic_table_created_async(info, Arc::new(request.clone()));
+
+    emit_bootstrap_grants_async(&grant_dispatcher, grant_request_metadata, bootstrap_grants);
 
     Ok(response)
 }

--- a/crates/lakekeeper/src/server/generic_tables/create.rs
+++ b/crates/lakekeeper/src/server/generic_tables/create.rs
@@ -324,8 +324,7 @@ async fn create_generic_table_inner<C: CatalogStore, A: Authorizer + Clone, S: S
 
     t.commit().await?;
 
-    // Held across the create event below, which consumes the context: the grants are
-    // announced after the table they are on.
+    // Held across the create event below, which consumes the context.
     let grant_dispatcher = event_ctx.dispatcher().clone();
     let grant_request_metadata = event_ctx.request_metadata_arc();
 

--- a/crates/lakekeeper/src/server/namespace.rs
+++ b/crates/lakekeeper/src/server/namespace.rs
@@ -31,8 +31,9 @@ use crate::{
         Transaction,
         authz::{
             Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, CatalogWarehouseAction,
-            NamespaceParent,
+            GrantResource, NamespaceParent,
         },
+        emit_bootstrap_grants,
         events::{
             APIEventContext, EventDispatcher, NamespaceOrWarehouseAPIContext,
             context::{
@@ -46,6 +47,7 @@ use crate::{
             CancelTasksFilter, ScheduleTaskMetadata, TaskEntity, WarehouseTaskEntityId,
             tabular_purge_queue::{TabularPurgePayload, TabularPurgeTask},
         },
+        write_bootstrap_grants,
     },
 };
 
@@ -357,7 +359,25 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             .create_namespace(event_ctx.request_metadata(), namespace_id, authz_parent)
             .await?;
 
+        let bootstrap_grants = write_bootstrap_grants::<A, C>(
+            &authorizer,
+            event_ctx.request_metadata(),
+            &GrantResource::Namespace {
+                warehouse_id,
+                namespace_id,
+            },
+            t.transaction(),
+        )
+        .await?;
+
         t.commit().await?;
+
+        emit_bootstrap_grants(
+            event_ctx.dispatcher(),
+            event_ctx.request_metadata().clone(),
+            bootstrap_grants,
+        )
+        .await;
 
         event_ctx.emit_namespace_created_async(r.clone());
 

--- a/crates/lakekeeper/src/server/namespace.rs
+++ b/crates/lakekeeper/src/server/namespace.rs
@@ -370,8 +370,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
 
         t.commit().await?;
 
-        // Held across the create event below, which consumes the context: the grants are
-        // announced after the namespace they are on.
+        // Held across the create event below, which consumes the context.
         let grant_dispatcher = event_ctx.dispatcher().clone();
         let grant_request_metadata = event_ctx.request_metadata().clone();
 

--- a/crates/lakekeeper/src/server/namespace.rs
+++ b/crates/lakekeeper/src/server/namespace.rs
@@ -31,9 +31,8 @@ use crate::{
         Transaction,
         authz::{
             Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, CatalogWarehouseAction,
-            GrantResource, NamespaceParent,
+            GrantResource, NamespaceParent, emit_bootstrap_grants_async, write_bootstrap_grants,
         },
-        emit_bootstrap_grants,
         events::{
             APIEventContext, EventDispatcher, NamespaceOrWarehouseAPIContext,
             context::{
@@ -47,7 +46,6 @@ use crate::{
             CancelTasksFilter, ScheduleTaskMetadata, TaskEntity, WarehouseTaskEntityId,
             tabular_purge_queue::{TabularPurgePayload, TabularPurgeTask},
         },
-        write_bootstrap_grants,
     },
 };
 
@@ -359,7 +357,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             .create_namespace(event_ctx.request_metadata(), namespace_id, authz_parent)
             .await?;
 
-        let bootstrap_grants = write_bootstrap_grants::<A, C>(
+        let bootstrap_grants = write_bootstrap_grants::<C, A>(
             &authorizer,
             event_ctx.request_metadata(),
             &GrantResource::Namespace {
@@ -372,14 +370,14 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
 
         t.commit().await?;
 
-        emit_bootstrap_grants(
-            event_ctx.dispatcher(),
-            event_ctx.request_metadata().clone(),
-            bootstrap_grants,
-        )
-        .await;
+        // Held across the create event below, which consumes the context: the grants are
+        // announced after the namespace they are on.
+        let grant_dispatcher = event_ctx.dispatcher().clone();
+        let grant_request_metadata = event_ctx.request_metadata().clone();
 
         event_ctx.emit_namespace_created_async(r.clone());
+
+        emit_bootstrap_grants_async(&grant_dispatcher, grant_request_metadata, bootstrap_grants);
 
         let r_namespace = r.namespace.clone();
         let mut properties = r_namespace.properties.clone().unwrap_or_default();

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -75,11 +75,12 @@ use crate::{
             ActionOnTableOrView, AuthZCannotSeeNamespace, AuthZCannotSeeTable, AuthZCannotSeeView,
             AuthZError, AuthZTableActionForbidden, AuthZTableOps, AuthorizationCountMismatch,
             Authorizer, AuthzNamespaceOps, AuthzWarehouseOps, BackendUnavailableOrCountMismatch,
-            CatalogNamespaceAction, CatalogTableAction, CatalogWarehouseAction,
+            CatalogNamespaceAction, CatalogTableAction, CatalogWarehouseAction, GrantResource,
             RequireNamespaceActionError, RequireTableActionError,
         },
         build_namespace_hierarchy,
         contract_verification::{ContractVerification, ContractVerificationOutcome},
+        emit_bootstrap_grants,
         events::{
             APIEventCommitContext, APIEventContext, CommitTransactionEvent,
             context::{ResolvedNamespace, ResolvedTable},
@@ -93,6 +94,7 @@ use crate::{
             tabular_expiration_queue::{TabularExpirationPayload, TabularExpirationTask},
             tabular_purge_queue::{TabularPurgePayload, TabularPurgeTask},
         },
+        write_bootstrap_grants,
     },
 };
 
@@ -549,8 +551,29 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
                 .await?;
         }
 
+        // Outside the branches above on purpose. Re-registering over a table that keeps
+        // its id runs no create hook, and the drop above already took that table's grants
+        // with it, so the registered table would end up with no owner at all.
+        let bootstrap_grants = write_bootstrap_grants::<A, C>(
+            &authorizer,
+            request_metadata,
+            &GrantResource::Table {
+                warehouse_id,
+                table_id: tabular_id,
+            },
+            t_write.transaction(),
+        )
+        .await?;
+
         // Commit the transaction
         t_write.commit().await?;
+
+        emit_bootstrap_grants(
+            event_ctx.dispatcher(),
+            event_ctx.request_metadata_arc(),
+            bootstrap_grants,
+        )
+        .await;
 
         // If we need to delete the previous table from authorizer
         if auth_needs_delete && let Some(previous_table) = &previous_table_to_drop {

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -76,11 +76,11 @@ use crate::{
             AuthZError, AuthZTableActionForbidden, AuthZTableOps, AuthorizationCountMismatch,
             Authorizer, AuthzNamespaceOps, AuthzWarehouseOps, BackendUnavailableOrCountMismatch,
             CatalogNamespaceAction, CatalogTableAction, CatalogWarehouseAction, GrantResource,
-            RequireNamespaceActionError, RequireTableActionError,
+            RequireNamespaceActionError, RequireTableActionError, emit_bootstrap_grants_async,
+            write_bootstrap_grants,
         },
         build_namespace_hierarchy,
         contract_verification::{ContractVerification, ContractVerificationOutcome},
-        emit_bootstrap_grants,
         events::{
             APIEventCommitContext, APIEventContext, CommitTransactionEvent,
             context::{ResolvedNamespace, ResolvedTable},
@@ -94,7 +94,6 @@ use crate::{
             tabular_expiration_queue::{TabularExpirationPayload, TabularExpirationTask},
             tabular_purge_queue::{TabularPurgePayload, TabularPurgeTask},
         },
-        write_bootstrap_grants,
     },
 };
 
@@ -554,7 +553,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         // Outside the branches above on purpose. Re-registering over a table that keeps
         // its id runs no create hook, and the drop above already took that table's grants
         // with it, so the registered table would end up with no owner at all.
-        let bootstrap_grants = write_bootstrap_grants::<A, C>(
+        let bootstrap_grants = write_bootstrap_grants::<C, A>(
             &authorizer,
             request_metadata,
             &GrantResource::Table {
@@ -568,12 +567,10 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         // Commit the transaction
         t_write.commit().await?;
 
-        emit_bootstrap_grants(
-            event_ctx.dispatcher(),
-            event_ctx.request_metadata_arc(),
-            bootstrap_grants,
-        )
-        .await;
+        // Held across the register event below, which consumes the context: the grants
+        // are announced after the table they are on.
+        let grant_dispatcher = event_ctx.dispatcher().clone();
+        let grant_request_metadata = event_ctx.request_metadata_arc();
 
         // If we need to delete the previous table from authorizer
         if auth_needs_delete && let Some(previous_table) = &previous_table_to_drop {
@@ -603,6 +600,8 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             Arc::new(metadata_location),
             data_access,
         );
+
+        emit_bootstrap_grants_async(&grant_dispatcher, grant_request_metadata, bootstrap_grants);
 
         // Full snapshot list from the metadata file, tagged with the delegation
         // and permission scope the config above was built for. A read-only

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -567,8 +567,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         // Commit the transaction
         t_write.commit().await?;
 
-        // Held across the register event below, which consumes the context: the grants
-        // are announced after the table they are on.
+        // Held across the register event below, which consumes the context.
         let grant_dispatcher = event_ctx.dispatcher().clone();
         let grant_request_metadata = event_ctx.request_metadata_arc();
 

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -31,7 +31,8 @@ use crate::{
     service::{
         AllowedFormatVersions, CachePolicy, CatalogIdempotencyOps, CatalogStore, CatalogTableOps,
         State, TableCreation, TableId, TabularId, TabularListFlags, Transaction,
-        authz::{Authorizer, AuthzNamespaceOps, CatalogNamespaceAction},
+        authz::{Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, GrantResource},
+        emit_bootstrap_grants,
         events::{
             APIEventContext,
             context::{ResolvedNamespace, UserProvidedNamespace},
@@ -39,6 +40,7 @@ use crate::{
         idempotency::{IdempotencyInfo, IdempotencyKey},
         secrets::SecretStore,
         storage::{StoragePermissions, ValidationError, credential_revalidate_after_ms},
+        write_bootstrap_grants,
     },
 };
 
@@ -399,6 +401,19 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
 
     guard.mark_authorizer_created();
 
+    // Grants the table is born with, in the transaction that creates it: they reference
+    // a table no other transaction can see yet.
+    let bootstrap_grants = write_bootstrap_grants::<A, C>(
+        &authorizer,
+        &request_metadata,
+        &GrantResource::Table {
+            warehouse_id,
+            table_id,
+        },
+        t.transaction(),
+    )
+    .await?;
+
     // Insert idempotency key in the same transaction.
     if let Some(key) = idempotency_key
         && !C::try_insert_idempotency_key(
@@ -423,6 +438,13 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
 
     // Commit transaction
     t.commit().await?;
+
+    emit_bootstrap_grants(
+        event_ctx.dispatcher(),
+        event_ctx.request_metadata_arc(),
+        bootstrap_grants,
+    )
+    .await;
 
     // If a staged table was overwritten, delete it from authorizer
     if let Some(staged_table_id) = staged_table_id {

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -31,8 +31,10 @@ use crate::{
     service::{
         AllowedFormatVersions, CachePolicy, CatalogIdempotencyOps, CatalogStore, CatalogTableOps,
         State, TableCreation, TableId, TabularId, TabularListFlags, Transaction,
-        authz::{Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, GrantResource},
-        emit_bootstrap_grants,
+        authz::{
+            Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, GrantResource,
+            emit_bootstrap_grants_async, write_bootstrap_grants,
+        },
         events::{
             APIEventContext,
             context::{ResolvedNamespace, UserProvidedNamespace},
@@ -40,7 +42,6 @@ use crate::{
         idempotency::{IdempotencyInfo, IdempotencyKey},
         secrets::SecretStore,
         storage::{StoragePermissions, ValidationError, credential_revalidate_after_ms},
-        write_bootstrap_grants,
     },
 };
 
@@ -403,7 +404,7 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
 
     // Grants the table is born with, in the transaction that creates it: they reference
     // a table no other transaction can see yet.
-    let bootstrap_grants = write_bootstrap_grants::<A, C>(
+    let bootstrap_grants = write_bootstrap_grants::<C, A>(
         &authorizer,
         &request_metadata,
         &GrantResource::Table {
@@ -439,12 +440,10 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
     // Commit transaction
     t.commit().await?;
 
-    emit_bootstrap_grants(
-        event_ctx.dispatcher(),
-        event_ctx.request_metadata_arc(),
-        bootstrap_grants,
-    )
-    .await;
+    // Held across the create event below, which consumes the context: the grants are
+    // announced after the table they are on.
+    let grant_dispatcher = event_ctx.dispatcher().clone();
+    let grant_request_metadata = event_ctx.request_metadata_arc();
 
     // If a staged table was overwritten, delete it from authorizer
     if let Some(staged_table_id) = staged_table_id {
@@ -462,6 +461,8 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
         table.name,
         Arc::new(request),
     );
+
+    emit_bootstrap_grants_async(&grant_dispatcher, grant_request_metadata, bootstrap_grants);
 
     Ok(load_table_result)
 }

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -440,8 +440,7 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
     // Commit transaction
     t.commit().await?;
 
-    // Held across the create event below, which consumes the context: the grants are
-    // announced after the table they are on.
+    // Held across the create event below, which consumes the context.
     let grant_dispatcher = event_ctx.dispatcher().clone();
     let grant_request_metadata = event_ctx.request_metadata_arc();
 

--- a/crates/lakekeeper/src/server/views/create.rs
+++ b/crates/lakekeeper/src/server/views/create.rs
@@ -20,14 +20,15 @@ use crate::{
     service::{
         CachePolicy, CatalogStore, CatalogViewOps, Result, SecretStore, State, TabularId,
         Transaction, ViewId,
-        authz::{Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, GrantResource},
-        emit_bootstrap_grants,
+        authz::{
+            Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, GrantResource,
+            emit_bootstrap_grants_async, write_bootstrap_grants,
+        },
         events::{
             APIEventContext,
             context::{ResolvedNamespace, UserProvidedNamespace},
         },
         storage::StoragePermissions,
-        write_bootstrap_grants,
     },
 };
 
@@ -202,7 +203,7 @@ pub async fn create_view<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         )
         .await?;
 
-    let bootstrap_grants = write_bootstrap_grants::<A, C>(
+    let bootstrap_grants = write_bootstrap_grants::<C, A>(
         authorizer,
         &request_metadata,
         &GrantResource::View {
@@ -215,12 +216,10 @@ pub async fn create_view<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
 
     t.commit().await?;
 
-    emit_bootstrap_grants(
-        event_ctx.dispatcher(),
-        event_ctx.request_metadata_arc(),
-        bootstrap_grants,
-    )
-    .await;
+    // Held across the create event below, which consumes the context: the grants are
+    // announced after the view they are on.
+    let grant_dispatcher = event_ctx.dispatcher().clone();
+    let grant_request_metadata = event_ctx.request_metadata_arc();
 
     let view_metadata = Arc::new(metadata_build_result.metadata);
     let metadata_location_str = metadata_location.to_string();
@@ -233,6 +232,8 @@ pub async fn create_view<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         view.name,
         Arc::new(request),
     );
+
+    emit_bootstrap_grants_async(&grant_dispatcher, grant_request_metadata, bootstrap_grants);
 
     let load_view_result = LoadViewResult {
         metadata_location: metadata_location_str,

--- a/crates/lakekeeper/src/server/views/create.rs
+++ b/crates/lakekeeper/src/server/views/create.rs
@@ -20,12 +20,14 @@ use crate::{
     service::{
         CachePolicy, CatalogStore, CatalogViewOps, Result, SecretStore, State, TabularId,
         Transaction, ViewId,
-        authz::{Authorizer, AuthzNamespaceOps, CatalogNamespaceAction},
+        authz::{Authorizer, AuthzNamespaceOps, CatalogNamespaceAction, GrantResource},
+        emit_bootstrap_grants,
         events::{
             APIEventContext,
             context::{ResolvedNamespace, UserProvidedNamespace},
         },
         storage::StoragePermissions,
+        write_bootstrap_grants,
     },
 };
 
@@ -190,16 +192,35 @@ pub async fn create_view<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         )
         .await?;
 
+    let view_id = ViewId::from(metadata_build_result.metadata.uuid());
     authorizer
         .create_view(
             &request_metadata,
             warehouse_id,
-            ViewId::from(metadata_build_result.metadata.uuid()),
+            view_id,
             ns_hierarchy.namespace_id(),
         )
         .await?;
 
+    let bootstrap_grants = write_bootstrap_grants::<A, C>(
+        authorizer,
+        &request_metadata,
+        &GrantResource::View {
+            warehouse_id,
+            view_id,
+        },
+        t.transaction(),
+    )
+    .await?;
+
     t.commit().await?;
+
+    emit_bootstrap_grants(
+        event_ctx.dispatcher(),
+        event_ctx.request_metadata_arc(),
+        bootstrap_grants,
+    )
+    .await;
 
     let view_metadata = Arc::new(metadata_build_result.metadata);
     let metadata_location_str = metadata_location.to_string();

--- a/crates/lakekeeper/src/server/views/create.rs
+++ b/crates/lakekeeper/src/server/views/create.rs
@@ -216,8 +216,7 @@ pub async fn create_view<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
 
     t.commit().await?;
 
-    // Held across the create event below, which consumes the context: the grants are
-    // announced after the view they are on.
+    // Held across the create event below, which consumes the context.
     let grant_dispatcher = event_ctx.dispatcher().clone();
     let grant_request_metadata = event_ctx.request_metadata_arc();
 

--- a/crates/lakekeeper/src/service/authz/error.rs
+++ b/crates/lakekeeper/src/service/authz/error.rs
@@ -356,6 +356,7 @@ pub enum AuthZError {
     BadRequest(AuthzBadRequest),
     IsAllowedActionError(IsAllowedActionError),
     GrantActionForbidden(super::grant::AuthZGrantActionForbidden),
+    ApplyGrantsStoreError(crate::service::ApplyGrantsStoreError),
 }
 impl From<ResolveTasksError> for AuthZError {
     fn from(err: ResolveTasksError) -> Self {
@@ -477,5 +478,6 @@ delegate_authorization_failure_source!(AuthZError => {
     GrantActionForbidden,
     BackendUnavailableOrCountMismatch,
     BadRequest,
-    IsAllowedActionError
+    IsAllowedActionError,
+    ApplyGrantsStoreError
 });

--- a/crates/lakekeeper/src/service/authz/grant.rs
+++ b/crates/lakekeeper/src/service/authz/grant.rs
@@ -542,8 +542,15 @@ impl AppliedGrants {
     }
 }
 
-/// One grant-authority question: may the subject grant and revoke `privilege` on the
-/// resource, to `grantee`?
+/// Which way a grant would move: handed out, or taken back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GrantOp {
+    Grant,
+    Revoke,
+}
+
+/// One grant-authority question: may the subject `op` `privilege` on the resource, to
+/// `grantee`?
 ///
 /// Extensible on purpose — construct with [`new`](Self::new) and read fields rather than
 /// destructuring, so a new term costs no out-of-workspace authorizer a compile error.
@@ -565,12 +572,25 @@ pub struct GrantAuthorityCheck<'a> {
     /// authorizer that does distinguish grantees may answer this form from the privilege
     /// alone.
     pub grantee: Option<&'a UserOrRoleId>,
+    /// Which way the privilege would move. An authorizer that grants and revokes on the
+    /// same authority ignores it; one that separates them — a role that may take access
+    /// away without being able to hand it out — answers the two differently.
+    ///
+    /// `None` asks about neither direction in particular, which is what the
+    /// grantable-privileges endpoint wants: authority over the privilege here at all.
+    /// Like a `None` grantee, that answer is advisory, since the apply path asks again
+    /// per entry.
+    pub op: Option<GrantOp>,
 }
 
 impl<'a> GrantAuthorityCheck<'a> {
     #[must_use]
-    pub fn new(privilege: &'a str, grantee: Option<&'a UserOrRoleId>) -> Self {
-        Self { privilege, grantee }
+    pub fn new(privilege: &'a str, grantee: Option<&'a UserOrRoleId>, op: Option<GrantOp>) -> Self {
+        Self {
+            privilege,
+            grantee,
+            op,
+        }
     }
 }
 
@@ -579,7 +599,7 @@ impl<'a> GrantAuthorityCheck<'a> {
 /// [`are_allowed_grants_impl`](Authorizer::are_allowed_grants_impl) instead.
 #[async_trait::async_trait]
 pub trait AuthZGrantOps: Authorizer {
-    /// May the actor (or `for_user`, when given) grant and revoke each of `checks` on
+    /// May the actor (or `for_user`, when given) administer each of `checks` on
     /// `resource`? Returns exactly one decision per check, in order.
     ///
     /// Grant *authority* is resolved here rather than modelled as a `Catalog*Action`

--- a/crates/lakekeeper/src/service/authz/grant.rs
+++ b/crates/lakekeeper/src/service/authz/grant.rs
@@ -312,7 +312,9 @@ impl From<InvalidGrantPrivilege> for ErrorModel {
 #[derive(Debug, PartialEq, Eq)]
 pub struct AuthZGrantActionForbidden {
     resource_type: ResourceType,
-    privileges: Vec<String>,
+    /// `(privilege, refused granting it, refused revoking it)` — each name once, in
+    /// refusal order.
+    privileges: Vec<(String, bool, bool)>,
 }
 
 impl AuthZGrantActionForbidden {
@@ -321,14 +323,34 @@ impl AuthZGrantActionForbidden {
     /// round trip fixes them all, but bounded so the message stays readable.
     const MAX_NAMED: usize = 5;
 
+    /// Names each refused privilege once, with the directions it was refused in, so the
+    /// message says which entries to fix — a caller refused only on the grant side needs
+    /// to know their deletes would have gone through.
     #[must_use]
     pub fn new(
         resource: &GrantResource,
-        privileges: impl IntoIterator<Item = impl Into<String>>,
+        refused: impl IntoIterator<Item = (GrantOp, impl Into<String>)>,
     ) -> Self {
+        let mut privileges: Vec<(String, bool, bool)> = Vec::new();
+        for (op, privilege) in refused {
+            let privilege = privilege.into();
+            let (granting, revoking) = match op {
+                GrantOp::Grant => (true, false),
+                GrantOp::Revoke => (false, true),
+            };
+            if let Some((_, seen_granting, seen_revoking)) = privileges
+                .iter_mut()
+                .find(|(name, _, _)| *name == privilege)
+            {
+                *seen_granting |= granting;
+                *seen_revoking |= revoking;
+            } else {
+                privileges.push((privilege, granting, revoking));
+            }
+        }
         Self {
             resource_type: resource.resource_type(),
-            privileges: privileges.into_iter().map(Into::into).collect(),
+            privileges,
         }
     }
 }
@@ -339,22 +361,49 @@ impl AuthorizationFailureSource for AuthZGrantActionForbidden {
             resource_type,
             privileges,
         } = self;
-        let named = privileges
-            .iter()
-            .take(Self::MAX_NAMED)
-            .map(|p| format!("`{p}`"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let listed = if privileges.len() > Self::MAX_NAMED {
-            format!("{named} and {} more", privileges.len() - Self::MAX_NAMED)
+        // One segment per refused direction, so nothing is claimed forbidden that was
+        // not refused: a grant-side refusal must not read as if revoking were too.
+        // The name budget is shared across segments; past it the tail is counted, not
+        // named, and a direction whose names all fall past the budget goes with it.
+        let mut budget = Self::MAX_NAMED;
+        let mut segments: Vec<String> = Vec::new();
+        for (verb, granting, revoking) in [
+            ("granting", true, false),
+            ("revoking", false, true),
+            ("granting or revoking", true, true),
+        ] {
+            let named = privileges
+                .iter()
+                .filter(|(_, g, r)| (*g, *r) == (granting, revoking))
+                .take(budget)
+                .map(|(name, _, _)| format!("`{name}`"))
+                .collect::<Vec<_>>();
+            if named.is_empty() {
+                continue;
+            }
+            budget -= named.len();
+            segments.push(format!("{verb} {}", named.join(", ")));
+        }
+        let described = match segments.as_slice() {
+            // No privilege at all is unreachable from the gate; kept total for safety.
+            [] => "granting or revoking".to_string(),
+            [one] => one.clone(),
+            [head @ .., last] => format!("{} and {last}", head.join(", ")),
+        };
+        let named_count = Self::MAX_NAMED - budget;
+        let listed = if privileges.len() > named_count {
+            format!("{described} and {} more", privileges.len() - named_count)
         } else {
-            named
+            described
+        };
+        // The segments read as one sentence, so only its first letter is capitalized.
+        let mut listed_chars = listed.chars();
+        let listed = match listed_chars.next() {
+            Some(first) => format!("{}{}", first.to_uppercase(), listed_chars.as_str()),
+            None => listed,
         };
         ErrorModel::forbidden(
-            format!(
-                "Granting or revoking {listed} on this {} is forbidden",
-                resource_type.as_str()
-            ),
+            format!("{listed} on this {} is forbidden", resource_type.as_str()),
             "GrantActionForbidden",
             None,
         )
@@ -543,6 +592,11 @@ impl AppliedGrants {
 }
 
 /// Which way a grant would move: handed out, or taken back.
+///
+/// Exhaustive, unlike the check that carries it: a new *term* on the check should not break
+/// an authorizer that ignores it, but a new value of a term it already branches on must,
+/// or the authorizer would fold something it has never considered into whichever arm it
+/// happens to have.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GrantOp {
     Grant,
@@ -552,10 +606,14 @@ pub enum GrantOp {
 /// One grant-authority question: may the subject `op` `privilege` on the resource, to
 /// `grantee`?
 ///
-/// Extensible on purpose — construct with [`new`](Self::new) and read fields rather than
-/// destructuring, so a new term costs no out-of-workspace authorizer a compile error.
-/// Compiling is not honoring: a term that changes what may be authorized (grant versus
-/// revoke, say) belongs in a change its implementors cannot silently ignore.
+/// Extensible on purpose — construct with [`entry`](Self::entry) or [`any`](Self::any)
+/// and read fields rather than destructuring, so a new term costs no out-of-workspace
+/// authorizer a compile error.
+///
+/// Compiling is therefore not honoring, and the release notes carry what the compiler
+/// cannot: an authorizer that reads only the terms it knows keeps its previous answers,
+/// which is safe but silent. Every term here narrows the question, so ignoring one can
+/// only make an answer coarser than intended — never wider than the caller asked for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub struct GrantAuthorityCheck<'a> {
@@ -584,12 +642,30 @@ pub struct GrantAuthorityCheck<'a> {
 }
 
 impl<'a> GrantAuthorityCheck<'a> {
+    /// The question one diff entry asks: may the subject move `privilege` in direction
+    /// `op`, to — or, for a revoke, from — `grantee`?
     #[must_use]
-    pub fn new(privilege: &'a str, grantee: Option<&'a UserOrRoleId>, op: Option<GrantOp>) -> Self {
+    pub fn entry(privilege: &'a str, grantee: &'a UserOrRoleId, op: GrantOp) -> Self {
         Self {
             privilege,
-            grantee,
-            op,
+            grantee: Some(grantee),
+            op: Some(op),
+        }
+    }
+
+    /// A question naming neither grantee nor direction: has the subject authority over
+    /// `privilege` here at all? What the grantable-privileges endpoint asks — advisory,
+    /// since the apply path asks [`entry`](Self::entry) questions again per entry.
+    ///
+    /// The two constructors are the two questions anything asks. Terms are left out
+    /// together or not at all — a third combination would be a question no caller has,
+    /// which an authorizer would still have to decide how to answer.
+    #[must_use]
+    pub fn any(privilege: &'a str) -> Self {
+        Self {
+            privilege,
+            grantee: None,
+            op: None,
         }
     }
 }
@@ -703,8 +779,9 @@ pub(crate) async fn write_bootstrap_grants<C: CatalogStore, A: Authorizer>(
 ///
 /// They still have to reach the audit log: the backend derives its per-grant records from
 /// grant events, so a consumer mirroring them would otherwise never learn the creator
-/// holds anything. Emitted after the resource's own creation event, and spawned like it,
-/// so a listener's latency stays off the create path.
+/// holds anything. Spawned, like the resource's own creation event, so a listener's
+/// latency stays off the create path — and independent of it, so nothing orders which of
+/// the two a listener sees first.
 ///
 /// Announces no removals. That is exact for every create except re-registering a table
 /// that keeps its id, where the drop this write follows cascaded the old grants away
@@ -783,29 +860,129 @@ mod tests {
     #[test]
     fn forbidden_grant_is_a_403_that_does_not_name_the_resource() {
         let resource = GrantResource::Warehouse(WarehouseId::new_random());
-        let err = AuthZGrantActionForbidden::new(&resource, ["select"]).into_error_model();
+        let err = AuthZGrantActionForbidden::new(&resource, [(GrantOp::Grant, "select")])
+            .into_error_model();
         assert_eq!(err.code, 403);
         assert_eq!(err.r#type, "GrantActionForbidden");
         assert_eq!(
             err.message,
-            "Granting or revoking `select` on this warehouse is forbidden"
+            "Granting `select` on this warehouse is forbidden"
+        );
+    }
+
+    /// The refusal names the directions it is actually about, per privilege. A caller
+    /// refused only on one side must not be told the other is forbidden too — that
+    /// reading was free while authority was symmetric, and wrong as soon as an
+    /// authorizer separates the two.
+    #[test]
+    fn forbidden_grant_names_the_refused_directions() {
+        let resource = GrantResource::Warehouse(WarehouseId::new_random());
+        let err = AuthZGrantActionForbidden::new(&resource, [(GrantOp::Revoke, "select")])
+            .into_error_model();
+        assert_eq!(
+            err.message,
+            "Revoking `select` on this warehouse is forbidden"
+        );
+
+        // Refused in different directions: each privilege sits under its own verb, so
+        // the message never claims a refusal that did not happen.
+        let err = AuthZGrantActionForbidden::new(
+            &resource,
+            [(GrantOp::Grant, "select"), (GrantOp::Revoke, "modify")],
+        )
+        .into_error_model();
+        assert_eq!(
+            err.message,
+            "Granting `select` and revoking `modify` on this warehouse is forbidden"
+        );
+
+        // All three groups at once, reading as one sentence.
+        let err = AuthZGrantActionForbidden::new(
+            &resource,
+            [
+                (GrantOp::Grant, "select"),
+                (GrantOp::Revoke, "modify"),
+                (GrantOp::Grant, "ownership"),
+                (GrantOp::Revoke, "ownership"),
+            ],
+        )
+        .into_error_model();
+        assert_eq!(
+            err.message,
+            "Granting `select`, revoking `modify` and granting or revoking `ownership` \
+             on this warehouse is forbidden"
         );
     }
 
     #[test]
     fn forbidden_grant_names_every_refused_privilege_bounded() {
         let resource = GrantResource::Warehouse(WarehouseId::new_random());
-        let err =
-            AuthZGrantActionForbidden::new(&resource, ["select", "modify"]).into_error_model();
+        let err = AuthZGrantActionForbidden::new(
+            &resource,
+            [(GrantOp::Grant, "select"), (GrantOp::Grant, "modify")],
+        )
+        .into_error_model();
         assert_eq!(
             err.message,
-            "Granting or revoking `select`, `modify` on this warehouse is forbidden"
+            "Granting `select`, `modify` on this warehouse is forbidden"
         );
-        let err = AuthZGrantActionForbidden::new(&resource, ["a", "b", "c", "d", "e", "f", "g"])
-            .into_error_model();
+        let err = AuthZGrantActionForbidden::new(
+            &resource,
+            ["a", "b", "c", "d", "e", "f", "g"].map(|p| (GrantOp::Grant, p)),
+        )
+        .into_error_model();
         assert_eq!(
             err.message,
-            "Granting or revoking `a`, `b`, `c`, `d`, `e` and 2 more on this warehouse is forbidden"
+            "Granting `a`, `b`, `c`, `d`, `e` and 2 more on this warehouse is forbidden"
+        );
+    }
+
+    /// The name budget is shared across directions, so one direction can exhaust it and
+    /// leave the other's names in the count. Under-reporting *which* direction the tail
+    /// was refused in is the honest failure: the alternative — naming the budget's worth
+    /// under a verb covering both — would claim refusals that never happened. Pinned
+    /// because it is the one case where the message stops naming a direction it knows
+    /// about.
+    #[test]
+    fn forbidden_grant_lets_one_direction_exhaust_the_name_budget() {
+        let resource = GrantResource::Warehouse(WarehouseId::new_random());
+        let refused = ["a", "b", "c", "d", "e"]
+            .map(|p| (GrantOp::Grant, p))
+            .into_iter()
+            .chain(["x", "y"].map(|p| (GrantOp::Revoke, p)));
+        let err = AuthZGrantActionForbidden::new(&resource, refused).into_error_model();
+        assert_eq!(
+            err.message,
+            "Granting `a`, `b`, `c`, `d`, `e` and 2 more on this warehouse is forbidden"
+        );
+
+        // One name left over, so the second direction is still named — and the count
+        // covers only what went unnamed.
+        let refused = ["a", "b", "c", "d"]
+            .map(|p| (GrantOp::Grant, p))
+            .into_iter()
+            .chain(["x", "y"].map(|p| (GrantOp::Revoke, p)));
+        let err = AuthZGrantActionForbidden::new(&resource, refused).into_error_model();
+        assert_eq!(
+            err.message,
+            "Granting `a`, `b`, `c`, `d` and revoking `x` and 1 more on this warehouse \
+             is forbidden"
+        );
+    }
+
+    /// One privilege refused in both directions is named once, not twice: it sits under
+    /// the one verb that carries both directions.
+    #[test]
+    fn forbidden_grant_names_a_privilege_refused_both_ways_once() {
+        let resource = GrantResource::Warehouse(WarehouseId::new_random());
+        let err = AuthZGrantActionForbidden::new(
+            &resource,
+            [(GrantOp::Grant, "select"), (GrantOp::Revoke, "select")],
+        )
+        .into_error_model();
+        assert_eq!(
+            err.message,
+            "Granting or revoking `select` on this warehouse is forbidden"
         );
     }
 

--- a/crates/lakekeeper/src/service/authz/grant.rs
+++ b/crates/lakekeeper/src/service/authz/grant.rs
@@ -20,7 +20,7 @@
 //! grant on a parent resource is a grant on the parent. Resolving what a principal
 //! may *effectively* do is a separate question answered by the action-check API.
 
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use iceberg_ext::catalog::rest::ErrorModel;
@@ -33,8 +33,12 @@ use super::{
 use crate::{
     api::{RequestMetadata, iceberg::v1::PaginationQuery},
     service::{
-        GenericTableId, NamespaceId, ProjectId, TableId, TagDefinitionId, ViewId, WarehouseId,
-        events::types::authorization::{AuthorizationFailureReason, AuthorizationFailureSource},
+        ApplyGrantsStoreError, CatalogStore, GenericTableId, NamespaceId, ProjectId, TableId,
+        TagDefinitionId, Transaction, ViewId, WarehouseId,
+        events::{
+            EventDispatcher, GrantsChangedEvent,
+            types::authorization::{AuthorizationFailureReason, AuthorizationFailureSource},
+        },
     },
 };
 
@@ -621,6 +625,85 @@ pub trait AuthZGrantOps: Authorizer {
 #[async_trait::async_trait]
 impl<T> AuthZGrantOps for T where T: Authorizer {}
 
+/// The grant rows a resource is born with.
+///
+/// Empty — and cheap, without touching the store — when the authorizer keeps its own
+/// grants, when it declares nothing for this kind of resource, or when nobody is acting.
+/// An anonymous create has no owner to name: the server-bootstrap path creates the
+/// default project that way when authentication is disabled.
+///
+/// The owner is the acting identity, so a request narrowed to a role makes the role the
+/// owner rather than the user behind it.
+pub(crate) fn bootstrap_grant_specs<A: Authorizer>(
+    authorizer: &A,
+    metadata: &RequestMetadata,
+    resource: &GrantResource,
+) -> Vec<GrantSpec> {
+    if authorizer.grants().is_some() {
+        return Vec::new();
+    }
+    let privileges = authorizer.bootstrap_grants(resource.resource_type());
+    if privileges.is_empty() {
+        return Vec::new();
+    }
+    let Some(owner) = metadata.actor().to_user_or_role() else {
+        return Vec::new();
+    };
+    let owner = UserOrRoleId::from(&owner);
+    privileges
+        .iter()
+        .map(|privilege| GrantSpec {
+            principal: owner.clone(),
+            resource: resource.clone(),
+            privilege: (*privilege).to_string(),
+        })
+        .collect()
+}
+
+/// Write the grants a resource is born with, in that resource's own transaction. Returns
+/// what was created, for the caller to announce once it commits.
+///
+/// Called after the authorizer's `create_*` hook so a hook failure still aborts first,
+/// and inside the create transaction because the rows reference a resource no other
+/// transaction can see yet.
+pub(crate) async fn write_bootstrap_grants<C: CatalogStore, A: Authorizer>(
+    authorizer: &A,
+    metadata: &RequestMetadata,
+    resource: &GrantResource,
+    transaction: <C::Transaction as Transaction<C::State>>::Transaction<'_>,
+) -> Result<Vec<GrantSpec>, ApplyGrantsStoreError> {
+    let writes = bootstrap_grant_specs(authorizer, metadata, resource);
+    if writes.is_empty() {
+        return Ok(Vec::new());
+    }
+    C::insert_grants_impl(&writes, transaction).await
+}
+
+/// Announce grants a resource was born with, once their transaction committed.
+///
+/// They still have to reach the audit log: the backend derives its per-grant records from
+/// grant events, so a consumer mirroring them would otherwise never learn the creator
+/// holds anything. Emitted after the resource's own creation event, and spawned like it,
+/// so a listener's latency stays off the create path.
+///
+/// Announces no removals. That is exact for every create except re-registering a table
+/// that keeps its id, where the drop this write follows cascaded the old grants away
+/// unannounced — as any hard delete of a resource does.
+pub(crate) fn emit_bootstrap_grants_async(
+    dispatcher: &EventDispatcher,
+    request_metadata: Arc<RequestMetadata>,
+    created: Vec<GrantSpec>,
+) {
+    if created.is_empty() {
+        return;
+    }
+    let event = GrantsChangedEvent::new(Vec::new(), created, request_metadata);
+    let dispatcher = dispatcher.clone();
+    tokio::spawn(async move {
+        dispatcher.grants_changed(event).await;
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -704,5 +787,167 @@ mod tests {
             err.message,
             "Granting or revoking `a`, `b`, `c`, `d`, `e` and 2 more on this warehouse is forbidden"
         );
+    }
+
+    mod bootstrap_grants {
+        use super::*;
+        use crate::{
+            request_metadata::RequestMetadataTestBuilder,
+            service::{
+                Role, RoleId,
+                authn::{Actor, UserId},
+                authz::{AllowAllAuthorizer, tests::HidingAuthorizer},
+            },
+        };
+
+        fn as_user(user: &UserId) -> RequestMetadata {
+            RequestMetadataTestBuilder::builder()
+                .actor(Actor::Principal(user.clone()))
+                .build()
+        }
+
+        #[test]
+        fn a_full_vocabulary_alone_confers_no_ownership() {
+            // AllowAll publishes every privilege at every level and stores grants in the
+            // catalog, yet declares no bootstrap privileges: an authorizer has to opt in
+            // before creation starts writing rows.
+            let authorizer = AllowAllAuthorizer::default();
+            let metadata = as_user(&UserId::new_unchecked("oidc", "alice"));
+            assert_eq!(
+                bootstrap_grant_specs(
+                    &authorizer,
+                    &metadata,
+                    &GrantResource::Warehouse(WarehouseId::new_random())
+                ),
+                Vec::new()
+            );
+        }
+
+        #[test]
+        fn the_creating_user_gets_one_row_per_declared_privilege() {
+            let authorizer = HidingAuthorizer::new()
+                .with_bootstrap_grants(&[(ResourceType::Warehouse, &["ownership", "modify"])]);
+            let alice = UserId::new_unchecked("oidc", "alice");
+            let warehouse_id = WarehouseId::new_random();
+            let resource = GrantResource::Warehouse(warehouse_id);
+
+            assert_eq!(
+                bootstrap_grant_specs(&authorizer, &as_user(&alice), &resource),
+                vec![
+                    GrantSpec {
+                        principal: UserOrRoleId::User(alice.clone()),
+                        resource: resource.clone(),
+                        privilege: "ownership".to_string(),
+                    },
+                    GrantSpec {
+                        principal: UserOrRoleId::User(alice),
+                        resource,
+                        privilege: "modify".to_string(),
+                    },
+                ]
+            );
+        }
+
+        #[test]
+        fn a_declaration_confers_only_on_the_type_it_names() {
+            // The whole point of the resource type parameter: ownership of tables need
+            // not imply ownership of the warehouse they are created in.
+            let authorizer = HidingAuthorizer::new()
+                .with_bootstrap_grants(&[(ResourceType::Table, &["ownership"])]);
+            let alice = UserId::new_unchecked("oidc", "alice");
+            let warehouse_id = WarehouseId::new_random();
+            let table_id = TableId::new_random();
+
+            let table = GrantResource::Table {
+                warehouse_id,
+                table_id,
+            };
+            assert_eq!(
+                bootstrap_grant_specs(&authorizer, &as_user(&alice), &table),
+                vec![GrantSpec {
+                    principal: UserOrRoleId::User(alice.clone()),
+                    resource: table,
+                    privilege: "ownership".to_string(),
+                }]
+            );
+            for undeclared in [
+                GrantResource::Server,
+                GrantResource::Warehouse(warehouse_id),
+                GrantResource::Namespace {
+                    warehouse_id,
+                    namespace_id: NamespaceId::new_random(),
+                },
+                GrantResource::View {
+                    warehouse_id,
+                    view_id: ViewId::new_random(),
+                },
+            ] {
+                assert_eq!(
+                    bootstrap_grant_specs(&authorizer, &as_user(&alice), &undeclared),
+                    Vec::new(),
+                    "{undeclared:?} was not declared"
+                );
+            }
+        }
+
+        #[test]
+        fn an_assumed_role_owns_what_it_creates() {
+            // The acting identity, not the user behind it: a token narrowed to a role must
+            // not make the whole user an owner.
+            let authorizer = HidingAuthorizer::new()
+                .with_bootstrap_grants(&[(ResourceType::Project, &["ownership"])]);
+            let role_id = RoleId::new_random();
+            let metadata = RequestMetadataTestBuilder::builder()
+                .actor(Actor::Role {
+                    principal: UserId::new_unchecked("oidc", "alice"),
+                    assumed_role: Role::new_random_with_id(role_id).into(),
+                })
+                .build();
+
+            let specs = bootstrap_grant_specs(
+                &authorizer,
+                &metadata,
+                &GrantResource::Project(ProjectId::new_random()),
+            );
+            assert_eq!(
+                specs
+                    .iter()
+                    .map(|spec| spec.principal.clone())
+                    .collect::<Vec<_>>(),
+                vec![UserOrRoleId::Role(role_id)]
+            );
+        }
+
+        #[test]
+        fn an_anonymous_create_leaves_no_owner() {
+            // The server-bootstrap path creates the default project this way when
+            // authentication is disabled: there is nobody to own it.
+            let authorizer = HidingAuthorizer::new()
+                .with_bootstrap_grants(&[(ResourceType::Warehouse, &["ownership"])]);
+            let metadata = RequestMetadataTestBuilder::builder()
+                .actor(Actor::Anonymous)
+                .build();
+            assert_eq!(
+                bootstrap_grant_specs(
+                    &authorizer,
+                    &metadata,
+                    &GrantResource::Warehouse(WarehouseId::new_random())
+                ),
+                Vec::new()
+            );
+        }
+
+        #[test]
+        fn declaring_nothing_writes_nothing() {
+            let authorizer = HidingAuthorizer::new();
+            assert_eq!(
+                bootstrap_grant_specs(
+                    &authorizer,
+                    &as_user(&UserId::new_unchecked("oidc", "alice")),
+                    &GrantResource::Warehouse(WarehouseId::new_random())
+                ),
+                Vec::new()
+            );
+        }
     }
 }

--- a/crates/lakekeeper/src/service/authz/grant.rs
+++ b/crates/lakekeeper/src/service/authz/grant.rs
@@ -710,7 +710,9 @@ pub enum GrantOp {
 /// cannot: an authorizer that reads only the terms it knows keeps its previous answers,
 /// which is safe but silent. Every term here narrows the question, so ignoring one can
 /// only make an answer coarser than intended — never wider than the caller asked for.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+// No `Hash`: the resolved grantee is not hashable, and nothing keys a map by a whole
+// question — the tuple-based authorizer keys its plan by privilege.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct GrantAuthorityCheck<'a> {
     /// A name from the authorizer's own vocabulary. An unrecognized name is answered
@@ -720,48 +722,63 @@ pub struct GrantAuthorityCheck<'a> {
     /// Who would come to hold the privilege — or lose it, for a revoke. An authorizer
     /// whose authority does not depend on the recipient ignores it.
     ///
-    /// `None` leaves the grantee out of the question: the grantable-privileges endpoint
-    /// asks whether the subject has authority over the privilege here at all. That
-    /// answer is advisory, since the apply path asks again for each grantee, so even an
-    /// authorizer that does distinguish grantees may answer this form from the privilege
-    /// alone.
-    pub grantee: Option<&'a UserOrRoleId>,
+    /// Resolved, not just identified: a role grantee carries the role itself, so an
+    /// authorizer can read its identity and attributes rather than only a `RoleId` it has
+    /// no way to look up.
+    ///
+    /// `None` means the question names nobody, which two callers do:
+    ///
+    /// - the grantable-privileges endpoint, asking whether the subject may grant the
+    ///   privilege here *to anyone*. Advisory, since the apply path asks again per entry,
+    ///   so an authorizer that distinguishes grantees may answer it from the privilege
+    ///   alone;
+    /// - a revoke whose role the catalog could not resolve. Grants cascade with their
+    ///   role, so the revoke is already a no-op; the gate runs before that is known, and
+    ///   the resolution ahead of it deliberately cannot fail, because refusing there
+    ///   would let an unauthorized caller probe which roles exist. A write naming such a
+    ///   role is still rejected, just after the gate.
+    ///
+    /// Both forms ask something broader than a named grantee would, so ignoring the term
+    /// or failing to match on it can only make an answer stricter, never wider.
+    pub grantee: Option<&'a UserOrRole>,
     /// Which way the privilege would move. An authorizer that grants and revokes on the
     /// same authority ignores it; one that separates them — a role that may take access
     /// away without being able to hand it out — answers the two differently.
     ///
-    /// `None` asks about neither direction in particular, which is what the
-    /// grantable-privileges endpoint wants: authority over the privilege here at all.
-    /// Like a `None` grantee, that answer is advisory, since the apply path asks again
-    /// per entry.
-    pub op: Option<GrantOp>,
+    /// Always present: every question is about moving a privilege in one direction. The
+    /// grantable-privileges endpoint asks about granting, so its answer is exact for an
+    /// authorizer that separates the directions rather than a blend of both.
+    pub op: GrantOp,
 }
 
 impl<'a> GrantAuthorityCheck<'a> {
     /// The question one diff entry asks: may the subject move `privilege` in direction
     /// `op`, to — or, for a revoke, from — `grantee`?
+    ///
+    /// `grantee` is `None` only when the entry names a role the catalog could not resolve;
+    /// see the field.
     #[must_use]
-    pub fn entry(privilege: &'a str, grantee: &'a UserOrRoleId, op: GrantOp) -> Self {
+    pub fn entry(privilege: &'a str, grantee: Option<&'a UserOrRole>, op: GrantOp) -> Self {
         Self {
             privilege,
-            grantee: Some(grantee),
-            op: Some(op),
+            grantee,
+            op,
         }
     }
 
-    /// A question naming neither grantee nor direction: has the subject authority over
-    /// `privilege` here at all? What the grantable-privileges endpoint asks — advisory,
-    /// since the apply path asks [`entry`](Self::entry) questions again per entry.
+    /// May the subject grant `privilege` here, to anyone? What the grantable-privileges
+    /// endpoint asks — advisory, since the apply path asks [`entry`](Self::entry)
+    /// questions again per entry, and those name the grantee.
     ///
-    /// The two constructors are the two questions anything asks. Terms are left out
-    /// together or not at all — a third combination would be a question no caller has,
-    /// which an authorizer would still have to decide how to answer.
+    /// Granting, not revoking: the endpoint exists to say what a principal could hand
+    /// out. Revocation needs no discovery question of its own — what can be taken away
+    /// is read off the existing grants, and each removal is authorized as it is applied.
     #[must_use]
-    pub fn any(privilege: &'a str) -> Self {
+    pub fn grantable(privilege: &'a str) -> Self {
         Self {
             privilege,
             grantee: None,
-            op: None,
+            op: GrantOp::Grant,
         }
     }
 }

--- a/crates/lakekeeper/src/service/authz/grant.rs
+++ b/crates/lakekeeper/src/service/authz/grant.rs
@@ -33,8 +33,9 @@ use super::{
 use crate::{
     api::{RequestMetadata, iceberg::v1::PaginationQuery},
     service::{
-        ApplyGrantsStoreError, CatalogStore, GenericTableId, NamespaceId, ProjectId, TableId,
-        TagDefinitionId, Transaction, ViewId, WarehouseId,
+        ApplyGrantsStoreError, CatalogStore, GenericTableId, GenericTabularInfo,
+        NamespaceHierarchy, NamespaceId, ProjectId, ResolvedWarehouse, TableId, TableInfo,
+        TagDefinition, TagDefinitionId, Transaction, ViewId, ViewInfo, WarehouseId,
         events::{
             EventDispatcher, GrantsChangedEvent,
             types::authorization::{AuthorizationFailureReason, AuthorizationFailureSource},
@@ -182,6 +183,101 @@ impl GrantResource {
             | GrantResource::View { warehouse_id, .. }
             | GrantResource::GenericTable { warehouse_id, .. } => Some(*warehouse_id),
             GrantResource::Server | GrantResource::Project(_) | GrantResource::Tag(_) => None,
+        }
+    }
+}
+
+/// A grant's resource together with the ancestry needed to decide authority on it.
+///
+/// [`GrantResource`] names a resource; this places it. Each variant carries what that
+/// level's `are_allowed_*_actions` check already takes, so an authorizer answers a grant
+/// question against the same entities it answers an action question against — a policy
+/// written against a project covers the warehouses beneath it either way. Ids alone cannot
+/// do that: an authorizer resolving inheritance itself has nothing to hang a bare
+/// [`WarehouseId`] under.
+///
+/// Borrowed rather than owned, and nothing here is fetched for the authorizer's benefit:
+/// every handler resolves this chain before the gate anyway, to establish that the resource
+/// exists at all.
+#[derive(Debug, Clone, Copy)]
+pub enum GrantTarget<'a> {
+    Server,
+    Project(&'a ProjectId),
+    Warehouse(&'a ResolvedWarehouse),
+    Namespace {
+        warehouse: &'a ResolvedWarehouse,
+        namespace: &'a NamespaceHierarchy,
+    },
+    Table {
+        warehouse: &'a ResolvedWarehouse,
+        namespace: &'a NamespaceHierarchy,
+        table: &'a TableInfo,
+    },
+    View {
+        warehouse: &'a ResolvedWarehouse,
+        namespace: &'a NamespaceHierarchy,
+        view: &'a ViewInfo,
+    },
+    GenericTable {
+        warehouse: &'a ResolvedWarehouse,
+        namespace: &'a NamespaceHierarchy,
+        generic_table: &'a GenericTabularInfo,
+    },
+    Tag(&'a TagDefinition),
+}
+
+impl GrantTarget<'_> {
+    /// The resource a grant on this target is held on: what gets stored, listed and
+    /// announced. Derived rather than passed alongside, so the placed and named forms
+    /// cannot disagree.
+    #[must_use]
+    pub fn resource(&self) -> GrantResource {
+        match self {
+            GrantTarget::Server => GrantResource::Server,
+            GrantTarget::Project(project_id) => GrantResource::Project((*project_id).clone()),
+            GrantTarget::Warehouse(warehouse) => GrantResource::Warehouse(warehouse.warehouse_id),
+            GrantTarget::Namespace {
+                warehouse,
+                namespace,
+            } => GrantResource::Namespace {
+                warehouse_id: warehouse.warehouse_id,
+                namespace_id: namespace.namespace.namespace_id(),
+            },
+            GrantTarget::Table {
+                warehouse, table, ..
+            } => GrantResource::Table {
+                warehouse_id: warehouse.warehouse_id,
+                table_id: table.tabular_id,
+            },
+            GrantTarget::View {
+                warehouse, view, ..
+            } => GrantResource::View {
+                warehouse_id: warehouse.warehouse_id,
+                view_id: view.tabular_id,
+            },
+            GrantTarget::GenericTable {
+                warehouse,
+                generic_table,
+                ..
+            } => GrantResource::GenericTable {
+                warehouse_id: warehouse.warehouse_id,
+                generic_table_id: generic_table.tabular_id,
+            },
+            GrantTarget::Tag(definition) => GrantResource::Tag(definition.tag_definition_id),
+        }
+    }
+
+    #[must_use]
+    pub fn resource_type(&self) -> ResourceType {
+        match self {
+            GrantTarget::Server => ResourceType::Server,
+            GrantTarget::Project(_) => ResourceType::Project,
+            GrantTarget::Warehouse(_) => ResourceType::Warehouse,
+            GrantTarget::Namespace { .. } => ResourceType::Namespace,
+            GrantTarget::Table { .. } => ResourceType::Table,
+            GrantTarget::View { .. } => ResourceType::View,
+            GrantTarget::GenericTable { .. } => ResourceType::GenericTable,
+            GrantTarget::Tag(_) => ResourceType::Tag,
         }
     }
 }
@@ -675,8 +771,8 @@ impl<'a> GrantAuthorityCheck<'a> {
 /// [`are_allowed_grants_impl`](Authorizer::are_allowed_grants_impl) instead.
 #[async_trait::async_trait]
 pub trait AuthZGrantOps: Authorizer {
-    /// May the actor (or `for_user`, when given) administer each of `checks` on
-    /// `resource`? Returns exactly one decision per check, in order.
+    /// May the actor (or `for_user`, when given) administer each of `checks` on `target`?
+    /// Returns exactly one decision per check, in order.
     ///
     /// Grant *authority* is resolved here rather than modelled as a `Catalog*Action`
     /// because the privilege is a name from this authorizer's own vocabulary: it cannot
@@ -690,7 +786,7 @@ pub trait AuthZGrantOps: Authorizer {
         &self,
         metadata: &RequestMetadata,
         mut for_user: Option<&UserOrRole>,
-        resource: &GrantResource,
+        target: &GrantTarget<'_>,
         checks: &[GrantAuthorityCheck<'_>],
     ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         // Naming yourself asks the same question as naming nobody, so it must not trip
@@ -705,7 +801,7 @@ pub trait AuthZGrantOps: Authorizer {
         // by writing the very records its own permission API refuses them. Instance
         // admins provision; they do not administer permissions.
         let decisions = self
-            .are_allowed_grants_impl(metadata, for_user, resource, checks)
+            .are_allowed_grants_impl(metadata, for_user, target, checks)
             .await?;
         // Callers zip decisions against the checks, and `zip` stops at the shorter side —
         // a short vector would silently authorize the tail rather than deny it.

--- a/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
+++ b/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
@@ -552,8 +552,8 @@ mod tests {
                 None,
                 &resource,
                 &[
-                    GrantAuthorityCheck::new("get_metadata", Some(&bob), Some(GrantOp::Grant)),
-                    GrantAuthorityCheck::new("not_a_privilege", None, None),
+                    GrantAuthorityCheck::entry("get_metadata", &bob, GrantOp::Grant),
+                    GrantAuthorityCheck::any("not_a_privilege"),
                 ],
             )
             .await

--- a/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
+++ b/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
@@ -453,7 +453,7 @@ fn build_vocabulary(resource_type: ResourceType) -> Vec<PrivilegeDescriptor> {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::super::{AuthZGrantOps, InvalidGrantPrivilege, UserOrRoleId},
+        super::super::{AuthZGrantOps, GrantOp, InvalidGrantPrivilege, UserOrRoleId},
         *,
     };
 
@@ -552,8 +552,8 @@ mod tests {
                 None,
                 &resource,
                 &[
-                    GrantAuthorityCheck::new("get_metadata", Some(&bob)),
-                    GrantAuthorityCheck::new("not_a_privilege", None),
+                    GrantAuthorityCheck::new("get_metadata", Some(&bob), Some(GrantOp::Grant)),
+                    GrantAuthorityCheck::new("not_a_privilege", None, None),
                 ],
             )
             .await

--- a/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
+++ b/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
@@ -453,7 +453,7 @@ fn build_vocabulary(resource_type: ResourceType) -> Vec<PrivilegeDescriptor> {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::super::{AuthZGrantOps, GrantOp, InvalidGrantPrivilege, UserOrRoleId},
+        super::super::{AuthZGrantOps, GrantOp, InvalidGrantPrivilege},
         *,
     };
 
@@ -546,15 +546,15 @@ mod tests {
         let authorizer = AllowAllAuthorizer::default();
         let warehouse = ResolvedWarehouse::new_random();
         let target = GrantTarget::Warehouse(&warehouse);
-        let bob = UserOrRoleId::User(UserId::new_unchecked("oidc", "bob"));
+        let bob = UserOrRole::User(UserId::new_unchecked("oidc", "bob"));
         let decisions = authorizer
             .are_allowed_grants(
                 &RequestMetadata::new_unauthenticated(),
                 None,
                 &target,
                 &[
-                    GrantAuthorityCheck::entry("get_metadata", &bob, GrantOp::Grant),
-                    GrantAuthorityCheck::any("not_a_privilege"),
+                    GrantAuthorityCheck::entry("get_metadata", Some(&bob), GrantOp::Grant),
+                    GrantAuthorityCheck::grantable("not_a_privilege"),
                 ],
             )
             .await

--- a/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
+++ b/crates/lakekeeper/src/service/authz/implementations/allow_all.rs
@@ -21,7 +21,7 @@ use crate::{
             AuthzBackendErrorOrBadRequest, CatalogAction, CatalogGenericTableAction,
             CatalogNamespaceAction, CatalogProjectAction, CatalogRoleAction, CatalogServerAction,
             CatalogTableAction, CatalogTagAction, CatalogUserAction, CatalogViewAction,
-            CatalogWarehouseAction, GrantAuthorityCheck, GrantResource, IsAllowedActionError,
+            CatalogWarehouseAction, GrantAuthorityCheck, GrantTarget, IsAllowedActionError,
             ListProjectsResponse, NamespaceParent, PrivilegeDescriptor, ResourceType, UserOrRole,
         },
         health::{Health, HealthExt},
@@ -286,7 +286,7 @@ impl Authorizer for AllowAllAuthorizer {
         &self,
         _metadata: &RequestMetadata,
         _for_user: Option<&UserOrRole>,
-        _resource: &GrantResource,
+        _target: &GrantTarget<'_>,
         checks: &[GrantAuthorityCheck<'_>],
     ) -> Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         Ok(vec![AuthorizationDecision::allow(); checks.len()])
@@ -544,13 +544,14 @@ mod tests {
     #[tokio::test]
     async fn grant_authority_is_allowed_for_every_privilege() {
         let authorizer = AllowAllAuthorizer::default();
-        let resource = GrantResource::Warehouse(WarehouseId::new_random());
+        let warehouse = ResolvedWarehouse::new_random();
+        let target = GrantTarget::Warehouse(&warehouse);
         let bob = UserOrRoleId::User(UserId::new_unchecked("oidc", "bob"));
         let decisions = authorizer
             .are_allowed_grants(
                 &RequestMetadata::new_unauthenticated(),
                 None,
-                &resource,
+                &target,
                 &[
                     GrantAuthorityCheck::entry("get_metadata", &bob, GrantOp::Grant),
                     GrantAuthorityCheck::any("not_a_privilege"),

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -2052,12 +2052,16 @@ where
     /// destined for and which way it would move. Whether either changes the answer is the
     /// authorizer's business; either way, return one decision per check, in order.
     ///
+    /// `target` carries the resource's resolved ancestry, not just its id, so an authorizer
+    /// that resolves inheritance itself can place the resource in its hierarchy — see
+    /// [`GrantTarget`].
+    ///
     /// The default denies everything.
     async fn are_allowed_grants_impl(
         &self,
         _metadata: &RequestMetadata,
         _for_user: Option<&UserOrRole>,
-        _resource: &GrantResource,
+        _target: &GrantTarget<'_>,
         checks: &[GrantAuthorityCheck<'_>],
     ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
         Ok(vec![AuthorizationDecision::deny(); checks.len()])
@@ -2235,7 +2239,7 @@ pub mod tests {
             .are_allowed_grants(
                 &md,
                 None,
-                &GrantResource::Server,
+                &GrantTarget::Server,
                 &[
                     GrantAuthorityCheck::any("admin"),
                     GrantAuthorityCheck::entry("select", &alice, GrantOp::Revoke),
@@ -3135,7 +3139,7 @@ pub mod tests {
             &self,
             _metadata: &RequestMetadata,
             _for_user: Option<&UserOrRole>,
-            _resource: &GrantResource,
+            _target: &GrantTarget<'_>,
             checks: &[GrantAuthorityCheck<'_>],
         ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
             // Authority over a direction, and only when the caller names one: a question

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -2048,9 +2048,9 @@ where
     /// warehouse's grants without being able to read it — so there is no visibility
     /// check to fold in here. Callers document what that discloses.
     ///
-    /// Each check names a privilege and, where the caller knows it, the grantee it is
-    /// destined for. Whether the grantee changes the answer is the authorizer's business;
-    /// either way, return one decision per check, in order.
+    /// Each check names a privilege and, where the caller knows them, the grantee it is
+    /// destined for and which way it would move. Whether either changes the answer is the
+    /// authorizer's business; either way, return one decision per check, in order.
     ///
     /// The default denies everything.
     async fn are_allowed_grants_impl(
@@ -2237,8 +2237,8 @@ pub mod tests {
                 None,
                 &GrantResource::Server,
                 &[
-                    GrantAuthorityCheck::new("admin", None),
-                    GrantAuthorityCheck::new("select", Some(&alice)),
+                    GrantAuthorityCheck::new("admin", None, None),
+                    GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Revoke)),
                 ],
             )
             .await

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -2237,8 +2237,8 @@ pub mod tests {
                 None,
                 &GrantResource::Server,
                 &[
-                    GrantAuthorityCheck::new("admin", None, None),
-                    GrantAuthorityCheck::new("select", Some(&alice), Some(GrantOp::Revoke)),
+                    GrantAuthorityCheck::any("admin"),
+                    GrantAuthorityCheck::entry("select", &alice, GrantOp::Revoke),
                 ],
             )
             .await
@@ -2976,6 +2976,9 @@ pub mod tests {
         /// What creation confers per resource type, for tests that exercise the catalog
         /// grant arm. Empty by default, so no test gains grant rows it did not ask for.
         bootstrap: &'static [(ResourceType, &'static [&'static str])],
+        /// Which grant directions this authorizer has authority over. Empty by default,
+        /// which answers every grant-authority question with the trait's deny.
+        grant_ops: &'static [GrantOp],
     }
 
     impl Default for HidingAuthorizer {
@@ -2993,7 +2996,16 @@ pub mod tests {
                 hidden_for_user: Arc::new(RwLock::new(HashMap::new())),
                 server_id: ServerId::new_random(),
                 bootstrap: &[],
+                grant_ops: &[],
             }
+        }
+
+        /// Give this authorizer authority over `ops` and nothing else, so a test can tell
+        /// a grant-authority question apart from a revoke one.
+        #[must_use]
+        pub fn with_grant_authority(mut self, ops: &'static [GrantOp]) -> Self {
+            self.grant_ops = ops;
+            self
         }
 
         /// Make creation confer privileges as catalog grant rows, per resource type.
@@ -3117,6 +3129,28 @@ pub mod tests {
                 .iter()
                 .find(|(declared_for, _)| *declared_for == resource_type)
                 .map_or(&[], |(_, privileges)| *privileges)
+        }
+
+        async fn are_allowed_grants_impl(
+            &self,
+            _metadata: &RequestMetadata,
+            _for_user: Option<&UserOrRole>,
+            _resource: &GrantResource,
+            checks: &[GrantAuthorityCheck<'_>],
+        ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
+            // Authority over a direction, and only when the caller names one: a question
+            // that names none is what the vocabulary endpoint asks, and this authorizer
+            // has nothing to say about it.
+            Ok(checks
+                .iter()
+                .map(|check| {
+                    if check.op.is_some_and(|op| self.grant_ops.contains(&op)) {
+                        AuthorizationDecision::allow()
+                    } else {
+                        AuthorizationDecision::deny()
+                    }
+                })
+                .collect())
         }
 
         #[cfg(feature = "open-api")]

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -1984,13 +1984,21 @@ where
     /// makes the role the owner — the same identity [`AuthZGrantOps::are_allowed_grants`]
     /// folds to `None`. An anonymous create leaves no rows.
     ///
-    /// Names should come from [`Self::grantable_privileges`]: one outside it still lands
-    /// and stays revocable, but listings mark it unrecognized. A name here is a
-    /// commitment that the creator can be *given* it — the write fails, and with it the
-    /// create, if the acting user has no user record yet.
+    /// Names should come from [`Self::grantable_privileges`]. One outside it is stored
+    /// and returned verbatim like any other name, but listings mark it unrecognized, and
+    /// revoking it needs [`AuthZGrantOps::are_allowed_grants`] to answer for a name the
+    /// authorizer does not know — which an enforcing one refuses, leaving the row
+    /// unrevocable through the API.
+    ///
+    /// A name here is also a commitment that the creator can be *given* it: the write,
+    /// and with it the create, fails if the acting user has no user record yet. That is
+    /// deliberate — a resource nobody owns is worse than a rejected create.
+    ///
+    /// [`ResourceType::Server`] is consulted when the server is bootstrapped; every
+    /// other type when a resource of it is created.
     ///
     /// The default is empty: creation confers nothing unless an authorizer opts in.
-    fn bootstrap_grants(&self, _resource_type: ResourceType) -> &'static [&'static str] {
+    fn bootstrap_grants(&self, _resource_type: ResourceType) -> &[&str] {
         &[]
     }
 
@@ -2965,9 +2973,9 @@ pub mod tests {
         /// but cannot override global hides. See [`Self::check_available_for_user`].
         hidden_for_user: Arc<RwLock<HashMap<String, HashSet<String>>>>,
         server_id: ServerId,
-        /// What creation confers, for tests that exercise the catalog grant arm.
-        /// Empty by default, so no test gains grant rows it did not ask for.
-        bootstrap: &'static [&'static str],
+        /// What creation confers per resource type, for tests that exercise the catalog
+        /// grant arm. Empty by default, so no test gains grant rows it did not ask for.
+        bootstrap: &'static [(ResourceType, &'static [&'static str])],
     }
 
     impl Default for HidingAuthorizer {
@@ -2988,9 +2996,13 @@ pub mod tests {
             }
         }
 
-        /// Make creation confer `privileges` as catalog grant rows.
+        /// Make creation confer privileges as catalog grant rows, per resource type.
+        /// A type absent from `privileges` confers nothing.
         #[must_use]
-        pub fn with_bootstrap_grants(mut self, privileges: &'static [&'static str]) -> Self {
+        pub fn with_bootstrap_grants(
+            mut self,
+            privileges: &'static [(ResourceType, &'static [&'static str])],
+        ) -> Self {
             self.bootstrap = privileges;
             self
         }
@@ -3100,8 +3112,11 @@ pub mod tests {
             self.server_id
         }
 
-        fn bootstrap_grants(&self, _resource_type: ResourceType) -> &'static [&'static str] {
+        fn bootstrap_grants(&self, resource_type: ResourceType) -> &[&str] {
             self.bootstrap
+                .iter()
+                .find(|(declared_for, _)| *declared_for == resource_type)
+                .map_or(&[], |(_, privileges)| *privileges)
         }
 
         #[cfg(feature = "open-api")]

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -1973,6 +1973,27 @@ where
         &[]
     }
 
+    /// Privileges the creating identity receives on a resource it just created, written
+    /// as ordinary grant rows in the same transaction as the resource itself.
+    ///
+    /// Only consulted when grants live in the catalog ([`Self::grants`] returns `None`).
+    /// An authorizer that owns its grant store records what creation confers in its
+    /// `create_*` hooks instead, where it can also write whatever else its model needs.
+    ///
+    /// The owner is the **acting** identity, so a request made under an assumed role
+    /// makes the role the owner — the same identity [`AuthZGrantOps::are_allowed_grants`]
+    /// folds to `None`. An anonymous create leaves no rows.
+    ///
+    /// Names should come from [`Self::grantable_privileges`]: one outside it still lands
+    /// and stays revocable, but listings mark it unrecognized. A name here is a
+    /// commitment that the creator can be *given* it — the write fails, and with it the
+    /// create, if the acting user has no user record yet.
+    ///
+    /// The default is empty: creation confers nothing unless an authorizer opts in.
+    fn bootstrap_grants(&self, _resource_type: ResourceType) -> &'static [&'static str] {
+        &[]
+    }
+
     /// Whether `privilege` is grantable on `resource_type`.
     ///
     /// Derived from [`Self::grantable_privileges`] so the two cannot disagree — an
@@ -2944,6 +2965,9 @@ pub mod tests {
         /// but cannot override global hides. See [`Self::check_available_for_user`].
         hidden_for_user: Arc<RwLock<HashMap<String, HashSet<String>>>>,
         server_id: ServerId,
+        /// What creation confers, for tests that exercise the catalog grant arm.
+        /// Empty by default, so no test gains grant rows it did not ask for.
+        bootstrap: &'static [&'static str],
     }
 
     impl Default for HidingAuthorizer {
@@ -2960,7 +2984,15 @@ pub mod tests {
                 blocked_actions: Arc::new(RwLock::new(HashSet::new())),
                 hidden_for_user: Arc::new(RwLock::new(HashMap::new())),
                 server_id: ServerId::new_random(),
+                bootstrap: &[],
             }
+        }
+
+        /// Make creation confer `privileges` as catalog grant rows.
+        #[must_use]
+        pub fn with_bootstrap_grants(mut self, privileges: &'static [&'static str]) -> Self {
+            self.bootstrap = privileges;
+            self
         }
 
         fn check_available(&self, object: &str) -> bool {
@@ -3066,6 +3098,10 @@ pub mod tests {
 
         fn server_id(&self) -> ServerId {
             self.server_id
+        }
+
+        fn bootstrap_grants(&self, _resource_type: ResourceType) -> &'static [&'static str] {
+            self.bootstrap
         }
 
         #[cfg(feature = "open-api")]

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -2234,15 +2234,15 @@ pub mod tests {
                 privilege: "select".to_string(),
             })
         );
-        let alice = UserOrRoleId::User(UserId::new_unchecked("oidc", "alice"));
+        let alice = UserOrRole::User(UserId::new_unchecked("oidc", "alice"));
         let decisions = authz
             .are_allowed_grants(
                 &md,
                 None,
                 &GrantTarget::Server,
                 &[
-                    GrantAuthorityCheck::any("admin"),
-                    GrantAuthorityCheck::entry("select", &alice, GrantOp::Revoke),
+                    GrantAuthorityCheck::grantable("admin"),
+                    GrantAuthorityCheck::entry("select", Some(&alice), GrantOp::Revoke),
                 ],
             )
             .await
@@ -3142,13 +3142,12 @@ pub mod tests {
             _target: &GrantTarget<'_>,
             checks: &[GrantAuthorityCheck<'_>],
         ) -> std::result::Result<Vec<AuthorizationDecision>, IsAllowedActionError> {
-            // Authority over a direction, and only when the caller names one: a question
-            // that names none is what the vocabulary endpoint asks, and this authorizer
-            // has nothing to say about it.
+            // Authority per direction, so a test can hold revoke authority alone and
+            // watch the grant side of a diff be refused.
             Ok(checks
                 .iter()
                 .map(|check| {
-                    if check.op.is_some_and(|op| self.grant_ops.contains(&op)) {
+                    if self.grant_ops.contains(&check.op) {
                         AuthorizationDecision::allow()
                     } else {
                         AuthorizationDecision::deny()

--- a/crates/lakekeeper/src/service/catalog_store.rs
+++ b/crates/lakekeeper/src/service/catalog_store.rs
@@ -785,15 +785,15 @@ where
         transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'a>,
     ) -> Result<AppliedGrants, ApplyGrantsStoreError>;
 
-    /// Insert grants a resource is born with, inside the transaction that creates it.
+    /// Insert grants, in the transaction that creates the resource they belong to.
     /// Returns the grants actually created; an identical existing grant is skipped.
     ///
-    /// Deliberately not [`Self::apply_grants_impl`] with an empty delete side. That path
-    /// serializes concurrent diffs per resource and sets a transaction-local lock
-    /// timeout, which would leak into the rest of the caller's create transaction — and
-    /// an insert-only write for a resource no other transaction can see yet has no diff
-    /// to cross.
-    async fn bootstrap_grants_impl<'a>(
+    /// Deliberately not [`Self::apply_grants_impl`] with an empty delete side: that path
+    /// serializes concurrent diffs per resource, and sets a transaction-local lock
+    /// timeout to do it that would then govern the rest of the caller's transaction.
+    /// The serialization exists for diffs that cross — each revoking what the other
+    /// adds — so an insert with no delete side has nothing to cross and needs none of it.
+    async fn insert_grants_impl<'a>(
         writes: &[GrantSpec],
         transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'a>,
     ) -> Result<Vec<GrantSpec>, ApplyGrantsStoreError>;

--- a/crates/lakekeeper/src/service/catalog_store.rs
+++ b/crates/lakekeeper/src/service/catalog_store.rs
@@ -785,6 +785,19 @@ where
         transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'a>,
     ) -> Result<AppliedGrants, ApplyGrantsStoreError>;
 
+    /// Insert grants a resource is born with, inside the transaction that creates it.
+    /// Returns the grants actually created; an identical existing grant is skipped.
+    ///
+    /// Deliberately not [`Self::apply_grants_impl`] with an empty delete side. That path
+    /// serializes concurrent diffs per resource and sets a transaction-local lock
+    /// timeout, which would leak into the rest of the caller's create transaction — and
+    /// an insert-only write for a resource no other transaction can see yet has no diff
+    /// to cross.
+    async fn bootstrap_grants_impl<'a>(
+        writes: &[GrantSpec],
+        transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'a>,
+    ) -> Result<Vec<GrantSpec>, ApplyGrantsStoreError>;
+
     /// Remove every grant held by a user, returning what was removed.
     ///
     /// Needed because users are soft-deleted, so no foreign key cascade fires for

--- a/crates/lakekeeper/src/service/catalog_store/grant.rs
+++ b/crates/lakekeeper/src/service/catalog_store/grant.rs
@@ -4,23 +4,16 @@
 //! [`CatalogGrantOps`] owns the transactions so handlers do not have to; the
 //! `*_impl` methods on [`CatalogStore`] do the work inside a caller-supplied one.
 
-use std::sync::Arc;
-
 use http::StatusCode;
 use iceberg_ext::catalog::rest::ErrorModel;
 
 use super::{CatalogStore, Transaction};
 use crate::{
-    api::{RequestMetadata, iceberg::v1::PaginationQuery},
+    api::iceberg::v1::PaginationQuery,
     service::{
         CatalogBackendError, DatabaseIntegrityError, InvalidPaginationToken,
-        authz::{
-            AppliedGrants, Authorizer, GrantFilter, GrantResource, GrantSpec, ListGrantsResultPage,
-            UserOrRoleId,
-        },
-        define_transparent_error,
-        events::{EventDispatcher, GrantsChangedEvent},
-        impl_error_stack_methods, impl_from_with_detail,
+        authz::{AppliedGrants, GrantFilter, GrantSpec, ListGrantsResultPage},
+        define_transparent_error, impl_error_stack_methods, impl_from_with_detail,
     },
 };
 
@@ -153,82 +146,6 @@ define_transparent_error! {
     ]
 }
 
-/// The grant rows a freshly created resource starts with.
-///
-/// Empty — and cheap, without touching the store — when the authorizer keeps its own
-/// grants, when it declares no bootstrap privileges for this kind of resource, or when
-/// nobody is acting. An anonymous create has no owner to name: the server-bootstrap path
-/// creates the default project that way when authentication is disabled.
-///
-/// The owner is the acting identity, so a request narrowed to a role makes the role the
-/// owner rather than the user behind it.
-pub(crate) fn bootstrap_grant_specs<A: Authorizer>(
-    authorizer: &A,
-    metadata: &RequestMetadata,
-    resource: &GrantResource,
-) -> Vec<GrantSpec> {
-    if authorizer.grants().is_some() {
-        return Vec::new();
-    }
-    let privileges = authorizer.bootstrap_grants(resource.resource_type());
-    if privileges.is_empty() {
-        return Vec::new();
-    }
-    let Some(owner) = metadata.actor().to_user_or_role() else {
-        return Vec::new();
-    };
-    let owner = UserOrRoleId::from(&owner);
-    privileges
-        .iter()
-        .map(|privilege| GrantSpec {
-            principal: owner.clone(),
-            resource: resource.clone(),
-            privilege: (*privilege).to_string(),
-        })
-        .collect()
-}
-
-/// Write the bootstrap grants for a just-created resource, in that resource's own
-/// transaction. Returns what was created, for the caller to emit after it commits.
-///
-/// Called after the authorizer's `create_*` hook so a hook failure still aborts first,
-/// and inside the create transaction because the rows reference a resource no other
-/// transaction can see yet.
-pub(crate) async fn write_bootstrap_grants<A: Authorizer, C: CatalogStore>(
-    authorizer: &A,
-    metadata: &RequestMetadata,
-    resource: &GrantResource,
-    transaction: <C::Transaction as Transaction<C::State>>::Transaction<'_>,
-) -> Result<Vec<GrantSpec>, ApplyGrantsStoreError> {
-    let writes = bootstrap_grant_specs(authorizer, metadata, resource);
-    if writes.is_empty() {
-        return Ok(Vec::new());
-    }
-    C::bootstrap_grants_impl(&writes, transaction).await
-}
-
-/// Announce bootstrap grants after their transaction committed.
-///
-/// Grant rows born with a resource still have to reach the audit log: the backend derives
-/// its per-grant records from grant events, so a consumer mirroring them would otherwise
-/// never learn the creator holds anything. Carries no removals — creation revokes nothing.
-pub(crate) async fn emit_bootstrap_grants(
-    dispatcher: &EventDispatcher,
-    request_metadata: Arc<RequestMetadata>,
-    created: Vec<GrantSpec>,
-) {
-    if created.is_empty() {
-        return;
-    }
-    dispatcher
-        .grants_changed(GrantsChangedEvent::new(
-            Vec::new(),
-            created,
-            request_metadata,
-        ))
-        .await;
-}
-
 /// Transaction-owning grant operations, available on every [`CatalogStore`].
 #[async_trait::async_trait]
 pub trait CatalogGrantOps
@@ -264,120 +181,9 @@ where
 
 impl<T> CatalogGrantOps for T where T: CatalogStore {}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        request_metadata::RequestMetadataTestBuilder,
-        service::{
-            RoleId, WarehouseId,
-            authn::{Actor, UserId},
-            authz::{AllowAllAuthorizer, tests::HidingAuthorizer},
-        },
-    };
-
-    fn as_user(user: &UserId) -> RequestMetadata {
-        RequestMetadataTestBuilder::builder()
-            .actor(Actor::Principal(user.clone()))
-            .build()
-    }
-
-    #[test]
-    fn a_full_vocabulary_alone_confers_no_ownership() {
-        // AllowAll publishes every privilege at every level and stores grants in the
-        // catalog, yet declares no bootstrap privileges: an authorizer has to opt in
-        // before creation starts writing rows.
-        let authorizer = AllowAllAuthorizer::default();
-        let metadata = as_user(&UserId::new_unchecked("oidc", "alice"));
-        assert_eq!(
-            bootstrap_grant_specs(
-                &authorizer,
-                &metadata,
-                &GrantResource::Warehouse(WarehouseId::new_random())
-            ),
-            Vec::new()
-        );
-    }
-
-    #[test]
-    fn the_creating_user_gets_one_row_per_declared_privilege() {
-        let authorizer = HidingAuthorizer::new().with_bootstrap_grants(&["ownership", "modify"]);
-        let alice = UserId::new_unchecked("oidc", "alice");
-        let warehouse_id = WarehouseId::new_random();
-        let resource = GrantResource::Warehouse(warehouse_id);
-
-        assert_eq!(
-            bootstrap_grant_specs(&authorizer, &as_user(&alice), &resource),
-            vec![
-                GrantSpec {
-                    principal: UserOrRoleId::User(alice.clone()),
-                    resource: resource.clone(),
-                    privilege: "ownership".to_string(),
-                },
-                GrantSpec {
-                    principal: UserOrRoleId::User(alice),
-                    resource,
-                    privilege: "modify".to_string(),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn an_assumed_role_owns_what_it_creates() {
-        // The acting identity, not the user behind it: a token narrowed to a role must
-        // not make the whole user an owner.
-        let authorizer = HidingAuthorizer::new().with_bootstrap_grants(&["ownership"]);
-        let role_id = RoleId::new_random();
-        let metadata = RequestMetadataTestBuilder::builder()
-            .actor(Actor::Role {
-                principal: UserId::new_unchecked("oidc", "alice"),
-                assumed_role: crate::service::Role::new_random_with_id(role_id).into(),
-            })
-            .build();
-
-        let specs = bootstrap_grant_specs(
-            &authorizer,
-            &metadata,
-            &GrantResource::Project(crate::service::ProjectId::new_random()),
-        );
-        assert_eq!(
-            specs
-                .iter()
-                .map(|spec| spec.principal.clone())
-                .collect::<Vec<_>>(),
-            vec![UserOrRoleId::Role(role_id)]
-        );
-    }
-
-    #[test]
-    fn an_anonymous_create_leaves_no_owner() {
-        // The server-bootstrap path creates the default project this way when
-        // authentication is disabled: there is nobody to own it.
-        let authorizer = HidingAuthorizer::new().with_bootstrap_grants(&["ownership"]);
-        let metadata = RequestMetadataTestBuilder::builder()
-            .actor(Actor::Anonymous)
-            .build();
-        assert_eq!(
-            bootstrap_grant_specs(
-                &authorizer,
-                &metadata,
-                &GrantResource::Warehouse(WarehouseId::new_random())
-            ),
-            Vec::new()
-        );
-    }
-
-    #[test]
-    fn declaring_nothing_writes_nothing() {
-        let authorizer = HidingAuthorizer::new();
-        assert_eq!(
-            bootstrap_grant_specs(
-                &authorizer,
-                &as_user(&UserId::new_unchecked("oidc", "alice")),
-                &GrantResource::Warehouse(WarehouseId::new_random())
-            ),
-            Vec::new()
-        );
-    }
-}
+// Grant writes that happen on behalf of another operation — the rows a resource is born
+// with — surface through that operation's error. Each variant keeps its own status: a
+// missing user is the caller's 400, a lock conflict their retriable 409.
+crate::service::events::impl_authorization_failure_source!(
+    ApplyGrantsStoreError => InternalCatalogError
+);

--- a/crates/lakekeeper/src/service/catalog_store/grant.rs
+++ b/crates/lakekeeper/src/service/catalog_store/grant.rs
@@ -4,16 +4,23 @@
 //! [`CatalogGrantOps`] owns the transactions so handlers do not have to; the
 //! `*_impl` methods on [`CatalogStore`] do the work inside a caller-supplied one.
 
+use std::sync::Arc;
+
 use http::StatusCode;
 use iceberg_ext::catalog::rest::ErrorModel;
 
 use super::{CatalogStore, Transaction};
 use crate::{
-    api::iceberg::v1::PaginationQuery,
+    api::{RequestMetadata, iceberg::v1::PaginationQuery},
     service::{
         CatalogBackendError, DatabaseIntegrityError, InvalidPaginationToken,
-        authz::{AppliedGrants, GrantFilter, GrantSpec, ListGrantsResultPage},
-        define_transparent_error, impl_error_stack_methods, impl_from_with_detail,
+        authz::{
+            AppliedGrants, Authorizer, GrantFilter, GrantResource, GrantSpec, ListGrantsResultPage,
+            UserOrRoleId,
+        },
+        define_transparent_error,
+        events::{EventDispatcher, GrantsChangedEvent},
+        impl_error_stack_methods, impl_from_with_detail,
     },
 };
 
@@ -146,6 +153,82 @@ define_transparent_error! {
     ]
 }
 
+/// The grant rows a freshly created resource starts with.
+///
+/// Empty — and cheap, without touching the store — when the authorizer keeps its own
+/// grants, when it declares no bootstrap privileges for this kind of resource, or when
+/// nobody is acting. An anonymous create has no owner to name: the server-bootstrap path
+/// creates the default project that way when authentication is disabled.
+///
+/// The owner is the acting identity, so a request narrowed to a role makes the role the
+/// owner rather than the user behind it.
+pub(crate) fn bootstrap_grant_specs<A: Authorizer>(
+    authorizer: &A,
+    metadata: &RequestMetadata,
+    resource: &GrantResource,
+) -> Vec<GrantSpec> {
+    if authorizer.grants().is_some() {
+        return Vec::new();
+    }
+    let privileges = authorizer.bootstrap_grants(resource.resource_type());
+    if privileges.is_empty() {
+        return Vec::new();
+    }
+    let Some(owner) = metadata.actor().to_user_or_role() else {
+        return Vec::new();
+    };
+    let owner = UserOrRoleId::from(&owner);
+    privileges
+        .iter()
+        .map(|privilege| GrantSpec {
+            principal: owner.clone(),
+            resource: resource.clone(),
+            privilege: (*privilege).to_string(),
+        })
+        .collect()
+}
+
+/// Write the bootstrap grants for a just-created resource, in that resource's own
+/// transaction. Returns what was created, for the caller to emit after it commits.
+///
+/// Called after the authorizer's `create_*` hook so a hook failure still aborts first,
+/// and inside the create transaction because the rows reference a resource no other
+/// transaction can see yet.
+pub(crate) async fn write_bootstrap_grants<A: Authorizer, C: CatalogStore>(
+    authorizer: &A,
+    metadata: &RequestMetadata,
+    resource: &GrantResource,
+    transaction: <C::Transaction as Transaction<C::State>>::Transaction<'_>,
+) -> Result<Vec<GrantSpec>, ApplyGrantsStoreError> {
+    let writes = bootstrap_grant_specs(authorizer, metadata, resource);
+    if writes.is_empty() {
+        return Ok(Vec::new());
+    }
+    C::bootstrap_grants_impl(&writes, transaction).await
+}
+
+/// Announce bootstrap grants after their transaction committed.
+///
+/// Grant rows born with a resource still have to reach the audit log: the backend derives
+/// its per-grant records from grant events, so a consumer mirroring them would otherwise
+/// never learn the creator holds anything. Carries no removals — creation revokes nothing.
+pub(crate) async fn emit_bootstrap_grants(
+    dispatcher: &EventDispatcher,
+    request_metadata: Arc<RequestMetadata>,
+    created: Vec<GrantSpec>,
+) {
+    if created.is_empty() {
+        return;
+    }
+    dispatcher
+        .grants_changed(GrantsChangedEvent::new(
+            Vec::new(),
+            created,
+            request_metadata,
+        ))
+        .await;
+}
+
 /// Transaction-owning grant operations, available on every [`CatalogStore`].
 #[async_trait::async_trait]
 pub trait CatalogGrantOps
@@ -180,3 +263,121 @@ where
 }
 
 impl<T> CatalogGrantOps for T where T: CatalogStore {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        request_metadata::RequestMetadataTestBuilder,
+        service::{
+            RoleId, WarehouseId,
+            authn::{Actor, UserId},
+            authz::{AllowAllAuthorizer, tests::HidingAuthorizer},
+        },
+    };
+
+    fn as_user(user: &UserId) -> RequestMetadata {
+        RequestMetadataTestBuilder::builder()
+            .actor(Actor::Principal(user.clone()))
+            .build()
+    }
+
+    #[test]
+    fn a_full_vocabulary_alone_confers_no_ownership() {
+        // AllowAll publishes every privilege at every level and stores grants in the
+        // catalog, yet declares no bootstrap privileges: an authorizer has to opt in
+        // before creation starts writing rows.
+        let authorizer = AllowAllAuthorizer::default();
+        let metadata = as_user(&UserId::new_unchecked("oidc", "alice"));
+        assert_eq!(
+            bootstrap_grant_specs(
+                &authorizer,
+                &metadata,
+                &GrantResource::Warehouse(WarehouseId::new_random())
+            ),
+            Vec::new()
+        );
+    }
+
+    #[test]
+    fn the_creating_user_gets_one_row_per_declared_privilege() {
+        let authorizer = HidingAuthorizer::new().with_bootstrap_grants(&["ownership", "modify"]);
+        let alice = UserId::new_unchecked("oidc", "alice");
+        let warehouse_id = WarehouseId::new_random();
+        let resource = GrantResource::Warehouse(warehouse_id);
+
+        assert_eq!(
+            bootstrap_grant_specs(&authorizer, &as_user(&alice), &resource),
+            vec![
+                GrantSpec {
+                    principal: UserOrRoleId::User(alice.clone()),
+                    resource: resource.clone(),
+                    privilege: "ownership".to_string(),
+                },
+                GrantSpec {
+                    principal: UserOrRoleId::User(alice),
+                    resource,
+                    privilege: "modify".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn an_assumed_role_owns_what_it_creates() {
+        // The acting identity, not the user behind it: a token narrowed to a role must
+        // not make the whole user an owner.
+        let authorizer = HidingAuthorizer::new().with_bootstrap_grants(&["ownership"]);
+        let role_id = RoleId::new_random();
+        let metadata = RequestMetadataTestBuilder::builder()
+            .actor(Actor::Role {
+                principal: UserId::new_unchecked("oidc", "alice"),
+                assumed_role: crate::service::Role::new_random_with_id(role_id).into(),
+            })
+            .build();
+
+        let specs = bootstrap_grant_specs(
+            &authorizer,
+            &metadata,
+            &GrantResource::Project(crate::service::ProjectId::new_random()),
+        );
+        assert_eq!(
+            specs
+                .iter()
+                .map(|spec| spec.principal.clone())
+                .collect::<Vec<_>>(),
+            vec![UserOrRoleId::Role(role_id)]
+        );
+    }
+
+    #[test]
+    fn an_anonymous_create_leaves_no_owner() {
+        // The server-bootstrap path creates the default project this way when
+        // authentication is disabled: there is nobody to own it.
+        let authorizer = HidingAuthorizer::new().with_bootstrap_grants(&["ownership"]);
+        let metadata = RequestMetadataTestBuilder::builder()
+            .actor(Actor::Anonymous)
+            .build();
+        assert_eq!(
+            bootstrap_grant_specs(
+                &authorizer,
+                &metadata,
+                &GrantResource::Warehouse(WarehouseId::new_random())
+            ),
+            Vec::new()
+        );
+    }
+
+    #[test]
+    fn declaring_nothing_writes_nothing() {
+        let authorizer = HidingAuthorizer::new();
+        assert_eq!(
+            bootstrap_grant_specs(
+                &authorizer,
+                &as_user(&UserId::new_unchecked("oidc", "alice")),
+                &GrantResource::Warehouse(WarehouseId::new_random())
+            ),
+            Vec::new()
+        );
+    }
+}

--- a/crates/lakekeeper/src/service/events/context.rs
+++ b/crates/lakekeeper/src/service/events/context.rs
@@ -1070,6 +1070,13 @@ where
         self.request_metadata.clone()
     }
 
+    /// For events this context has no `emit_*` of its own — a handler that creates a
+    /// resource also announces the grants it was born with.
+    #[must_use]
+    pub fn dispatcher(&self) -> &EventDispatcher {
+        &self.dispatcher
+    }
+
     pub fn push_extra_context(&mut self, key: impl Into<String>, value: impl Into<String>) {
         self.extra_context.insert(key.into(), value.into());
     }
@@ -1129,11 +1136,6 @@ where
     #[must_use]
     pub fn resolved_mut(&mut self) -> &mut T {
         &mut self.resolved_entity.data
-    }
-
-    #[must_use]
-    pub fn dispatcher(&self) -> &EventDispatcher {
-        &self.dispatcher
     }
 }
 

--- a/crates/lakekeeper/src/service/events/types/grant.rs
+++ b/crates/lakekeeper/src/service/events/types/grant.rs
@@ -7,11 +7,11 @@ use crate::{api::RequestMetadata, service::authz::GrantSpec};
 /// Event emitted when a request changed grants: everything it created and everything it
 /// removed, in one event.
 ///
-/// One event per request rather than one per grant. Both emitters are batch — the apply
-/// endpoint and the cascade when a user is deleted — and the latter is unbounded, so
-/// per-grant events would make dispatch cost scale with a number nothing caps. A
-/// listener that wants per-grant granularity iterates; the audit backend does exactly
-/// that, emitting one record per triple.
+/// One event per request rather than one per grant. Every emitter is batch — the apply
+/// endpoint, the cascade when a user is deleted, and the rows a resource is born with —
+/// and the cascade is unbounded, so per-grant events would make dispatch cost scale with
+/// a number nothing caps. A listener that wants per-grant granularity iterates; the audit
+/// backend does exactly that, emitting one record per triple.
 ///
 /// Each entry carries the whole `(principal, privilege, resource)` triple because that
 /// triple *is* the grant's identity — there is no grant id to reference, and a revoked

--- a/crates/lakekeeper/src/service/events/types/grant.rs
+++ b/crates/lakekeeper/src/service/events/types/grant.rs
@@ -17,6 +17,15 @@ use crate::{api::RequestMetadata, service::authz::GrantSpec};
 /// triple *is* the grant's identity — there is no grant id to reference, and a revoked
 /// grant is hard-deleted, so nothing remains to look up afterwards.
 ///
+/// Not every disappearance is announced. Grant rows are deleted by foreign key with the
+/// principal or resource they name, and only the user-deletion path turns that into an
+/// event — a deleted role, project, warehouse, namespace, tabular or tag definition takes
+/// its grants with it silently, traced by that resource's own deletion event. A listener
+/// mirroring grants must therefore treat a resource deletion as terminating the grants on
+/// it, rather than waiting for a `removed` entry that never comes. Announcing them would
+/// mean reading every affected row back before each delete, on paths that today delete a
+/// whole subtree in one statement.
+///
 /// `removed` is listed before `created` to match the order storage applies them: a diff
 /// that revokes and re-grants the same privilege ends granted.
 #[derive(Clone, Debug)]

--- a/crates/lakekeeper/src/service/events/types/namespace.rs
+++ b/crates/lakekeeper/src/service/events/types/namespace.rs
@@ -14,7 +14,7 @@ use crate::{
         NamespaceWithParent, ResolvedWarehouse,
         authz::{CatalogNamespaceAction, CatalogWarehouseAction},
         events::{
-            APIEventContext, AuthorizationFailureSource,
+            APIEventContext, AuthorizationFailureSource, EventDispatcher,
             context::{
                 AuthzChecked, AuthzState, AuthzUnchecked, ResolutionState, Resolved,
                 ResolvedNamespace, UserProvidedNamespace,
@@ -119,6 +119,15 @@ impl<RW: ResolutionState, RN: ResolutionState, Z: AuthzState>
         match self {
             NamespaceOrWarehouseAPIContext::Warehouse(ctx) => &ctx.request_metadata,
             NamespaceOrWarehouseAPIContext::Namespace(ctx) => &ctx.request_metadata,
+        }
+    }
+
+    /// Either arm carries the same dispatcher — namespace creation is authorized against
+    /// the warehouse or the parent namespace, but emits into one event stream.
+    pub fn dispatcher(&self) -> &EventDispatcher {
+        match self {
+            NamespaceOrWarehouseAPIContext::Warehouse(ctx) => ctx.dispatcher(),
+            NamespaceOrWarehouseAPIContext::Namespace(ctx) => ctx.dispatcher(),
         }
     }
 }

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -1866,7 +1866,7 @@ paths:
         - name: principalUser
           in: query
           description: |-
-            Report which privileges this user may grant, instead of the caller. Requires
+            Report which privileges this user may administer, instead of the caller. Requires
             authority to read the resource's grants, since it discloses another principal's
             access. Mutually exclusive with `principalRole`.
           required: false
@@ -1877,7 +1877,7 @@ paths:
         - name: principalRole
           in: query
           description: |-
-            Report which privileges this role may grant, instead of the caller. Same
+            Report which privileges this role may administer, instead of the caller. Same
             authority requirement as `principalUser`, and mutually exclusive with it.
           required: false
           schema:
@@ -3100,7 +3100,7 @@ paths:
         - name: principalUser
           in: query
           description: |-
-            Report which privileges this user may grant, instead of the caller. Requires
+            Report which privileges this user may administer, instead of the caller. Requires
             authority to read the resource's grants, since it discloses another principal's
             access. Mutually exclusive with `principalRole`.
           required: false
@@ -3111,7 +3111,7 @@ paths:
         - name: principalRole
           in: query
           description: |-
-            Report which privileges this role may grant, instead of the caller. Same
+            Report which privileges this role may administer, instead of the caller. Same
             authority requirement as `principalUser`, and mutually exclusive with it.
           required: false
           schema:
@@ -3629,7 +3629,7 @@ paths:
         - name: principalUser
           in: query
           description: |-
-            Report which privileges this user may grant, instead of the caller. Requires
+            Report which privileges this user may administer, instead of the caller. Requires
             authority to read the resource's grants, since it discloses another principal's
             access. Mutually exclusive with `principalRole`.
           required: false
@@ -3640,7 +3640,7 @@ paths:
         - name: principalRole
           in: query
           description: |-
-            Report which privileges this role may grant, instead of the caller. Same
+            Report which privileges this role may administer, instead of the caller. Same
             authority requirement as `principalUser`, and mutually exclusive with it.
           required: false
           schema:
@@ -4604,7 +4604,7 @@ paths:
         - name: principalUser
           in: query
           description: |-
-            Report which privileges this user may grant, instead of the caller. Requires
+            Report which privileges this user may administer, instead of the caller. Requires
             authority to read the resource's grants, since it discloses another principal's
             access. Mutually exclusive with `principalRole`.
           required: false
@@ -4615,7 +4615,7 @@ paths:
         - name: principalRole
           in: query
           description: |-
-            Report which privileges this role may grant, instead of the caller. Same
+            Report which privileges this role may administer, instead of the caller. Same
             authority requirement as `principalUser`, and mutually exclusive with it.
           required: false
           schema:
@@ -5038,7 +5038,7 @@ paths:
         - name: principalUser
           in: query
           description: |-
-            Report which privileges this user may grant, instead of the caller. Requires
+            Report which privileges this user may administer, instead of the caller. Requires
             authority to read the resource's grants, since it discloses another principal's
             access. Mutually exclusive with `principalRole`.
           required: false
@@ -5049,7 +5049,7 @@ paths:
         - name: principalRole
           in: query
           description: |-
-            Report which privileges this role may grant, instead of the caller. Same
+            Report which privileges this role may administer, instead of the caller. Same
             authority requirement as `principalUser`, and mutually exclusive with it.
           required: false
           schema:
@@ -5330,7 +5330,7 @@ paths:
         - name: principalUser
           in: query
           description: |-
-            Report which privileges this user may grant, instead of the caller. Requires
+            Report which privileges this user may administer, instead of the caller. Requires
             authority to read the resource's grants, since it discloses another principal's
             access. Mutually exclusive with `principalRole`.
           required: false
@@ -5341,7 +5341,7 @@ paths:
         - name: principalRole
           in: query
           description: |-
-            Report which privileges this role may grant, instead of the caller. Same
+            Report which privileges this role may administer, instead of the caller. Same
             authority requirement as `principalUser`, and mutually exclusive with it.
           required: false
           schema:
@@ -6380,7 +6380,7 @@ paths:
         - name: principalUser
           in: query
           description: |-
-            Report which privileges this user may grant, instead of the caller. Requires
+            Report which privileges this user may administer, instead of the caller. Requires
             authority to read the resource's grants, since it discloses another principal's
             access. Mutually exclusive with `principalRole`.
           required: false
@@ -6391,7 +6391,7 @@ paths:
         - name: principalRole
           in: query
           description: |-
-            Report which privileges this role may grant, instead of the caller. Same
+            Report which privileges this role may administer, instead of the caller. Same
             authority requirement as `principalUser`, and mutually exclusive with it.
           required: false
           schema:
@@ -7229,7 +7229,7 @@ paths:
         - name: principalUser
           in: query
           description: |-
-            Report which privileges this user may grant, instead of the caller. Requires
+            Report which privileges this user may administer, instead of the caller. Requires
             authority to read the resource's grants, since it discloses another principal's
             access. Mutually exclusive with `principalRole`.
           required: false
@@ -7240,7 +7240,7 @@ paths:
         - name: principalRole
           in: query
           description: |-
-            Report which privileges this role may grant, instead of the caller. Same
+            Report which privileges this role may administer, instead of the caller. Same
             authority requirement as `principalUser`, and mutually exclusive with it.
           required: false
           schema:
@@ -9611,7 +9611,7 @@ components:
           $ref: '#/components/schemas/GrantResourceResponse'
     GrantablePrivilege:
       type: object
-      description: One privilege of a resource's vocabulary, and whether the principal may grant it.
+      description: One privilege of a resource's vocabulary, and whether the principal may administer it.
       required:
         - privilege
         - allowed
@@ -13156,7 +13156,7 @@ components:
       type: object
       description: |-
         This resource's whole vocabulary, each entry marked with whether the principal may
-        grant it.
+        administer it — grant it, revoke it, or both.
 
         The deployment-wide vocabulary answers "what does this server understand"; this
         answers "what may I do here", which is the question a grant dialog asks. Grant

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -1857,7 +1857,7 @@ paths:
         This API may change in a backward-incompatible way in a future release.
 
         Every privilege this project publishes, each marked with whether the caller may
-        grant and revoke it here. Not filtered: a picker needs to show the ones it
+        administer it here. Not filtered: a picker needs to show the ones it
         cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
         another principal's behalf, which requires authority to read this project's
         grants.
@@ -3091,7 +3091,7 @@ paths:
         This API may change in a backward-incompatible way in a future release.
 
         Every privilege this server publishes, each marked with whether the caller may
-        grant and revoke it here. Not filtered: a picker needs to show the ones it
+        administer it here. Not filtered: a picker needs to show the ones it
         cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
         another principal's behalf, which requires authority to read this server's
         grants.
@@ -3620,7 +3620,7 @@ paths:
         This API may change in a backward-incompatible way in a future release.
 
         Every privilege this tag definition publishes, each marked with whether the caller may
-        grant and revoke it here. Not filtered: a picker needs to show the ones it
+        administer it here. Not filtered: a picker needs to show the ones it
         cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
         another principal's behalf, which requires authority to read this tag definition's
         grants.
@@ -4595,7 +4595,7 @@ paths:
         This API may change in a backward-incompatible way in a future release.
 
         Every privilege this generic table publishes, each marked with whether the caller may
-        grant and revoke it here. Not filtered: a picker needs to show the ones it
+        administer it here. Not filtered: a picker needs to show the ones it
         cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
         another principal's behalf, which requires authority to read this generic table's
         grants.
@@ -5029,7 +5029,7 @@ paths:
         This API may change in a backward-incompatible way in a future release.
 
         Every privilege this warehouse publishes, each marked with whether the caller may
-        grant and revoke it here. Not filtered: a picker needs to show the ones it
+        administer it here. Not filtered: a picker needs to show the ones it
         cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
         another principal's behalf, which requires authority to read this warehouse's
         grants.
@@ -5321,7 +5321,7 @@ paths:
         This API may change in a backward-incompatible way in a future release.
 
         Every privilege this namespace publishes, each marked with whether the caller may
-        grant and revoke it here. Not filtered: a picker needs to show the ones it
+        administer it here. Not filtered: a picker needs to show the ones it
         cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
         another principal's behalf, which requires authority to read this namespace's
         grants.
@@ -6371,7 +6371,7 @@ paths:
         This API may change in a backward-incompatible way in a future release.
 
         Every privilege this table publishes, each marked with whether the caller may
-        grant and revoke it here. Not filtered: a picker needs to show the ones it
+        administer it here. Not filtered: a picker needs to show the ones it
         cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
         another principal's behalf, which requires authority to read this table's
         grants.
@@ -7220,7 +7220,7 @@ paths:
         This API may change in a backward-incompatible way in a future release.
 
         Every privilege this view publishes, each marked with whether the caller may
-        grant and revoke it here. Not filtered: a picker needs to show the ones it
+        administer it here. Not filtered: a picker needs to show the ones it
         cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
         another principal's behalf, which requires authority to read this view's
         grants.
@@ -9619,9 +9619,8 @@ components:
         allowed:
           type: boolean
           description: |-
-            Whether the principal has authority over this privilege on this resource. Asked
-            without a direction, so an authorizer that separates granting from revoking may
-            answer for either; an apply is checked per entry.
+            Whether the principal may administer this privilege here — grant it, revoke it, or
+            both. Advisory: an apply checks each of its entries on its own.
         privilege:
           $ref: '#/components/schemas/PrivilegeDescriptor'
           description: |-

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -9618,7 +9618,10 @@ components:
       properties:
         allowed:
           type: boolean
-          description: Whether the principal may grant and revoke this privilege on this resource.
+          description: |-
+            Whether the principal has authority over this privilege on this resource. Asked
+            without a direction, so an authorizer that separates granting from revoking may
+            answer for either; an apply is checked per entry.
         privilege:
           $ref: '#/components/schemas/PrivilegeDescriptor'
           description: |-

--- a/docs/docs/grants.md
+++ b/docs/docs/grants.md
@@ -140,6 +140,7 @@ Grants say what a principal *may* do. They cannot express deny rules, conditions
 
 **Lifecycle.**
 
+- Creating a resource can grant the creator privileges on it, if the authorization backend says creation confers them.
 - Deleting a resource revokes its grants with it. Under OpenFGA this covers the deleted resource itself but not everything inside a deleted warehouse — see [grants outlive the resources they name](./authorization-openfga.md#managing-grants-through-the-grants-api).
 - Deleting a user revokes their grants, so a re-created user id never inherits access.
 - Soft-deleted tables and views keep their grants until expiration, so an undrop restores the access that was there before. They stay visible on the resource's own listing and are left out of the project-scoped listing until the table is restored.

--- a/docs/docs/grants.md
+++ b/docs/docs/grants.md
@@ -143,6 +143,7 @@ Grants say what a principal *may* do. They cannot express deny rules, conditions
 - Creating a resource can grant the creator privileges on it, if the authorization backend says creation confers them.
 - Deleting a resource revokes its grants with it. Under OpenFGA this covers the deleted resource itself but not everything inside a deleted warehouse — see [grants outlive the resources they name](./authorization-openfga.md#managing-grants-through-the-grants-api).
 - Deleting a user revokes their grants, so a re-created user id never inherits access.
+- Grants removed *with* their principal or resource are not audited individually: deleting a user emits one revocation record per grant, but deleting a role or a resource does not. The deletion of the role or resource is the audit record, and the grants on it are gone by definition. Only explicit revocations through the grants API produce per-grant records.
 - Soft-deleted tables and views keep their grants until expiration, so an undrop restores the access that was there before. They stay visible on the resource's own listing and are left out of the project-scoped listing until the table is restored.
 - Deactivating a warehouse hides its children's grants but not its own, so an administrator can still audit and revoke at the warehouse level.
 


### PR DESCRIPTION
An authorizer that stores grants in the catalog had no way to say what creating a resource confers, so a created warehouse, namespace or table had no owner and nothing to build owner-may-grant rules on. The authz create hook cannot fill that gap: it runs inside the create transaction with only ids, and grant rows reference the resource it has not committed yet, so a write over a second connection either violates the foreign key or races the commit — and holding a second connection while a transaction is open risks starving the pool.

Authorizers now declare `bootstrap_grants` per resource type, and the create path writes those rows in the resource's own transaction, for the acting identity: under an assumed role, the role owns what it creates. Nothing happens by default, and the tuple-based arm keeps recording ownership in its own store.

Bootstrap gets its own insert-only store method rather than the diff path, whose per-resource serialization sets a transaction-local lock timeout that would otherwise apply to the rest of every create.

Re-registering a table over one that keeps its id now also records ownership; that path runs no create hook, and the in-transaction drop takes the old table's grants with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Newly created projects, warehouses, namespaces, tables, views, generic tables, and tag definitions can receive configured bootstrap grants.
  - Grant and revoke authorization checks validate each change independently.
  - Grant events are emitted for newly created bootstrap grants.
  - Documentation now covers creator privileges and grant-removal audit behavior.

- **Bug Fixes**
  - Bootstrap grants are created transactionally, with duplicate grants avoided.
  - Anonymous or unregistered creators receive no bootstrap grants, and rejected creations are not persisted.
  - Re-registering a table preserves its ownership grant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->