### PR TITLE
fix(docs): index only the latest version in the site search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,8 @@ docs/_build/
 # website build
 docs/site/
 site/site/
-site/docs/docs/
+# Worktree of the `docs` branch, created by site/dev/setup_env.sh.
+site/versions/
 **.bkp
 
 # PyBuilder

--- a/site/dev/common.sh
+++ b/site/dev/common.sh
@@ -88,30 +88,30 @@ update_version () {
 
 create_nightly () {
     echo " --> create nightly"
-    
-    # Ensure the docs/docs directory exists
-    mkdir -p docs/docs/
-    
+
+    # Ensure the versions directory exists
+    mkdir -p versions/
+
     # Remove any existing 'nightly' directory and recreate it
-    rm -rf docs/docs/nightly/
-    mkdir docs/docs/nightly/
-    
+    rm -rf versions/nightly/
+    mkdir versions/nightly/
+
     # Create symbolic links and copy configuration files for the 'nightly' documentation
-    ln -s "../../../../docs/docs/" docs/docs/nightly/docs
-    cp "../docs/mkdocs.yml" docs/docs/nightly/
-    
-    cd docs/docs/
-    
+    ln -s "../../../docs/docs/" versions/nightly/docs
+    cp "../docs/mkdocs.yml" versions/nightly/
+
+    cd versions/
+
     # Update mkdocs version field within the 'nightly' documentation
     update_version "nightly"
     cd -
 }
 
 # Finds and retrieves the latest version of the documentation based on the directory structure.
-# Assumes the documentation versions are numeric folders within 'docs/docs/'.
+# Assumes the documentation versions are numeric folders within 'versions/'.
 get_latest_version () {
-  # Find the latest numeric folder within 'docs/docs/' structure
-  local latest=$(ls -d docs/docs/[0-9]* | sort -V | tail -1)
+  # Find the latest numeric folder within 'versions/' structure
+  local latest=$(ls -d versions/[0-9]* | sort -V | tail -1)
 
   # Extract the version number from the latest directory path
   local latest_version=$(basename "${latest}")
@@ -132,14 +132,14 @@ create_latest () {
 
 
   # Remove any existing 'latest' directory and recreate it
-  rm -rf docs/docs/latest/
-  mkdir docs/docs/latest/
+  rm -rf versions/latest/
+  mkdir versions/latest/
 
   # Create symbolic links and copy configuration files for the 'latest' documentation
-  ln -s "../${LAKEKEEPER_VERSION}/docs" docs/docs/latest/docs
-  cp "docs/docs/${LAKEKEEPER_VERSION}/mkdocs.yml" docs/docs/latest/
+  ln -s "../${LAKEKEEPER_VERSION}/docs" versions/latest/docs
+  cp "versions/${LAKEKEEPER_VERSION}/mkdocs.yml" versions/latest/
 
-  cd docs/docs/
+  cd versions/
 
   # Update version information within the 'latest' documentation
   update_version "latest"
@@ -155,8 +155,14 @@ pull_versioned_docs () {
 
   # Add local worktrees for documentation and javadoc either from the remote repository
   # or from a local branch.
+  #
+  # The worktree MUST stay outside mkdocs' docs_dir (`docs/`). The monorepo plugin
+  # copies the whole docs_dir into its temporary build directory and then layers each
+  # `!include`d unit on top, so a version living inside docs_dir gets rendered twice:
+  # once at its site_name alias (`/docs/0.13.x/…`) and once as an orphan page
+  # (`/docs/0.13.x/docs/…`), which duplicates every page in the search index.
   local docs_branch="${LAKEKEEPER_VERSIONED_DOCS_BRANCH:-${REMOTE}/docs}"
-  git worktree add -f docs/docs "${docs_branch}"
+  git worktree add -f versions "${docs_branch}"
 
   # Retrieve the latest version of documentation for processing
   local latest_version=$(get_latest_version)
@@ -175,10 +181,20 @@ clean () {
   set +e
 
   # Remove temp directories and related Git worktrees
-  rm -rf docs/docs/latest &> /dev/null
-  rm -rf docs/docs/nightly &> /dev/null
+  rm -rf versions/latest &> /dev/null
+  rm -rf versions/nightly &> /dev/null
 
-  git worktree remove docs/docs &> /dev/null
+  git worktree remove versions &> /dev/null
+  rm -rf versions &> /dev/null
+
+  # Drop a worktree from the previous layout, where the versioned docs were checked
+  # out inside docs_dir. Left in place it would keep shadowing every version page.
+  rm -rf docs/docs/latest docs/docs/nightly &> /dev/null
+  git worktree remove --force docs/docs &> /dev/null
+  rm -rf docs/docs &> /dev/null
+
+  # Deregister worktrees whose directories are now gone
+  git worktree prune &> /dev/null
 
   # Remove any remaining artifacts
   rm -rf site/

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -46,7 +46,7 @@ Then open your browser and head to `localhost:8888` to load the example Jupyter 
 
 ### Option 2: 🐳 Docker Compose
 
-For a Docker-Compose deployment that is used with external object storage, and external Identity Providers, you can use the [`docker-compose` Setup](https://github.com/lakekeeper/lakekeeper/tree/main/docker-compose). Please also check the [Examples](#option-1-examples) and our [User Guides](./docs/nightly/docs/configuration.md) for additional information on customization.
+For a Docker-Compose deployment that is used with external object storage, and external Identity Providers, you can use the [`docker-compose` Setup](https://github.com/lakekeeper/lakekeeper/tree/main/docker-compose). Please also check the [Examples](#option-1-examples) and our [User Guides](./docs/nightly/configuration.md) for additional information on customization.
 
 While you can start the "🐳 Unsecured" variant without any external dependencies, you will need at least an external object store (S3, ADLS, GCS) to create a Warehouse.
 
@@ -60,7 +60,7 @@ While you can start the "🐳 Unsecured" variant without any external dependenci
 
 === "🐳 Authentication & Authorization"
 
-    Please follow the [Authentication Guide](./docs/nightly/docs/authentication.md) to prepare your Identity Provider. Additional environment variables might be required.
+    Please follow the [Authentication Guide](./docs/nightly/authentication.md) to prepare your Identity Provider. Additional environment variables might be required.
 
     ```bash
     git clone https://github.com/lakekeeper/lakekeeper
@@ -101,7 +101,7 @@ The default `LAKEKEEPER__BASE_URI` is `http://localhost:8181`.
 
 ### Option 5: 👨‍💻 Build from Sources
 
-To customize Lakekeeper, for example to connect to your own Authorization system, you might want to build the binary yourself. Please check the [Developer Guide](./docs/nightly/docs/developer-guide.md) for more information.
+To customize Lakekeeper, for example to connect to your own Authorization system, you might want to build the binary yourself. Please check the [Developer Guide](./docs/nightly/developer-guide.md) for more information.
 
 ## First Steps
 
@@ -163,7 +163,7 @@ If you want to use a different storage backend, see the [Storage Guide](docs/nig
 
 ### Connect Compute
 
-That's it - we can now use the catalog. The example below targets the **unsecured** deployment: it sends the literal token `dummy` because no Authentication is configured, so any bearer token is accepted. If you enabled Authentication, replace `"dummy"` with a real OAuth2 token (or configure your engine's OAuth2 flow) — see the [Authentication Guide](./docs/nightly/docs/authentication.md).
+That's it - we can now use the catalog. The example below targets the **unsecured** deployment: it sends the literal token `dummy` because no Authentication is configured, so any bearer token is accepted. If you enabled Authentication, replace `"dummy"` with a real OAuth2 token (or configure your engine's OAuth2 flow) — see the [Authentication Guide](./docs/nightly/authentication.md).
 
 !!! tip
 

--- a/site/docs/production.md
+++ b/site/docs/production.md
@@ -19,7 +19,7 @@ Everything you need to run Lakekeeper OSS safely is covered in the docs. In shor
 - **TLS termination** at a reverse proxy or ingress — Lakekeeper does not terminate connections itself.
 - **Monitoring & observability** wired to your stack.
 
-See the full [Production Checklist](./docs/nightly/docs/production.md) for the complete, up-to-date list.
+See the full [Production Checklist](./docs/nightly/production.md) for the complete, up-to-date list.
 
 ## Lakekeeper+: the production-grade path <span class="lkp"></span>
 
@@ -31,19 +31,19 @@ Lakekeeper+ builds on the open-source catalog with the capabilities regulated an
 
     ---
 
-    Express access policy as versioned, reviewable [Cedar](./docs/nightly/docs/authorization-cedar.md) policies — RBAC, ABAC, and property-based access in one model. Every decision is inspectable, with a per-decision policy trace and audit log, so you can prove *why* access was granted. Built for **regulated industries** where access must be governed, testable, and provable.
+    Express access policy as versioned, reviewable [Cedar](./docs/nightly/authorization-cedar.md) policies — RBAC, ABAC, and property-based access in one model. Every decision is inspectable, with a per-decision policy trace and audit log, so you can prove *why* access was granted. Built for **regulated industries** where access must be governed, testable, and provable.
 
 - :material-robot: &nbsp; __Autonomous maintenance__
 
     ---
 
-    Keep query performance high and storage costs low without operating maintenance jobs yourself. [Table maintenance](./docs/nightly/docs/table-maintenance.md) — expiring snapshots and removing orphan files — runs automatically and adaptively, scheduling itself per table based on how fast reclaimable data builds up.
+    Keep query performance high and storage costs low without operating maintenance jobs yourself. [Table maintenance](./docs/nightly/table-maintenance.md) — expiring snapshots and removing orphan files — runs automatically and adaptively, scheduling itself per table based on how fast reclaimable data builds up.
 
 - :material-account-key: &nbsp; __Enterprise identity & governance__
 
     ---
 
-    Resolve roles through [role providers](./docs/nightly/docs/configuration.md#role-provider) — Okta, Microsoft Entra ID, and LDAP; gate access with an external admission check; protect provider-synced roles from drift. Structured audit logs make the catalog auditable end to end.
+    Resolve roles through [role providers](./docs/nightly/configuration.md#role-provider) — Okta, Microsoft Entra ID, and LDAP; gate access with an external admission check; protect provider-synced roles from drift. Structured audit logs make the catalog auditable end to end.
 
 - :material-lifebuoy: &nbsp; __Enterprise support & LTS__
 

--- a/site/justfile
+++ b/site/justfile
@@ -25,7 +25,7 @@ build:
 #      source version (released versions are frozen snapshots and may carry old links).
 #   2. File/asset existence — lychee resolves the cross-unit/shared-asset paths that
 #      mkdocs' per-unit validation can't. Fragments are skipped (lychee mis-resolves
-#      mkdocs' pretty `page/` URLs), and the doubled `nightly/docs` orphan is excluded.
+#      mkdocs' pretty `page/` URLs).
 # Needs lychee: `cargo install lychee` (CI installs it via taiki-e/install-action).
 linkcheck:
   #!/usr/bin/env bash
@@ -38,7 +38,6 @@ linkcheck:
     exit 1
   fi
   lychee --offline --root-dir "$PWD/site" --no-progress \
-    --exclude-path site/docs/nightly/docs \
     site/index.html site/getting-started site/support site/about site/docs/nightly
 
 # Clean the local docs site.

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -52,18 +52,21 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Production: production.md
+  # `versions/` is the docs-branch worktree, deliberately outside docs_dir — see
+  # dev/common.sh. Public URLs come from each unit's `site_name` (`docs/<version>`),
+  # not from this path, so they are unaffected by where the worktree lives.
   - Docs:
-      - nightly: "!include docs/docs/nightly/mkdocs.yml"
-      - latest: "!include docs/docs/latest/mkdocs.yml"
-      - Release 0.13.x: "!include docs/docs/0.13.x/mkdocs.yml"
-      - Release 0.12.x: "!include docs/docs/0.12.x/mkdocs.yml"
-      - Release 0.11.x: "!include docs/docs/0.11.x/mkdocs.yml"
-      - Release 0.10.x: "!include docs/docs/0.10.x/mkdocs.yml"
-      - Release 0.9.x: "!include docs/docs/0.9.x/mkdocs.yml"
-      - Release 0.8.x: "!include docs/docs/0.8.x/mkdocs.yml"
-      - Release 0.7.x: "!include docs/docs/0.7.x/mkdocs.yml"
-      - Release 0.6.x: "!include docs/docs/0.6.x/mkdocs.yml"
-      - Release 0.5.x: "!include docs/docs/0.5.x/mkdocs.yml"
+      - nightly: "!include versions/nightly/mkdocs.yml"
+      - latest: "!include versions/latest/mkdocs.yml"
+      - Release 0.13.x: "!include versions/0.13.x/mkdocs.yml"
+      - Release 0.12.x: "!include versions/0.12.x/mkdocs.yml"
+      - Release 0.11.x: "!include versions/0.11.x/mkdocs.yml"
+      - Release 0.10.x: "!include versions/0.10.x/mkdocs.yml"
+      - Release 0.9.x: "!include versions/0.9.x/mkdocs.yml"
+      - Release 0.8.x: "!include versions/0.8.x/mkdocs.yml"
+      - Release 0.7.x: "!include versions/0.7.x/mkdocs.yml"
+      - Release 0.6.x: "!include versions/0.6.x/mkdocs.yml"
+      - Release 0.5.x: "!include versions/0.5.x/mkdocs.yml"
   - Release Notes:
       - Stay Updated: about/subscribe.md
       - Lakekeeper (OSS): about/release-notes.md
@@ -109,18 +112,23 @@ hooks:
 plugins:
   - monorepo
   - search
+  # Only `latest` is searchable. Every version ships the same page titles, so
+  # indexing more than one makes a single query return a near-identical hit per
+  # version. Numbered snapshots and `nightly` stay fully browsable — this trims
+  # the index only. Patterns are fnmatch against the search record's page path,
+  # where `*` also matches `/`, so `docs/[0-9]*` covers every numbered release
+  # without needing an entry per version.
   - exclude-search:
       exclude:
-        - docs/0.9.x/*
-        - docs/0.8.x/*
-        - docs/0.7.x/*
-        - docs/0.6.x/*
-        - docs/0.5.x/*
+        - docs/[0-9]*
         - docs/nightly/*
+      # Backstop: anything not reachable from the nav stays out of the index.
+      exclude_unreferenced: true
   - autorefs
 
 watch:
   - docs
+  - versions
   - overrides
 
 extra:


### PR DESCRIPTION
Searching the docs site returned the same page many times: the live index held 2971 records, 2465 of them redundant, so one query for "storage" matched 13 near-identical pages.

Two causes, stacking:

- The versioned-docs worktree was checked out at site/docs/docs, inside mkdocs' docs_dir. The monorepo plugin copies the whole docs_dir into its temporary build directory and then layers each !included unit on top, so every version was rendered twice — once at its site_name alias (/docs/0.13.x/...) and once as an orphan page (/docs/0.13.x/docs/...). Old point releases (0.5.0, 0.5.2, 0.6.0), absent from the nav, were published through that orphan path alone.

- exclude-search only excluded 0.5.x through 0.9.x, so latest, 0.13.x, 0.12.x, 0.11.x and 0.10.x were all indexed — and latest is a symlink to the newest release, making its 744 records byte-identical to 0.13.x.

Check the worktree out at site/versions, outside docs_dir, and index only latest. The exclusion is now a single docs/[0-9]* glob, so future releases need no config change. Every version stays fully browsable; only the index is trimmed, down to a predicted 466 records with 2 redundant. Public URLs are unchanged — they come from each unit's site_name, not the checkout path. clean now also tears down a worktree from the old layout, so existing checkouts self-heal, and linkcheck loses the lychee workaround for the doubled nightly/docs orphan.

The orphan /docs/<version>/docs/... URLs are gone. Nothing in the nav linked them; equivalent content for the dropped point releases remains at /docs/0.5.x/ and /docs/0.6.x/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation versioning to use a dedicated `versions/` layout.
  * Improved navigation, search exclusions, and live-reload coverage for versioned and nightly documentation.
  * Enabled offline link checking for nightly documentation paths.
  * Updated documentation setup and cleanup processes to remove obsolete layouts and stale worktree references.
  * Corrected links in getting-started and production documentation to point to the proper pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->