### PR TITLE
feat(catalog): advertise scan-planning-mode on table responses

### DIFF
--- a/crates/iceberg-ext/src/configs/table.rs
+++ b/crates/iceberg-ext/src/configs/table.rs
@@ -33,6 +33,9 @@ impl TableProperties {
             } else if [creds::ExpirationTimeMs::KEY].contains(&key.as_str()) {
                 creds::validate(&key, &value)?;
                 config.props.insert(key, value);
+            } else if [general::ScanPlanningMode::KEY].contains(&key.as_str()) {
+                general::validate(&key, &value)?;
+                config.props.insert(key, value);
             } else {
                 let pair = custom::CustomConfig {
                     key: key.clone(),
@@ -164,6 +167,23 @@ pub mod adls {
     );
 }
 
+/// Behaviour advertised per table with no storage namespace of its own. Named for
+/// the spec's "General Configurations" heading in `LoadTableResult`; `catalog`
+/// would collide with this crate's own `catalog` module.
+pub mod general {
+    use super::{
+        super::ConfigProperty, ConfigParseError, NotCustomProp, ParseFromStr, TableProperties,
+        TableProperty,
+    };
+    use crate::configs::impl_config_values;
+    impl_config_values!(
+        Table,
+        {
+            ScanPlanningMode, String, "scan-planning-mode", "scan_planning_mode";
+        }
+    );
+}
+
 pub mod custom {
     use super::TableProperty;
     pub use crate::configs::CustomConfig;
@@ -183,6 +203,14 @@ mod tests {
         assert_eq!(iceberg::io::S3_ACCESS_KEY_ID, s3::AccessKeyId::KEY);
         assert_eq!(iceberg::io::S3_SECRET_ACCESS_KEY, s3::SecretAccessKey::KEY);
         assert_eq!(iceberg::io::S3_SESSION_TOKEN, s3::SessionToken::KEY);
+    }
+
+    /// Pinned against the spec literal, not against the constant, so a typo in the
+    /// key cannot rename it on the wire while every test that reads it through
+    /// `KEY` keeps agreeing with itself.
+    #[test]
+    fn test_scan_planning_mode_key_matches_the_spec() {
+        assert_eq!(general::ScanPlanningMode::KEY, "scan-planning-mode");
     }
 
     #[test]

--- a/crates/lakekeeper-integration-tests/src/lib.rs
+++ b/crates/lakekeeper-integration-tests/src/lib.rs
@@ -154,6 +154,23 @@ pub async fn create_view_helper(
 /// signature for tests extracted from lakekeeper that pre-date the
 /// num-warehouses / project-id arguments.
 #[allow(clippy::too_many_arguments)]
+/// Assert a `loadTable`-shaped response advertises client-side scan planning.
+///
+/// `loadTable`, `createTable` and `registerTable` all return the same body, so all
+/// three must carry it; asserting on the response rather than on the server-side
+/// helper is what catches a path that was never wired up.
+pub fn assert_advertises_client_planning(
+    config: Option<&std::collections::HashMap<String, String>>,
+    endpoint: &str,
+) {
+    let config = config.unwrap_or_else(|| panic!("{endpoint} must carry a config"));
+    assert_eq!(
+        config.get("scan-planning-mode").map(String::as_str),
+        Some("client"),
+        "{endpoint} must advertise client-side planning: {config:?}"
+    );
+}
+
 pub async fn setup_simple<T: lakekeeper::service::authz::Authorizer>(
     pool: sqlx::PgPool,
     storage_profile: lakekeeper::service::storage::StorageProfile,

--- a/crates/lakekeeper-integration-tests/tests/server_load_table.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_load_table.rs
@@ -22,7 +22,7 @@ use lakekeeper::{
     api::{
         ApiContext,
         iceberg::v1::{
-            NamespaceParameters, TableParameters,
+            NamespaceParameters, Prefix, TableParameters,
             namespace::NamespaceService as _,
             tables::{
                 DataAccess, DataAccessMode, LoadTableFilters, LoadTableRequest,
@@ -32,9 +32,15 @@ use lakekeeper::{
         management::v1::warehouse::TabularDeleteProfile,
     },
     server::{CatalogServer, tables::load_table::load_table},
-    service::{State, authz::AllowAllAuthorizer},
+    service::{
+        State,
+        authz::{AllowAllAuthorizer, CatalogTableAction, tests::HidingAuthorizer},
+    },
 };
-use lakekeeper_integration_tests::{random_request_metadata, setup_simple};
+use lakekeeper_integration_tests::{
+    SetupTestCatalog, create_ns, create_table, memory_io_profile, random_request_metadata,
+    setup_simple,
+};
 use lakekeeper_storage_postgres::{PostgresBackend, SecretsState};
 use sqlx::PgPool;
 
@@ -310,6 +316,93 @@ async fn setup_table_with_snapshots(
     .unwrap();
 
     (ctx, ns_params, table_ident, table)
+}
+
+/// A caller with `GetMetadata` but neither `ReadData` nor `WriteData` gets no
+/// storage config — the one body shape the `CatalogDefaultsOnly` ETag axis exists
+/// for. It must still carry the advertisement, and must still carry a `config`
+/// map at all, which is what distinguishes it from a commit response.
+#[sqlx::test]
+async fn test_load_table_without_storage_access_still_advertises_planning(pool: PgPool) {
+    let authz = HidingAuthorizer::new();
+    let (ctx, warehouse) = SetupTestCatalog::builder()
+        .pool(pool)
+        .authorizer(authz.clone())
+        .storage_profile(memory_io_profile())
+        .build()
+        .setup()
+        .await;
+
+    let prefix = warehouse.warehouse_id.to_string();
+    let ns = create_ns(ctx.clone(), prefix.clone(), "planning_ns".to_string()).await;
+    create_table(ctx.clone(), &prefix, "planning_ns", "t1", false)
+        .await
+        .unwrap();
+
+    // Metadata stays visible; storage access does not.
+    authz.block_action(&format!("table:{:?}", CatalogTableAction::ReadData));
+    authz.block_action(&format!("table:{:?}", CatalogTableAction::WriteData));
+
+    let result = CatalogServer::load_table(
+        TableParameters {
+            prefix: Some(Prefix(prefix)),
+            table: TableIdent::new(ns.namespace.clone(), "t1".to_string()),
+        },
+        LoadTableRequest::builder().build(),
+        ctx,
+        random_request_metadata(),
+    )
+    .await
+    .expect("metadata access alone must still load the table");
+
+    let LoadTableResultOrNotModified::LoadTableResult(result) = result else {
+        panic!("an unconditional load must not return 304");
+    };
+
+    assert!(
+        result.storage_credentials.is_none(),
+        "no storage access must vend nothing: {:?}",
+        result.storage_credentials
+    );
+    let config = result
+        .config
+        .expect("a load without storage access still carries a config");
+    assert_eq!(
+        config.get("scan-planning-mode").map(String::as_str),
+        Some("client"),
+        "the advertisement must not depend on storage access: {config:?}"
+    );
+}
+
+/// The spec puts `scan-planning-mode` in the `loadTable` config map, and we serve
+/// no `planTableScan` endpoint, so every load must say `client`. Asserted on the
+/// response rather than on the helper, since the helper is easy to leave unwired.
+#[sqlx::test]
+async fn test_load_table_advertises_client_side_scan_planning(pool: PgPool) {
+    let (ctx, ns_params, table_ident, _) = setup_table_with_snapshots(pool).await;
+
+    let result = CatalogServer::load_table(
+        TableParameters {
+            prefix: ns_params.prefix.clone(),
+            table: table_ident.clone(),
+        },
+        LoadTableRequest::builder().build(),
+        ctx,
+        random_request_metadata(),
+    )
+    .await
+    .unwrap();
+
+    let LoadTableResultOrNotModified::LoadTableResult(result) = result else {
+        panic!("an unconditional load must not return 304");
+    };
+
+    let config = result.config.expect("a load always carries a config");
+    assert_eq!(
+        config.get("scan-planning-mode").map(String::as_str),
+        Some("client"),
+        "loadTable must advertise client-side planning: {config:?}"
+    );
 }
 
 #[sqlx::test]

--- a/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
+++ b/crates/lakekeeper-integration-tests/tests/server_tables_postgres.rs
@@ -47,9 +47,9 @@ use lakekeeper::{
     },
 };
 use lakekeeper_integration_tests::{
-    create_ns, create_table as create_table_helper, create_table_request as create_request,
-    create_view, drop_table as drop_table_helper, impl_pagination_tests, memory_io_profile,
-    setup_simple, tabular_test_multi_warehouse_setup,
+    assert_advertises_client_planning, create_ns, create_table as create_table_helper,
+    create_table_request as create_request, create_view, drop_table as drop_table_helper,
+    impl_pagination_tests, memory_io_profile, setup_simple, tabular_test_multi_warehouse_setup,
 };
 use lakekeeper_storage_postgres::{
     PostgresBackend, SecretsState, tabular::table::tests::initialize_table,
@@ -777,6 +777,27 @@ async fn test_default_format_version_is_v2(pg_pool: PgPool) {
     .unwrap();
 
     assert_eq!(table.metadata.format_version(), FormatVersion::V2);
+}
+
+/// `createTable` returns a `LoadTableResult`, so it carries the same advertisement
+/// `loadTable` does.
+#[sqlx::test]
+async fn test_create_table_advertises_client_side_scan_planning(pg_pool: PgPool) {
+    let (ctx, _ns, ns_params, _) = table_test_setup(pg_pool).await;
+    let table = CatalogServer::create_table(
+        ns_params,
+        create_table_request_with_format("planning_advertised", None),
+        DataAccess {
+            vended_credentials: true,
+            remote_signing: false,
+        },
+        ctx,
+        RequestMetadata::new_unauthenticated(),
+    )
+    .await
+    .unwrap();
+
+    assert_advertises_client_planning(table.config.as_ref(), "createTable");
 }
 
 #[sqlx::test]
@@ -2528,6 +2549,39 @@ async fn test_rename_table_onto_a_soft_deleted_name_succeeds(pool: sqlx::PgPool)
     )
     .await
     .expect("the renamed table must be loadable under the reused name");
+}
+
+#[sqlx::test]
+async fn test_register_table_advertises_client_side_scan_planning(pool: PgPool) {
+    let (ctx, _ns, ns_params, _) = table_test_setup(pool).await;
+
+    // Register reuses an existing table's metadata file; overwrite lets it attach
+    // to a live name without a drop first.
+    let source = CatalogServer::create_table(
+        ns_params.clone(),
+        create_request(Some("planning_register".to_string()), Some(false)),
+        DataAccess::not_specified(),
+        ctx.clone(),
+        RequestMetadata::new_unauthenticated(),
+    )
+    .await
+    .unwrap();
+
+    let registered = CatalogServer::register_table(
+        ns_params,
+        iceberg_ext::catalog::rest::RegisterTableRequest::builder()
+            .name("planning_register".to_string())
+            .metadata_location(source.metadata_location.unwrap())
+            .overwrite(true)
+            .build(),
+        DataAccess::not_specified(),
+        ctx,
+        RequestMetadata::new_unauthenticated(),
+    )
+    .await
+    .expect("registering over the same name must succeed");
+
+    assert_advertises_client_planning(registered.config.as_ref(), "registerTable");
 }
 
 #[sqlx::test]

--- a/crates/lakekeeper/src/server/tables.rs
+++ b/crates/lakekeeper/src/server/tables.rs
@@ -15,7 +15,10 @@ use iceberg::{
 };
 use iceberg_ext::{
     catalog::rest::{IcebergErrorResponse, LoadCredentialsResponse},
-    configs::ParseFromStr,
+    configs::{
+        ParseFromStr,
+        table::{TableProperties as TableConfigProperties, general},
+    },
 };
 use itertools::Itertools;
 use lakekeeper_io::Location;
@@ -627,7 +630,7 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             metadata_location: Some(metadata_location_str),
             metadata: table_metadata,
             remote_signing_config: config.remote_signing.clone(),
-            config: Some(config.config.into()),
+            config: Some(load_response_config(Some(config.config))),
             storage_credentials,
             etag: Some(etag),
         })
@@ -1065,6 +1068,30 @@ impl<C: CatalogStore, A: Authorizer + Clone, S: SecretStore>
             }
         }
     }
