### PR TITLE
fix(idempotency): collapse the replay check to a single variant

### DIFF
--- a/crates/lakekeeper-storage-postgres/src/idempotency.rs
+++ b/crates/lakekeeper-storage-postgres/src/idempotency.rs
@@ -1,6 +1,5 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use http::StatusCode;
 use lakekeeper::{
     WarehouseId,
     api::{Result, endpoints::EndpointFlat},
@@ -147,23 +146,27 @@ impl PostgresBackend {
             .into());
         }
 
+        // Records are written only for committed successes, so any row means the
+        // mutation already happened. A non-2xx status is therefore unreachable
+        // today; it is refused rather than swallowed, because both ways of
+        // swallowing it are worse than a loud failure — re-running the mutation
+        // would break at-most-once, and replaying it as a success would report an
+        // outcome that never occurred.
         match record.http_status {
-            204 => Ok(IdempotencyCheck::ReplayNoContent),
-            status @ 200..300 => Ok(IdempotencyCheck::ReplaySuccess {
-                http_status: u16::try_from(status)
-                    .ok()
-                    .and_then(|s| StatusCode::from_u16(s).ok())
-                    .unwrap_or(StatusCode::OK),
-            }),
+            200..300 => Ok(IdempotencyCheck::Replay),
             status => {
-                // Unexpected status in DB — log and treat as new request
-                tracing::warn!(
+                tracing::error!(
                     warehouse_id = %warehouse_id,
                     idempotency_key = %key.as_uuid(),
                     status,
-                    "Unexpected http_status in idempotency record, treating as new request"
+                    "Idempotency record holds a non-success status, which the write path cannot produce"
                 );
-                Ok(IdempotencyCheck::NewRequest)
+                Err(lakekeeper::api::ErrorModel::internal(
+                    "Idempotency record holds an unexpected status and cannot be replayed.",
+                    "CorruptIdempotencyRecord",
+                    None,
+                )
+                .into())
             }
         }
     }

--- a/crates/lakekeeper/src/service/idempotency.rs
+++ b/crates/lakekeeper/src/service/idempotency.rs
@@ -73,15 +73,24 @@ impl IdempotencyKey {
 /// Result of checking an idempotency key before the mutation.
 ///
 /// With the in-transaction design, records only exist for committed successes.
-/// There is no "in-progress" state and no stored error bodies.
+/// There is no "in-progress" state and no stored error bodies, so "a record
+/// exists" is the whole of what a caller needs to know: the mutation already
+/// happened and the handler should re-derive its success response rather than
+/// execute again.
+///
+/// Deliberately carries no status. The recorded `http_status` is kept in the row
+/// for forensics, but replaying it would be the wrong contract — every handler
+/// already knows the one status its success produces, and re-deriving is what
+/// lets the response reflect current catalog state, which the spec explicitly
+/// permits. A stored status is only worth surfacing here once records exist for
+/// outcomes a handler cannot re-derive on its own, i.e. finalized terminal 4xx.
 #[derive(Debug)]
 pub enum IdempotencyCheck {
     /// No existing record — proceed with the mutation.
     NewRequest,
-    /// Finalized with success (2xx) — handler should re-derive the response.
-    ReplaySuccess { http_status: StatusCode },
-    /// Finalized with 204 — return 204 No Content.
-    ReplayNoContent,
+    /// A finalized record exists — re-derive the success response instead of
+    /// executing the mutation.
+    Replay,
 }
 
 impl IdempotencyCheck {
@@ -89,10 +98,7 @@ impl IdempotencyCheck {
     /// instead of executing the mutation).
     #[must_use]
     pub fn is_replay(&self) -> bool {
-        matches!(
-            self,
-            IdempotencyCheck::ReplaySuccess { .. } | IdempotencyCheck::ReplayNoContent
-        )
+        matches!(self, IdempotencyCheck::Replay)
     }
 }
 
@@ -220,13 +226,7 @@ mod tests {
     #[test]
     fn idempotency_check_is_replay() {
         assert!(!IdempotencyCheck::NewRequest.is_replay());
-        assert!(
-            IdempotencyCheck::ReplaySuccess {
-                http_status: StatusCode::OK
-            }
-            .is_replay()
-        );
-        assert!(IdempotencyCheck::ReplayNoContent.is_replay());
+        assert!(IdempotencyCheck::Replay.is_replay());
     }
 }
 
@@ -237,5 +237,8 @@ mod tests {
 pub struct IdempotencyInfo {
     pub key: IdempotencyKey,
     pub endpoint: crate::api::endpoints::EndpointFlat,
+    /// Recorded but not replayed — [`IdempotencyCheck`] says why. Kept because it
+    /// is the only trace of what the original request answered, which is what
+    /// makes a stored record interpretable when diagnosing a replay.
     pub http_status: StatusCode,
 }


### PR DESCRIPTION
`IdempotencyCheck` carried an `http_status` no caller read and two replay variants nothing distinguished — every handler already knows the status its own success produces, and re-deriving is what lets the response reflect current catalog state.

Removing the dead field exposed the arm beneath it: an unexpected stored status fell through to `NewRequest` and silently re-ran the mutation. Records exist only for committed successes, so that state is unreachable from the write path; it now fails loudly instead of breaking at-most-once. The recorded status stays in the row as the only trace of what the original request answered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idempotent request replay handling for successful responses.
  * Replayed requests now consistently return a response based on the current catalog state.
  * Invalid idempotency records now produce an internal error instead of being processed as new requests.
* **Refactor**
  * Simplified idempotency replay outcomes into a single replay state, with consistent detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->