### PR TITLE
fix(catalog): scope table ETags to the warehouse

### DIFF
--- a/crates/iceberg-ext/src/catalog/rest/table.rs
+++ b/crates/iceberg-ext/src/catalog/rest/table.rs
@@ -240,13 +240,13 @@ mod tests {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
-            etag: Some(ETag::from("W/\"lk1.deadbeef\"")),
+            etag: Some(ETag::from("W/\"lk2.deadbeef\"")),
         };
 
         let response = load_table_result.into_response();
         let headers = response.headers();
 
-        assert_eq!(headers.get(header::ETAG).unwrap(), "W/\"lk1.deadbeef\"");
+        assert_eq!(headers.get(header::ETAG).unwrap(), "W/\"lk2.deadbeef\"");
     }
 
     #[test]
@@ -259,13 +259,13 @@ mod tests {
             metadata: create_table_metadata_mock(),
             config: None,
             storage_credentials: None,
-            etag: Some(ETag::from("W/\"lk1.abc.199e1e0f9c3\"")),
+            etag: Some(ETag::from("W/\"lk2.abc.199e1e0f9c3\"")),
         };
 
         let response = load_table_result.into_response();
         assert_eq!(
             response.headers().get(header::ETAG).unwrap(),
-            "W/\"lk1.abc.199e1e0f9c3\""
+            "W/\"lk2.abc.199e1e0f9c3\""
         );
     }
 
@@ -299,7 +299,7 @@ mod tests {
             metadata: table_metadata.clone(),
             config: None,
             storage_credentials: None,
-            etag: Some(ETag::from("W/\"lk1.deadbeef\"")),
+            etag: Some(ETag::from("W/\"lk2.deadbeef\"")),
         };
 
         let response = load_table_result.clone().into_response();

--- a/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
@@ -3066,7 +3066,7 @@ mod register_data_access {
                 "the ETag must distinguish the delegation the response was built for"
             );
             // A vended credential expires, so the tag must carry its revalidation
