### PR TITLE
feat(signer): serve the spec's per-table sign route and advertise it 

### DIFF
--- a/.sqlx/query-3f118743d59e0e035f57c9106816533c092fead83b8420cdab3149b040664910.json
+++ b/.sqlx/query-3f118743d59e0e035f57c9106816533c092fead83b8420cdab3149b040664910.json
@@ -194,7 +194,8 @@
                 "management-v1-get-view-grantable-privileges",
                 "management-v1-get-generic-table-grantable-privileges",
                 "management-v1-get-tag-grantable-privileges",
-                "management-v1-move-namespace"
+                "management-v1-move-namespace",
+                "sign-s3-request-by-table-name"
               ]
             }
           }

--- a/.sqlx/query-62b9aeb0ed103e7f63a42f246d713b7727307c032df2c983e7ab8a72d569ddb1.json
+++ b/.sqlx/query-62b9aeb0ed103e7f63a42f246d713b7727307c032df2c983e7ab8a72d569ddb1.json
@@ -209,7 +209,8 @@
                       "management-v1-get-view-grantable-privileges",
                       "management-v1-get-generic-table-grantable-privileges",
                       "management-v1-get-tag-grantable-privileges",
-                      "management-v1-move-namespace"
+                      "management-v1-move-namespace",
+                      "sign-s3-request-by-table-name"
                     ]
                   }
                 }

--- a/.sqlx/query-6eb81444b25f070f01777ccbbc5f7b662bb3ed494b55616479cd36c66694f968.json
+++ b/.sqlx/query-6eb81444b25f070f01777ccbbc5f7b662bb3ed494b55616479cd36c66694f968.json
@@ -199,7 +199,8 @@
                       "management-v1-get-view-grantable-privileges",
                       "management-v1-get-generic-table-grantable-privileges",
                       "management-v1-get-tag-grantable-privileges",
-                      "management-v1-move-namespace"
+                      "management-v1-move-namespace",
+                      "sign-s3-request-by-table-name"
                     ]
                   }
                 }

--- a/.sqlx/query-f0f4d3b6d69711b2bb9c94ea2ed752dfb1b220cf4ddb02f02c6a3b6ebebdf5d6.json
+++ b/.sqlx/query-f0f4d3b6d69711b2bb9c94ea2ed752dfb1b220cf4ddb02f02c6a3b6ebebdf5d6.json
@@ -202,7 +202,8 @@
                 "management-v1-get-view-grantable-privileges",
                 "management-v1-get-generic-table-grantable-privileges",
                 "management-v1-get-tag-grantable-privileges",
-                "management-v1-move-namespace"
+                "management-v1-move-namespace",
+                "sign-s3-request-by-table-name"
               ]
             }
           }

