### PR TITLE
docs(roles): document provider-managed roles

### DIFF
--- a/docs/docs/authorization.md
+++ b/docs/docs/authorization.md
@@ -41,6 +41,12 @@ Three words are used consistently across the authorizers and the API:
 - A **grant** gives one privilege on one resource to one principal: *Alice may `select` on this warehouse*.
 - A **principal** is a user or a **role**. Granting to a role once and then managing its membership is how you keep the number of grants manageable. Where role membership comes from — an identity provider, or Lakekeeper itself — depends on your setup; see [Configuration](./configuration.md).
 
+### Provider-managed roles { .lkp }
+
+A role's `provider-id` says who owns it. `lakekeeper` roles are yours to manage through the API; roles in a [role provider's](./configuration.md#role-provider) namespace belong to that provider, so create, rename, delete and member (un)assignment are rejected with `400 ManagedRoleImmutable` — change them in the identity provider instead. They are still ordinary grant principals: grant privileges to them like any other role.
+
+Membership is synced per user at login. A provider-managed role therefore appears once its first member authenticates, and lists only the members Lakekeeper has seen so far — not the full group. A group nobody has logged in from does not exist as a role yet and cannot be granted to; under Cedar, match on `principal.project_roles` instead, which needs no catalog role.
+
 ### Direct grants are not effective permissions
 
 A grant recorded on a resource is not the whole answer to "what can Alice do here". Your authorizer's model decides what a grant *reaches*: whether `select` implies `describe`, and whether a warehouse grant covers the tables inside it. Role membership and inheritance are resolved when a request is decided, not stored as extra grants.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -650,6 +650,8 @@ LAKEKEEPER__TRUSTED_ENGINES__TRINO__IDENTITIES__KUBERNETES__SUBJECTS=[trino-sa]
 
 Authorizers such as `Cedar` support pluggable role providers that resolve a user's group memberships from an external directory (e.g. LDAP / Active Directory). Multiple providers can be configured in parallel, each with a unique identifier. `OpenFGA` does not use role providers — roles are stored directly in OpenFGA.
 
+Roles in a provider's namespace are the provider's to manage — see [Provider-managed roles](./authorization.md#provider-managed-roles) for what the management API rejects and how membership becomes visible.
+
 Role providers that resolve groups over HTTPS — the Microsoft Graph (Entra ID) provider — honor the standard `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` environment variables for outbound requests. There is no per-provider proxy setting.
 
 #### Chain settings


### PR DESCRIPTION
A role's provider-id decides who may change it, but nothing in the reference docs said so. Add a short "Provider-managed roles" section to the authorization page: namespace ownership, the 400 ManagedRoleImmutable rejection on create/rename/delete/member changes, that provider roles are still ordinary grant principals, and that membership syncs per user at login — so a provider role appears with its first authenticated member and lists only the members seen so far, never the full group. Points at the Cedar project_roles match for authorizing a group that has no catalog role yet. Cross-linked from the Role Provider configuration section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on provider-managed roles, including ownership rules and restricted mutations.
  * Documented login-based membership synchronization and Cedar considerations for groups not yet observed.
  * Clarified role-provider namespace management and linked to related behavior and API restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->