+}
+
+/// The only scan-planning mode this server supports: it serves no `planTableScan`
+/// endpoint, and `SUPPORTED_ENDPOINTS` filters the plan routes out of `getConfig`.
+const SCAN_PLANNING_MODE_CLIENT: &str = "client";
+
+/// The `config` map to return on a `loadTable`-shaped response — `loadTable`,
+/// `createTable` and `registerTable` all return one — given whatever the storage
+/// profile produced (`None` when the caller has no storage access).
+///
+/// Never empty: the catalog-wide keys are advertised to every caller, so the map
+/// has content even with no storage config to merge. That is why
+/// [`etag::StorageAccess`] separates a load without storage access from a commit,
+/// whose body carries no `config` at all; the two must not share a validator.
+pub(crate) fn load_response_config(
+    storage_config: Option<TableConfigProperties>,
+) -> HashMap<String, String> {
+    let mut config = storage_config.unwrap_or_default();
+    // Said outright rather than left for the client to discover from a 404 on the
+    // plan routes; this is the signal the spec points clients at.
+    config.insert(&general::ScanPlanningMode(
+        SCAN_PLANNING_MODE_CLIENT.to_string(),
+    ));
+    config.into()
 }
 
 async fn authorize_load_table<C: CatalogStore, A: Authorizer + Clone>(
@@ -2297,6 +2324,36 @@ mod unit_tests {
     use uuid::Uuid;
 
     use super::*;
+
+    /// Advertised to every caller, whether or not they have storage access, and
+    /// without displacing the storage keys it is merged into.
+    #[test]
+    fn load_response_config_advertises_client_side_planning() {
+        use iceberg_ext::configs::ConfigProperty as _;
+
+        let no_storage = load_response_config(None);
+        assert_eq!(
+            no_storage.get("scan-planning-mode").map(String::as_str),
+            Some("client")
+        );
+
+        let mut storage = TableConfigProperties::default();
+        storage.insert(&iceberg_ext::configs::table::s3::Region(
+            "eu-central-1".to_string(),
+        ));
+        let merged = load_response_config(Some(storage));
+        assert_eq!(
+            merged
+                .get(general::ScanPlanningMode::KEY)
+                .map(String::as_str),
+            Some("client")
+        );
+        assert_eq!(
+            merged.get("s3.region").map(String::as_str),
+            Some("eu-central-1"),
+            "the storage config must survive the merge: {merged:?}"
+        );
+    }
     use crate::{
         WarehouseId,
         service::{Actor, NamespaceHierarchy, UserId, ViewInfo, ViewOrTableInfo},

--- a/crates/lakekeeper/src/server/tables/create_table.rs
+++ b/crates/lakekeeper/src/server/tables/create_table.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use super::{
     super::{io::write_file, require_warehouse_id},
     etag::{StorageAccess, TableETag, TableResponseShape},
-    validate_table_properties,
+    load_response_config, validate_table_properties,
 };
 use crate::{
     WarehouseId,
@@ -378,7 +378,7 @@ async fn create_table_inner<C: CatalogStore, A: Authorizer + Clone, S: SecretSto
         metadata_location: metadata_location.as_ref().map(ToString::to_string),
         metadata: table_metadata.clone(),
         remote_signing_config: config.remote_signing.clone(),
-        config: Some(config.config.into()),
+        config: Some(load_response_config(Some(config.config))),
         storage_credentials,
         etag: metadata_location.as_ref().map(|loc| {
             TableETag::new(

--- a/crates/lakekeeper/src/server/tables/etag.rs
+++ b/crates/lakekeeper/src/server/tables/etag.rs
@@ -17,11 +17,18 @@ use crate::{
 
 /// Version prefix for structured `loadTable` [`ETag`]s. Anything not parsing
 /// under this prefix (pre-upgrade or future-version values) isn't matched, so
-/// the client reloads. Bump the suffix on incompatible encoding changes.
+/// the client reloads.
 ///
-/// `lk2` added the warehouse id to the hash. Every `lk1` tag in a client cache
-/// stops matching and the client reloads once — the cost of any axis change.
-const ETAG_PREFIX: &str = "lk2";
+/// Bump it whenever a cached tag could otherwise survive a change to the body it
+/// validates — which is *not* only when the encoding changes. Adding a key to
+/// every response is the case that catches people out: the hash inputs are
+/// untouched, so the tag is byte-identical across the upgrade and a conditional
+/// load 304s onto the old body indefinitely.
+///
+/// `lk2` added the warehouse id to the hash. `lk3` added `scan-planning-mode` to
+/// every response config, leaving the hash inputs alone. Either way every cached
+/// tag stops matching and each client reloads once — the standing cost.
+const ETAG_PREFIX: &str = "lk3";
 
 /// One axis of a [`TableResponseShape`].
 ///
@@ -80,15 +87,28 @@ impl EtagAxis for StoragePermissions {
 /// delegation or permission level that would mean nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StorageAccess {
-    /// No `config` in the body at all — a commit response, or a caller with no
-    /// storage access.
+    /// No `config` key in the body at all — a commit response. The spec's
+    /// `CommitTableResponse` carries only the metadata and its location.
     NoConfig,
+    /// A `config` carrying the catalog-wide keys and nothing else — a load by a
+    /// caller with no storage access. Distinct from [`Self::NoConfig`] because
+    /// that body really is empty of config while this one advertises
+    /// `scan-planning-mode`, so one tag must not stand for both.
+    ///
+    /// Carries the warehouse revision even though today's catalog-wide keys are
+    /// compile-time constants that no warehouse edit can vary. A tag for this
+    /// shape never has a revalidation point and never vends credentials, so it
+    /// 304s for as long as the metadata location holds; the first
+    /// warehouse-derived key added here would otherwise pin a stale body with
+    /// nothing left to invalidate it. An extra axis costs a cache miss, which is
+    /// the direction this type is documented to err in.
+    CatalogDefaultsOnly { warehouse_version: WarehouseVersion },
     /// Config present, scoped to this delegation and permission level, and
     /// generated from this revision of the warehouse's storage profile.
     ///
-    /// The revision belongs here rather than alongside `snapshots`: a warehouse
-    /// edit changes region, endpoint, KMS key or the STS toggle, none of which
-    /// can reach a body that carries no config at all.
+    /// The revision belongs on the variants that carry a config rather than
+    /// alongside `snapshots`: a warehouse edit changes region, endpoint, KMS key
+    /// or the STS toggle, none of which can reach [`Self::NoConfig`].
     Config {
         delegation: DataAccessMode,
         permissions: StoragePermissions,
@@ -135,11 +155,12 @@ impl TableResponseShape {
         Self::new(*snapshots, storage)
     }
 
-    /// Shape of a response carrying the full metadata and no storage config.
+    /// Shape of a commit response: full metadata, no `config` key at all.
     ///
-    /// A commit response, and equally a load by a caller with no storage access —
-    /// those bodies are genuinely equivalent, so sharing a tag is correct.
-    pub(crate) fn no_storage_config() -> Self {
+    /// Deliberately *not* shared with a load by a caller who has no storage
+    /// access. That load still carries a `config` holding the catalog-wide keys,
+    /// so the two bodies differ and must not answer each other.
+    pub(crate) fn commit_response() -> Self {
         Self::new(SnapshotsQuery::All, StorageAccess::NoConfig)
     }
 }
@@ -198,6 +219,11 @@ impl TableETag {
         hasher.update(&[0]);
         match storage {
             StorageAccess::NoConfig => hasher.update(b"nc"),
+            StorageAccess::CatalogDefaultsOnly { warehouse_version } => {
+                hasher.update(b"cd");
+                hasher.update(&[0]);
+                hasher.update(&warehouse_version.to_le_bytes());
+            }
             StorageAccess::Config {
                 delegation,
                 permissions,
@@ -266,7 +292,7 @@ pub(crate) fn commit_etag(warehouse_id: WarehouseId, metadata_location: &str) ->
     TableETag::new(
         warehouse_id,
         metadata_location,
-        TableResponseShape::no_storage_config(),
+        TableResponseShape::commit_response(),
         None,
     )
     .into_etag()
@@ -300,6 +326,12 @@ mod tests {
         let mut shapes = Vec::new();
         for snapshots in [SnapshotsQuery::All, SnapshotsQuery::Refs] {
             shapes.push(TableResponseShape::new(snapshots, StorageAccess::NoConfig));
+            shapes.push(TableResponseShape::new(
+                snapshots,
+                StorageAccess::CatalogDefaultsOnly {
+                    warehouse_version: wv(),
+                },
+            ));
             for delegation in [
                 DataAccessMode::ClientManaged,
                 delegated(false, false),
@@ -340,8 +372,9 @@ mod tests {
             );
         }
         assert_eq!(seen.len(), shapes.len());
-        // 2 snapshot modes x (1 no-config + 5 delegations x 3 permission levels)
-        assert_eq!(shapes.len(), 32);
+        // 2 snapshot modes x (no-config + catalog-defaults-only
+        // + 5 delegations x 3 permission levels)
+        assert_eq!(shapes.len(), 34);
     }
 
     /// Pins the wire format against literals rather than against another
@@ -364,7 +397,7 @@ mod tests {
             TableETag::new(wh(), LOC, delegated_shape, None)
                 .into_etag()
                 .as_str(),
-            "W/\"lk2.ca98cf6daac60cd\""
+            "W/\"lk3.ca98cf6daac60cd\""
         );
         // Same shape, next warehouse version: differs only in the trailing
         // little-endian bytes, so a big-endian slip changes this value.
@@ -380,20 +413,15 @@ mod tests {
             TableETag::new(wh(), LOC, next_version, None)
                 .into_etag()
                 .as_str(),
-            "W/\"lk2.e475cfa1e21ecde5\""
+            "W/\"lk3.e475cfa1e21ecde5\""
         );
         // The `nc` branch skips the version entirely, and the revalidation
         // point is appended as lower-case hex.
         assert_eq!(
-            TableETag::new(
-                wh(),
-                LOC,
-                TableResponseShape::no_storage_config(),
-                Some(255)
-            )
-            .into_etag()
-            .as_str(),
-            "W/\"lk2.165c4d5b6eec0d9a.ff\""
+            TableETag::new(wh(), LOC, TableResponseShape::commit_response(), Some(255))
+                .into_etag()
+                .as_str(),
+            "W/\"lk3.165c4d5b6eec0d9a.ff\""
         );
     }
 
@@ -475,10 +503,11 @@ mod tests {
         // trailing junk, non-hex expiry.
         assert!(TableETag::parse("e34615aade2e6333").is_none());
         assert!(TableETag::parse("lk1.abc").is_none());
-        assert!(TableETag::parse("lk3.abc").is_none());
-        assert!(TableETag::parse("lk2.").is_none());
-        assert!(TableETag::parse("lk2.abc.def.ghi").is_none());
-        assert!(TableETag::parse("lk2.abc.zzz").is_none());
+        assert!(TableETag::parse("lk2.abc").is_none());
+        assert!(TableETag::parse("lk4.abc").is_none());
+        assert!(TableETag::parse("lk3.").is_none());
+        assert!(TableETag::parse("lk3.abc.def.ghi").is_none());
+        assert!(TableETag::parse("lk3.abc.zzz").is_none());
     }
 
     #[test]
@@ -498,6 +527,7 @@ mod tests {
                 "storage",
                 vec![
                     "nc",
+                    "cd",
                     DataAccessMode::ClientManaged.as_tag(),
                     delegated(false, false).as_tag(),
                     delegated(true, false).as_tag(),
@@ -527,16 +557,35 @@ mod tests {
         }
     }
 
+    /// A commit response carries no `config` key; a load by a caller with no
+    /// storage access carries one holding `scan-planning-mode`. The bodies differ,
+    /// so the tags must too — otherwise a conditional load could be answered from
+    /// a commit tag and the client would keep a body missing the advertisement.
     #[test]
-    fn commit_etag_matches_a_load_with_no_storage_access() {
-        // A commit body and a no-storage-access load body are both metadata with
-        // no config, so they are the same shape and sharing a tag is correct.
-        // Every config-bearing load differs and must not match.
+    fn commit_etag_does_not_match_any_load() {
         let commit = commit_etag(wh(), LOC);
         assert_eq!(
             commit,
-            TableETag::new(wh(), LOC, TableResponseShape::no_storage_config(), None).into_etag()
+            TableETag::new(wh(), LOC, TableResponseShape::commit_response(), None).into_etag()
         );
+
+        let no_storage_access = TableETag::new(
+            wh(),
+            LOC,
+            TableResponseShape::new(
+                SnapshotsQuery::All,
+                StorageAccess::CatalogDefaultsOnly {
+                    warehouse_version: wv(),
+                },
+            ),
+            None,
+        )
+        .into_etag();
+        assert_ne!(
+            commit, no_storage_access,
+            "a load still advertises catalog config, a commit body carries none"
+        );
+
         let delegated_load = TableETag::new(
             wh(),
             LOC,

--- a/crates/lakekeeper/src/server/tables/load_table.rs
+++ b/crates/lakekeeper/src/server/tables/load_table.rs
@@ -8,7 +8,7 @@ use crate::{
     api::iceberg::v1::{
         ApiContext, LoadTableResult, LoadTableResultOrNotModified, Result, TableIdent,
         TableParameters,
-        tables::{LoadTableFilters, LoadTableRequest},
+        tables::{DataAccessMode, LoadTableFilters, LoadTableRequest},
     },
     request_metadata::RequestMetadata,
     server::{
@@ -16,20 +16,21 @@ use crate::{
         tables::{
             authorize_load_table,
             etag::{StorageAccess, TableETag, TableResponseShape},
-            parse_location, validate_referenced_by, validate_table_or_view_ident,
+            load_response_config, parse_location, validate_referenced_by,
+            validate_table_or_view_ident,
         },
     },
     service::{
         AuthZTableInfo as _, CachePolicy, CatalogStore, CatalogTableOps, CatalogWarehouseOps,
         LoadTableResponse as CatalogLoadTableResult, State, TableId, TableIdentOrId,
-        TabularListFlags, TabularNotFound, Transaction, WarehouseStatus,
+        TabularListFlags, TabularNotFound, Transaction, WarehouseStatus, WarehouseVersion,
         authz::{Authorizer, AuthzWarehouseOps, CatalogTableAction},
         events::{
             APIEventContext,
             context::{ResolvedTable, authz_to_error_no_audit},
         },
         secrets::SecretStore,
-        storage::{credential_revalidate_after_ms, now_epoch_ms},
+        storage::{StoragePermissions, credential_revalidate_after_ms, now_epoch_ms},
     },
 };
 
@@ -149,19 +150,7 @@ pub(crate) async fn load_table_with_flags<
     let shape_at = |warehouse_version| {
         TableResponseShape::for_load(
             &filters,
-            // Both per-request inputs to `generate_table_config`. Without storage
-            // access there is no `config` at all — a load made before access was
-            // granted must not answer one made after; and credentials are
-            // policy-scoped per permission level, so a read-scoped body must not
-            // answer a request from a caller who can now write.
-            match storage_permissions {
-                None => StorageAccess::NoConfig,
-                Some(permissions) => StorageAccess::Config {
-                    delegation: data_access,
-                    permissions,
-                    warehouse_version,
-                },
-            },
+            storage_access_for(storage_permissions, data_access, warehouse_version),
         )
     };
     if let Some(etag) = match_not_modified(
@@ -263,7 +252,7 @@ pub(crate) async fn load_table_with_flags<
     let load_table_result = LoadTableResult {
         metadata_location: metadata_location_ref.as_ref().map(ToString::to_string),
         metadata: metadata_ref,
-        config: storage_config.map(|c| c.config.into()),
+        config: Some(load_response_config(storage_config.map(|c| c.config))),
         storage_credentials,
         remote_signing_config,
         etag: metadata_location_ref.as_ref().map(|loc| {
@@ -280,6 +269,32 @@ pub(crate) async fn load_table_with_flags<
     Ok(LoadTableResultOrNotModified::LoadTableResult(
         load_table_result,
     ))
+}
+
+/// Which [`StorageAccess`] a load response has, from the two per-request inputs
+/// to `generate_table_config`.
+///
+/// Without storage access the `config` holds only the catalog-wide keys — a load
+/// made before access was granted must not answer one made after; and credentials
+/// are policy-scoped per permission level, so a read-scoped body must not answer a
+/// request from a caller who can now write.
+///
+/// Named rather than inlined at its one call site so a test can drive the mapping
+/// directly: inlined, the `None` arm was reachable only through a full request and
+/// nothing pinned which variant it produced.
+fn storage_access_for(
+    storage_permissions: Option<StoragePermissions>,
+    delegation: DataAccessMode,
+    warehouse_version: WarehouseVersion,
+) -> StorageAccess {
+    match storage_permissions {
+        None => StorageAccess::CatalogDefaultsOnly { warehouse_version },
+        Some(permissions) => StorageAccess::Config {
+            delegation,
+            permissions,
+            warehouse_version,
+        },
+    }
 }
 
 /// Load a table from the catalog, by default rejecting a staged one.
@@ -676,17 +691,43 @@ mod etag_tests {
         assert!(matches_repr(&[cached], vended, true));
     }
 
+    /// Pins the mapping against the variant literal rather than through
+    /// [`storage_access_for`]. Routing the expectation through the same function
+    /// makes the test move with the code: reverting the `None` arm to
+    /// [`StorageAccess::NoConfig`] would leave both sides agreeing and the
+    /// regression invisible.
+    #[test]
+    fn no_storage_access_maps_to_the_catalog_defaults_shape() {
+        let mapped = storage_access_for(None, DataAccessMode::ClientManaged, wv());
+        assert_eq!(
+            mapped,
+            StorageAccess::CatalogDefaultsOnly {
+                warehouse_version: wv()
+            }
+        );
+        // The consequence that matters: a commit's tag must not answer this load.
+        assert_ne!(
+            TableResponseShape::new(SnapshotsQuery::All, mapped),
+            TableResponseShape::commit_response(),
+            "a load with no storage access still carries a config; a commit does not"
+        );
+    }
+
     #[test]
     fn no_storage_access_is_its_own_shape() {
-        // A load the caller has no storage access for returns `config: null`.
+        // A load the caller has no storage access for returns a `config` holding
+        // only the catalog-wide keys, and no credentials.
         // That body must not satisfy a later load made after access is granted.
-        let no_config = TableResponseShape::no_storage_config();
-        let cached = client_etag_for(LOC, no_config, None);
+        let catalog_defaults_only = TableResponseShape::new(
+            SnapshotsQuery::All,
+            storage_access_for(None, DataAccessMode::ClientManaged, wv()),
+        );
+        let cached = client_etag_for(LOC, catalog_defaults_only, None);
         assert!(
             !matches_repr(std::slice::from_ref(&cached), all(), false),
-            "304'd a config-bearing load from a config-less ETag"
+            "304'd a credential-bearing load from a tag minted without storage access"
         );
-        assert!(matches_repr(&[cached], no_config, false));
+        assert!(matches_repr(&[cached], catalog_defaults_only, false));
     }
 
     #[test]


### PR DESCRIPTION
loadTable, createTable and registerTable all return a LoadTableResult, so all three now carry `scan-planning-mode: client` in their config map. We serve no planTableScan endpoint; this is the signal the spec points clients at, rather than leaving them to discover a 404.

The config map previously came only from the storage profile, so a caller without storage access got `config: null`. It is now always present, which splits two ETag shapes that used to share one: a commit response carries no config at all, a load without storage access carries the catalog-wide keys. `CatalogDefaultsOnly` also takes the warehouse revision, since its tag has no revalidation point and would otherwise pin a stale body the moment any catalog-wide key becomes warehouse-derived.

ETAG_PREFIX moves to lk3. The hash inputs are unchanged, so without the bump a cached tag would stay byte-identical while the body it validates gained a key — a conditional load would 304 onto the old body indefinitely. Every cached tag stops matching and each client reloads once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Table responses now advertise client-side scan planning through the `scan-planning-mode` configuration.
  - `createTable`, `registerTable`, and `loadTable` responses consistently include this setting.
  - Responses preserve available storage configuration while still exposing catalog defaults when storage access is limited.

- **Bug Fixes**
  - Improved response configuration and ETag handling for different storage-access scenarios.
  - Ensured storage credentials are not exposed when callers lack storage permissions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->