### PR TITLE
feat(warehouse): accept a caller-supplied warehouse id on create

### DIFF
--- a/.sqlx/query-b0b62261528a2eace96cc50900c34f478bb6a27b65f779a2089a57f233b1b3d1.json
+++ b/.sqlx/query-b0b62261528a2eace96cc50900c34f478bb6a27b65f779a2089a57f233b1b3d1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH\n            whi AS (INSERT INTO warehouse (\n                                   warehouse_name,\n                                   project_id,\n                                   storage_profile,\n                                   storage_secret_id,\n                                   status,\n                                   tabular_expiration_seconds,\n                                   tabular_delete_mode,\n                                   allowed_format_versions,\n                                   default_format_version,\n                                   managed_by)\n                                VALUES ($1, $2, $3, $4, 'active', $5, $6, $7, $8, $9)\n                                RETURNING\n                                    project_id,\n                                    warehouse_id,\n                                    warehouse_name,\n                                    storage_profile as \"storage_profile: Json<StorageProfile>\",\n                                    storage_secret_id,\n                                    status AS \"status: WarehouseStatus\",\n                                    tabular_delete_mode as \"tabular_delete_mode: DbTabularDeleteProfile\",\n                                    tabular_expiration_seconds,\n                                    protected,\n                                    allowed_format_versions,\n                                    default_format_version,\n                                    managed_by as \"managed_by: ManagedBy\",\n                                    updated_at,\n                                    version),\n            whs AS (INSERT INTO warehouse_statistics (number_of_views,\n                                                      number_of_tables,\n                                                      warehouse_id)\n                     VALUES (0, 0, (SELECT warehouse_id FROM whi)))\n            SELECT\n                *\n            FROM whi",
+  "query": "WITH\n            whi AS (INSERT INTO warehouse (\n                                   warehouse_id,\n                                   warehouse_name,\n                                   project_id,\n                                   storage_profile,\n                                   storage_secret_id,\n                                   status,\n                                   tabular_expiration_seconds,\n                                   tabular_delete_mode,\n                                   allowed_format_versions,\n                                   default_format_version,\n                                   managed_by)\n                                -- COALESCE keeps the column's own default as the\n                                -- fallback for callers that do not pick an id.\n                                VALUES (COALESCE($10, uuid_generate_v1mc()), $1, $2, $3, $4, 'active', $5, $6, $7, $8, $9)\n                                RETURNING\n                                    project_id,\n                                    warehouse_id,\n                                    warehouse_name,\n                                    storage_profile as \"storage_profile: Json<StorageProfile>\",\n                                    storage_secret_id,\n                                    status AS \"status: WarehouseStatus\",\n                                    tabular_delete_mode as \"tabular_delete_mode: DbTabularDeleteProfile\",\n                                    tabular_expiration_seconds,\n                                    protected,\n                                    allowed_format_versions,\n                                    default_format_version,\n                                    managed_by as \"managed_by: ManagedBy\",\n                                    updated_at,\n                                    version),\n            whs AS (INSERT INTO warehouse_statistics (number_of_views,\n                                                      number_of_tables,\n                                                      warehouse_id)\n                     VALUES (0, 0, (SELECT warehouse_id FROM whi)))\n            SELECT\n                *\n            FROM whi",
   "describe": {
     "columns": [
       {
@@ -218,7 +218,8 @@
               ]
             }
           }
-        }
+        },
+        "Uuid"
       ]
     },
     "nullable": [
@@ -238,5 +239,5 @@
       false
     ]
   },
-  "hash": "59a05644da791a59cab8e03f95054d8eb770d86ffe89067f1cf080018a82df82"
+  "hash": "b0b62261528a2eace96cc50900c34f478bb6a27b65f779a2089a57f233b1b3d1"
 }

--- a/crates/authz-openfga/src/authorizer.rs
+++ b/crates/authz-openfga/src/authorizer.rs
@@ -1571,16 +1571,25 @@ impl OpenFGAAuthorizer {
                         .map_err(authz_to_error_no_audit)?;
 
                     if !tuples.tuples.is_empty() {
-                        return Err(IcebergErrorResponse::from(
-                            ErrorModel::conflict(
-                                format!(
-                                    "Object to create {fga_object_str} is used as user for type {o}",
-                                ),
-                                "ObjectUsedInRelation",
-                                None,
-                            )
-                                .append_detail(format!("Found: {tuples:?}")),
-                        ));
+                        // The tuples name other entities — a warehouse's hierarchy
+                        // tuple carries its owning project — and for a 4xx the
+                        // error `stack` is serialized to the caller verbatim. Now
+                        // that a caller can pick the id being created, and so aim
+                        // this check at an id they do not own, the tuples go to the
+                        // log rather than into the response.
+                        tracing::warn!(
+                            object = %fga_object_str,
+                            related_type = %o,
+                            ?tuples,
+                            "Refusing to create an object that is still used as a user in existing relations"
+                        );
+                        return Err(IcebergErrorResponse::from(ErrorModel::conflict(
+                            format!(
+                                "Object to create {fga_object_str} is used as user for type {o}",
+                            ),
+                            "ObjectUsedInRelation",
+                            None,
+                        )));
                     }
                 }
 
