### PR TITLE
feat(catalog): honor data-access on registerTable

### DIFF
--- a/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
@@ -3065,7 +3065,23 @@ mod register_data_access {
                 client_managed.etag, vended.etag,
                 "the ETag must distinguish the delegation the response was built for"
             );
-            assert!(vended.etag.is_some());
+            // A vended credential expires, so the tag must carry its revalidation
+            // point — `lk1.<hash>.<revalidate-after-hex>`. Without the third
+            // segment the client holds a validator that can never yield a 304.
+            let vended_etag = vended.etag.expect("a vending response must be taggable");
+            assert_eq!(
+                vended_etag.as_str().split('.').count(),
+                3,
+                "expected a revalidation point in {}",
+                vended_etag.as_str()
+            );
+            let client_managed_etag = client_managed.etag.expect("still taggable without creds");
+            assert_eq!(
+                client_managed_etag.as_str().split('.').count(),
+                2,
+                "no credential means no revalidation point: {}",
+                client_managed_etag.as_str()
+            );
         }
     }
 }

--- a/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
@@ -2603,6 +2603,7 @@ async fn test_register_table_with_overwrite(pool: PgPool) {
     CatalogServer::register_table(
         ns_params.clone(),
         register_request.clone(),
+        DataAccess::not_specified(),
         ctx.clone(),
         RequestMetadata::new_unauthenticated(),
     )
@@ -2620,6 +2621,7 @@ async fn test_register_table_with_overwrite(pool: PgPool) {
     let result = CatalogServer::register_table(
         ns_params.clone(),
         register_request_with_overwrite,
+        DataAccess::not_specified(),
         ctx.clone(),
         RequestMetadata::new_unauthenticated(),
     )
@@ -2921,6 +2923,7 @@ async fn test_register_table_enforces_the_format_version_policy(pg_pool: PgPool)
         CatalogServer::register_table(
             ns_params.clone(),
             request,
+            DataAccess::not_specified(),
             ctx.clone(),
             RequestMetadata::new_unauthenticated(),
         )
@@ -2936,4 +2939,133 @@ async fn test_register_table_enforces_the_format_version_policy(pg_pool: PgPool)
     register("registered_v2", FormatVersion::V2)
         .await
         .expect("a v2 file is allowed by the policy");
+}
+
+/// `data-access` on register is only observable against a storage profile that
+/// actually vends. The memory profile the rest of this file uses ignores it and
+/// returns an empty config, so these live against MinIO.
+mod register_data_access {
+    /// Named so nextest's default profile filters it out; CI runs it with MinIO up.
+    pub mod minio_integration_tests {
+        use lakekeeper::api::iceberg::v1::DataAccessMode;
+        use lakekeeper_integration_tests::s3_compatible_profile;
+
+        use super::super::*;
+
+        type Ctx = ApiContext<State<AllowAllAuthorizer, PostgresBackend, SecretsState>>;
+
+        async fn drop_keeping_data(ctx: &Ctx, ns_params: &NamespaceParameters, table: &TableIdent) {
+            CatalogServer::drop_table(
+                TableParameters {
+                    prefix: ns_params.prefix.clone(),
+                    table: table.clone(),
+                },
+                DropParams {
+                    purge_requested: false,
+                    force: false,
+                },
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .expect("dropping without purge must leave the metadata file in place");
+        }
+
+        async fn register(
+            ctx: &Ctx,
+            ns_params: &NamespaceParameters,
+            metadata_location: &str,
+            data_access: impl Into<DataAccessMode> + Send,
+        ) -> LoadTableResult {
+            CatalogServer::register_table(
+                ns_params.clone(),
+                iceberg_ext::catalog::rest::RegisterTableRequest::builder()
+                    .name("registered".to_string())
+                    .metadata_location(metadata_location.to_string())
+                    .build(),
+                data_access,
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .unwrap()
+        }
+
+        #[sqlx::test]
+        async fn test_register_honors_the_requested_data_access(pool: PgPool) {
+            let (profile, cred) = s3_compatible_profile();
+            let (ctx, warehouse) = lakekeeper_integration_tests::setup_simple(
+                pool,
+                profile,
+                Some(cred),
+                AllowAllAuthorizer::default(),
+                TabularDeleteProfile::Hard {},
+                None,
+            )
+            .await;
+            let ns = create_ns(
+                ctx.clone(),
+                warehouse.warehouse_id.to_string(),
+                "ns1".to_string(),
+            )
+            .await;
+            let ns_params = NamespaceParameters {
+                prefix: Some(Prefix(warehouse.warehouse_id.to_string())),
+                namespace: ns.namespace.clone(),
+            };
+            let table = TableIdent {
+                namespace: ns.namespace.clone(),
+                name: "registered".to_string(),
+            };
+
+            // Creating writes the metadata file that register then reads back.
+            let created = CatalogServer::create_table(
+                ns_params.clone(),
+                create_request(Some("registered".to_string()), Some(false)),
+                DataAccess::not_specified(),
+                ctx.clone(),
+                RequestMetadata::new_unauthenticated(),
+            )
+            .await
+            .unwrap();
+            let metadata_location = created.metadata_location.clone().unwrap();
+
+            drop_keeping_data(&ctx, &ns_params, &table).await;
+            let client_managed = register(
+                &ctx,
+                &ns_params,
+                &metadata_location,
+                DataAccessMode::ClientManaged,
+            )
+            .await;
+            assert!(
+                client_managed.storage_credentials.is_none(),
+                "client-managed must suppress vending, got {:?}",
+                client_managed.storage_credentials
+            );
+
+            drop_keeping_data(&ctx, &ns_params, &table).await;
+            let vended = register(
+                &ctx,
+                &ns_params,
+                &metadata_location,
+                DataAccess {
+                    vended_credentials: true,
+                    remote_signing: false,
+                },
+            )
+            .await;
+            let credentials = vended
+                .storage_credentials
+                .expect("vended-credentials must reach the modern storage-credentials field");
+            assert_eq!(credentials.len(), 1);
+            // The tag encodes the delegation the config was built for, so the two
+            // registrations must not hand a client a validator for the other's scope.
+            assert_ne!(
+                client_managed.etag, vended.etag,
+                "the ETag must distinguish the delegation the response was built for"
+            );
+            assert!(vended.etag.is_some());
+        }
+    }
 }

--- a/crates/lakekeeper/src/api/iceberg/v1/tables.rs
+++ b/crates/lakekeeper/src/api/iceberg/v1/tables.rs
@@ -266,6 +266,7 @@ where
     async fn register_table(
         parameters: NamespaceParameters,
         request: RegisterTableRequest,
+        data_access: impl Into<DataAccessMode> + Send,
         state: ApiContext<S>,
         request_metadata: RequestMetadata,
     ) -> Result<LoadTableResult>;
@@ -377,6 +378,7 @@ pub fn router<I: TablesService<S>, S: crate::api::ThreadSafe>() -> Router<ApiCon
             post(
                 |Path((prefix, namespace)): Path<(Prefix, NamespaceIdentUrl)>,
                  State(api_context): State<ApiContext<S>>,
+                 headers: HeaderMap,
                  Extension(metadata): Extension<RequestMetadata>,
                  Json(request): Json<RegisterTableRequest>| {
                     I::register_table(
@@ -385,6 +387,7 @@ pub fn router<I: TablesService<S>, S: crate::api::ThreadSafe>() -> Router<ApiCon
                             namespace: namespace.into(),
                         },
                         request,
+                        parse_data_access(&headers),
                         api_context,
                         metadata,
                     )
@@ -936,6 +939,7 @@ mod test {
             async fn register_table(
                 _parameters: super::super::namespace::NamespaceParameters,
                 _request: crate::api::RegisterTableRequest,
+                _data_access: impl Into<super::DataAccessMode> + Send,
                 _state: ApiContext<ThisState>,
                 _request_metadata: RequestMetadata,
             ) -> crate::api::Result<LoadTableResult> {
@@ -1124,6 +1128,7 @@ mod test {
             async fn register_table(
                 _parameters: super::super::namespace::NamespaceParameters,
                 _request: crate::api::RegisterTableRequest,
+                _data_access: impl Into<super::DataAccessMode> + Send,
                 _state: ApiContext<ThisState>,
                 _request_metadata: RequestMetadata,
             ) -> crate::api::Result<LoadTableResult> {
@@ -1570,5 +1575,179 @@ mod test {
         let headers = response.headers();
 
         assert!(headers.is_empty());
+    }
+
+    /// The register route extracted no `HeaderMap`, so the delegation the client
+    /// asked for could not reach the handler at all. Driven through axum because
+    /// the extractor is the thing under test.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn register_table_forwards_the_requested_data_access() {
+        use async_trait::async_trait;
+        use iceberg_ext::catalog::rest::{ErrorModel, IcebergErrorResponse};
+        use tower::ServiceExt;
+
+        use crate::{
+            api::{ApiContext, LoadTableResult},
+            request_metadata::RequestMetadata,
+        };
+
+        #[derive(Debug, Clone)]
+        struct TestService;
+
+        #[derive(Debug, Clone)]
+        struct ThisState;
+
+        impl crate::api::ThreadSafe for ThisState {}
+
+        #[async_trait]
+        impl super::TablesService<ThisState> for TestService {
+            async fn list_tables(
+                _parameters: super::super::namespace::NamespaceParameters,
+                _query: super::ListTablesQuery,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<crate::api::ListTablesResponse> {
+                panic!("Should not be called");
+            }
+
+            async fn create_table(
+                _parameters: super::super::namespace::NamespaceParameters,
+                _request: crate::api::CreateTableRequest,
+                _data_access: impl Into<super::DataAccessMode> + Send,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<LoadTableResult> {
+                panic!("Should not be called");
+            }
+
+            async fn register_table(
+                _parameters: super::super::namespace::NamespaceParameters,
+                _request: crate::api::RegisterTableRequest,
+                data_access: impl Into<super::DataAccessMode> + Send,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<LoadTableResult> {
+                // The delegation is what is under test, so report it back as an error.
+                Err(ErrorModel::builder()
+                    .message(format!("{:?}", data_access.into()))
+                    .r#type("UnsupportedOperationException".to_string())
+                    .code(406)
+                    .build()
+                    .into())
+            }
+
+            async fn load_table(
+                _parameters: super::TableParameters,
+                _request: super::LoadTableRequest,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<LoadTableResultOrNotModified> {
+                panic!("Should not be called");
+            }
+
+            async fn load_table_credentials(
+                _parameters: super::TableParameters,
+                _request: super::LoadTableCredentialsRequest,
+                _data_access: super::DataAccess,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<iceberg_ext::catalog::rest::LoadCredentialsResponse>
+            {
+                panic!("Should not be called");
+            }
+
+            async fn commit_table(
+                _parameters: super::TableParameters,
+                _request: crate::api::CommitTableRequest,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<crate::api::CommitTableResponse> {
+                panic!("Should not be called");
+            }
+
+            async fn drop_table(
+                _parameters: super::TableParameters,
+                _drop_params: crate::api::iceberg::types::DropParams,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<()> {
+                panic!("Should not be called");
+            }
+
+            async fn table_exists(
+                _parameters: super::TableParameters,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<()> {
+                panic!("Should not be called");
+            }
+
+            async fn rename_table(
+                _prefix: Option<crate::api::iceberg::types::Prefix>,
+                _request: crate::api::RenameTableRequest,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<()> {
+                panic!("Should not be called");
+            }
+
+            async fn commit_transaction(
+                _prefix: Option<crate::api::iceberg::types::Prefix>,
+                _request: crate::api::CommitTransactionRequest,
+                _state: ApiContext<ThisState>,
+                _request_metadata: RequestMetadata,
+            ) -> crate::api::Result<()> {
+                panic!("Should not be called");
+            }
+        }
+
+        let router = axum::Router::new()
+            .merge(super::router::<TestService, ThisState>())
+            .with_state(ApiContext {
+                v1_state: ThisState,
+            });
+
+        let body = serde_json::json!({
+            "name": "test-table",
+            "metadata-location": "s3://bucket/table/metadata/v1.metadata.json",
+        })
+        .to_string();
+
+        for (header, expected) in [
+            (
+                Some("vended-credentials"),
+                DataAccessMode::ServerDelegated(DataAccess {
+                    vended_credentials: true,
+                    remote_signing: false,
+                }),
+            ),
+            (Some("client-managed"), DataAccessMode::ClientManaged),
+            // No header at all leaves the choice to the server, as before.
+            (
+                None,
+                DataAccessMode::ServerDelegated(DataAccess::not_specified()),
+            ),
+        ] {
+            let mut req = http::Request::builder()
+                .method(http::Method::POST)
+                .uri("/test/namespaces/test-namespace/register")
+                .header(header::CONTENT_TYPE, "application/json");
+            if let Some(header) = header {
+                req = req.header(super::DATA_ACCESS_HEADER, header);
+            }
+            let mut req = req.body(axum::body::Body::from(body.clone())).unwrap();
+            req.extensions_mut()
+                .insert(RequestMetadata::new_unauthenticated());
+
+            let response = router.clone().oneshot(req).await.unwrap();
+            assert_eq!(response.status().as_u16(), 406, "{header:?}");
+            let bytes = http_body_util::BodyExt::collect(response)
+                .await
+                .unwrap()
+                .to_bytes();
+            let error: IcebergErrorResponse = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(error.error.message, format!("{expected:?}"), "{header:?}");
+        }
     }
 }

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -87,7 +87,7 @@ use crate::{
         idempotency::{IdempotencyCheck, IdempotencyInfo},
         require_namespace_for_tabular,
         secrets::SecretStore,
-        storage::StoragePermissions,
+        storage::{StoragePermissions, credential_revalidate_after_ms},
         tasks::{
             ScheduleTaskMetadata, TaskEntity, WarehouseTaskEntityId,
             tabular_expiration_queue::{TabularExpirationPayload, TabularExpirationTask},
@@ -487,6 +487,9 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             )
             .await?;
         let storage_credentials = config.storage_credentials(&table_location);
+        let credentials_revalidate_after_ms = config
+            .credentials_expiration_ms
+            .map(credential_revalidate_after_ms);
 
         // Insert idempotency key in the same transaction.
         if let Some(ref key) = idempotency_key
@@ -556,12 +559,15 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             Arc::new(request),
             table_metadata.clone(),
             Arc::new(metadata_location),
+            data_access,
         );
 
         // Full snapshot list from the metadata file, tagged with the delegation
         // and permission scope the config above was built for. A read-only
         // caller's later load is scoped narrower, so it gets a distinct tag
-        // rather than matching this one.
+        // rather than matching this one. Now that register vends, the tag has to
+        // carry the credential's revalidation point too: without it a vending
+        // response yields a tag that can never produce a 304.
         let etag = etag::TableETag::new(
             &metadata_location_str,
             etag::TableResponseShape::new(
@@ -572,7 +578,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
                     warehouse_version: warehouse.version,
                 },
             ),
-            None,
+            credentials_revalidate_after_ms,
         )
         .into_etag();
 

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -130,8 +130,8 @@ async fn replay_load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStor
     match load_result {
         LoadTableResultOrNotModified::LoadTableResult(r) => Ok(r),
         LoadTableResultOrNotModified::NotModifiedResponse(_) => {
-            // Should not happen: replay uses LoadTableRequest::default() with no
-            // If-None-Match header. If it does, treat as an internal error.
+            // Should not happen: a replay carries no `If-None-Match`, so the load
+            // has no etag to match. If it does, treat as an internal error.
             Err(ErrorModel::internal(
                 "Unexpected NotModified during idempotency replay",
                 "IdempotencyReplayFailed",
@@ -273,10 +273,12 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
     async fn register_table(
         parameters: NamespaceParameters,
         request: RegisterTableRequest,
+        data_access: impl Into<DataAccessMode> + Send,
         state: ApiContext<State<A, C, S>>,
         request_metadata: RequestMetadata,
     ) -> Result<LoadTableResult> {
         // ------------------- VALIDATIONS -------------------
+        let data_access: DataAccessMode = data_access.into();
         let NamespaceParameters {
             namespace: provided_ns,
             prefix,
@@ -299,7 +301,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
                 };
                 return replay_load_table::<C, A, S>(
                     load_params,
-                    DataAccessMode::default(),
+                    data_access,
                     state,
                     request_metadata,
                     "registerTable",
@@ -471,9 +473,8 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         )
         .await?;
 
-        // Bound once and reused for the ETag shape below: if register ever starts
-        // honouring the delegation header, the tag must follow the config.
-        let data_access: DataAccessMode = DataAccess::not_specified().into();
+        // Bound once and reused for the ETag shape below, so the tag follows the
+        // config the delegation actually produced.
         let storage_permissions = StoragePermissions::ReadWriteDelete;
         let config = storage_profile
             .generate_table_config(
@@ -485,6 +486,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
                 &table_info,
             )
             .await?;
+        let storage_credentials = config.storage_credentials(&table_location);
 
         // Insert idempotency key in the same transaction.
         if let Some(ref key) = idempotency_key
@@ -559,9 +561,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         // Full snapshot list from the metadata file, tagged with the delegation
         // and permission scope the config above was built for. A read-only
         // caller's later load is scoped narrower, so it gets a distinct tag
-        // rather than matching this one. Register never honours the delegation
-        // header, so a client that sent one misses this tag on its next load —
-        // a lost validator, not a wrong one.
+        // rather than matching this one.
         let etag = etag::TableETag::new(
             &metadata_location_str,
             etag::TableResponseShape::new(
@@ -580,7 +580,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             metadata_location: Some(metadata_location_str),
             metadata: table_metadata,
             config: Some(config.config.into()),
-            storage_credentials: None,
+            storage_credentials,
             etag: Some(etag),
         })
     }

--- a/crates/lakekeeper/src/service/events/publisher.rs
+++ b/crates/lakekeeper/src/service/events/publisher.rs
@@ -197,6 +197,7 @@ impl EventListener for CloudEventsPublisher {
             request,
             metadata,
             metadata_location: _metadata_location,
+            data_access: _data_access,
             request_metadata,
         } = event;
         self.publish(

--- a/crates/lakekeeper/src/service/events/types/namespace.rs
+++ b/crates/lakekeeper/src/service/events/types/namespace.rs
@@ -84,6 +84,10 @@ pub struct RegisterTableEvent {
     pub request: Arc<RegisterTableRequest>,
     pub metadata: TableMetadataRef,
     pub metadata_location: Arc<Location>,
+    /// The delegation the response was built for. Register vends credentials, so
+    /// without this a subscriber cannot tell a registration that handed out
+    /// read-write-delete credentials from one that handed out none.
+    pub data_access: DataAccessMode,
     pub request_metadata: Arc<RequestMetadata>,
 }
 
@@ -274,12 +278,14 @@ impl
         request: Arc<RegisterTableRequest>,
         metadata: TableMetadataRef,
         metadata_location: Arc<Location>,
+        data_access: DataAccessMode,
     ) {
         let event = RegisterTableEvent {
             namespace: self.resolved_entity.data,
             request,
             metadata,
             metadata_location,
+            data_access,
             request_metadata: self.request_metadata,
         };
         let dispatcher = self.dispatcher;


### PR DESCRIPTION
The register route extracted no HeaderMap, so the delegation a client asked for could not reach the handler at all. The comment claiming register vends nothing was already false: generate_table_config ran with not_specified(), which S3 auto-promotes to vending, and all three backends duplicate the credential into the legacy config map. Clients got a credential they were never told about, in the field the spec deprecates.

Now parsed like createTable and passed through, so the response carries storage-credentials and its revalidation point (which the ETag embeds, so a 304 can no longer outlive the credential). client-managed can suppress vending, remote-signing is requestable, and the idempotency replay uses the caller's mode instead of the default.

No change for existing clients: an absent header still parses to ServerDelegated(not_specified()), which is what was hardcoded.

Tested at two levels: a router test over three header states, since the extractor is what was broken, and a MinIO-backed register test, since the memory profile every other register test uses ignores data-access entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table registration now supports requested data-access modes.
  * Client-managed access no longer returns storage credentials.
  * Delegated access returns storage credentials and credential revalidation information.
  * Access preferences are preserved when registration requests are safely replayed.
  * Registration responses now generate access-aware ETags while preserving metadata files.

* **Tests**
  * Added coverage for delegated, client-managed, and unspecified access requests, including credential handling and ETag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->