--- a/crates/iceberg-ext/src/catalog/mod.rs
+++ b/crates/iceberg-ext/src/catalog/mod.rs
@@ -11,7 +11,7 @@ pub mod rest {
     pub use catalog_config::CatalogConfig;
 
     mod s3_signer;
-    pub use s3_signer::{S3SignRequest, S3SignResponse};
+    pub use s3_signer::{RemoteSigningConfig, S3SignRequest, S3SignResponse};
 
     mod view_update;
     pub use view_update::ViewUpdate;

--- a/crates/iceberg-ext/src/catalog/rest/s3_signer.rs
+++ b/crates/iceberg-ext/src/catalog/rest/s3_signer.rs
@@ -30,9 +30,10 @@ pub struct S3SignRequest {
 /// Signer settings advertised on `loadTable`, superseding the deprecated
 /// `signer.uri` / `signer.endpoint` config keys.
 ///
-/// Deliberately carries no endpoint: a client that reads this field derives the
-/// endpoint as the table's standard `…/tables/{table}/sign` path, which is why
-/// serving that route is a precondition for emitting this at all.
+/// Deliberately carries no endpoint: a client that reads this field calls the
+/// table's standard `…/tables/{table}/sign` path, discovered through the
+/// `endpoints` capability list, which is why serving that route is a
+/// precondition for emitting this at all.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "kebab-case")]
 pub struct RemoteSigningConfig {

--- a/crates/iceberg-ext/src/catalog/rest/s3_signer.rs
+++ b/crates/iceberg-ext/src/catalog/rest/s3_signer.rs
@@ -13,6 +13,37 @@ pub struct S3SignRequest {
     pub method: http::Method,
     pub headers: HashMap<String, Vec<String>>,
     pub body: Option<String>,
+    /// Echoed back verbatim from [`RemoteSigningConfig::properties`]. The spec
+    /// makes this the signer's only channel for per-table state, since the
+    /// config carries no endpoint of its own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub properties: Option<HashMap<String, String>>,
+    /// Storage provider the request is to be signed for, matching the scheme of
+    /// a native storage URI. Absent means `s3`, per the spec's backwards
+    /// compatibility rule.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub provider: Option<String>,
+}
+
+/// Signer settings advertised on `loadTable`, superseding the deprecated
+/// `signer.uri` / `signer.endpoint` config keys.
+///
+/// Deliberately carries no endpoint: a client that reads this field derives the
+/// endpoint as the table's standard `…/tables/{table}/sign` path, which is why
+/// serving that route is a precondition for emitting this at all.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[serde(rename_all = "kebab-case")]
+pub struct RemoteSigningConfig {
+    /// Passed through unchanged in the `properties` of every sign request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub properties: Option<HashMap<String, String>>,
+    /// Included unchanged in every request to the signing endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub headers: Option<HashMap<String, Vec<String>>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TypedBuilder)]
@@ -72,6 +103,55 @@ mod tests {
         let serialized = serde_json::to_string(&sign_request).unwrap();
         let deserialized: S3SignRequest = serde_json::from_str(&serialized).unwrap();
         assert_eq!(sign_request, deserialized);
+    }
+
+    /// Every released signing client predates `properties` / `provider`. Their
+    /// payloads must keep deserializing, and we must not start emitting the new
+    /// keys as `null` to servers reading them back.
+    #[test]
+    fn sign_request_stays_compatible_without_the_new_fields() {
+        let legacy = serde_json::json!({
+            "region": "us-west-2",
+            "uri": "https://example.com",
+            "method": "GET",
+            "headers": {},
+            "body": null,
+        });
+        let parsed: S3SignRequest = serde_json::from_value(legacy).unwrap();
+        assert_eq!(parsed.properties, None);
+        assert_eq!(parsed.provider, None);
+
+        let reserialized = serde_json::to_value(&parsed).unwrap();
+        assert!(reserialized.get("properties").is_none());
+        assert!(reserialized.get("provider").is_none());
+    }
+
+    #[test]
+    fn sign_request_round_trips_the_new_fields() {
+        let request = S3SignRequest::builder()
+            .region("us-west-2".to_string())
+            .uri(url::Url::parse("https://example.com").unwrap())
+            .method(http::Method::GET)
+            .headers(HashMap::new())
+            .body(None)
+            .properties(Some(HashMap::from([(
+                "lakekeeper.tabular-id".to_string(),
+                "some-id".to_string(),
+            )])))
+            .provider(Some("s3".to_string()))
+            .build();
+
+        let round_tripped: S3SignRequest =
+            serde_json::from_str(&serde_json::to_string(&request).unwrap()).unwrap();
+        assert_eq!(request, round_tripped);
+    }
+
+    /// Absence is the signal that a client should fall back to the deprecated
+    /// `signer.*` config keys, so an unset config must not serialize as `null`.
+    #[test]
+    fn remote_signing_config_omits_unset_fields() {
+        let serialized = serde_json::to_value(RemoteSigningConfig::default()).unwrap();
+        assert_eq!(serialized, serde_json::json!({}));
     }
 
     #[test]

--- a/crates/iceberg-ext/src/catalog/rest/table.rs
+++ b/crates/iceberg-ext/src/catalog/rest/table.rs
@@ -37,10 +37,10 @@ pub struct LoadTableResult {
     pub config: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_credentials: Option<Vec<StorageCredential>>,
-    /// Signer settings for clients that support them. Its presence is what tells
-    /// a client to use the standard per-table `/sign` endpoint instead of the
-    /// deprecated `signer.uri` / `signer.endpoint` config keys, so it is omitted
-    /// rather than sent as `null` when remote signing is off.
+    /// Signer settings for clients that support them, superseding the deprecated
+    /// `signer.uri` / `signer.endpoint` config keys. Omitted rather than sent as
+    /// `null` when remote signing is off, since a client that finds it absent
+    /// falls back to those keys.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_signing_config: Option<RemoteSigningConfig>,
     /// Validator for this exact body, emitted as the `ETag` header.

--- a/crates/iceberg-ext/src/catalog/rest/table.rs
+++ b/crates/iceberg-ext/src/catalog/rest/table.rs
@@ -11,7 +11,7 @@ use typed_builder::TypedBuilder;
 #[cfg(feature = "axum")]
 use super::impl_into_response;
 use crate::{
-    catalog::{TableIdent, TableRequirement, TableUpdate},
+    catalog::{TableIdent, TableRequirement, TableUpdate, rest::RemoteSigningConfig},
     spec::{Schema, SortOrder, UnboundPartitionSpec},
 };
 
@@ -37,6 +37,12 @@ pub struct LoadTableResult {
     pub config: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_credentials: Option<Vec<StorageCredential>>,
+    /// Signer settings for clients that support them. Its presence is what tells
+    /// a client to use the standard per-table `/sign` endpoint instead of the
+    /// deprecated `signer.uri` / `signer.endpoint` config keys, so it is omitted
+    /// rather than sent as `null` when remote signing is off.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_signing_config: Option<RemoteSigningConfig>,
     /// Validator for this exact body, emitted as the `ETag` header.
     ///
     /// Not serialized, and deliberately not derivable from this struct: the tag
@@ -240,6 +246,7 @@ mod tests {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
+            remote_signing_config: None,
             etag: Some(ETag::from("W/\"lk2.deadbeef\"")),
         };
 
@@ -259,6 +266,7 @@ mod tests {
             metadata: create_table_metadata_mock(),
             config: None,
             storage_credentials: None,
+            remote_signing_config: None,
             etag: Some(ETag::from("W/\"lk2.abc.199e1e0f9c3\"")),
         };
 
@@ -279,6 +287,7 @@ mod tests {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
+            remote_signing_config: None,
             // Staged tables have no metadata location, so the caller mints no tag.
             etag: None,
         };
@@ -299,6 +308,7 @@ mod tests {
             metadata: table_metadata.clone(),
             config: None,
             storage_credentials: None,
+            remote_signing_config: None,
             etag: Some(ETag::from("W/\"lk2.deadbeef\"")),
         };
 

--- a/crates/lakekeeper-integration-tests/tests/server_generic_table_signing.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_generic_table_signing.rs
@@ -957,9 +957,9 @@ async fn test_sign_by_table_name(pool: PgPool) {
     assert_signed(&response);
 }
 
-/// A name can be renamed out from under an open session. The name route stays
-/// usable because it falls back to resolving the table from the request
-/// location — the same fallback the id route relies on.
+/// A name that resolves to nothing still signs: the route falls back to
+/// resolving the table from the request location, as the id route does for an
+/// unknown id.
 #[sqlx::test]
 async fn test_sign_by_table_name_falls_back_to_the_request_location(pool: PgPool) {
     let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
@@ -979,6 +979,34 @@ async fn test_sign_by_table_name_falls_back_to_the_request_location(pool: PgPool
     .await
     .expect("a stale name must still sign via the request location");
     assert_signed(&response);
+}
+
+/// Naming a real table in the path does not license signing anything: the
+/// request URI must still fall under that table's location. A URI outside it is
+/// resolved by location instead, and is refused when no tabular owns it — the
+/// same guard the id route applies.
+#[sqlx::test]
+async fn test_sign_by_table_name_cross_checks_the_request_location(pool: PgPool) {
+    let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
+    create_catalog_table(&ctx, &namespace_name, warehouse_id, "named_table").await;
+
+    // The namespace directory above the table belongs to no tabular.
+    let err = CatalogServer::sign(
+        Some(Prefix(warehouse_id.to_string())),
+        SignTarget::Table(Box::new(TableIdent::new(
+            NamespaceIdent::new(namespace_name.clone()),
+            "named_table".to_string(),
+        ))),
+        sign_request(
+            Method::GET,
+            sign_url(&format!("s3://{BUCKET}/{namespace_name}"), "file.bin"),
+        ),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .expect_err("a URI outside the named table's location must not be signed");
+    assert_eq!(err.error.r#type, "NoSuchTableLocationException", "{err:?}");
 }
 
 /// `provider` is absent-means-s3 per the spec. Anything else must be refused
@@ -1018,8 +1046,11 @@ async fn test_sign_rejects_a_foreign_provider(pool: PgPool) {
 }
 
 /// `loadTable` advertises the signer settings that replace `signer.uri` /
-/// `signer.endpoint`. Presence is the signal, so it must carry the table id and
-/// must appear only when remote signing is actually on.
+/// `signer.endpoint`. Presence alone is the signal: the config is deliberately
+/// empty, since the sign route comes from the `endpoints` capability list and the
+/// signer resolves the table from the request path, so there is nothing for the
+/// client to echo back. Whether it appears at all is decided — and tested — where
+/// the storage profile builds the table config.
 #[sqlx::test]
 async fn test_load_table_advertises_remote_signing_config(pool: PgPool) {
     let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;

--- a/crates/lakekeeper-integration-tests/tests/server_generic_table_signing.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_generic_table_signing.rs
@@ -20,7 +20,12 @@ use lakekeeper::{
         },
         iceberg::{
             types::Prefix,
-            v1::{DataAccess, namespace::NamespaceParameters, s3_signer::Service as _},
+            v1::{
+                DataAccess, LoadTableResultOrNotModified, TableParameters,
+                namespace::NamespaceParameters,
+                s3_signer::{Service as _, SignTarget},
+                tables::{LoadTableRequest, TablesService as _},
+            },
         },
     },
     server::{CatalogServer, tables::create_table::create_table_request_into_table_metadata},
@@ -353,7 +358,7 @@ async fn sign_warehouse_scoped_request<A: Authorizer>(
 ) -> lakekeeper::api::Result<S3SignResponse> {
     CatalogServer::sign(
         Some(Prefix(warehouse_id.to_string())),
-        None,
+        SignTarget::FromRequestUri,
         request,
         ctx.clone(),
         random_request_metadata(),
@@ -372,7 +377,7 @@ async fn sign_table_scoped<A: Authorizer>(
 ) -> lakekeeper::api::Result<S3SignResponse> {
     CatalogServer::sign(
         Some(Prefix(warehouse_id.to_string())),
-        Some(tabular_id),
+        SignTarget::TabularId(tabular_id),
         sign_request(method, sign_url(base_location, "data/file.bin")),
         ctx.clone(),
         random_request_metadata(),
@@ -690,7 +695,7 @@ async fn test_sign_iceberg_table_list_prefix(pool: PgPool) {
 
     let response = CatalogServer::sign(
         Some(Prefix(warehouse_id.to_string())),
-        Some(*table_id),
+        SignTarget::TabularId(*table_id),
         list_prefix_request(&prefix),
         ctx.clone(),
         random_request_metadata(),
@@ -703,7 +708,7 @@ async fn test_sign_iceberg_table_list_prefix(pool: PgPool) {
     // path owns it, then again after authorization. Both must apply the directory rule.
     let err = CatalogServer::sign(
         Some(Prefix(warehouse_id.to_string())),
-        Some(*table_id),
+        SignTarget::TabularId(*table_id),
         list_prefix_request(prefix.trim_end_matches('/')),
         ctx.clone(),
         random_request_metadata(),
@@ -925,5 +930,141 @@ async fn test_generic_table_load_omits_credentials_when_nothing_is_vended(pool: 
         config.get("s3.endpoint").map(String::as_str),
         Some(format!("{ENDPOINT}/").as_str()),
         "config must still carry the endpoint: {config:?}"
+    );
+}
+
+/// The spec's per-table signer route (`…/tables/{table}/sign`), which adopting
+/// `remote-signing-config` obliges us to serve since that config carries no
+/// endpoint of its own.
+#[sqlx::test]
+async fn test_sign_by_table_name(pool: PgPool) {
+    let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
+    let (_table_id, location) =
+        create_catalog_table(&ctx, &namespace_name, warehouse_id, "by_name").await;
+
+    let response = CatalogServer::sign(
+        Some(Prefix(warehouse_id.to_string())),
+        SignTarget::Table(Box::new(TableIdent::new(
+            NamespaceIdent::new(namespace_name),
+            "by_name".to_string(),
+        ))),
+        sign_request(Method::GET, sign_url(location.as_ref(), "data/file.bin")),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .expect("the standard per-table signer route must sign for a table named in the path");
+    assert_signed(&response);
+}
+
+/// A name can be renamed out from under an open session. The name route stays
+/// usable because it falls back to resolving the table from the request
+/// location — the same fallback the id route relies on.
+#[sqlx::test]
+async fn test_sign_by_table_name_falls_back_to_the_request_location(pool: PgPool) {
+    let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
+    let (_table_id, location) =
+        create_catalog_table(&ctx, &namespace_name, warehouse_id, "real_name").await;
+
+    let response = CatalogServer::sign(
+        Some(Prefix(warehouse_id.to_string())),
+        SignTarget::Table(Box::new(TableIdent::new(
+            NamespaceIdent::new(namespace_name),
+            "name_it_no_longer_has".to_string(),
+        ))),
+        sign_request(Method::GET, sign_url(location.as_ref(), "data/file.bin")),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .expect("a stale name must still sign via the request location");
+    assert_signed(&response);
+}
+
+/// `provider` is absent-means-s3 per the spec. Anything else must be refused
+/// rather than quietly signed as S3.
+#[sqlx::test]
+async fn test_sign_rejects_a_foreign_provider(pool: PgPool) {
+    let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
+    let (table_id, location) =
+        create_catalog_table(&ctx, &namespace_name, warehouse_id, "provider_check").await;
+
+    let mut request = sign_request(Method::GET, sign_url(location.as_ref(), "data/file.bin"));
+    request.provider = Some("gcs".to_string());
+
+    let err = CatalogServer::sign(
+        Some(Prefix(warehouse_id.to_string())),
+        SignTarget::TabularId(*table_id),
+        request,
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .expect_err("a non-s3 provider must not be signed as s3");
+    assert_eq!(err.error.code, StatusCode::BAD_REQUEST, "{err:?}");
+    assert_eq!(err.error.r#type, "UnsupportedSignerProvider", "{err:?}");
+
+    // Absent still means s3.
+    let response = CatalogServer::sign(
+        Some(Prefix(warehouse_id.to_string())),
+        SignTarget::TabularId(*table_id),
+        sign_request(Method::GET, sign_url(location.as_ref(), "data/file.bin")),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .expect("an absent provider means s3");
+    assert_signed(&response);
+}
+
+/// `loadTable` advertises the signer settings that replace `signer.uri` /
+/// `signer.endpoint`. Presence is the signal, so it must carry the table id and
+/// must appear only when remote signing is actually on.
+#[sqlx::test]
+async fn test_load_table_advertises_remote_signing_config(pool: PgPool) {
+    let (ctx, namespace_name, warehouse_id) = setup(pool, AllowAllAuthorizer::default()).await;
+    create_catalog_table(&ctx, &namespace_name, warehouse_id, "advertised").await;
+
+    let response = CatalogServer::load_table(
+        TableParameters {
+            prefix: Some(Prefix(warehouse_id.to_string())),
+            table: TableIdent::new(
+                NamespaceIdent::new(namespace_name),
+                "advertised".to_string(),
+            ),
+        },
+        LoadTableRequest::builder()
+            .data_access(
+                DataAccess {
+                    vended_credentials: false,
+                    remote_signing: true,
+                }
+                .into(),
+            )
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .expect("loading the table must succeed");
+
+    let LoadTableResultOrNotModified::LoadTableResult(response) = response else {
+        panic!("an unconditional load must not return 304");
+    };
+
+    let signing = response
+        .remote_signing_config
+        .expect("remote signing is enabled, so the config must be advertised");
+    assert_eq!(
+        signing,
+        Default::default(),
+        "presence is the signal; we advertise no properties or headers: {signing:?}"
+    );
+
+    // The deprecated keys stay: no released client reads the config yet.
+    let config = response.config.expect("load response must carry a config");
+    assert!(
+        config.contains_key("signer.endpoint"),
+        "the deprecated signer keys must remain until clients read the config: {config:?}"
     );
 }

--- a/crates/lakekeeper-storage-postgres/migrations/20260814090000_sign_by_table_name_endpoint.sql
+++ b/crates/lakekeeper-storage-postgres/migrations/20260814090000_sign_by_table_name_endpoint.sql
@@ -1,0 +1,1 @@
+ALTER TYPE api_endpoints ADD VALUE 'sign-s3-request-by-table-name';

--- a/crates/lakekeeper-storage-postgres/migrations/20260814090000_sign_by_table_name_endpoint.sql
+++ b/crates/lakekeeper-storage-postgres/migrations/20260814090000_sign_by_table_name_endpoint.sql
@@ -1,1 +1,1 @@
-ALTER TYPE api_endpoints ADD VALUE 'sign-s3-request-by-table-name';
+alter type api_endpoints add value if not exists 'sign-s3-request-by-table-name';

--- a/crates/lakekeeper/src/api/endpoints.rs
+++ b/crates/lakekeeper/src/api/endpoints.rs
@@ -194,6 +194,7 @@ generate_endpoints! {
         S3RequestGlobal(POST, "/catalog/v1/aws/s3/sign"),
         S3RequestPrefix(POST, "/catalog/v1/{prefix}/v1/aws/s3/sign"),
         S3RequestTabular(POST, "/catalog/v1/signer/{prefix}/tabular-id/{tabular_id}/v1/aws/s3/sign"),
+        S3RequestByTableName(POST, "/catalog/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign"),
     }
 
     enum ManagementV1 {

--- a/crates/lakekeeper/src/api/iceberg/mod.rs
+++ b/crates/lakekeeper/src/api/iceberg/mod.rs
@@ -302,6 +302,25 @@ pub(crate) fn supported_endpoints() -> &'static [String] {
     &SUPPORTED_ENDPOINTS
 }
 
+/// [`supported_endpoints`] plus the spec's per-table signing route.
+///
+/// Signing is not in the common list because it is only reachable on S3
+/// warehouses that allow remote signing. It has to be advertised somewhere
+/// though: the route is the endpoint `remote-signing-config` implies, and a
+/// client that gates calls on this list would otherwise never make one.
+pub(crate) fn supported_endpoints_with_signing() -> &'static [String] {
+    static ENDPOINTS: LazyLock<Vec<String>> = LazyLock::new(|| {
+        let mut endpoints = SUPPORTED_ENDPOINTS.clone();
+        endpoints.push(
+            crate::api::endpoints::SignEndpoint::S3RequestByTableName
+                .as_http_route()
+                .replace(" /catalog/", " /"),
+        );
+        endpoints
+    });
+    &ENDPOINTS
+}
+
 #[cfg(test)]
 mod test {
     use uuid::Uuid;

--- a/crates/lakekeeper/src/api/iceberg/v1/s3_signer.rs
+++ b/crates/lakekeeper/src/api/iceberg/v1/s3_signer.rs
@@ -6,7 +6,10 @@ use axum::{
 };
 use iceberg_ext::catalog::rest::{S3SignRequest, S3SignResponse};
 
-use super::{ApiContext, Prefix, Result, TableIdent, namespace::NamespaceIdentUrl};
+use super::{
+    ApiContext, Prefix, Result, TableIdent, namespace::NamespaceIdentUrl,
+    tables::normalize_tabular_name,
+};
 use crate::request_metadata::RequestMetadata;
 
 /// The spec's per-table signer route, relative to the catalog v1 mount.
@@ -25,6 +28,20 @@ pub enum SignTarget {
     TabularId(uuid::Uuid),
     /// The spec's `…/tables/{table}/sign` route, addressed by name.
     Table(Box<TableIdent>),
+}
+
+impl SignTarget {
+    /// Build the target the spec's per-table route addresses.
+    ///
+    /// The table segment gets the same `+`-to-space normalization every other
+    /// table route applies, so a client that encodes a space one way on
+    /// `loadTable` and the other way here still reaches the same table.
+    fn from_table_path(namespace: NamespaceIdentUrl, table: &str) -> Self {
+        Self::Table(Box::new(TableIdent {
+            namespace: namespace.into(),
+            name: normalize_tabular_name(table),
+        }))
+    }
 }
 
 #[async_trait]
@@ -108,10 +125,7 @@ pub fn router<I: Service<S>, S: crate::api::ThreadSafe>() -> Router<ApiContext<S
                  Json(request): Json<S3SignRequest>| {
                     I::sign(
                         Some(prefix),
-                        SignTarget::Table(Box::new(TableIdent {
-                            namespace: namespace.into(),
-                            name: table,
-                        })),
+                        SignTarget::from_table_path(namespace, &table),
                         request,
                         api_context,
                         metadata,
@@ -123,8 +137,10 @@ pub fn router<I: Service<S>, S: crate::api::ThreadSafe>() -> Router<ApiContext<S
 
 #[cfg(test)]
 mod tests {
+    use tower::ServiceExt;
+
     use super::*;
-    use crate::api::endpoints::Endpoint;
+    use crate::api::{ErrorModel, endpoints::Endpoint};
 
     /// Endpoint statistics key on axum's matched path, so if the route literal
     /// and the endpoint table drift apart the route silently stops being counted.
@@ -134,5 +150,78 @@ mod tests {
         let endpoint = Endpoint::from_method_and_matched_path(&http::Method::POST, &matched)
             .expect("the standard sign route must be in the endpoint table");
         assert_eq!(endpoint.as_http_route(), format!("POST {matched}"));
+    }
+
+    /// Exercises the route through axum, so the path extractors — multipart
+    /// namespace separator and table-name normalization — are covered rather
+    /// than bypassed by handing a [`SignTarget`] to the service directly.
+    #[tokio::test]
+    async fn the_standard_sign_route_parses_namespace_and_table_from_the_path() {
+        #[derive(Debug, Clone)]
+        struct TestService;
+
+        #[derive(Debug, Clone)]
+        struct ThisState;
+
+        impl crate::api::ThreadSafe for ThisState {}
+
+        #[async_trait]
+        impl Service<ThisState> for TestService {
+            async fn sign(
+                _prefix: Option<Prefix>,
+                target: SignTarget,
+                _request: S3SignRequest,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> Result<S3SignResponse> {
+                // The target is what is under test, so report it back as an error message.
+                Err(ErrorModel::bad_request(format!("{target:?}"), "TargetUnderTest", None).into())
+            }
+        }
+
+        let router = axum::Router::new()
+            .merge(super::router::<TestService, ThisState>())
+            .with_state(ApiContext {
+                v1_state: ThisState,
+            });
+
+        let mut req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(format!(
+                "/{}/namespaces/ns1%1Fns2/tables/my+table/sign",
+                uuid::Uuid::now_v7()
+            ))
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::from(
+                serde_json::json!({
+                    "region": "us-east-1",
+                    "uri": "https://example.com/foo/bar",
+                    "method": "GET",
+                    "headers": {},
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        req.extensions_mut()
+            .insert(RequestMetadata::new_unauthenticated());
+
+        let response = router.oneshot(req).await.unwrap();
+        assert_eq!(response.status().as_u16(), 400);
+        let bytes = http_body_util::BodyExt::collect(response)
+            .await
+            .unwrap()
+            .to_bytes();
+        let error: crate::api::IcebergErrorResponse =
+            serde_json::from_slice(&bytes).expect("the route must be served, not 404");
+
+        let expected = SignTarget::Table(Box::new(TableIdent {
+            namespace: super::super::NamespaceIdent::from_vec(vec![
+                "ns1".to_string(),
+                "ns2".to_string(),
+            ])
+            .unwrap(),
+            name: "my table".to_string(),
+        }));
+        assert_eq!(error.error.message, format!("{expected:?}"));
     }
 }

--- a/crates/lakekeeper/src/api/iceberg/v1/s3_signer.rs
+++ b/crates/lakekeeper/src/api/iceberg/v1/s3_signer.rs
@@ -6,25 +6,41 @@ use axum::{
 };
 use iceberg_ext::catalog::rest::{S3SignRequest, S3SignResponse};
 
-use super::{ApiContext, Prefix, Result};
+use super::{ApiContext, Prefix, Result, TableIdent, namespace::NamespaceIdentUrl};
 use crate::request_metadata::RequestMetadata;
+
+/// The spec's per-table signer route, relative to the catalog v1 mount.
+///
+/// Shared with the test that checks it still resolves to an [`Endpoint`], so the
+/// route and the path endpoint statistics are keyed on cannot drift apart.
+pub const SIGN_TABLE_ROUTE: &str = "/{prefix}/namespaces/{namespace}/tables/{table}/sign";
+
+/// How a sign request identifies the table it is signing for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignTarget {
+    /// The pre-standard global and prefix routes carry no table, so it has to be
+    /// recovered from the location in the request URI.
+    FromRequestUri,
+    /// The pre-standard per-table route, addressed by tabular id.
+    TabularId(uuid::Uuid),
+    /// The spec's `…/tables/{table}/sign` route, addressed by name.
+    Table(Box<TableIdent>),
+}
 
 #[async_trait]
 pub trait Service<S: crate::api::ThreadSafe>
 where
     Self: Send + Sync + 'static,
 {
-    /// Sign an S3 request.
-    /// Requests should be send to `/:prefix/namespace/:namespace/table/:table/v1/aws/s3/sign`,
-    /// where :namespace and :table can be any string. Typically these strings would be
-    /// ids of the namespace and table, respectively - not their names.
-    /// For clients to use this route, the server implementation should specify "s3.signer.uri"
-    /// accordingly on `load_table` and other methods that require data access.
+    /// Sign a request to object storage.
     ///
-    /// If a request is recieved at `/aws/s3/sign`, table and namespace will be `None`.
+    /// Reachable at the spec's `…/namespaces/{namespace}/tables/{table}/sign`,
+    /// and at Lakekeeper's older `/aws/s3/sign` routes. The older ones stay
+    /// because `signer.endpoint` — still the only endpoint any released client
+    /// reads — points at them.
     async fn sign(
         prefix: Option<Prefix>,
-        tabular_id: Option<uuid::Uuid>,
+        target: SignTarget,
         request: S3SignRequest,
         state: ApiContext<S>,
         request_metadata: RequestMetadata,
@@ -39,7 +55,13 @@ pub fn router<I: Service<S>, S: crate::api::ThreadSafe>() -> Router<ApiContext<S
                 |State(api_context): State<ApiContext<S>>,
                  Extension(metadata): Extension<RequestMetadata>,
                  Json(request): Json<S3SignRequest>| {
-                    I::sign(None, None, request, api_context, metadata)
+                    I::sign(
+                        None,
+                        SignTarget::FromRequestUri,
+                        request,
+                        api_context,
+                        metadata,
+                    )
                 },
             ),
         )
@@ -50,7 +72,13 @@ pub fn router<I: Service<S>, S: crate::api::ThreadSafe>() -> Router<ApiContext<S
                  State(api_context): State<ApiContext<S>>,
                  Extension(metadata): Extension<RequestMetadata>,
                  Json(request): Json<S3SignRequest>| {
-                    I::sign(Some(prefix), None, request, api_context, metadata)
+                    I::sign(
+                        Some(prefix),
+                        SignTarget::FromRequestUri,
+                        request,
+                        api_context,
+                        metadata,
+                    )
                 },
             ),
         )
@@ -61,16 +89,50 @@ pub fn router<I: Service<S>, S: crate::api::ThreadSafe>() -> Router<ApiContext<S
                  State(api_context): State<ApiContext<S>>,
                  Extension(metadata): Extension<RequestMetadata>,
                  Json(request): Json<S3SignRequest>| {
-                    {
-                        I::sign(
-                            Some(prefix),
-                            Some(tabular_id),
-                            request,
-                            api_context,
-                            metadata,
-                        )
-                    }
+                    I::sign(
+                        Some(prefix),
+                        SignTarget::TabularId(tabular_id),
+                        request,
+                        api_context,
+                        metadata,
+                    )
                 },
             ),
         )
+        .route(
+            SIGN_TABLE_ROUTE,
+            post(
+                |Path((prefix, namespace, table)): Path<(Prefix, NamespaceIdentUrl, String)>,
+                 State(api_context): State<ApiContext<S>>,
+                 Extension(metadata): Extension<RequestMetadata>,
+                 Json(request): Json<S3SignRequest>| {
+                    I::sign(
+                        Some(prefix),
+                        SignTarget::Table(Box::new(TableIdent {
+                            namespace: namespace.into(),
+                            name: table,
+                        })),
+                        request,
+                        api_context,
+                        metadata,
+                    )
+                },
+            ),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::endpoints::Endpoint;
+
+    /// Endpoint statistics key on axum's matched path, so if the route literal
+    /// and the endpoint table drift apart the route silently stops being counted.
+    #[test]
+    fn the_standard_sign_route_resolves_to_an_endpoint() {
+        let matched = format!("/catalog/v1{SIGN_TABLE_ROUTE}");
+        let endpoint = Endpoint::from_method_and_matched_path(&http::Method::POST, &matched)
+            .expect("the standard sign route must be in the endpoint table");
+        assert_eq!(endpoint.as_http_route(), format!("POST {matched}"));
+    }
 }

--- a/crates/lakekeeper/src/api/iceberg/v1/tables.rs
+++ b/crates/lakekeeper/src/api/iceberg/v1/tables.rs
@@ -1283,6 +1283,7 @@ mod test {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
+            remote_signing_config: None,
             etag: Some(ETag::from("W/\"lk2.deadbeef\"")),
         };
         let load_table_result_response_expected = load_table_result.clone().into_response();

--- a/crates/lakekeeper/src/server/s3_signer/sign.rs
+++ b/crates/lakekeeper/src/server/s3_signer/sign.rs
@@ -207,6 +207,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
                 resolve_signable_by_id(
                     warehouse_id,
                     tabular_id,
+                    Addressing::TabularId,
                     &parsed_url,
                     first_location,
                     &state,
@@ -488,12 +489,22 @@ fn validate_region(region: &str, storage_profile: &S3Profile) -> Result<()> {
     Ok(())
 }
 
+/// How the request named the tabular. Only affects how a location mismatch is reported.
+#[derive(Clone, Copy)]
+enum Addressing {
+    /// Lakekeeper's `tabular-id` route, where a mismatch has one known cause.
+    TabularId,
+    /// The spec's per-table route.
+    TableName,
+}
+
 /// Resolve the tabular addressed by the table-scoped signer route
 /// (`/v1/signer/{warehouse-id}/tabular-id/{uuid}/v1/aws/s3/sign`). That route carries a
 /// bare UUID, so the id is resolved across all tabular types.
 async fn resolve_signable_by_id<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
     warehouse_id: WarehouseId,
     tabular_id: uuid::Uuid,
+    addressing: Addressing,
     parsed_url: &s3_utils::ParsedSignRequest,
     first_location: &S3Location,
     state: &ApiContext<State<A, C, S>>,
@@ -513,14 +524,24 @@ async fn resolve_signable_by_id<C: CatalogStore, A: Authorizer + Clone, S: Secre
             return Ok(Some(signable));
         }
 
-        // The id resolved, but its location does not cover the request URI.
+        // The id resolved, but its location does not cover the request URI. Fall back to a
+        // location based lookup; the request may still be legitimate for another tabular.
+        //
         // Up to version 0.9.1 pyiceberg had a bug that did not allow table specific signer URIs.
-        // Instead the first URI of the first sign call would be used for subsequent calls in the same runtime too.
-        // This is fixed in 0.9.2 onward: https://github.com/apache/iceberg-python/pull/2005
-        // To keep backward compatibility we fall back to location based lookup when the location does not match.
-        // This fallback will be removed in a future version of Lakekeeper.
+        // Instead the first URI of the first sign call would be used for subsequent calls in the
+        // same runtime too. This is fixed in 0.9.2 onward:
+        // https://github.com/apache/iceberg-python/pull/2005
+        // The fallback exists for that bug and will be removed in a future version of Lakekeeper,
+        // so only the route that bug hits names it — the per-table route reaches this line for
+        // other reasons and must not accuse the client of it.
+        let hint = match addressing {
+            Addressing::TabularId => {
+                " This is a bug in the query engine. When using PyIceberg, please update to versions > 0.9.1"
+            }
+            Addressing::TableName => "",
+        };
         tracing::warn!(
-            "Received a tabular specific sign request for tabular {tabular_id} with a location {} that does not match the request URI {}. Falling back to location based lookup. This is a bug in the query engine. When using PyIceberg, please update to versions > 0.9.1",
+            "Received a tabular specific sign request for tabular {tabular_id} with a location {} that does not match the request URI {}. Falling back to location based lookup.{hint}",
             signable.location(),
             parsed_url.uri.received()
         );
@@ -555,6 +576,7 @@ async fn resolve_signable_by_name<C: CatalogStore, A: Authorizer + Clone, S: Sec
         return resolve_signable_by_id(
             warehouse_id,
             *table_info.table_id(),
+            Addressing::TableName,
             parsed_url,
             first_location,
             state,

--- a/crates/lakekeeper/src/server/s3_signer/sign.rs
+++ b/crates/lakekeeper/src/server/s3_signer/sign.rs
@@ -83,6 +83,13 @@ impl SignableTabular {
             Self::GenericTable(info) => &info.location,
         }
     }
+
+    fn tabular_id(&self) -> uuid::Uuid {
+        match self {
+            Self::Table(info) => *info.tabular_id,
+            Self::GenericTable(info) => *info.tabular_id,
+        }
+    }
 }
 
 /// The resolution outcome, split by the authorization path that has to handle it.
@@ -498,6 +505,62 @@ enum Addressing {
     TableName,
 }
 
+impl Addressing {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::TabularId => "tabular-id",
+            Self::TableName => "table-name",
+        }
+    }
+}
+
+/// Accept a tabular the request named directly, or fall back to a location based
+/// lookup when its location does not cover the request URI.
+///
+/// Shared by both named routes so neither grows its own cross-check.
+async fn cross_check_or_fall_back<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
+    warehouse_id: WarehouseId,
+    named: Option<SignableTabular>,
+    addressing: Addressing,
+    parsed_url: &s3_utils::ParsedSignRequest,
+    first_location: &S3Location,
+    state: &ApiContext<State<A, C, S>>,
+) -> std::result::Result<Option<SignableTabular>, RequireTableActionError> {
+    if let Some(signable) = named {
+        if validate_uri(parsed_url, signable.location()).is_ok() {
+            return Ok(Some(signable));
+        }
+
+        // The name resolved, but its location does not cover the request URI. Fall back to a
+        // location based lookup; the request may still be legitimate for another tabular.
+        //
+        // Up to version 0.9.1 pyiceberg had a bug that did not allow table specific signer URIs.
+        // Instead the first URI of the first sign call would be used for subsequent calls in the
+        // same runtime too. This is fixed in 0.9.2 onward:
+        // https://github.com/apache/iceberg-python/pull/2005
+        // The fallback exists for that bug and will be removed in a future version of Lakekeeper,
+        // so only the route that bug hits names it — the per-table route reaches this line for
+        // other reasons and must not accuse the client of it.
+        let hint = match addressing {
+            Addressing::TabularId => {
+                " This is a bug in the query engine. When using PyIceberg, please update to versions > 0.9.1"
+            }
+            Addressing::TableName => "",
+        };
+        tracing::warn!(
+            addressing = addressing.as_str(),
+            "Received a tabular specific sign request for tabular {} with a location {} that does not match the request URI {}. Falling back to location based lookup.{hint}",
+            signable.tabular_id(),
+            signable.location(),
+            parsed_url.uri.received()
+        );
+    }
+
+    resolve_signable_by_location(warehouse_id, first_location, state)
+        .await
+        .map_err(RequireTableActionError::from)
+}
+
 /// Resolve the tabular addressed by the table-scoped signer route
 /// (`/v1/signer/{warehouse-id}/tabular-id/{uuid}/v1/aws/s3/sign`). That route carries a
 /// bare UUID, so the id is resolved across all tabular types.
@@ -519,43 +582,22 @@ async fn resolve_signable_by_id<C: CatalogStore, A: Authorizer + Clone, S: Secre
     .await
     .map_err(RequireTableActionError::from)?;
 
-    if let Some(signable) = info_by_id.and_then(SignableTabular::from_view_or_table) {
-        if validate_uri(parsed_url, signable.location()).is_ok() {
-            return Ok(Some(signable));
-        }
-
-        // The id resolved, but its location does not cover the request URI. Fall back to a
-        // location based lookup; the request may still be legitimate for another tabular.
-        //
-        // Up to version 0.9.1 pyiceberg had a bug that did not allow table specific signer URIs.
-        // Instead the first URI of the first sign call would be used for subsequent calls in the
-        // same runtime too. This is fixed in 0.9.2 onward:
-        // https://github.com/apache/iceberg-python/pull/2005
-        // The fallback exists for that bug and will be removed in a future version of Lakekeeper,
-        // so only the route that bug hits names it — the per-table route reaches this line for
-        // other reasons and must not accuse the client of it.
-        let hint = match addressing {
-            Addressing::TabularId => {
-                " This is a bug in the query engine. When using PyIceberg, please update to versions > 0.9.1"
-            }
-            Addressing::TableName => "",
-        };
-        tracing::warn!(
-            "Received a tabular specific sign request for tabular {tabular_id} with a location {} that does not match the request URI {}. Falling back to location based lookup.{hint}",
-            signable.location(),
-            parsed_url.uri.received()
-        );
-    }
-
-    resolve_signable_by_location(warehouse_id, first_location, state)
-        .await
-        .map_err(RequireTableActionError::from)
+    cross_check_or_fall_back(
+        warehouse_id,
+        info_by_id.and_then(SignableTabular::from_view_or_table),
+        addressing,
+        parsed_url,
+        first_location,
+        state,
+    )
+    .await
 }
 
 /// Resolve the table the spec's per-table `/sign` route names.
 ///
-/// Funnels into [`resolve_signable_by_id`] so the name path inherits its
-/// location cross-check and its fallback, rather than growing a second set.
+/// The looked-up table is used as resolved rather than re-fetched by id, so the
+/// ident keeps the caller's case like every other by-name route. Only the id and
+/// the location travel onward, and both are case-independent.
 async fn resolve_signable_by_name<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
     warehouse_id: WarehouseId,
     table: TableIdent,
@@ -572,21 +614,15 @@ async fn resolve_signable_by_name<C: CatalogStore, A: Authorizer + Clone, S: Sec
     .await
     .map_err(RequireTableActionError::from)?;
 
-    if let Some(table_info) = table_info {
-        return resolve_signable_by_id(
-            warehouse_id,
-            *table_info.table_id(),
-            Addressing::TableName,
-            parsed_url,
-            first_location,
-            state,
-        )
-        .await;
-    }
-
-    resolve_signable_by_location(warehouse_id, first_location, state)
-        .await
-        .map_err(RequireTableActionError::from)
+    cross_check_or_fall_back(
+        warehouse_id,
+        table_info.map(SignableTabular::Table),
+        Addressing::TableName,
+        parsed_url,
+        first_location,
+        state,
+    )
+    .await
 }
 
 async fn resolve_signable_by_location<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(

--- a/crates/lakekeeper/src/server/s3_signer/sign.rs
+++ b/crates/lakekeeper/src/server/s3_signer/sign.rs
@@ -12,7 +12,10 @@ use crate::{
     WarehouseId,
     api::{
         ApiContext, ErrorModel, IcebergErrorResponse, Result, S3SignRequest, S3SignResponse,
-        iceberg::types::Prefix,
+        iceberg::{
+            types::Prefix,
+            v1::{TableIdent, s3_signer::SignTarget},
+        },
     },
     request_metadata::RequestMetadata,
     server::require_warehouse_id,
@@ -108,7 +111,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
     #[allow(clippy::too_many_lines)]
     async fn sign(
         prefix: Option<Prefix>,
-        path_table_id: Option<uuid::Uuid>,
+        target: SignTarget,
         request: S3SignRequest,
         state: ApiContext<State<A, C, S>>,
         request_metadata: RequestMetadata,
@@ -160,7 +163,26 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             method: request_method,
             headers: request_headers,
             body: request_body,
+            // Accepted per spec; we advertise no properties to echo back.
+            properties: _,
+            provider: request_provider,
         } = request;
+
+        // Absent means S3 per the spec's backwards-compatibility rule. Anything
+        // else is refused rather than signed as S3 — we reached this point only
+        // because the warehouse is an S3 profile, so a different provider means
+        // the client is asking for something we cannot produce.
+        if let Some(provider) = request_provider.as_deref()
+            && !provider.eq_ignore_ascii_case("s3")
+        {
+            return Err(IcebergErrorResponse::from(ErrorModel::bad_request(
+                format!(
+                    "Cannot sign requests for storage provider '{provider}'. Only 's3' is supported."
+                ),
+                "UnsupportedSignerProvider",
+                None,
+            )));
+        }
 
         let (parsed_url, operation) = s3_utils::parse_s3_url(
             &s3_utils::SignRequestUri::new(request_url.clone())?,
@@ -177,23 +199,33 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             )
         })?;
 
-        let resolved = if let Some(tabular_id) = path_table_id {
-            tracing::debug!("Got S3 sign request for tabular {tabular_id} with URL {request_url}");
-            resolve_signable_by_id(
-                warehouse_id,
-                tabular_id,
-                &parsed_url,
-                first_location,
-                &state,
-            )
-            .await
-        } else {
-            tracing::debug!(
-                "Got S3 sign request for URL {request_url} without tabular id. Searching for tabular by location"
-            );
-            resolve_signable_by_location(warehouse_id, first_location, &state)
+        let resolved = match target {
+            SignTarget::TabularId(tabular_id) => {
+                tracing::debug!(
+                    "Got S3 sign request for tabular {tabular_id} with URL {request_url}"
+                );
+                resolve_signable_by_id(
+                    warehouse_id,
+                    tabular_id,
+                    &parsed_url,
+                    first_location,
+                    &state,
+                )
                 .await
-                .map_err(RequireTableActionError::from)
+            }
+            SignTarget::Table(ident) => {
+                tracing::debug!("Got S3 sign request for table {ident:?} with URL {request_url}");
+                resolve_signable_by_name(warehouse_id, *ident, &parsed_url, first_location, &state)
+                    .await
+            }
+            SignTarget::FromRequestUri => {
+                tracing::debug!(
+                    "Got S3 sign request for URL {request_url} without tabular id. Searching for tabular by location"
+                );
+                resolve_signable_by_location(warehouse_id, first_location, &state)
+                    .await
+                    .map_err(RequireTableActionError::from)
+            }
         };
         // Can't fail here before AuthZ!
 
@@ -492,6 +524,42 @@ async fn resolve_signable_by_id<C: CatalogStore, A: Authorizer + Clone, S: Secre
             signable.location(),
             parsed_url.uri.received()
         );
+    }
+
+    resolve_signable_by_location(warehouse_id, first_location, state)
+        .await
+        .map_err(RequireTableActionError::from)
+}
+
+/// Resolve the table the spec's per-table `/sign` route names.
+///
+/// Funnels into [`resolve_signable_by_id`] so the name path inherits its
+/// location cross-check and its fallback, rather than growing a second set.
+async fn resolve_signable_by_name<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
+    warehouse_id: WarehouseId,
+    table: TableIdent,
+    parsed_url: &s3_utils::ParsedSignRequest,
+    first_location: &S3Location,
+    state: &ApiContext<State<A, C, S>>,
+) -> std::result::Result<Option<SignableTabular>, RequireTableActionError> {
+    let table_info = C::get_table_info(
+        warehouse_id,
+        table,
+        TabularListFlags::active_and_staged(),
+        state.v1_state.catalog.clone(),
+    )
+    .await
+    .map_err(RequireTableActionError::from)?;
+
+    if let Some(table_info) = table_info {
+        return resolve_signable_by_id(
+            warehouse_id,
+            *table_info.table_id(),
+            parsed_url,
+            first_location,
+            state,
+        )
+        .await;
     }
 
     resolve_signable_by_location(warehouse_id, first_location, state)

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -626,6 +626,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         Ok(LoadTableResult {
             metadata_location: Some(metadata_location_str),
             metadata: table_metadata,
+            remote_signing_config: config.remote_signing.clone(),
             config: Some(config.config.into()),
             storage_credentials,
             etag: Some(etag),

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -377,6 +377,7 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
     let load_table_result = LoadTableResult {
         metadata_location: metadata_location.as_ref().map(ToString::to_string),
         metadata: table_metadata.clone(),
+        remote_signing_config: config.remote_signing.clone(),
         config: Some(config.config.into()),
         storage_credentials,
         etag: metadata_location.as_ref().map(|loc| {

--- a/crates/lakekeeper/src/server/tables/load_table.rs
+++ b/crates/lakekeeper/src/server/tables/load_table.rs
@@ -253,11 +253,15 @@ pub(crate) async fn load_table_with_flags<
 
     event_ctx.emit_table_loaded_async(metadata_ref.clone(), metadata_location_ref.clone());
 
+    let remote_signing_config = storage_config
+        .as_ref()
+        .and_then(|c| c.remote_signing.clone());
     let load_table_result = LoadTableResult {
         metadata_location: metadata_location_ref.as_ref().map(ToString::to_string),
         metadata: metadata_ref,
         config: storage_config.map(|c| c.config.into()),
         storage_credentials,
+        remote_signing_config,
         etag: metadata_location_ref.as_ref().map(|loc| {
             TableETag::new(
                 warehouse_id,

--- a/crates/lakekeeper/src/service/storage/az/az_profile.rs
+++ b/crates/lakekeeper/src/service/storage/az/az_profile.rs
@@ -250,6 +250,7 @@ impl GenericAdlsProfile {
                 creds: TableProperties::default(),
                 config: TableProperties::default(),
                 credentials_expiration_ms: None,
+                remote_signing: None,
             });
         }
 

--- a/crates/lakekeeper/src/service/storage/az/mod.rs
+++ b/crates/lakekeeper/src/service/storage/az/mod.rs
@@ -527,6 +527,7 @@ pub(super) async fn generate_adls_table_config<T: BasicTabularInfo>(
         config: creds.clone(),
         creds,
         credentials_expiration_ms: Some(expiration_ms),
+        remote_signing: None,
     })
 }
 

--- a/crates/lakekeeper/src/service/storage/az/onelake_profile.rs
+++ b/crates/lakekeeper/src/service/storage/az/onelake_profile.rs
@@ -528,6 +528,7 @@ impl OneLakeProfile {
                 creds: TableProperties::default(),
                 config: TableProperties::default(),
                 credentials_expiration_ms: None,
+                remote_signing: None,
             });
         }
 

--- a/crates/lakekeeper/src/service/storage/gcs/mod.rs
+++ b/crates/lakekeeper/src/service/storage/gcs/mod.rs
@@ -366,6 +366,7 @@ impl GcsProfile {
                 creds: table_properties.clone(),
                 config: table_properties,
                 credentials_expiration_ms: None,
+                remote_signing: None,
             });
         }
 
@@ -445,6 +446,7 @@ impl GcsProfile {
             config: table_properties.clone(),
             creds: table_properties,
             credentials_expiration_ms,
+            remote_signing: None,
         })
     }
 

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -24,7 +24,9 @@ use iceberg::{NamespaceIdent, TableIdent};
 // `rest::StorageCredential` is the response-side credential entry; `StorageCredential` in this
 // module is the warehouse's stored secret. Aliased to keep the two apart.
 use iceberg_ext::{
-    catalog::rest::{ErrorModel, StorageCredential as VendedStorageCredential},
+    catalog::rest::{
+        ErrorModel, RemoteSigningConfig, StorageCredential as VendedStorageCredential,
+    },
     configs::table::TableProperties,
 };
 use lakekeeper_io::{
@@ -145,6 +147,10 @@ pub struct TableConfig {
     /// `None` if none expire. Set wherever a backend vends an expiring
     /// credential; the source for the `loadTable` `ETag`'s revalidation point.
     pub(crate) credentials_expiration_ms: Option<i64>,
+    /// Signer settings to advertise, or `None` when the backend does not use
+    /// remote signing. Emitting it tells the client to sign against the table's
+    /// standard `/sign` path rather than the deprecated `signer.*` config keys.
+    pub(crate) remote_signing: Option<RemoteSigningConfig>,
 }
 
 impl TableConfig {
@@ -539,6 +545,7 @@ impl StorageProfile {
                 creds: TableProperties::default(),
                 config: TableProperties::default(),
                 credentials_expiration_ms: None,
+                remote_signing: None,
             }),
         }
     }

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -34,7 +34,7 @@ use crate::{
     api::{
         CatalogConfig,
         iceberg::{
-            supported_endpoints,
+            supported_endpoints, supported_endpoints_with_signing,
             v1::{DataAccess, tables::DataAccessMode},
         },
         management::v1::warehouse::TabularDeleteProfile,
@@ -436,7 +436,11 @@ impl S3Profile {
         CatalogConfig {
             defaults,
             overrides: HashMap::new(),
-            endpoints: supported_endpoints().to_vec(),
+            endpoints: if self.remote_signing_enabled {
+                supported_endpoints_with_signing().to_vec()
+            } else {
+                supported_endpoints().to_vec()
+            },
             idempotency_key_lifetime: None,
         }
     }
@@ -612,20 +616,21 @@ impl S3Profile {
             let signer_uri = request_metadata.s3_signer_uri(warehouse_id);
             let signer_endpoint =
                 request_metadata.s3_signer_endpoint_for_table(warehouse_id, tabular_id);
-            // Iceberg 1.11.0 renamed `s3.signer.*` to `signer.*`. Emit both so clients >=1.11 read
-            // the new keys (no deprecation warning) and older clients keep using the old ones.
-            // Both are deprecated by the spec in favour of `remote-signing-config` below, but no
-            // released client reads that yet, so dropping them would break every signing client.
+            // Iceberg 1.11.0 renamed the client-side `s3.signer.*` properties to `signer.*`. Emit
+            // both so clients >=1.11 read the new keys (no deprecation warning) and older clients
+            // keep using the old ones. The spec deprecates `signer.uri`/`signer.endpoint` in
+            // favour of `remote-signing-config` below, but no released client reads that yet, and
+            // a client following the spec's resolution order picks these up first anyway.
             config.insert(&signer::Uri(signer_uri.clone()));
             config.insert(&signer::Endpoint(signer_endpoint.clone()));
             config.insert(&s3::SignerUri(signer_uri));
             config.insert(&s3::SignerEndpoint(signer_endpoint));
 
-            // Empty on purpose: presence is the whole signal. A client reading
-            // this field derives the endpoint as the table's standard `/sign`
-            // path, and we need no properties or headers echoed back — the
-            // signer resolves the table from the path, falling back to the
-            // request location, which already survives a rename.
+            // Empty on purpose. The field carries no endpoint — a client that
+            // uses it calls the table's standard `/sign` route, which the
+            // `endpoints` capability list advertises — and we need nothing
+            // echoed back: the signer resolves the table from the path, falling
+            // back to the request location, which already survives a rename.
             Some(RemoteSigningConfig::default())
         } else {
             None
@@ -3137,6 +3142,13 @@ pub(crate) mod test {
                     signs_remotely.then_some(true),
                     "({context})"
                 );
+                // Advertised only when we actually sign: it points the client at the per-table
+                // `/sign` route, which rejects requests for a table we do not sign for.
+                assert_eq!(
+                    table_config.remote_signing.is_some(),
+                    signs_remotely,
+                    "({context})"
+                );
             }
         }
     }
@@ -3293,6 +3305,38 @@ pub(crate) mod test {
         );
         assert!(!config.defaults.contains_key("s3.sse.type"));
         assert!(!config.defaults.contains_key("s3.sse.key"));
+    }
+
+    /// `remote-signing-config` carries no endpoint, so the `endpoints` capability list is the
+    /// only place a client learns that the per-table `/sign` route is served here.
+    #[test]
+    fn catalog_config_advertises_the_sign_route_only_when_signing_is_enabled() {
+        let sign_route = "POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/sign";
+        for remote_signing_enabled in [false, true] {
+            let profile = S3Profile::builder()
+                .bucket("bucket-name".to_string())
+                .region("us-east-1".to_string())
+                .flavor(S3Flavor::S3Compat)
+                .sts_enabled(false)
+                .remote_signing_enabled(remote_signing_enabled)
+                .build();
+            let config = profile.generate_catalog_config(
+                WarehouseId::new_random(),
+                &RequestMetadata::new_unauthenticated(),
+                crate::api::management::v1::warehouse::TabularDeleteProfile::Hard {},
+            );
+            assert_eq!(
+                config.endpoints.iter().any(|e| e == sign_route),
+                remote_signing_enabled,
+                "remote_signing_enabled={remote_signing_enabled}"
+            );
+            // The rest of the list is unchanged either way.
+            assert!(
+                config.endpoints.contains(
+                    &"GET /v1/{prefix}/namespaces/{namespace}/tables/{table}".to_string()
+                )
+            );
+        }
     }
 
     #[test]

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -11,7 +11,7 @@ use aws_config::SdkConfig;
 use aws_sdk_sts::{config::ProvideCredentials as _, types::Tag};
 use aws_smithy_runtime_api::client::identity::Identity;
 use iceberg_ext::{
-    catalog::rest::ErrorModel,
+    catalog::rest::{ErrorModel, RemoteSigningConfig},
     configs::{
         ConfigProperty as _,
         table::{TableProperties, client, creds, custom, s3, signer},
@@ -604,7 +604,7 @@ impl S3Profile {
             TableProperties::default()
         };
 
-        if remote_signing {
+        let remote_signing_config = if remote_signing {
             let warehouse_id = stc_request.warehouse_id;
             let tabular_id = stc_request.tabular_id;
             push_fsspec_fileio_with_s3v4restsigner(&mut config);
@@ -614,16 +614,28 @@ impl S3Profile {
                 request_metadata.s3_signer_endpoint_for_table(warehouse_id, tabular_id);
             // Iceberg 1.11.0 renamed `s3.signer.*` to `signer.*`. Emit both so clients >=1.11 read
             // the new keys (no deprecation warning) and older clients keep using the old ones.
+            // Both are deprecated by the spec in favour of `remote-signing-config` below, but no
+            // released client reads that yet, so dropping them would break every signing client.
             config.insert(&signer::Uri(signer_uri.clone()));
             config.insert(&signer::Endpoint(signer_endpoint.clone()));
             config.insert(&s3::SignerUri(signer_uri));
             config.insert(&s3::SignerEndpoint(signer_endpoint));
-        }
+
+            // Empty on purpose: presence is the whole signal. A client reading
+            // this field derives the endpoint as the table's standard `/sign`
+            // path, and we need no properties or headers echoed back — the
+            // signer resolves the table from the path, falling back to the
+            // request location, which already survives a rename.
+            Some(RemoteSigningConfig::default())
+        } else {
+            None
+        };
 
         Ok(TableConfig {
             creds,
             config,
             credentials_expiration_ms,
+            remote_signing: remote_signing_config,
         })
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added S3 request signing by table name through a standard catalog endpoint.
  - Added table-level remote-signing configuration, including signing properties, providers, and headers.
  - Catalogs now advertise signing endpoints when remote signing is enabled.

- **Bug Fixes**
  - Added validation for unsupported signing providers.
  - Improved table and location fallback handling.
  - Improved ETag behavior to prevent incorrect cache reuse across differing table responses.

- **Tests**
  - Expanded coverage for signing routes, configuration serialization, endpoint registration, compatibility, and ETag isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->