@@ -1846,6 +1855,15 @@ pub(crate) mod tests {
                 .unwrap_err();
             assert_eq!(err.error.code, StatusCode::CONFLICT.as_u16());
             assert_eq!(err.error.r#type, "ObjectUsedInRelation");
+            // The tuples that triggered the refusal must not travel to the caller:
+            // for a 4xx the error `stack` is serialized verbatim, and the tuples
+            // name a *different* object than the one being created (here the
+            // server, for a warehouse its owning project). They belong in the log.
+            let rendered = format!("{:?}", err.error);
+            assert!(
+                !rendered.contains("this_server"),
+                "refusal disclosed the related object: {rendered}"
+            );
         }
 
         #[tokio::test]

--- a/crates/lakekeeper-integration-tests/tests/openfga_warehouse_id.rs
+++ b/crates/lakekeeper-integration-tests/tests/openfga_warehouse_id.rs
@@ -1,0 +1,217 @@
+//! Caller-supplied warehouse ids against a **real** OpenFGA store plus a Postgres catalog.
+//!
+//! `warehouse_ops.rs` covers the same endpoint with `AllowAllAuthorizer`, which writes no
+//! tuples and consults no model. That leaves the part of a chosen id that actually carries
+//! safety weight untested:
+//!
+//! * whether deleting a warehouse really frees its id — the whole "an id becomes available
+//!   again" behaviour rests on `delete_all_relations` clearing the tuples, and under
+//!   `AllowAllAuthorizer` there are none to clear, so the test passes vacuously;
+//! * whether a recreated warehouse is owned by whoever recreated it, rather than inheriting
+//!   its predecessor's ownership;
+//! * what a caller sees when they aim a chosen id at one that still has tuples — the
+//!   orphaned-tuple case a create whose commit failed leaves behind.
+//!
+//! Gated behind the `openfga_integration_tests` module so the default nextest filter
+//! excludes it; runs with a live OpenFGA at `LAKEKEEPER__OPENFGA__ENDPOINT`.
+
+// Nested one level deep so the test path contains `::openfga_integration_tests::`,
+// which the default nextest filter excludes (a root module would not match).
+mod warehouse_id {
+    mod openfga_integration_tests {
+        use std::sync::Arc;
+
+        use lakekeeper::{
+            ProjectId, WarehouseId,
+            api::{
+                ApiContext, RequestMetadata, RequestMetadataTestBuilder,
+                management::v1::{
+                    ApiServer, DeleteWarehouseQuery,
+                    warehouse::{CreateWarehouseRequest, Service as _, TabularDeleteProfile},
+                },
+            },
+            service::{
+                CatalogStore, CatalogWarehouseOps, State, Transaction, UserId, authn::Actor,
+                authz::CatalogWarehouseAction,
+            },
+        };
+        use lakekeeper_authz_openfga::{
+            OpenFGAAuthorizer, new_authorizer_in_empty_store_from_default_config,
+        };
+        use lakekeeper_integration_tests::{SetupTestCatalog, memory_io_profile};
+        use lakekeeper_storage_postgres::{PostgresBackend, SecretsState};
+        use sqlx::PgPool;
+        use uuid::Uuid;
+
+        type Ctx = ApiContext<State<OpenFGAAuthorizer, PostgresBackend, SecretsState>>;
+
+        /// OpenFGA-backed context with a freshly-migrated, isolated store, bootstrapping
+        /// `admin` as operator.
+        async fn setup(pool: PgPool) -> (Ctx, UserId, Arc<ProjectId>) {
+            let authorizer = new_authorizer_in_empty_store_from_default_config()
+                .await
+                .expect("OpenFGA must be reachable at LAKEKEEPER__OPENFGA__ENDPOINT");
+            let user_id = UserId::new_unchecked("oidc", "admin");
+            let (ctx, warehouse) = SetupTestCatalog::builder()
+                .pool(pool)
+                .storage_profile(memory_io_profile())
+                .authorizer(authorizer)
+                .user_id(Some(user_id.clone()))
+                .number_of_warehouses(1)
+                .build()
+                .setup()
+                .await;
+            (ctx, user_id, warehouse.project_id)
+        }
+
+        fn metadata(user_id: &UserId, project_id: &ProjectId) -> RequestMetadata {
+            RequestMetadataTestBuilder::builder()
+                .actor(Actor::Principal(user_id.clone()))
+                .project_id(Some(project_id.clone().into()))
+                .build()
+        }
+
+        fn request(
+            name: String,
+            warehouse_id: WarehouseId,
+            project_id: &ProjectId,
+        ) -> CreateWarehouseRequest {
+            CreateWarehouseRequest::builder()
+                .warehouse_name(name)
+                .warehouse_id(warehouse_id)
+                .project_id(project_id.clone())
+                .storage_profile(memory_io_profile())
+                .delete_profile(TabularDeleteProfile::Hard {})
+                .build()
+        }
+
+        /// Deleting a warehouse frees its id for real: the authorizer's tuple cleanup runs,
+        /// so the guard that would otherwise refuse the id is satisfied, and the recreated
+        /// warehouse belongs to whoever recreated it.
+        #[sqlx::test]
+        async fn delete_frees_the_id_and_recreate_takes_fresh_ownership(pool: PgPool) {
+            let (ctx, admin, project_id) = setup(pool).await;
+            let md = metadata(&admin, &project_id);
+            let warehouse_id = WarehouseId::new_random();
+
+            ApiServer::create_warehouse(
+                request(
+                    format!("recycled-{}", Uuid::now_v7()),
+                    warehouse_id,
+                    &project_id,
+                ),
+                ctx.clone(),
+                md.clone(),
+            )
+            .await
+            .unwrap();
+
+            ApiServer::delete_warehouse(
+                warehouse_id,
+                DeleteWarehouseQuery { force: false },
+                ctx.clone(),
+                md.clone(),
+            )
+            .await
+            .unwrap();
+
+            // The load-bearing assertion: with the predecessor's tuples gone, the create
+            // guard passes and the id is usable again. If `delete_all_relations` ever stops
+            // clearing them, this fails with `ObjectHasRelations` instead.
+            let recreated = ApiServer::create_warehouse(
+                request(
+                    format!("recycled-{}", Uuid::now_v7()),
+                    warehouse_id,
+                    &project_id,
+                ),
+                ctx.clone(),
+                md.clone(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(recreated.warehouse_id(), warehouse_id);
+
+            // Ownership was written fresh rather than inherited: the recreating principal can
+            // act on the warehouse it just made.
+            ApiServer::set_warehouse_protection(warehouse_id, true, ctx.clone(), md)
+                .await
+                .unwrap();
+        }
+
+        /// A chosen id whose tuples outlived its warehouse is refused rather than silently
+        /// adopting them.
+        ///
+        /// Reproduces the orphaned-tuple state a create leaves behind when the authorizer
+        /// write lands and the transaction then fails to commit, by deleting the warehouse
+        /// through the catalog only — skipping the endpoint's authz cleanup.
+        #[sqlx::test]
+        async fn a_chosen_id_with_leftover_tuples_is_refused(pool: PgPool) {
+            let (ctx, admin, project_id) = setup(pool).await;
+            let md = metadata(&admin, &project_id);
+            let warehouse_id = WarehouseId::new_random();
+
+            ApiServer::create_warehouse(
+                request(
+                    format!("orphaned-{}", Uuid::now_v7()),
+                    warehouse_id,
+                    &project_id,
+                ),
+                ctx.clone(),
+                md.clone(),
+            )
+            .await
+            .unwrap();
+
+            // Catalog-only delete: the row goes, the tuples stay.
+            let mut t = <PostgresBackend as CatalogStore>::Transaction::begin_write(
+                ctx.v1_state.catalog.clone(),
+            )
+            .await
+            .unwrap();
+            PostgresBackend::delete_warehouse(
+                warehouse_id,
+                DeleteWarehouseQuery { force: false },
+                t.transaction(),
+            )
+            .await
+            .unwrap();
+            t.commit().await.unwrap();
+
+            let err = ApiServer::create_warehouse(
+                request(
+                    format!("orphaned-{}", Uuid::now_v7()),
+                    warehouse_id,
+                    &project_id,
+                ),
+                ctx.clone(),
+                md,
+            )
+            .await
+            .unwrap_err();
+
+            assert_eq!(err.error.code, 409, "{:?}", err.error);
+            assert_eq!(err.error.r#type, "ObjectHasRelations");
+
+            // Ownership tuples make the warehouse an *object*, so this is the guard's first
+            // phase, which never described what it found. The second phase — reached only
+            // when the warehouse survives as a *user* of another object, i.e. after a partial
+            // cleanup — did, and no longer does; that one is pinned in `authz-openfga`'s
+            // `test_require_no_relations_used_in_other_relations`. Asserted here too because
+            // the invariant is the same either way: for a 4xx the stack is serialized to the
+            // caller verbatim, and a caller aiming at someone else's id must not learn whose
+            // project it is.
+            let rendered = format!("{:?}", err.error);
+            assert!(
+                !rendered.contains(&project_id.to_string()),
+                "conflict leaked the owning project: {rendered}"
+            );
+        }
+
+        /// The action used above is a spec mutation, so the ownership assertion in the first
+        /// test is meaningful rather than a no-op for any caller.
+        #[test]
+        fn protection_is_a_spec_mutation() {
+            assert!(CatalogWarehouseAction::SetProtection.is_spec_mutation());
+        }
+    }
+}

--- a/crates/lakekeeper-integration-tests/tests/tag_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/tag_ops.rs
@@ -1704,6 +1704,7 @@ async fn test_cross_project_target_rejected(pool: PgPool) {
     let warehouse_b = Server::create_warehouse(
         CreateWarehouseRequest {
             warehouse_name: "warehouse-b".to_string(),
+            warehouse_id: None,
             project_id: Some((*project_b).clone()),
             storage_profile: memory_io_profile(),
             storage_credential: None,

--- a/crates/lakekeeper-integration-tests/tests/warehouse_ops.rs
+++ b/crates/lakekeeper-integration-tests/tests/warehouse_ops.rs
@@ -1678,3 +1678,294 @@ async fn test_all_spec_mutations_blocked_on_managed_warehouse(pool: PgPool) {
         )
     );
 }
+
+/// A caller-supplied `warehouse-id` is honoured verbatim, and an omitted one is
+/// assigned by the server as a UUIDv7.
+#[sqlx::test]
+async fn test_create_warehouse_with_requested_id(pool: PgPool) {
+    let storage_profile = memory_io_profile();
+    let (ctx, _) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(storage_profile.clone())
+        .authorizer(AllowAllAuthorizer::default())
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+
+    let project_id = ProjectId::from(Uuid::nil());
+    // Deliberately a v4: a caller mirroring ids from an external system must not
+    // be forced onto v7, however much v7 is the recommendation.
+    let requested = WarehouseId::from(Uuid::new_v4());
+    let created = ApiServer::create_warehouse(
+        CreateWarehouseRequest::builder()
+            .warehouse_name(format!("requested-{}", Uuid::now_v7()))
+            .warehouse_id(requested)
+            .project_id(project_id.clone())
+            .storage_profile(storage_profile.clone())
+            .delete_profile(TabularDeleteProfile::Hard {})
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(created.warehouse_id(), requested);
+
+    // Readable back under the requested id, so the id in the response is the id
+    // the catalog actually stored.
+    let fetched = PostgresBackend::get_warehouse_by_id(
+        requested,
+        WarehouseStatus::active(),
+        ctx.v1_state.catalog.clone(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(fetched.warehouse_id, requested);
+
+    // Omitting the field still yields a server-assigned id, and it is a v7.
+    let generated = ApiServer::create_warehouse(
+        CreateWarehouseRequest::builder()
+            .warehouse_name(format!("generated-{}", Uuid::now_v7()))
+            .project_id(project_id)
+            .storage_profile(storage_profile)
+            .delete_profile(TabularDeleteProfile::Hard {})
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        generated.warehouse_id().get_version_num(),
+        7,
+        "server-assigned warehouse ids must be UUIDv7"
+    );
+}
+
+/// A requested id already in use is a 409, and the error discloses nothing about
+/// the warehouse holding it.
+#[sqlx::test]
+async fn test_create_warehouse_requested_id_conflict(pool: PgPool) {
+    let storage_profile = memory_io_profile();
+    let (ctx, _) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(storage_profile.clone())
+        .authorizer(AllowAllAuthorizer::default())
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+
+    let project_id = ProjectId::from(Uuid::nil());
+    let taken = WarehouseId::new_random();
+    let first_name = format!("first-{}", Uuid::now_v7());
+    ApiServer::create_warehouse(
+        CreateWarehouseRequest::builder()
+            .warehouse_name(first_name.clone())
+            .warehouse_id(taken)
+            .project_id(project_id.clone())
+            .storage_profile(storage_profile.clone())
+            .delete_profile(TabularDeleteProfile::Hard {})
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+
+    let err = ApiServer::create_warehouse(
+        CreateWarehouseRequest::builder()
+            .warehouse_name(format!("second-{}", Uuid::now_v7()))
+            .warehouse_id(taken)
+            .project_id(project_id)
+            .storage_profile(memory_io_profile())
+            .delete_profile(TabularDeleteProfile::Hard {})
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.error.code, 409);
+    assert_eq!(err.error.r#type, "WarehouseIdAlreadyExists");
+    // Warehouse ids are unique instance-wide, so the conflict may be with a
+    // warehouse in a project the caller cannot see. Nothing about the holder may
+    // leak — otherwise a requested id becomes an existence oracle.
+    let rendered = format!("{:?}", err.error);
+    assert!(
+        !rendered.contains(&first_name),
+        "conflict error leaked the holding warehouse's name: {rendered}"
+    );
+}
+
+/// The uniqueness of warehouse ids is instance-wide, not per project: an id held
+/// in another project is still refused.
+#[sqlx::test]
+async fn test_create_warehouse_requested_id_conflict_across_projects(pool: PgPool) {
+    let storage_profile = memory_io_profile();
+    let (ctx, _) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(storage_profile.clone())
+        .authorizer(AllowAllAuthorizer::default())
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+
+    let taken = WarehouseId::new_random();
+    ApiServer::create_warehouse(
+        CreateWarehouseRequest::builder()
+            .warehouse_name(format!("in-default-project-{}", Uuid::now_v7()))
+            .warehouse_id(taken)
+            .project_id(ProjectId::from(Uuid::nil()))
+            .storage_profile(storage_profile.clone())
+            .delete_profile(TabularDeleteProfile::Hard {})
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+
+    let other_project = ProjectId::from(Uuid::now_v7());
+    let mut transaction =
+        <PostgresBackend as CatalogStore>::Transaction::begin_write(ctx.v1_state.catalog.clone())
+            .await
+            .unwrap();
+    PostgresBackend::create_project(
+        &other_project,
+        format!("other-{}", Uuid::now_v7()),
+        transaction.transaction(),
+    )
+    .await
+    .unwrap();
+    transaction.commit().await.unwrap();
+
+    let err = ApiServer::create_warehouse(
+        CreateWarehouseRequest::builder()
+            .warehouse_name(format!("in-other-project-{}", Uuid::now_v7()))
+            .warehouse_id(taken)
+            .project_id(other_project)
+            .storage_profile(memory_io_profile())
+            .delete_profile(TabularDeleteProfile::Hard {})
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.error.code, 409);
+    assert_eq!(err.error.r#type, "WarehouseIdAlreadyExists");
+}
+
+/// An id becomes available again once the warehouse holding it is gone, so a
+/// warehouse can be recreated under its original id after a delete.
+///
+/// This pins the behaviour, it does not endorse the practice — the docs advise
+/// against reuse. Caches and permission records key on the warehouse id alone,
+/// and a recreated warehouse restarts at `version` 0, so a replica that still
+/// holds the predecessor can briefly resolve the id to it. `create_warehouse`
+/// invalidates locally, which covers the single-replica case this test exercises;
+/// across replicas the stale entry lives until its TTL.
+#[sqlx::test]
+async fn test_create_warehouse_reuses_id_after_delete(pool: PgPool) {
+    let storage_profile = memory_io_profile();
+    let (ctx, _) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(storage_profile.clone())
+        .authorizer(AllowAllAuthorizer::default())
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+
+    let project_id = ProjectId::from(Uuid::nil());
+    let warehouse_id = WarehouseId::new_random();
+    let request = |name: String, profile| {
+        CreateWarehouseRequest::builder()
+            .warehouse_name(name)
+            .warehouse_id(warehouse_id)
+            .project_id(project_id.clone())
+            .storage_profile(profile)
+            .delete_profile(TabularDeleteProfile::Hard {})
+            .build()
+    };
+
+    ApiServer::create_warehouse(
+        request(format!("recycled-{}", Uuid::now_v7()), storage_profile),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+
+    ApiServer::delete_warehouse(
+        warehouse_id,
+        DeleteWarehouseQuery { force: false },
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+
+    let recreated = ApiServer::create_warehouse(
+        request(format!("recycled-{}", Uuid::now_v7()), memory_io_profile()),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(recreated.warehouse_id(), warehouse_id);
+}
+
+/// Two concurrent creates racing for the same requested id: exactly one wins and
+/// the loser gets the conflict, rather than both appearing to succeed.
+#[sqlx::test]
+async fn test_create_warehouse_concurrent_requested_id(pool: PgPool) {
+    let storage_profile = memory_io_profile();
+    let (ctx, _) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(storage_profile.clone())
+        .authorizer(AllowAllAuthorizer::default())
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+
+    let project_id = ProjectId::from(Uuid::nil());
+    let contested = WarehouseId::new_random();
+    let request = |name: String| {
+        CreateWarehouseRequest::builder()
+            .warehouse_name(name)
+            .warehouse_id(contested)
+            .project_id(project_id.clone())
+            .storage_profile(memory_io_profile())
+            .delete_profile(TabularDeleteProfile::Hard {})
+            .build()
+    };
+
+    let (a, b) = tokio::join!(
+        ApiServer::create_warehouse(
+            request(format!("race-a-{}", Uuid::now_v7())),
+            ctx.clone(),
+            random_request_metadata(),
+        ),
+        ApiServer::create_warehouse(
+            request(format!("race-b-{}", Uuid::now_v7())),
+            ctx.clone(),
+            random_request_metadata(),
+        )
+    );
+
+    let (winner, loser) = match (a, b) {
+        (Ok(ok), Err(err)) | (Err(err), Ok(ok)) => (ok, err),
+        (Ok(_), Ok(_)) => panic!("both creates claimed the same warehouse id"),
+        (Err(a), Err(b)) => panic!("neither create succeeded: {a:?} / {b:?}"),
+    };
+    assert_eq!(winner.warehouse_id(), contested);
+    assert_eq!(loser.error.code, 409);
+}

--- a/crates/lakekeeper-integration-tests/tests/warehouse_validate.rs
+++ b/crates/lakekeeper-integration-tests/tests/warehouse_validate.rs
@@ -4,7 +4,7 @@
 //! considered, never stops at the first failure, and never mutates anything.
 
 use lakekeeper::{
-    ProjectId,
+    ProjectId, WarehouseId,
     api::management::v1::{
         ApiServer,
         warehouse::{
@@ -576,4 +576,98 @@ async fn test_validate_endpoints_deny_an_unauthorized_caller(pool: PgPool) {
     )
     .await;
     assert!(stored_denied.is_err());
+}
+
+/// The id-availability check reports what the dry run can actually determine:
+/// skipped when no id was requested, failed when the id is held by a warehouse in
+/// this project, passed otherwise.
+#[sqlx::test]
+async fn test_validate_warehouse_id_availability(pool: PgPool) {
+    let storage_profile = memory_io_profile();
+    let (ctx, _) = SetupTestCatalog::builder()
+        .pool(pool.clone())
+        .storage_profile(storage_profile.clone())
+        .authorizer(AllowAllAuthorizer::default())
+        .number_of_warehouses(1)
+        .build()
+        .setup()
+        .await;
+
+    let project_id = ProjectId::from(Uuid::nil());
+    let existing = PostgresBackend::list_warehouses(
+        &project_id,
+        Some(WarehouseStatus::active_and_inactive().to_vec()),
+        ctx.v1_state.catalog.clone(),
+    )
+    .await
+    .unwrap();
+    let taken = existing.first().unwrap().warehouse_id;
+
+    // No id requested: nothing to check, and the report says so rather than
+    // silently omitting the check.
+    let response = ApiServer::validate_warehouse(
+        CreateWarehouseRequest::builder()
+            .warehouse_name(format!("no-id-{}", Uuid::now_v7()))
+            .storage_profile(memory_io_profile())
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+    assert_report_is_exhaustive(&response);
+    assert_eq!(
+        status_of(&response, ValidationCheckName::WarehouseIdAvailable),
+        ValidationCheckStatus::Skipped
+    );
+    assert!(response.valid, "{:?}", response.checks);
+
+    // A free id passes.
+    let response = ApiServer::validate_warehouse(
+        CreateWarehouseRequest::builder()
+            .warehouse_name(format!("free-id-{}", Uuid::now_v7()))
+            .warehouse_id(WarehouseId::new_random())
+            .storage_profile(memory_io_profile())
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+    assert_report_is_exhaustive(&response);
+    assert_eq!(
+        status_of(&response, ValidationCheckName::WarehouseIdAvailable),
+        ValidationCheckStatus::Passed
+    );
+    assert!(response.valid, "{:?}", response.checks);
+
+    // An id held by a warehouse in this project fails, and the whole report is
+    // invalid because of it.
+    let response = ApiServer::validate_warehouse(
+        CreateWarehouseRequest::builder()
+            .warehouse_name(format!("taken-id-{}", Uuid::now_v7()))
+            .warehouse_id(taken)
+            .storage_profile(memory_io_profile())
+            .build(),
+        ctx.clone(),
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+    assert_report_is_exhaustive(&response);
+    assert_eq!(
+        status_of(&response, ValidationCheckName::WarehouseIdAvailable),
+        ValidationCheckStatus::Failed
+    );
+    assert!(!response.valid, "{:?}", response.checks);
+
+    // Nothing was created by any of the three dry runs.
+    let after = PostgresBackend::list_warehouses(
+        &project_id,
+        Some(WarehouseStatus::active_and_inactive().to_vec()),
+        ctx.v1_state.catalog.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(after.len(), existing.len());
 }

--- a/crates/lakekeeper-storage-postgres/src/test_utils.rs
+++ b/crates/lakekeeper-storage-postgres/src/test_utils.rs
@@ -192,6 +192,7 @@ pub async fn setup_with_registry<T: Authorizer>(
     let warehouse = ApiServer::create_warehouse(
         CreateWarehouseRequest {
             warehouse_name: warehouse_name.clone(),
+            warehouse_id: None,
             project_id,
             storage_profile,
             storage_credential,
@@ -211,6 +212,7 @@ pub async fn setup_with_registry<T: Authorizer>(
         let create_wh_response = ApiServer::create_warehouse(
             CreateWarehouseRequest {
                 warehouse_name: warehouse_name.clone(),
+                warehouse_id: None,
                 project_id: Some(Arc::unwrap_or_clone(warehouse.project_id())),
                 storage_profile: memory_io_profile(),
                 storage_credential: None,

--- a/crates/lakekeeper-storage-postgres/src/warehouse.rs
+++ b/crates/lakekeeper-storage-postgres/src/warehouse.rs
@@ -20,9 +20,9 @@ use lakekeeper::{
         SetWarehouseFormatVersionPolicyError, SetWarehouseManagedByError,
         SetWarehouseProtectedError, SetWarehouseStatusError, StorageProfileSerializationError,
         SystemRoleSeederCap, UpdateWarehouseStorageProfileError, WarehouseAlreadyExists,
-        WarehouseFormatVersionPolicy, WarehouseHasUnfinishedTasks, WarehouseIdNotFound,
-        WarehouseNotEmpty, WarehouseProtected, WarehouseSpecLocked, WarehouseStatus,
-        WarehouseVersion, registered_system_roles, storage::StorageProfile,
+        WarehouseFormatVersionPolicy, WarehouseHasUnfinishedTasks, WarehouseIdAlreadyExists,
+        WarehouseIdNotFound, WarehouseNotEmpty, WarehouseProtected, WarehouseSpecLocked,
+        WarehouseStatus, WarehouseVersion, registered_system_roles, storage::StorageProfile,
     },
 };
 use sqlx::{PgPool, types::Json};
@@ -93,6 +93,7 @@ pub(crate) async fn create_warehouse(
 ) -> Result<ResolvedWarehouse, CatalogCreateWarehouseError> {
     let CatalogCreateWarehouseRequest {
         warehouse_name,
+        warehouse_id,
         storage_profile,
         storage_secret_id,
         delete_profile: tabular_delete_profile,
@@ -117,6 +118,7 @@ pub(crate) async fn create_warehouse(
         WarehouseRecord,
         r#"WITH
             whi AS (INSERT INTO warehouse (
+                                   warehouse_id,
                                    warehouse_name,
                                    project_id,
                                    storage_profile,
@@ -127,7 +129,9 @@ pub(crate) async fn create_warehouse(
                                    allowed_format_versions,
                                    default_format_version,
                                    managed_by)
-                                VALUES ($1, $2, $3, $4, 'active', $5, $6, $7, $8, $9)
+                                -- COALESCE keeps the column's own default as the
+                                -- fallback for callers that do not pick an id.
+                                VALUES (COALESCE($10, uuid_generate_v1mc()), $1, $2, $3, $4, 'active', $5, $6, $7, $8, $9)
                                 RETURNING
                                     project_id,
                                     warehouse_id,
@@ -158,7 +162,8 @@ pub(crate) async fn create_warehouse(
         prof as _,
         &allowed_format_versions_db,
         default_format_version_db,
-        managed_by as ManagedBy
+        managed_by as ManagedBy,
+        warehouse_id.map(|id| *id)
     )
     .fetch_one(&mut **transaction)
     .await
@@ -168,6 +173,13 @@ pub(crate) async fn create_warehouse(
             Some("unique_warehouse_name_in_project") => CatalogCreateWarehouseError::from(
                 WarehouseAlreadyExists::new(warehouse_name, project_id.clone()),
             ),
+            // Reachable only for a caller-supplied id: the column default cannot
+            // collide in practice.
+            Some("warehouse_pkey") => warehouse_id
+                .map_or_else(
+                    || e.into_catalog_backend_error().into(),
+                    |id| CatalogCreateWarehouseError::from(WarehouseIdAlreadyExists::new(id)),
+                ),
             Some("warehouse_project_id_fk") => {
                 ProjectIdNotFoundError::new(project_id.clone()).into()
             }

--- a/crates/lakekeeper/src/api/management/mod.rs
+++ b/crates/lakekeeper/src/api/management/mod.rs
@@ -2779,13 +2779,19 @@ pub mod v1 {
 
     /// Validate Warehouse Configuration
     ///
-    /// Runs the checks `Create Warehouse` runs — profile syntax, name
+    /// Runs the checks `Create Warehouse` runs — profile syntax, name and ID
     /// availability, location overlap, format-version policy, `managed-by`, and
     /// physical storage access including credential vending — without creating
     /// anything. No warehouse is persisted and no credential is stored.
     ///
     /// Returns 200 whether or not the configuration is usable; inspect `valid` and
     /// the per-check results. Requires the same permission as creating a warehouse.
+    ///
+    /// Results are advisory and reserve nothing: a concurrent request can take a
+    /// name or ID between this call and the create. `warehouse-id-available` in
+    /// particular examines only the caller's own project, while warehouse IDs are
+    /// unique across the whole instance — so an ID it reports as available can
+    /// still be refused with `409 WarehouseIdAlreadyExists` on create.
     #[cfg_attr(feature = "open-api", utoipa::path(
         post,
         tag = "warehouse",

--- a/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
+++ b/crates/lakekeeper/src/api/management/v1/warehouse/mod.rs
@@ -102,6 +102,31 @@ pub struct CreateWarehouseRequest {
     /// Name of the warehouse to create. Must be unique
     /// within a project and may not contain "/"
     pub warehouse_name: String,
+    /// Request a specific warehouse ID - optional.
+    /// If not provided, a new warehouse ID will be generated (recommended).
+    /// Warehouse IDs are unique across the whole Lakekeeper instance, not just
+    /// within a project. If you do provide one, prefer a UUIDv7, so that IDs
+    /// sort by creation time.
+    // Why v7: the standard random-vs-time-ordered B-tree argument. A random id
+    // scatters inserts across the whole index, so pages split down the middle and
+    // the index ends up fragmented, larger, and read from disk at random;
+    // published Postgres benchmarks put v4 inserts several times slower than v7
+    // at scale, with a measurably bigger index. A time-ordered id keeps inserts
+    // at the growing edge, so pages fill densely.
+    //
+    // It reaches `warehouse_id` transitively: this column leads the primary key
+    // of most catalog tables, so it decides where a warehouse's whole subtree of
+    // rows lands. Loading tables into a freshly created warehouse is the case
+    // that benefits — with a time-ordered warehouse id those inserts extend the
+    // end of each index instead of splitting pages in its middle.
+    //
+    // Kept out of the doc comment above deliberately: that text ships into the
+    // committed OpenAPI spec, and the primary-key layout is not something the
+    // public API should promise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    #[cfg_attr(feature = "open-api", schema(value_type = Option::<uuid::Uuid>))]
+    pub warehouse_id: Option<WarehouseId>,
     /// Project ID in which to create the warehouse.
     /// Deprecated: Please use the `x-project-id` header instead.
     #[cfg_attr(feature = "open-api", schema(value_type=Option::<String>))]
@@ -444,6 +469,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
     ) -> Result<CreateWarehouseResponse> {
         let CreateWarehouseRequest {
             warehouse_name,
+            warehouse_id,
             project_id,
             mut storage_profile,
             storage_credential,
@@ -455,6 +481,10 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         let project_id = request_metadata.require_project_id(project_id)?;
         let format_version_policy =
             validate_format_version_policy(allowed_format_versions, default_format_version)?;
+        // Generated here rather than left to the database default so that the ID
+        // is known before the insert, and so that an omitted `warehouse-id`
+        // yields the same UUIDv7 we recommend to callers who supply one.
+        let warehouse_id = warehouse_id.unwrap_or_else(WarehouseId::new_random);
 
         // ------------------- AuthZ -------------------
         let authorizer = context.v1_state.authz;
@@ -533,6 +563,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
             project_id,
             CatalogCreateWarehouseRequest::builder()
                 .warehouse_name(warehouse_name)
+                .warehouse_id(Some(warehouse_id))
                 .storage_profile(storage_profile)
                 .storage_secret_id(secret_id)
                 .delete_profile(delete_profile)
@@ -560,6 +591,16 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
 
         transaction.commit().await?;
 
+        // Drop any entry this replica still holds for the id before the create
+        // event repopulates it. Every other warehouse write invalidates; create
+        // could skip it while ids were always fresh, because there was nothing to
+        // displace. A caller-supplied id can name a warehouse this replica cached
+        // before it was deleted, and `warehouse_cache_insert` refuses to overwrite
+        // a higher `version` — a recreated warehouse starts back at 0, so without
+        // this the replica would keep serving the previous warehouse's project and
+        // storage profile under an id that now belongs to a different one.
+        warehouse_cache_invalidate(resolved_warehouse.warehouse_id).await;
+
         // Held across the create event below, which consumes the context.
         let grant_dispatcher = event_ctx.dispatcher().clone();
         let grant_request_metadata = event_ctx.request_metadata_arc();
@@ -584,6 +625,7 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // thing it predicts if it is literally the same type.
         let CreateWarehouseRequest {
             warehouse_name,
+            warehouse_id,
             project_id,
             mut storage_profile,
             storage_credential,
@@ -643,8 +685,8 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         // warehouse into existence already owned by a control plane.
         report.push(managed_by_check(managed_by, request_metadata));
 
-        // The project listing serves both the name-availability and the
-        // location-overlap check; fetch it once, alongside the storage probes.
+        // The project listing serves the name-availability, id-availability and
+        // location-overlap checks; fetch it once, alongside the storage probes.
         let listing = C::list_warehouses(
             project_id,
             Some(WarehouseStatus::active_and_inactive().to_vec()),
@@ -677,12 +719,17 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                     ValidationCheckName::LocationExclusive,
                     "Could not list the warehouses in this project.",
                 );
+                report.skip(
+                    ValidationCheckName::WarehouseIdAvailable,
+                    "Could not list the warehouses in this project.",
+                );
                 report.extend(probe_checks);
                 return Ok(report.build().into());
             }
         };
 
         report.push(warehouse_name_check(&warehouse_name, &warehouses));
+        report.push(warehouse_id_check(warehouse_id, &warehouses));
         report.push(if normalized {
             location_overlap_check(&storage_profile, &warehouses)
         } else {
@@ -731,6 +778,10 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
         report.push(ValidationCheck::skipped(
             ValidationCheckName::WarehouseNameValid,
             "Updating storage does not change the warehouse name.",
+        ));
+        report.push(ValidationCheck::skipped(
+            ValidationCheckName::WarehouseIdAvailable,
+            "Updating storage does not change the warehouse id.",
         ));
         report.push(ValidationCheck::skipped(
             ValidationCheckName::LocationExclusive,
@@ -2272,6 +2323,44 @@ fn warehouse_name_check(
     ValidationCheck::passed(ValidationCheckName::WarehouseNameValid, elapsed_ms(started))
 }
 
+/// Check that a requested warehouse id is not already used in this project.
+///
+/// Only the caller's own project is examined, so this cannot confirm the id is
+/// free instance-wide — deliberately: the dry run must not become a cheap oracle
+/// for which ids exist in projects the caller cannot see. A collision outside
+/// the project surfaces as a conflict on the real create.
+fn warehouse_id_check(
+    warehouse_id: Option<WarehouseId>,
+    warehouses: &[Arc<ResolvedWarehouse>],
+) -> ValidationCheck {
+    let started = Instant::now();
+    let Some(warehouse_id) = warehouse_id else {
+        return ValidationCheck::skipped(
+            ValidationCheckName::WarehouseIdAvailable,
+            "No warehouse id was requested; the server will assign one.",
+        );
+    };
+    if warehouses.iter().any(|w| w.warehouse_id == warehouse_id) {
+        return ValidationCheck::failed(
+            ValidationCheckName::WarehouseIdAvailable,
+            elapsed_ms(started),
+            warehouse_id_taken_error(warehouse_id),
+        );
+    }
+    ValidationCheck::passed(
+        ValidationCheckName::WarehouseIdAvailable,
+        elapsed_ms(started),
+    )
+}
+
+fn warehouse_id_taken_error(warehouse_id: WarehouseId) -> ErrorModel {
+    ErrorModel::bad_request(
+        format!("A warehouse with id `{warehouse_id}` already exists."),
+        "WarehouseIdAlreadyTaken",
+        None,
+    )
+}
+
 /// Check that no other warehouse in the project already occupies this location.
 fn location_overlap_check(
     storage_profile: &StorageProfile,
@@ -2364,6 +2453,10 @@ async fn stored_profile_report(
     report.skip(ValidationCheckName::ProfileCompatible, compatibility_reason);
     report.skip(
         ValidationCheckName::WarehouseNameValid,
+        "The warehouse already exists.",
+    );
+    report.skip(
+        ValidationCheckName::WarehouseIdAvailable,
         "The warehouse already exists.",
     );
     report.skip(

--- a/crates/lakekeeper/src/service/catalog_store.rs
+++ b/crates/lakekeeper/src/service/catalog_store.rs
@@ -271,6 +271,11 @@ pub struct CatalogCreateRoleRequest<'a> {
 #[derive(Debug, typed_builder::TypedBuilder)]
 pub struct CatalogCreateWarehouseRequest {
     pub warehouse_name: String,
+    /// ID to create the warehouse under. `None` leaves the choice to the
+    /// backend's own default. The management API always supplies one so the ID
+    /// is known before the insert; direct callers may omit it.
+    #[builder(default)]
+    pub warehouse_id: Option<WarehouseId>,
     pub storage_profile: StorageProfile,
     #[builder(default)]
     pub storage_secret_id: Option<SecretId>,

--- a/crates/lakekeeper/src/service/catalog_store/warehouse.rs
+++ b/crates/lakekeeper/src/service/catalog_store/warehouse.rs
@@ -440,6 +440,7 @@ define_transparent_error! {
     stack_message: "Error creating warehouse in catalog",
     variants: [
         WarehouseAlreadyExists,
+        WarehouseIdAlreadyExists,
         CatalogBackendError,
         StorageProfileSerializationError,
         ProjectIdNotFoundError,
@@ -472,6 +473,39 @@ impl From<WarehouseAlreadyExists> for ErrorModel {
     fn from(err: WarehouseAlreadyExists) -> Self {
         ErrorModel::builder()
             .r#type("WarehouseAlreadyExists")
+            .code(StatusCode::CONFLICT.as_u16())
+            .message(err.to_string())
+            .stack(err.stack)
+            .build()
+    }
+}
+
+// Warehouse ids are unique across the whole instance, so this conflict may be
+// with a warehouse in a project the caller cannot see. The message therefore
+// names neither the owning project nor the warehouse: a caller who may create
+// warehouses somewhere must not be able to use a requested id as an oracle for
+// what exists elsewhere on the instance.
+#[derive(thiserror::Error, PartialEq, Debug)]
+#[error("A warehouse with id '{warehouse_id}' already exists")]
+pub struct WarehouseIdAlreadyExists {
+    pub warehouse_id: WarehouseId,
+    pub stack: Vec<String>,
+}
+impl WarehouseIdAlreadyExists {
+    #[must_use]
+    pub fn new(warehouse_id: WarehouseId) -> Self {
+        Self {
+            warehouse_id,
+            stack: Vec::new(),
+        }
+    }
+}
+impl_error_stack_methods!(WarehouseIdAlreadyExists);
+
+impl From<WarehouseIdAlreadyExists> for ErrorModel {
+    fn from(err: WarehouseIdAlreadyExists) -> Self {
+        ErrorModel::builder()
+            .r#type("WarehouseIdAlreadyExists")
             .code(StatusCode::CONFLICT.as_u16())
             .message(err.to_string())
             .stack(err.stack)

--- a/crates/lakekeeper/src/service/storage/validation.rs
+++ b/crates/lakekeeper/src/service/storage/validation.rs
@@ -48,10 +48,13 @@ pub enum ValidationCheckName {
     /// Compared case-insensitively, matching the database's uniqueness constraint.
     WarehouseNameValid,
     /// The requested warehouse ID is not already used by a warehouse in this
-    /// project. Skipped when no ID was requested. Warehouse IDs are unique across
-    /// the whole instance, so passing this check does not guarantee the ID is
-    /// free — a collision with a warehouse outside this project is only reported
-    /// when the warehouse is actually created.
+    /// project. Skipped when no ID was requested.
+    ///
+    /// Advisory: it examines this project only and reserves nothing, so passing
+    /// it does not mean the ID is free. IDs are unique instance-wide, so a
+    /// collision — with a warehouse in another project, or one created between
+    /// this check and the create request — surfaces only on the create itself,
+    /// as `WarehouseIdAlreadyExists`.
     WarehouseIdAvailable,
     /// No other warehouse in the project occupies or overlaps this location.
     /// Overlapping locations would let one warehouse's vended credentials reach

--- a/crates/lakekeeper/src/service/storage/validation.rs
+++ b/crates/lakekeeper/src/service/storage/validation.rs
@@ -47,6 +47,12 @@ pub enum ValidationCheckName {
     /// The warehouse name is well-formed and not already used in the project.
     /// Compared case-insensitively, matching the database's uniqueness constraint.
     WarehouseNameValid,
+    /// The requested warehouse ID is not already used by a warehouse in this
+    /// project. Skipped when no ID was requested. Warehouse IDs are unique across
+    /// the whole instance, so passing this check does not guarantee the ID is
+    /// free — a collision with a warehouse outside this project is only reported
+    /// when the warehouse is actually created.
+    WarehouseIdAvailable,
     /// No other warehouse in the project occupies or overlaps this location.
     /// Overlapping locations would let one warehouse's vended credentials reach
     /// another's data.

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -4067,13 +4067,19 @@ paths:
         - warehouse
       summary: Validate Warehouse Configuration
       description: |-
-        Runs the checks `Create Warehouse` runs — profile syntax, name
+        Runs the checks `Create Warehouse` runs — profile syntax, name and ID
         availability, location overlap, format-version policy, `managed-by`, and
         physical storage access including credential vending — without creating
         anything. No warehouse is persisted and no credential is stored.
 
         Returns 200 whether or not the configuration is usable; inspect `valid` and
         the per-check results. Requires the same permission as creating a warehouse.
+
+        Results are advisory and reserve nothing: a concurrent request can take a
+        name or ID between this call and the create. `warehouse-id-available` in
+        particular examines only the caller's own project, while warehouse IDs are
+        unique across the whole instance — so an ID it reports as available can
+        still be refused with `409 WarehouseIdAlreadyExists` on create.
       operationId: validate_warehouse
       parameters:
         - name: x-project-id

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -8413,6 +8413,17 @@ components:
         storage-profile:
           $ref: '#/components/schemas/StorageProfile'
           description: Storage profile to use for the warehouse.
+        warehouse-id:
+          type:
+            - string
+            - 'null'
+          format: uuid
+          description: |-
+            Request a specific warehouse ID - optional.
+            If not provided, a new warehouse ID will be generated (recommended).
+            Warehouse IDs are unique across the whole Lakekeeper instance, not just
+            within a project. If you do provide one, prefer a UUIDv7, so that IDs
+            sort by creation time.
         warehouse-name:
           type: string
           description: |-
@@ -16005,6 +16016,7 @@ components:
         - profile-well-formed
         - profile-compatible
         - warehouse-name-valid
+        - warehouse-id-available
         - location-exclusive
         - spec-mutable
         - format-version-policy-consistent

--- a/docs/docs/concepts.md
+++ b/docs/docs/concepts.md
@@ -112,6 +112,8 @@ Each Project can contain multiple Warehouses. Query engines connect to Lakekeepe
 
 Each Warehouse is associated with a unique location on object stores. Never share locations between Warehouses to ensure no data is leaked via vended credentials. Each Warehouse stores information on how to connect to its location via a `storage-profile` and an optional `storage-credential`.
 
+Each Warehouse also has a UUID, unique across the whole instance, which appears as the `prefix` in `/catalog` URLs. Lakekeeper assigns it, which is what we recommend; provisioning tools that need the ID up front can pass `warehouse-id` to `POST /management/v1/warehouse` instead — prefer a UUIDv7, and expect a `409` if the ID is taken. Do not re-use the ID of a deleted Warehouse: caches and permission records key on the Warehouse ID alone, so an ID that changes hands can briefly resolve to the previous Warehouse.
+
 Warehouses can be configured to use [Soft-Deletes](./concepts.md#soft-deletion). When enabled, tables are not eagerly deleted but kept in a deleted state for a configurable amount of time. During this time, they can be restored. Please note that Warehouses and Namespaces cannot be deleted via the `/catalog` API if child objects are present. This includes soft-deleted Tables. A cascade-drop API is added in one of the next releases as part of the `/management` API.
 
 ### Namespaces


### PR DESCRIPTION
`POST /management/v1/warehouse` takes an optional `warehouse-id`, so a provisioning tool can fix the id up front instead of reading it back. Omitting it stays the recommendation, as with `project-id` on create-project. Any UUID is accepted; v7 is recommended because `warehouse_id` leads the primary key of most catalog tables, where a random id scatters inserts. Server-assigned ids move from the Postgres column default to a UUIDv7 generated in the service layer.

A taken id is now `409 WarehouseIdAlreadyExists`, naming neither the owning project nor the warehouse — ids are unique instance-wide. `validate_warehouse` gains a `warehouse-id-available` check, scoped to the caller's own project so the dry run is not a free existence oracle.

Re-using a deleted warehouse's id is documented against, not blocked: caches and permissions key on the id alone.

## Release notes

`POST /management/v1/warehouse` accepts an optional `warehouse-id`, so a provisioning tool can choose a warehouse's id instead of reading it back. Omitting it remains recommended; if you supply one, prefer a UUIDv7. Server-assigned ids are now UUIDv7.

A taken id returns `409 WarehouseIdAlreadyExists`, and the warehouse dry-run endpoint reports a new `warehouse-id-available` check. Do not re-use the id of a deleted warehouse: Lakekeeper keys caches and permission records on the warehouse id alone, so an id that changes hands can briefly resolve to the previous warehouse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create warehouses with an optional caller-specified UUID.
  * Automatically generate an ID when none is provided.
  * Validate warehouse ID availability before creation; checks are advisory and do not reserve IDs.
  * Reuse IDs after deletion when ownership records are properly removed.

* **Bug Fixes**
  * Duplicate ID conflicts return a clear `409 Conflict` without exposing ownership details.
  * Authorization errors no longer reveal related object identifiers.

* **Documentation**
  * Documented warehouse UUID behavior, instance-wide uniqueness, and recommended usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->