-            // point — `lk1.<hash>.<revalidate-after-hex>`. Without the third
+            // point — `lk2.<hash>.<revalidate-after-hex>`. Without the third
             // segment the client holds a validator that can never yield a 304.
             let vended_etag = vended.etag.expect("a vending response must be taggable");
             assert_eq!(

--- a/crates/lakekeeper/src/api/iceberg/v1/tables.rs
+++ b/crates/lakekeeper/src/api/iceberg/v1/tables.rs
@@ -1283,7 +1283,7 @@ mod test {
             metadata: table_metadata,
             config: None,
             storage_credentials: None,
-            etag: Some(ETag::from("W/\"lk1.deadbeef\"")),
+            etag: Some(ETag::from("W/\"lk2.deadbeef\"")),
         };
         let load_table_result_response_expected = load_table_result.clone().into_response();
 

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -150,6 +150,7 @@ async fn replay_commit_table<C: CatalogStore, A: Authorizer + Clone, S: SecretSt
     state: ApiContext<State<A, C, S>>,
     request_metadata: RequestMetadata,
 ) -> Result<CommitTableResponse> {
+    let warehouse_id = require_warehouse_id(parameters.prefix.as_ref())?;
     // CommitTableResponse doesn't include storage credentials, so default access mode is fine.
     let r = replay_load_table::<C, A, S>(
         parameters,
@@ -167,7 +168,7 @@ async fn replay_commit_table<C: CatalogStore, A: Authorizer + Clone, S: SecretSt
         )
     })?;
     Ok(CommitTableResponse {
-        etag: Some(etag::commit_etag(&metadata_location)),
+        etag: Some(etag::commit_etag(warehouse_id, &metadata_location)),
         metadata_location,
         metadata: r.metadata,
         config: None,
@@ -569,6 +570,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         // carry the credential's revalidation point too: without it a vending
         // response yields a tag that can never produce a 304.
         let etag = etag::TableETag::new(
+            warehouse_id,
             &metadata_location_str,
             etag::TableResponseShape::new(
                 SnapshotsQuery::All,
@@ -691,6 +693,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
         request_metadata: RequestMetadata,
     ) -> Result<CommitTableResponse> {
         // ------------------- VALIDATIONS -------------------
+        let warehouse_id = require_warehouse_id(parameters.prefix.as_ref())?;
         request.identifier = Some(determine_table_ident(
             &parameters.table,
             request.identifier.as_ref(),
@@ -735,7 +738,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
 
                 let metadata_location = item.new_metadata_location.to_string();
                 Ok(CommitTableResponse {
-                    etag: Some(etag::commit_etag(&metadata_location)),
+                    etag: Some(etag::commit_etag(warehouse_id, &metadata_location)),
                     metadata_location,
                     metadata: item.new_metadata.clone(),
                     config: None,

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -360,7 +360,13 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
         config: Some(config.config.into()),
         storage_credentials,
         etag: metadata_location.as_ref().map(|loc| {
-            TableETag::new(loc.as_str(), shape, credentials_revalidate_after_ms).into_etag()
+            TableETag::new(
+                warehouse_id,
+                loc.as_str(),
+                shape,
+                credentials_revalidate_after_ms,
+            )
+            .into_etag()
         }),
     };
 

--- a/crates/lakekeeper/src/server/tables/etag.rs
+++ b/crates/lakekeeper/src/server/tables/etag.rs
@@ -1,7 +1,7 @@
 //! Construction of the `ETag` that lets a conditional `loadTable` be answered
 //! with `304 Not Modified`.
 //!
-//! This is Lakekeeper policy rather than Iceberg wire format — the `lk1.`
+//! This is Lakekeeper policy rather than Iceberg wire format — the `lk2.`
 //! encoding is ours, and the inputs include our authorization model — so it
 //! lives here and not in `iceberg-ext`. That crate keeps only the [`ETag`]
 //! newtype and emits whatever tag it is handed.
@@ -10,6 +10,7 @@ use iceberg_ext::catalog::rest::ETag;
 use xxhash_rust::xxh3::Xxh3Default;
 
 use crate::{
+    WarehouseId,
     api::iceberg::v1::tables::{DataAccessMode, LoadTableFilters, SnapshotsQuery},
     service::{WarehouseVersion, storage::StoragePermissions},
 };
@@ -17,7 +18,10 @@ use crate::{
 /// Version prefix for structured `loadTable` [`ETag`]s. Anything not parsing
 /// under this prefix (pre-upgrade or future-version values) isn't matched, so
 /// the client reloads. Bump the suffix on incompatible encoding changes.
-const ETAG_PREFIX: &str = "lk1";
+///
+/// `lk2` added the warehouse id to the hash. Every `lk1` tag in a client cache
+/// stops matching and the client reloads once — the cost of any axis change.
+const ETAG_PREFIX: &str = "lk2";
 
 /// One axis of a [`TableResponseShape`].
 ///
@@ -142,7 +146,7 @@ impl TableResponseShape {
 
 /// Structured contents of a `loadTable` [`ETag`].
 ///
-/// Wire form (inside the quotes): `lk1.<hash>`, or `lk1.<hash>.<revalidate_hex>`
+/// Wire form (inside the quotes): `lk2.<hash>`, or `lk2.<hash>.<revalidate_hex>`
 /// when credentials are vended (revalidate-after as epoch-ms in hex). Embedding
 /// the revalidation point lets the server decide, from the client-echoed tag
 /// alone, whether the held credentials are still within their serve window —
@@ -157,7 +161,21 @@ pub(crate) struct TableETag {
 }
 
 impl TableETag {
+    /// `warehouse_id` scopes the tag to the resource, not just to its metadata
+    /// location. The `(warehouse_id, fs_location)` index is not unique and every
+    /// lookup filters by warehouse, so two warehouses may hold the same metadata
+    /// file — `registerTable` is the one endpoint that can attach it to a table in
+    /// each. Without this axis one warehouse's tag would satisfy a conditional
+    /// load on the other and return the wrong warehouse's config.
+    ///
+    /// The table id is deliberately *not* an axis. Within a warehouse a location
+    /// belongs to at most one *live* table; a drop-keeping-data followed by a
+    /// re-register does let another table take it over later, but that body
+    /// differs only in the table-name-dependent credential-refresh URI, which
+    /// [`TableResponseShape`] already declares bounded by the credential window
+    /// rather than by the tag.
     pub(crate) fn new(
+        warehouse_id: WarehouseId,
         metadata_location: &str,
         shape: TableResponseShape,
         revalidate_after_ms: Option<i64>,
@@ -167,8 +185,13 @@ impl TableETag {
 
         // NUL-separated: each axis occupies a fixed slot, so no combination of an
         // arbitrary metadata location and the fixed tags can be re-split into a
-        // different combination that hashes the same.
+        // different combination that hashes the same. The warehouse id gets a
+        // separator like every other slot even though `as_bytes` is 16 bytes by
+        // type — the injectivity should come from the framing, not from a width
+        // invariant a future encoding change could quietly drop.
         let mut hasher = Xxh3Default::new();
+        hasher.update(warehouse_id.as_bytes());
+        hasher.update(&[0]);
         hasher.update(metadata_location.as_bytes());
         hasher.update(&[0]);
         hasher.update(snapshots.as_tag().as_bytes());
@@ -239,8 +262,9 @@ impl TableETag {
 }
 
 /// Mint the [`ETag`] for a commit response, which carries no storage config.
-pub(crate) fn commit_etag(metadata_location: &str) -> ETag {
+pub(crate) fn commit_etag(warehouse_id: WarehouseId, metadata_location: &str) -> ETag {
     TableETag::new(
+        warehouse_id,
         metadata_location,
         TableResponseShape::no_storage_config(),
         None,
@@ -256,6 +280,10 @@ mod tests {
     use crate::api::iceberg::v1::tables::DataAccess;
 
     const LOC: &str = "s3://bucket/table/metadata.json";
+    /// Fixed so the pinned wire-format values stay reproducible.
+    fn wh() -> WarehouseId {
+        WarehouseId::new(uuid::uuid!("019bbf1a-0000-7000-8000-0000000000a1"))
+    }
     fn wv() -> WarehouseVersion {
         WarehouseVersion::new(7)
     }
@@ -307,7 +335,7 @@ mod tests {
         let mut seen = HashSet::new();
         for shape in &shapes {
             assert!(
-                seen.insert(TableETag::new(LOC, *shape, None).into_etag()),
+                seen.insert(TableETag::new(wh(), LOC, *shape, None).into_etag()),
                 "duplicate ETag for {shape:?}"
             );
         }
@@ -333,10 +361,10 @@ mod tests {
         );
 
         assert_eq!(
-            TableETag::new(LOC, delegated_shape, None)
+            TableETag::new(wh(), LOC, delegated_shape, None)
                 .into_etag()
                 .as_str(),
-            "W/\"lk1.d6f45486df4c5bc3\""
+            "W/\"lk2.ca98cf6daac60cd\""
         );
         // Same shape, next warehouse version: differs only in the trailing
         // little-endian bytes, so a big-endian slip changes this value.
@@ -349,17 +377,52 @@ mod tests {
             },
         );
         assert_eq!(
-            TableETag::new(LOC, next_version, None).into_etag().as_str(),
-            "W/\"lk1.ce4d3de4c470d7d0\""
+            TableETag::new(wh(), LOC, next_version, None)
+                .into_etag()
+                .as_str(),
+            "W/\"lk2.e475cfa1e21ecde5\""
         );
         // The `nc` branch skips the version entirely, and the revalidation
         // point is appended as lower-case hex.
         assert_eq!(
-            TableETag::new(LOC, TableResponseShape::no_storage_config(), Some(255))
-                .into_etag()
-                .as_str(),
-            "W/\"lk1.7ccceafed717f689.ff\""
+            TableETag::new(
+                wh(),
+                LOC,
+                TableResponseShape::no_storage_config(),
+                Some(255)
+            )
+            .into_etag()
+            .as_str(),
+            "W/\"lk2.165c4d5b6eec0d9a.ff\""
         );
+    }
+
+    /// Two warehouses may cover overlapping locations, and `registerTable` is the
+    /// one endpoint that can attach the same metadata file to a table in each.
+    /// Every other axis is identical there, so only the warehouse id keeps
+    /// warehouse A's tag from answering a conditional load on warehouse B.
+    #[test]
+    fn warehouse_id_is_part_of_the_tag() {
+        // Spent on id entropy rather than on shapes: the id is hashed before any
+        // shape branching, so looping the shapes re-tests one code path, while
+        // ids differing only in their trailing bytes let a truncating slip
+        // (hashing half the UUID) pass. These differ in the trailing bytes, in
+        // the leading bytes, and throughout.
+        let ids = [
+            uuid::uuid!("019bbf1a-0000-7000-8000-0000000000a1"),
+            uuid::uuid!("019bbf1a-0000-7000-8000-0000000000b2"),
+            uuid::uuid!("f19bbf1a-0000-7000-8000-0000000000a1"),
+            uuid::uuid!("7c3d51e8-9a44-4b21-b6ff-2e1d0c8b7a90"),
+        ]
+        .map(WarehouseId::new);
+        let shape = all_shapes()[1];
+        let mut seen = HashSet::new();
+        for id in ids {
+            assert!(
+                seen.insert(TableETag::new(id, LOC, shape, None).into_etag()),
+                "two warehouses share a tag at the same location: {id:?}"
+            );
+        }
     }
 
     #[test]
@@ -380,15 +443,15 @@ mod tests {
             )
         };
         assert_ne!(
-            TableETag::new(LOC, shape(WarehouseVersion::new(1)), None),
-            TableETag::new(LOC, shape(WarehouseVersion::new(2)), None)
+            TableETag::new(wh(), LOC, shape(WarehouseVersion::new(1)), None),
+            TableETag::new(wh(), LOC, shape(WarehouseVersion::new(2)), None)
         );
     }
 
     #[test]
     fn etag_round_trips_through_the_wire_form() {
         for revalidate in [None, Some(1_750_000_000_123)] {
-            let etag = TableETag::new(LOC, all_shapes()[0], revalidate);
+            let etag = TableETag::new(wh(), LOC, all_shapes()[0], revalidate);
             let wire = etag.clone().into_etag();
             // `parse_etags` strips the quotes and the weak marker before we see it.
             let bare = wire.as_str().trim_start_matches("W/").trim_matches('"');
@@ -401,19 +464,21 @@ mod tests {
     fn etag_is_emitted_as_a_weak_validator() {
         // Two responses sharing a tag are not byte-identical — each vends freshly
         // minted credentials — so the tag is weak per RFC 9110 8.8.1.
-        let wire = TableETag::new(LOC, all_shapes()[0], None).into_etag();
+        let wire = TableETag::new(wh(), LOC, all_shapes()[0], None).into_etag();
         assert!(wire.as_str().starts_with("W/\""), "{}", wire.as_str());
         assert!(wire.as_str().ends_with('"'));
     }
 
     #[test]
     fn parse_rejects_legacy_and_junk() {
-        // Legacy bare hash, wrong prefix, empty hash, trailing junk, non-hex expiry.
+        // Legacy bare hash, superseded prefix, future prefix, empty hash,
+        // trailing junk, non-hex expiry.
         assert!(TableETag::parse("e34615aade2e6333").is_none());
-        assert!(TableETag::parse("lk2.abc").is_none());
-        assert!(TableETag::parse("lk1.").is_none());
-        assert!(TableETag::parse("lk1.abc.def.ghi").is_none());
-        assert!(TableETag::parse("lk1.abc.zzz").is_none());
+        assert!(TableETag::parse("lk1.abc").is_none());
+        assert!(TableETag::parse("lk3.abc").is_none());
+        assert!(TableETag::parse("lk2.").is_none());
+        assert!(TableETag::parse("lk2.abc.def.ghi").is_none());
+        assert!(TableETag::parse("lk2.abc.zzz").is_none());
     }
 
     #[test]
@@ -467,12 +532,13 @@ mod tests {
         // A commit body and a no-storage-access load body are both metadata with
         // no config, so they are the same shape and sharing a tag is correct.
         // Every config-bearing load differs and must not match.
-        let commit = commit_etag(LOC);
+        let commit = commit_etag(wh(), LOC);
         assert_eq!(
             commit,
-            TableETag::new(LOC, TableResponseShape::no_storage_config(), None).into_etag()
+            TableETag::new(wh(), LOC, TableResponseShape::no_storage_config(), None).into_etag()
         );
         let delegated_load = TableETag::new(
+            wh(),
             LOC,
             TableResponseShape::new(
                 SnapshotsQuery::All,

--- a/crates/lakekeeper/src/server/tables/load_table.rs
+++ b/crates/lakekeeper/src/server/tables/load_table.rs
@@ -133,6 +133,7 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
     };
     if let Some(etag) = match_not_modified(
         &etags,
+        warehouse_id,
         event_ctx
             .resolved()
             .table
@@ -229,6 +230,7 @@ pub async fn load_table<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>(
         storage_credentials,
         etag: metadata_location_ref.as_ref().map(|loc| {
             TableETag::new(
+                warehouse_id,
                 loc.as_str(),
                 response_shape,
                 credentials_revalidate_after_ms,
@@ -315,13 +317,14 @@ fn require_not_staged<T>(
 /// received.
 fn match_not_modified(
     client_etags: &[ETag],
+    warehouse_id: WarehouseId,
     metadata_location: Option<&str>,
     shape: TableResponseShape,
     now_ms: i64,
     vends_credentials: bool,
 ) -> Option<ETag> {
     let metadata_location = metadata_location?;
-    let current = TableETag::new(metadata_location, shape, None);
+    let current = TableETag::new(warehouse_id, metadata_location, shape, None);
 
     for client in client_etags {
         let value = client.as_str();
@@ -415,6 +418,12 @@ mod etag_tests {
         )
     }
 
+    /// Fixed: the tag is scoped to a warehouse, and every helper here uses the
+    /// same one so a mismatch means a real shape difference.
+    fn wh() -> WarehouseId {
+        WarehouseId::new(uuid::uuid!("019bbf1a-0000-7000-8000-0000000000a1"))
+    }
+
     /// Build a client-supplied `ETag` for a given shape, in the form
     /// `parse_etags` yields. `revalidate_after` = `None` for a metadata-only
     /// cached response.
@@ -423,7 +432,7 @@ mod etag_tests {
         shape: TableResponseShape,
         revalidate_after: Option<i64>,
     ) -> ETag {
-        as_client_etag(&TableETag::new(loc, shape, revalidate_after).into_etag())
+        as_client_etag(&TableETag::new(wh(), loc, shape, revalidate_after).into_etag())
     }
 
     /// The shape a client echoes back: the wire value with the weak marker and
@@ -438,7 +447,7 @@ mod etag_tests {
     }
 
     fn matches_repr(etags: &[ETag], shape: TableResponseShape, vends_credentials: bool) -> bool {
-        match_not_modified(etags, Some(LOC), shape, NOW, vends_credentials).is_some()
+        match_not_modified(etags, wh(), Some(LOC), shape, NOW, vends_credentials).is_some()
     }
 
     fn matches(etags: &[ETag], vends_credentials: bool) -> bool {
@@ -454,9 +463,9 @@ mod etag_tests {
 
     #[test]
     fn unparseable_etag_triggers_reload() {
-        // A pre-upgrade bare-hash ETag (or any non-`lk1` value) can't be parsed,
+        // A pre-upgrade bare-hash ETag (or any non-`lk2` value) can't be parsed,
         // so it never yields a 304. The client reloads once and re-primes.
-        let legacy = ETag::from(TableETag::new(LOC, all(), None).hash());
+        let legacy = ETag::from(TableETag::new(wh(), LOC, all(), None).hash());
         assert!(!matches(&[legacy], false));
         assert!(!matches(&[ETag::from("not-our-etag")], false));
     }
@@ -470,7 +479,7 @@ mod etag_tests {
 
     #[test]
     fn no_match_when_metadata_location_absent() {
-        assert!(match_not_modified(&[ETag::from("*")], None, all(), NOW, false).is_none());
+        assert!(match_not_modified(&[ETag::from("*")], wh(), None, all(), NOW, false).is_none());
     }
 
     #[test]
@@ -491,6 +500,7 @@ mod etag_tests {
                 assert!(
                     match_not_modified(
                         std::slice::from_ref(&etag),
+                        wh(),
                         Some(LOC),
                         all(),
                         check_now,
@@ -524,7 +534,7 @@ mod etag_tests {
     #[test]
     fn credential_load_rejects_unparseable_and_wildcard() {
         // Unparseable ETag and wildcard carry no revalidation point → reload.
-        let legacy = ETag::from(TableETag::new(LOC, all(), None).hash());
+        let legacy = ETag::from(TableETag::new(wh(), LOC, all(), None).hash());
         assert!(!matches(&[legacy], true));
         assert!(!matches(&[ETag::from("*")], true));
     }
@@ -661,7 +671,7 @@ mod etag_tests {
     fn commit_etag_does_not_satisfy_a_delegated_load() {
         // A commit response carries `config: None`, which no load reproduces, so
         // its tag must not 304 a load that expects storage config.
-        let commit = as_client_etag(&super::super::etag::commit_etag(LOC));
+        let commit = as_client_etag(&super::super::etag::commit_etag(wh(), LOC));
         assert!(!matches(std::slice::from_ref(&commit), false));
         assert!(!matches_repr(&[commit], refs(), false));
     }
@@ -671,14 +681,14 @@ mod etag_tests {
         // `If-None-Match: *` carries no representation, so the tag we echo must be
         // the one for the body this request would have produced. Echoing the
         // default here would hand the client an `all` tag for a `refs` body.
-        let echoed = match_not_modified(&[ETag::from("*")], Some(LOC), refs(), NOW, false)
+        let echoed = match_not_modified(&[ETag::from("*")], wh(), Some(LOC), refs(), NOW, false)
             .expect("wildcard should 304 when no credentials are vended");
         // Compare against the quoted wire form — `client_etag_for` yields the
         // unquoted shape a client echoes back, which is not what we emit.
-        assert_eq!(echoed, TableETag::new(LOC, refs(), None).into_etag());
+        assert_eq!(echoed, TableETag::new(wh(), LOC, refs(), None).into_etag());
         assert_ne!(
             echoed,
-            TableETag::new(LOC, all(), None).into_etag(),
+            TableETag::new(wh(), LOC, all(), None).into_etag(),
             "wildcard echoed the default representation instead of the requested one"
         );
         // That echoed tag must then be accepted for `refs` and rejected for `all`.
@@ -689,6 +699,39 @@ mod etag_tests {
             false
         ));
         assert!(!matches_repr(&[echoed_bare], all(), false));
+    }
+
+    /// The defect the warehouse-id axis exists for, asserted at the decision
+    /// level rather than only on the hash. Every other helper here shares one
+    /// warehouse — correctly, so that a differing id cannot mask a shape bug —
+    /// which is exactly why this case needs its own test.
+    ///
+    /// `vends_credentials` is true with an open revalidation window on purpose:
+    /// that neuters the credential gate, so only the warehouse axis can refuse.
+    #[test]
+    fn no_304_across_warehouses_at_the_same_location() {
+        let other = WarehouseId::new(uuid::uuid!("f1000000-0000-7000-8000-00000000000f"));
+        let cached_a =
+            as_client_etag(&TableETag::new(wh(), LOC, all(), Some(NOW + 60_000)).into_etag());
+
+        assert!(
+            match_not_modified(
+                std::slice::from_ref(&cached_a),
+                other,
+                Some(LOC),
+                all(),
+                NOW,
+                true
+            )
+            .is_none(),
+            "304'd warehouse B's load from warehouse A's ETag"
+        );
+        // Same tag, its own warehouse: still a 304, so the refusal above is the
+        // warehouse axis and not the window.
+        assert!(
+            match_not_modified(&[cached_a], wh(), Some(LOC), all(), NOW, true).is_some(),
+            "the tag must still match its own warehouse"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The tag hash covered metadata_location, snapshots, delegation, permissions and the warehouse version, but no warehouse identity. The (warehouse_id, fs_location) index is not unique and every lookup filters by warehouse, so two warehouses can hold the same metadata file — registerTable is the one endpoint that attaches it to a table in each. Warehouse A's tag would then satisfy a conditional load on warehouse B and return A's config.

Reaching it needs a client to replay a tag across two URLs, which no URL-keyed cache does, so this is a hole closed rather than a bug observed.

ETAG_PREFIX goes lk1 -> lk2: every cached tag stops matching and each client reloads once. Unparseable tags were already a reload rather than an error, so mixed-version deploys degrade in both directions.

The id gets a NUL separator like every other slot. It is 16 bytes by type, so a leading fixed-width field is already uniquely splittable — but the framing should not rest on a width invariant that is argued rather than enforced, and the separator is only free while the prefix bump is already redoing the pinned values.

The table id is deliberately not an axis: within a warehouse a location has at most one live table, and the drop-keeping-data/re-register case differs only in the name-dependent refresh URI, which the tag already declares bounded by the credential window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table response validation by including the warehouse in ETags.
  * Prevented identical metadata locations across different warehouses from sharing ETags.
  * Updated conditional requests and replayed responses to use the new warehouse-scoped ETag format.
  * Preserved matching behavior within the same warehouse while maintaining validation for malformed or unsupported ETags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->