### PR TITLE
chore: seaweedfs just test seaweedfs and rename minio tests to s3 compat tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -69,3 +69,17 @@ retries = 0
 
 [profile.ci_no_secrets.junit] # this can be some other profile, too
 path = "junit.xml"
+
+# Only the tests that talk to the S3-compatible object store configured via
+# LAKEKEEPER_TEST__S3_*.
+[profile.s3_compat]
+default-filter = """
+    test(::minio_integration_tests::)
+    or (package(lakekeeper-io) and binary(integration_tests) and test(/_s3$/))
+"""
+failure-output = "immediate-final"
+fail-fast = false
+retries = 0
+
+[profile.s3_compat.junit]
+path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,7 +18,7 @@ default-filter = """
     and not test(::gcs_hns_integration_tests::)
     and not test(::gcp_system_credentials_integration_tests::)
     and not test(::kv2_integration_tests::)
-    and not test(::minio_integration_tests::)
+    and not test(::s3_compat_integration_tests::)
     and not test(::openfga_integration_tests::)
     and not test(::r2_integration_tests::)
     and not test(::oss_integration_tests::)
@@ -74,7 +74,7 @@ path = "junit.xml"
 # LAKEKEEPER_TEST__S3_*.
 [profile.s3_compat]
 default-filter = """
