### PR TITLE
feat(audit): record the caller's user agent on authorization events

### DIFF
--- a/crates/lakekeeper/src/request_metadata.rs
+++ b/crates/lakekeeper/src/request_metadata.rs
@@ -42,23 +42,44 @@ pub const X_REQUEST_ID_HEADER_NAME: HeaderName = HeaderName::from_static(X_REQUE
 
 const ANONYMOUS_ACTOR: &Actor = &Actor::Anonymous;
 
+/// The `User-Agent` request header, recorded as the caller sent it.
+///
+/// Deliberately not parsed into a client taxonomy. The value is surfaced in the
+/// audit log, where a normalised form would be a reconstruction rather than
+/// evidence, and where classifying it would mean maintaining a parser against
+/// strings the caller chooses. Consumers classify; Lakekeeper records.
 #[derive(Debug, Clone)]
-pub enum UserAgent {
-    // User-Agent: PyIceberg/<version>
-    PyIceberg { version: String },
-    Unknown(String),
-}
+pub struct UserAgent(String);
 
 impl UserAgent {
-    #[cfg(feature = "router")]
-    fn parse(user_agent: &str) -> Self {
-        if let Some(version) = user_agent.strip_prefix("PyIceberg/") {
-            Self::PyIceberg {
-                version: version.to_string(),
-            }
-        } else {
-            Self::Unknown(user_agent.to_string())
+    /// Longest header value retained. The header is caller-controlled and is
+    /// recorded on every audit event, so it is bounded at capture.
+    #[cfg(any(feature = "router", test))]
+    const MAX_LEN: usize = 256;
+
+    #[cfg(any(feature = "router", test))]
+    pub(crate) fn parse(user_agent: &str) -> Self {
+        let mut end = user_agent.len().min(Self::MAX_LEN);
+        // Header values are visible ASCII in practice, but never split a code
+        // point — a partial character would not survive JSON encoding.
+        while !user_agent.is_char_boundary(end) {
+            end -= 1;
         }
+        Self(user_agent[..end].to_string())
+    }
+
+    /// The header value, truncated at capture to a bounded length.
+    ///
+    /// Caller-supplied and unverified — see the audit-log documentation.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The version from a `PyIceberg/<version>` user agent, if this is one.
+    #[must_use]
+    pub fn pyiceberg_version(&self) -> Option<&str> {
+        self.0.strip_prefix("PyIceberg/")
     }
 }
 
@@ -581,6 +602,10 @@ pub struct RequestMetadataTestBuilder {
     /// construct a request that carries them.
     #[builder(default, setter(strip_option))]
     pub admission_roles: Option<TokenRoles>,
+    /// The `User-Agent` header the caller sent, as captured by the request
+    /// middleware. Lets tests exercise the audit log's `user_agent` field.
+    #[builder(default, setter(strip_option))]
+    pub user_agent: Option<UserAgent>,
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -594,7 +619,7 @@ impl From<RequestMetadataTestBuilder> for RequestMetadata {
             project_id: b.project_id,
             matched_path: b.matched_path,
             request_method: b.request_method,
-            user_agent: None,
+            user_agent: b.user_agent,
             engines: MatchedEngines::default(),
             token_roles: b.token_roles,
             admission_roles: b.admission_roles,
@@ -781,6 +806,59 @@ mod test {
     use http::{HeaderMap, header::HeaderValue};
 
     use super::*;
+
+    /// The audit log records the user agent as the caller sent it, so the
+    /// header must survive capture byte-for-byte. A parsed representation that
+    /// only kept the version would make the recorded value a reconstruction
+    /// rather than evidence.
+    #[test]
+    fn a_user_agent_is_captured_verbatim() {
+        for raw in [
+            "PyIceberg/0.9.1",
+            "Trino/476",
+            "Apache-Spark/3.5.1 (Scala/2.12)",
+            "",
+        ] {
+            assert_eq!(UserAgent::parse(raw).as_str(), raw);
+        }
+    }
+
+    /// The header is caller-controlled and lands on every audit record, so its
+    /// length is bounded at capture rather than at emit.
+    #[test]
+    fn an_overlong_user_agent_is_truncated() {
+        let raw = "x".repeat(UserAgent::MAX_LEN * 2);
+        let captured = UserAgent::parse(&raw);
+        assert_eq!(captured.as_str().len(), UserAgent::MAX_LEN);
+        assert!(raw.starts_with(captured.as_str()));
+    }
+
+    /// Truncation must not split a multi-byte character — a partial code point
+    /// would render as invalid JSON in the audit log.
+    #[test]
+    fn truncation_respects_char_boundaries() {
+        // 'ä' is two bytes, so a 256-byte cut lands mid-character.
+        let raw = "ä".repeat(UserAgent::MAX_LEN);
+        let captured = UserAgent::parse(&raw);
+        assert!(captured.as_str().len() <= UserAgent::MAX_LEN);
+        assert!(raw.starts_with(captured.as_str()));
+    }
+
+    /// The ADLS SAS-property workaround needs the `PyIceberg` version; it is
+    /// derived from the raw header rather than stored separately.
+    #[test]
+    fn a_pyiceberg_version_is_derived_from_the_raw_header() {
+        assert_eq!(
+            UserAgent::parse("PyIceberg/0.9.1").pyiceberg_version(),
+            Some("0.9.1")
+        );
+        assert_eq!(UserAgent::parse("Trino/476").pyiceberg_version(), None);
+        // Case-sensitive prefix: a different product is not PyIceberg.
+        assert_eq!(
+            UserAgent::parse("pyiceberg/0.9.1").pyiceberg_version(),
+            None
+        );
+    }
 
     #[test]
     fn test_bypass_matrix() {

--- a/crates/lakekeeper/src/service/events/backends/audit.rs
+++ b/crates/lakekeeper/src/service/events/backends/audit.rs
@@ -4,6 +4,7 @@ use valuable::{Listable, Mappable, Valuable, Value, Visit};
 
 use crate::{
     audit_operation,
+    request_metadata::{RequestMetadata, UserAgent},
     service::{
         authn::{Actor, InternalActor},
         authz::{ActionDescriptor, ContextValue, DeterminingFactor, GrantResource, UserOrRoleId},
@@ -224,6 +225,16 @@ macro_rules! audit_log {
     }};
 }
 
+/// The `User-Agent` header for the `user_agent` audit field, or `None` when the
+/// caller sent none — which `valuable` renders as JSON `null`.
+///
+/// Recorded verbatim and **unverified**: any caller can set the header to any
+/// value, including one naming another client. `actor` and `privilege_source`
+/// are the authenticated facts on the same event.
+fn user_agent_value(request_metadata: &RequestMetadata) -> Option<&str> {
+    request_metadata.user_agent().map(UserAgent::as_str)
+}
+
 #[derive(Debug)]
 pub struct AuditEventListener;
 
@@ -237,6 +248,7 @@ impl Display for AuditEventListener {
 impl EventListener for AuditEventListener {
     async fn authorization_failed(&self, event: AuthorizationFailedEvent) -> anyhow::Result<()> {
         let authorizations = AuthorizationsList(&event.authorizations);
+        let user_agent = user_agent_value(&event.request_metadata);
         if event.extra_context.is_empty() {
             audit_log!(
                 &*event.actions,
@@ -244,6 +256,7 @@ impl EventListener for AuditEventListener {
                 {
                     actor = tracing::field::valuable(&event.request_metadata.internal_actor().as_value()),
                     privilege_source = event.request_metadata.privilege_source().as_str(),
+                    user_agent = tracing::field::valuable(&user_agent),
                     failure_reason = tracing::field::valuable(&event.failure_reason.as_value()),
                     error = tracing::field::valuable(&event.error.as_value()),
                     authorizations = tracing::field::valuable(&authorizations.as_value()),
@@ -258,6 +271,7 @@ impl EventListener for AuditEventListener {
                 {
                     actor = tracing::field::valuable(&event.request_metadata.internal_actor().as_value()),
                     privilege_source = event.request_metadata.privilege_source().as_str(),
+                    user_agent = tracing::field::valuable(&user_agent),
                     failure_reason = tracing::field::valuable(&event.failure_reason.as_value()),
                     error = tracing::field::valuable(&event.error.as_value()),
                     context = tracing::field::valuable(&event.extra_context.as_value()),
@@ -315,6 +329,7 @@ impl EventListener for AuditEventListener {
         event: AuthorizationSucceededEvent,
     ) -> anyhow::Result<()> {
         let authorizations = AuthorizationsList(&event.authorizations);
+        let user_agent = user_agent_value(&event.request_metadata);
         if event.extra_context.is_empty() {
             audit_log!(
                 &*event.actions,
@@ -322,6 +337,7 @@ impl EventListener for AuditEventListener {
                 {
                     actor = tracing::field::valuable(&event.request_metadata.internal_actor().as_value()),
                     privilege_source = event.request_metadata.privilege_source().as_str(),
+                    user_agent = tracing::field::valuable(&user_agent),
                     authorizations = tracing::field::valuable(&authorizations.as_value()),
                     decision = "allowed",
                 },
@@ -334,6 +350,7 @@ impl EventListener for AuditEventListener {
                 {
                     actor = tracing::field::valuable(&event.request_metadata.internal_actor().as_value()),
                     privilege_source = event.request_metadata.privilege_source().as_str(),
+                    user_agent = tracing::field::valuable(&user_agent),
                     context = tracing::field::valuable(&event.extra_context.as_value()),
                     authorizations = tracing::field::valuable(&authorizations.as_value()),
                     decision = "allowed",
@@ -622,10 +639,108 @@ macro_rules! audit_operation {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use valuable::{Valuable, Value, Visit};
 
     use super::*;
-    use crate::service::authz::{ActionDescriptor, DeterminingFactor, PolicyEffect};
+    use crate::{
+        request_metadata::{RequestMetadata, RequestMetadataTestBuilder, UserAgent},
+        service::{
+            authz::{ActionDescriptor, DeterminingFactor, PolicyEffect},
+            events::context::EventEntities,
+        },
+    };
+
+    /// Collects rendered log lines so a test can assert on the JSON a consumer
+    /// actually receives, rather than on the `Valuable` shape alone.
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CapturedLogs {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("log buffer poisoned").extend(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl tracing_subscriber::fmt::MakeWriter<'_> for CapturedLogs {
+        type Writer = Self;
+
+        fn make_writer(&self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Render one audit event through the same JSON formatter the binary
+    /// configures (`lakekeeper-bin`'s `main`), and return it parsed.
+    fn emit_and_capture(event: AuthorizationSucceededEvent) -> serde_json::Value {
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .flatten_event(true)
+            .with_writer(logs.clone())
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            futures::executor::block_on(AuditEventListener.authorization_succeeded(event))
+                .expect("emitting an audit event must not fail");
+        });
+
+        let bytes = logs.0.lock().expect("log buffer poisoned").clone();
+        let line = String::from_utf8(bytes).expect("log output must be utf-8");
+        serde_json::from_str(line.trim()).expect("log line must be valid json")
+    }
+
+    fn succeeded_event(request_metadata: RequestMetadata) -> AuthorizationSucceededEvent {
+        let entities = Arc::new(EventEntities::one(EntityDescriptor::new("table")));
+        let actions = Arc::new(vec![
+            ActionDescriptor::builder().action_name("read_data").build(),
+        ]);
+        AuthorizationSucceededEvent {
+            request_metadata: Arc::new(request_metadata),
+            entities,
+            actions,
+            extra_context: Arc::new(std::collections::HashMap::new()),
+            authorizations: Arc::new(vec![sample(Vec::new())]),
+        }
+    }
+
+    /// The audit log has to say which client made the call, verbatim — a SIEM
+    /// classifies the string, so Lakekeeper must not normalise it away.
+    #[test]
+    fn an_audit_event_records_the_user_agent_verbatim() {
+        let metadata = RequestMetadataTestBuilder::builder()
+            .user_agent(UserAgent::parse("Apache-Spark/3.5.1 (Scala/2.12)"))
+            .build();
+
+        let event = emit_and_capture(succeeded_event(metadata));
+
+        assert_eq!(
+            event.get("user_agent").and_then(serde_json::Value::as_str),
+            Some("Apache-Spark/3.5.1 (Scala/2.12)"),
+        );
+    }
+
+    /// A request that sent no `User-Agent` must be distinguishable from one
+    /// that sent a client named "unknown", so the field is null rather than a
+    /// sentinel.
+    #[test]
+    fn an_audit_event_without_a_user_agent_records_null() {
+        let metadata = RequestMetadataTestBuilder::builder().build();
+
+        let event = emit_and_capture(succeeded_event(metadata));
+
+        assert_eq!(
+            event.get("user_agent"),
+            Some(&serde_json::Value::Null),
+            "the key must be present so consumers can tell 'not sent' from 'not recorded'"
+        );
+    }
 
     /// Records key/value pairs, flattening a nested map into `key=value` pairs joined
     /// by `,` so a whole context can be asserted with one exact comparison.

--- a/crates/lakekeeper/src/service/storage/az/mod.rs
+++ b/crates/lakekeeper/src/service/storage/az/mod.rs
@@ -444,11 +444,10 @@ pub(super) fn key_prefix_overlaps(a: Option<&str>, b: Option<&str>) -> bool {
 /// starting with `adls.sas-token`, including `…-expires-at-ms.*`, which breaks
 /// endpoint detection. Skip the expires-at key for those versions.
 pub(super) fn should_emit_sas_expires_at_key(request_metadata: &RequestMetadata) -> bool {
-    let pyiceberg_version = match request_metadata.user_agent() {
-        Some(UserAgent::PyIceberg { version }) => Some(version),
-        _ => None,
-    };
-    let Some(version) = pyiceberg_version else {
+    let Some(version) = request_metadata
+        .user_agent()
+        .and_then(UserAgent::pyiceberg_version)
+    else {
         return true;
     };
     semver::Version::parse(version)

--- a/docs/docs/logging.md
+++ b/docs/docs/logging.md
@@ -36,7 +36,7 @@ To disable audit logs entirely:
 LAKEKEEPER__AUDIT__TRACING__ENABLED=false
 ```
 
-**Note:** Audit logs contain PII. When disabling them, ensure you have alternative mechanisms for compliance and security monitoring.
+**Note:** Audit logs contain PII — user identities, and a caller-supplied `user_agent` string that some clients populate with hostnames or OS usernames. When disabling them, ensure you have alternative mechanisms for compliance and security monitoring.
 
 ## Log Types
 
@@ -63,6 +63,7 @@ Emitted for every authz check. Always contain `action`/`actions`, `entity`/`enti
 | `entity` or `entities` | Object or Array | Resource(s) accessed, containing `entity_type` and type-specific fields (e.g., `warehouse-id`, `namespace`, `table`) |
 | `actor`                | Object          | Who performed the action (see format below) |
 | `privilege_source`     | String          | Request-level classification of the caller's privilege: `"authorizer"` (no special privileges — all decisions come from the configured Authorizer backend), `"instance_admin"` (caller listed in `LAKEKEEPER__INSTANCE_ADMINS` — control-plane actions are auto-approved, data-plane actions still go through the Authorizer), or `"internal"` (in-process call — full bypass). This is a property of the request, not of individual entries in the `authorizations` array. See [Instance Admins](./instance-admins.md). |
+| `user_agent`           | String or null  | The caller's `User-Agent` request header, recorded verbatim and truncated to 256 bytes. `null` when the request sent no `User-Agent` (or sent one that was not valid text) — for example an in-process call from a background worker. **Client-supplied and unverified** — see below. |
 | `decision`             | String          | `"allowed"` or `"denied"` — the rollup decision for the whole event |
 | `authorizations`       | Array           | Per-decision breakdown. Always present and non-empty. Each entry is self-contained — see [Per-decision breakdown](#per-decision-breakdown-authorizations) below |
 | `context`              | Object          | Optional. Additional operation context (e.g., `project-id`, `warehouse-name`) |
@@ -70,6 +71,10 @@ Emitted for every authz check. Always contain `action`/`actions`, `entity`/`enti
 | `error`                | Object          | Only on failed events. Contains `type`, `message`, `code`, `error_id`, `stack` |
 
 **Note:** Empty arrays and objects are omitted from the output. For example, if `stack` is empty, the field will not appear in the log.
+
+**`user_agent` is client-supplied and unverified.** It is the `User-Agent` request header, recorded as sent. Any caller can set it to any value, including one that names a different client, and Lakekeeper neither validates it nor cross-checks it against the token. Treat it as a hint — fleet inventory, spotting an unexpected client library, triaging why one client started failing — never as identity, and never as an authorization or attribution input. The authoritative statements of *who* and *as what* are `actor` and `privilege_source` on the same event. A detection rule keyed on `user_agent` can be evaded by changing one header; one keyed on `actor` cannot.
+
+Lakekeeper records the header rather than a parsed client name, so a consumer can classify it however it needs and no information is lost to normalisation. Two consequences worth planning for: values are free-form and some clients embed hostnames or usernames in them, so treat the field as potentially disclosing infrastructure detail; and browsers cannot set `User-Agent`, so requests from the web UI are recorded with the browser's own value.
 
 **Ordering:** An authorization event records the *attempt*, and is dispatched to the audit log before the authorized operation issues its write. An `"allowed"` decision therefore means the caller was permitted to perform the action, not that the action succeeded — if the operation fails afterwards the request returns an error while the authorization event remains in the log. Audit consumers should treat authorization events as attempts rather than as confirmation that state changed.
 
@@ -178,6 +183,7 @@ Each entry is **self-contained** — it does not require zipping with the top-le
     "principal": "oidc~94eb1d88-7854-43a0-b517-a75f92c533a5"
   },
   "privilege_source": "authorizer",
+  "user_agent": "PyIceberg/0.9.1",
   "decision": "allowed",
   "authorizations": [
     {
@@ -221,6 +227,7 @@ Each entry is **self-contained** — it does not require zipping with the top-le
     "principal": "oidc~user@example.com"
   },
   "privilege_source": "authorizer",
+  "user_agent": "Trino/476",
   "decision": "denied",
   "authorizations": [
     {
@@ -282,6 +289,7 @@ A single `POST /management/v1/action/batch-check` call from `oidc~94eb1d88-…` 
     "principal": "oidc~94eb1d88-7854-43a0-b517-a75f92c533a5"
   },
   "privilege_source": "authorizer",
+  "user_agent": "curl/8.7.1",
   "decision": "allowed",
   "authorizations": [
     {
@@ -705,6 +713,9 @@ cat logs.json | jq -R 'fromjson? | select(.event_source == "audit" and any((.aut
 
 # Every grant change, allowed or refused
 cat logs.json | jq -R 'fromjson? | select(.event_source == "audit" and .action.action_name == "apply_grants")'
+
+# Which client libraries are calling, and how often (remember: caller-supplied, unverified)
+cat logs.json | jq -R -r 'fromjson? | select(.event_source == "audit") | .user_agent // "(none sent)"' | sort | uniq -c | sort -rn
 
 # Refused attempts to grant privileges TO a specific principal (not by them)
 cat logs.json | jq -R 'fromjson? | select(.event_source == "audit" and .action.action_name == "apply_grants" and any((.action.principals // [])[]; . == "user:oidc~alice") and any((.authorizations // [])[]; .allowed == false))'


### PR DESCRIPTION
Authorization audit events now carry a top-level `user_agent` field holding the `User-Agent` request header, so consumers can tell which client made a call. It is `null` when the request sent no header — for example an in-process call from a background worker.

The header is recorded verbatim rather than classified. `UserAgent` was an enum that only distinguished PyIceberg, because the ADLS SAS-property workaround is the sole caller that needs to branch on a client, and that shape discarded the original string for PyIceberg requests. It is now a newtype over the raw header, truncated at 256 bytes since the value is caller-controlled and lands on every audit record; the ADLS path derives the version by prefix strip.

Recording the header as sent keeps the audit log evidential and avoids committing to a client parser maintained against strings the caller chooses. Consumers classify; Lakekeeper records.

The field is client-supplied and unverified — any caller can set it to any value, including one naming a different client. `actor` and `privilege_source` remain the authenticated facts on the same event, and the logging docs say so explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Audit authorization events now include the caller-reported user agent when available.
  - User-agent values are preserved verbatim and truncated safely to 256 bytes; missing values appear as `null`.
  - PyIceberg client versions can be identified from user-agent information.

- **Documentation**
  - Audit-log documentation now describes user-agent data, privacy considerations, truncation, and limitations.
  - Added examples for successful, failed, and batch authorization events.
  - Added a query for counting audit events by reported user agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->