### PR TITLE
feat: raise default max request body size to 32 MB

### DIFF
--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -573,7 +573,11 @@ pub struct DynAppConfig {
     pub role: RoleConfig,
 
     // ------------- Request Limits -------------
-    /// Maximum request body size in bytes. Defaults to 2 MB.
+    /// Maximum request body size in bytes. Defaults to 32 MB.
+    ///
+    /// Table commits that remove many snapshots at once (e.g. the first
+    /// `expire_snapshots` run on a table with a large snapshot backlog) send a single
+    /// `updateTable` request listing every removed snapshot id, which can grow to several MB.
     pub max_request_body_size: usize,
     /// Maximum request time. Defaults to 30 seconds.
     #[serde(
@@ -1138,7 +1142,7 @@ impl Default for DynAppConfig {
             debug: DebugConfig::default(),
             role: RoleConfig::default(),
             cache: Cache::default(),
-            max_request_body_size: 2 * 1024 * 1024, // 2 MB
+            max_request_body_size: 32 * 1024 * 1024, // 32 MB
             max_request_time: Duration::from_secs(30),
             audit: AuditConfig {
                 tracing: AuditTracingConfig { enabled: true },

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -515,7 +515,7 @@ Lakekeeper allows you to configure limits on incoming requests to protect agains
 
 | Variable                                         | Example   | Description   |
 |--------------------------------------------------|-----------|---------------|
-| <nobr>`LAKEKEEPER__MAX_REQUEST_BODY_SIZE`</nobr> | `2097152` | Maximum request body size in bytes. Default: `2097152` (2 MB) |
+| <nobr>`LAKEKEEPER__MAX_REQUEST_BODY_SIZE`</nobr> | `33554432` | Maximum request body size in bytes. Default: `33554432` (32 MB) |
 | <nobr>`LAKEKEEPER__MAX_REQUEST_TIME`</nobr>      | `30s`     | Maximum time allowed for a request to complete. Accepts format `{number}{ms\|s}`. Default: `30s` |
 
 ### Roles


### PR DESCRIPTION
The previous default of 2 MB rejected legitimate table commits with 413 "Failed to buffer the request body: length limit exceeded". A single expire_snapshots run against a table with a large snapshot backlog sends one updateTable request listing every removed snapshot id, which crosses 2 MB at roughly 50-80k snapshots — reachable on high-frequency ingest tables that have never had snapshots expired. Multi-table commitTransaction bundles stack the same way.

2 MB was also axum's implicit default before
LAKEKEEPER__MAX_REQUEST_BODY_SIZE was introduced, so despite the knob being added in 0.12 this is the first time the effective limit has moved.

Request bodies are only buffered once a handler extractor runs, which is after the authentication layer, so the larger ceiling is reachable by authenticated callers only. Operators with tighter memory budgets can still lower it via the existing config variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the default maximum request body size from 2 MB to 32 MB.
  * Large snapshot-removal requests can now be submitted without exceeding the default limit.

* **Documentation**
  * Updated configuration documentation to reflect the new 32 MB default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->