-    test(::minio_integration_tests::)
+    test(::s3_compat_integration_tests::)
     or (package(lakekeeper-io) and binary(integration_tests) and test(/_s3$/))
 """
 failure-output = "immediate-final"

--- a/.github/workflows/seaweedfs.yml
+++ b/.github/workflows/seaweedfs.yml
@@ -1,5 +1,4 @@
 name: SeaweedFS Tests
-
 on:
   push:
     branches:
@@ -13,6 +12,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN: 1.94.1
   RUSTFLAGS: --cfg tracing_unstable -D warnings
+  NEXTEST_PROFILE: s3_compat
 
 permissions:
   contents: read # Needed to checkout code
@@ -26,23 +26,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     services:
-      vault:
-        # Recent vault images run as non-root and hard-require IPC_LOCK; the
-        # old SKIP_SETCAP escape hatch is now ignored. Granting the capability
-        # via `options: --cap-add IPC_LOCK` is the supported workaround. Pin
-        # to a specific patch so an image refresh can't break CI again.
-        image: hashicorp/vault:1.21.4
-        ports:
-          - 8200:8200
-        env:
-          VAULT_DEV_ROOT_TOKEN_ID: myroot
-          VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
-        options: >-
-          --cap-add IPC_LOCK
-          --health-cmd "vault status -address http://localhost:8200"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+      # Required by the catalog-level S3 tests, which are `#[sqlx::test]`s.
       postgres:
         image: postgres:16
         env:
@@ -58,8 +42,6 @@ jobs:
           - 5432:5432
     env:
       RUSTFLAGS: --cfg tracing_unstable -D warnings -C debuginfo=0
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      GCS_CREDENTIAL: ${{ secrets.GCS_CREDENTIAL }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -103,17 +85,6 @@ jobs:
           netstat -tlnp
           exit 1
 
-      - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
-        if: ${{ env.AZURE_CLIENT_ID != '' }}
-        with:
-          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
-          allow-no-subscriptions: true
-
-      - name: Write gcp credential to file
-        if: ${{ env.GCS_CREDENTIAL != '' }}
-        run: echo '${{ secrets.GCS_CREDENTIAL }}' > /tmp/gcs.json
-        shell: bash
-
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
@@ -126,17 +97,6 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Determine nextest profile
-        run: |
-          if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
-            # PR is made off this repo, so workflows have access to secrets and the entire suite
-            # can be run.
-            echo "NEXTEST_PROFILE=ci" >> $GITHUB_ENV
-          else
-            # PR is made off a fork, so secrets are not available in ci workflows.
-            echo "NEXTEST_PROFILE=ci_no_secrets" >> $GITHUB_ENV
-          fi
-
       - name: Migrate database
         run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -147,100 +107,17 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
 
-      - name: Setup vault
-        run: |
-          export VAULT_ADDR=http://localhost:8200
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update && sudo apt-get install -yqq gpg wget --no-install-recommends
-          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt-get update && sudo apt-get install -yqq vault --no-install-recommends
-
-          vault login -address "${VAULT_ADDR}" myroot
-          vault auth  enable -address "${VAULT_ADDR}"  userpass
-          echo "path \"secret/*\" { capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"] }" > /tmp/app.hcl
-          vault policy write -address "${VAULT_ADDR}" app /tmp/app.hcl
-          vault write -address "${VAULT_ADDR}" auth/userpass/users/test password=test policies=app
-
-      - name: Setup openfga
-        # v1.11+ required: reconcile/rebuild calls write_with_options(idempotent),
-        # which relies on the on_duplicate/on_missing fields added in v1.11.
-        run: docker run -d -p 35081:8081 openfga/openfga:v1.14 run
-
       - name: Test
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          max_attempts: 2
-          timeout_minutes: 25
-          command: cargo nextest run --profile ${{ env.NEXTEST_PROFILE }} --all-targets --all-features --workspace
+        timeout-minutes: 25
+        run: cargo nextest run --profile ${{ env.NEXTEST_PROFILE }} --all-targets --all-features --workspace
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
-          LAKEKEEPER_TEST__KV2__URL: http://localhost:8200
-          LAKEKEEPER_TEST__KV2__USER: test
-          LAKEKEEPER_TEST__KV2__PASSWORD: test
-          LAKEKEEPER_TEST__KV2__SECRET_MOUNT: secret
           # seaweedfs test envs
           LAKEKEEPER_TEST__S3_BUCKET: tests
           LAKEKEEPER_TEST__S3_REGION: local
           LAKEKEEPER_TEST__S3_ACCESS_KEY: some_access_key1
           LAKEKEEPER_TEST__S3_SECRET_KEY: some_secret_key1
           LAKEKEEPER_TEST__S3_ENDPOINT: http://127.0.0.1:8333
-
-          LAKEKEEPER_TEST__ENABLE_AZURE_SYSTEM_CREDENTIALS: true
-          LAKEKEEPER_TEST__ENABLE_GCP_SYSTEM_CREDENTIALS: true
-
-          LAKEKEEPER_TEST__OPENFGA__ENDPOINT: http://localhost:35081
-          # The lakekeeper-integration-tests OpenFGA e2e harness links authz-openfga
-          # as a NON-test dependency, so it reads the `LAKEKEEPER__` config prefix
-          # (not `LAKEKEEPER_TEST__`, which only applies to authz-openfga's own
-          # cfg(test) builds). Point both at the same store.
-          LAKEKEEPER__OPENFGA__ENDPOINT: http://localhost:35081
-          GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcs.json
-
-          LAKEKEEPER_TEST__AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          LAKEKEEPER_TEST__AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          LAKEKEEPER_TEST__AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          LAKEKEEPER_TEST__AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
-          LAKEKEEPER_TEST__AZURE_STORAGE_FILESYSTEM: ${{ secrets.AZURE_STORAGE_FILESYSTEM }}
-          LAKEKEEPER_TEST__AZURE_STORAGE_SHARED_KEY: ${{ secrets.AZURE_STORAGE_SHARED_KEY }}
-
-          LAKEKEEPER_TEST__AWS_S3_BUCKET: ${{ secrets.LAKEKEEPER_TEST__AWS_S3_BUCKET }}
-          LAKEKEEPER_TEST__AWS_S3_REGION: ${{ secrets.LAKEKEEPER_TEST__AWS_S3_REGION }}
-          LAKEKEEPER_TEST__AWS_S3_ACCESS_KEY_ID: ${{ secrets.LAKEKEEPER_TEST__AWS_S3_ACCESS_KEY_ID }}
-          LAKEKEEPER_TEST__AWS_S3_SECRET_ACCESS_KEY: ${{ secrets.LAKEKEEPER_TEST__AWS_S3_SECRET_ACCESS_KEY }}
-          LAKEKEEPER_TEST__AWS_S3_STS_ROLE_ARN: ${{ secrets.LAKEKEEPER_TEST__AWS_S3_STS_ROLE_ARN }}
-          LAKEKEEPER_TEST__AWS_KMS_S3_BUCKET: ${{ secrets.LAKEKEEPER_TEST__AWS_KMS_S3_BUCKET }}
-          LAKEKEEPER_TEST__AWS_S3_KMS_ARN: ${{ secrets.LAKEKEEPER_TEST__AWS_S3_KMS_ARN }}
-
-          TEST_R2: ${{ secrets.TEST_R2 }}
-          LAKEKEEPER_TEST__R2_BUCKET: ${{ secrets.LAKEKEEPER_TEST__R2_BUCKET }}
-          LAKEKEEPER_TEST__R2_TOKEN: ${{ secrets.LAKEKEEPER_TEST__R2_TOKEN }}
-          LAKEKEEPER_TEST__R2_SECRET_ACCESS_KEY: ${{ secrets.LAKEKEEPER_TEST__R2_SECRET_ACCESS_KEY }}
-          LAKEKEEPER_TEST__R2_ACCESS_KEY_ID: ${{ secrets.LAKEKEEPER_TEST__R2_ACCESS_KEY_ID }}
-          LAKEKEEPER_TEST__R2_ACCOUNT_ID: ${{ secrets.LAKEKEEPER_TEST__R2_ACCOUNT_ID }}
-          LAKEKEEPER_TEST__R2_ENDPOINT: ${{ secrets.LAKEKEEPER_TEST__R2_ENDPOINT }}
-
-          LAKEKEEPER_TEST__OSS_BUCKET: ${{ secrets.LAKEKEEPER_TEST__OSS_BUCKET }}
-          LAKEKEEPER_TEST__OSS_REGION: ${{ secrets.LAKEKEEPER_TEST__OSS_REGION }}
-          LAKEKEEPER_TEST__OSS_ENDPOINT: ${{ secrets.LAKEKEEPER_TEST__OSS_ENDPOINT }}
-          LAKEKEEPER_TEST__OSS_ACCESS_KEY_ID: ${{ secrets.LAKEKEEPER_TEST__OSS_ACCESS_KEY_ID }}
-          LAKEKEEPER_TEST__OSS_SECRET_ACCESS_KEY: ${{ secrets.LAKEKEEPER_TEST__OSS_SECRET_ACCESS_KEY }}
-          LAKEKEEPER_TEST__OSS_STS_ROLE_ARN: ${{ secrets.LAKEKEEPER_TEST__OSS_STS_ROLE_ARN }}
-
-          # Only the secret key is a credential; the rest are repo variables.
-          # _ENDPOINT is the interim dataplatform grid, the only STACKIT storage
-          # with an STS endpoint until object.storage reaches StorageGRID 12.0.
-          LAKEKEEPER_TEST__STACKIT_BUCKET: ${{ vars.LAKEKEEPER_TEST__STACKIT_BUCKET }}
-          LAKEKEEPER_TEST__STACKIT_REGION: ${{ vars.LAKEKEEPER_TEST__STACKIT_REGION }}
-          LAKEKEEPER_TEST__STACKIT_ENDPOINT: ${{ vars.LAKEKEEPER_TEST__STACKIT_ENDPOINT }}
-          LAKEKEEPER_TEST__STACKIT_ACCESS_KEY_ID: ${{ vars.LAKEKEEPER_TEST__STACKIT_ACCESS_KEY_ID }}
-          LAKEKEEPER_TEST__STACKIT_SECRET_ACCESS_KEY: ${{ secrets.LAKEKEEPER_TEST__STACKIT_SECRET_ACCESS_KEY }}
-          LAKEKEEPER_TEST__STACKIT_CREDENTIALS_GROUP_URN: ${{ vars.LAKEKEEPER_TEST__STACKIT_CREDENTIALS_GROUP_URN }}
-
-          LAKEKEEPER_TEST__GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
-          LAKEKEEPER_TEST__GCS_HNS_BUCKET: ${{ secrets.GCS_HNS_BUCKET }}
-          LAKEKEEPER_TEST__GCS_CREDENTIAL: ${{ secrets.GCS_CREDENTIAL }}
 
       - name: Dump SeaweedFS Logs
         if: always()
@@ -258,7 +135,3 @@ jobs:
         with:
           name: junit
           path: target/nextest/${{ env.NEXTEST_PROFILE }}/junit.xml
-      - name: Doc Test
-        run: cargo test --no-fail-fast --doc --all-features --workspace
-        env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = ["OpenFGA", "OAuth", "CloudEvents", "UUIDv7", "SemVer"]
+doc-valid-idents = ["OpenFGA", "OAuth", "CloudEvents", "UUIDv7", "SemVer", "MinIO", "SeaweedFS"]

--- a/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
@@ -2943,10 +2943,11 @@ async fn test_register_table_enforces_the_format_version_policy(pg_pool: PgPool)
 
 /// `data-access` on register is only observable against a storage profile that
 /// actually vends. The memory profile the rest of this file uses ignores it and
-/// returns an empty config, so these live against MinIO.
+/// returns an empty config, so these live against a real S3-compatible store.
 mod register_data_access {
-    /// Named so nextest's default profile filters it out; CI runs it with MinIO up.
-    pub mod minio_integration_tests {
+    /// Named so nextest's default profile filters it out; CI runs it against the
+    /// store configured via `LAKEKEEPER_TEST__S3_*`.
+    pub mod s3_compat_integration_tests {
         use lakekeeper::api::iceberg::v1::DataAccessMode;
         use lakekeeper_integration_tests::s3_compatible_profile;
 

--- a/crates/lakekeeper/src/service/storage/mod.rs
+++ b/crates/lakekeeper/src/service/storage/mod.rs
@@ -2176,12 +2176,12 @@ mod tests {
         }
     }
 
-    mod minio_integration_tests {
+    mod s3_compat_integration_tests {
         use super::*;
 
         #[test]
         fn test_vended_s3_compat() {
-            use super::super::s3::test::minio_integration_tests::storage_profile;
+            use super::super::s3::test::s3_compat_integration_tests::storage_profile;
 
             test_block_on(
                 async {

--- a/crates/lakekeeper/src/service/storage/s3.rs
+++ b/crates/lakekeeper/src/service/storage/s3.rs
@@ -2440,7 +2440,9 @@ pub(crate) mod test {
         assert_eq!(location.to_string(), expected);
     }
 
-    pub(crate) mod minio_integration_tests {
+    /// Tests against the S3-compatible store configured via `LAKEKEEPER_TEST__S3_*`
+    /// (MinIO in the Unittests workflow, SeaweedFS in the SeaweedFS workflow).
+    pub(crate) mod s3_compat_integration_tests {
         use std::sync::LazyLock;
 
         use super::test_block_on;

--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -341,6 +341,14 @@ cargo nextest run --all-features --ignore-default-filter -E "test(::aws_integrat
 # see .config/nextest.toml for all filters
 ```
 
+To check a new S3-compatible store, point the `LAKEKEEPER_TEST__S3_*` variables at it and run the `s3_compat` profile, which selects exactly the tests that use those variables and nothing else:
+
+```sh
+cargo nextest run --profile s3_compat --all-features --all-targets --workspace
+```
+
+This is what the SeaweedFS workflow runs.
+
 ## Running integration test
 
 Our integration tests are written in Python and use pytest. They are located in the `tests` folder. The integration tests spin up Lakekeeper and all the dependencies via `docker compose`. Please check the [Integration Test Docs](https://github.com/lakekeeper/lakekeeper/tree/main/tests) for more information.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Testing**
  - Added a dedicated profile for S3-compatible storage integration tests.
  - Improved test output with immediate failure reporting, time limits, and JUnit results.
  - Updated SeaweedFS validation to use the dedicated profile with streamlined configuration.
  - Expanded support terminology to cover configurable S3-compatible stores, including MinIO and SeaweedFS.

- **Documentation**
  - Added developer guidance for running S3-compatible storage tests locally, including the command used by automated SeaweedFS validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->