### PR TITLE
chore(docs): Sync documentation from lakekeeper plus

### DIFF
--- a/docs/docs/api/lakekeeper.cedarschema
+++ b/docs/docs/api/lakekeeper.cedarschema
@@ -88,9 +88,23 @@ namespace Lakekeeper {
   //                    Use `principal.project_roles.contains({provider_id: "ldap",
   //                    source_id: "admins"})` to match.
   //
-  // Both attributes are populated from the same provider role resolution and are
-  // empty when no project context is available (server-level actions such as
-  // CreateProject that span multiple projects).
+  // Both attributes are populated from the same provider role resolution, which
+  // resolves the roles of ONE project: the one the request names, or the
+  // configured default project when it names none. They are empty only when
+  // neither exists.
+  //
+  // That matters above the project level. A role is defined inside a project, so
+  // at a server or user-management action — `CreateProject`, `ListUsers` — these
+  // attributes still hold one project's roles, and which project that is comes
+  // from the request. A policy of the form
+  //
+  //   permit(principal in Role::"<project>/ldap~ops", action in ServerActions, ..)
+  //
+  // therefore matches or does not according to `x-project-id`, and a `forbid`
+  // written that way can stop firing when the header changes. Express authority
+  // that must not depend on the request as a grant on the server — grants are
+  // project-less and are read across every project the caller holds a role in —
+  // or name the user.
   entity User in [Role, Server] {
     // Email of the user, extracted from the authentication token.
     // Not available for all token types.
@@ -119,6 +133,8 @@ namespace Lakekeeper {
     // source IDs (no two providers share the same source_id for different roles).
     // Prefer `project_roles` when provider uniqueness cannot be guaranteed.
     // Use `principal.global_role_ids.contains("admins")` to match.
+    // Carries no project in its *shape*, but its *content* is one project's roles,
+    // the same ones `project_roles` holds — it is not a server-wide set.
     // Always present (empty set when the feature is disabled or no project context exists).
     global_role_ids: Set<String>,
     // Authentication provider of the user (e.g. "oidc", "kubernetes", etc.)
@@ -150,12 +166,144 @@ namespace Lakekeeper {
   // ID: "<project-id>/<provider_id>~<source_id>"
   //     e.g. "my-project/lakekeeper~01943e3d-43c5-7a4e-b6dd-a88f0029gcgd"
   //          "my-project/oidc~data-engineers"
+  //
+  // A role nested in other roles has them as Cedar parents, so `in` means
+  // membership: `principal in Role::"my-project/oidc~admins"` holds for a
+  // caller acting as any role nested inside `admins`, at any depth. The same
+  // applies to a role named as a grant's grantee, to the subject of an
+  // introspection, and to the role named when assuming one.
   entity Role in [Role, Project] = {
     project: Project,
     // Provider of this role (e.g. "oidc", "lakekeeper", etc.)
     provider_id: String,
     // The ID of this role in its provider
     source_id: String,
+  };
+
+  // ---------- Grants ----------
+  //
+  // Every object below carries two records naming the privileges the principal
+  // being authorized holds, granted to them or to one of their roles:
+  //
+  //   direct_privileges    — granted on this object.
+  //   inherited_privileges — granted on an object above it, up to the server.
+  //
+  // Read a field: `resource.direct_privileges.select`. Every field is always
+  // set; with no grants they are all false. Values are relative to the
+  // principal being authorized.
+  //
+  // Each level has its own record type below, listing the privileges grantable
+  // there. `inherited_privileges` uses that same vocabulary, so an ancestor
+  // privilege that means nothing here is absent.
+  //
+  // Two consequences worth knowing before writing a policy against an inherited
+  // field:
+  //   - `create` is grantable from the server down to a namespace but not on a
+  //     table, view or generic table, so a warehouse-level `create` grant does
+  //     not appear in a table's inherited record. Creating a table is authorized
+  //     on its namespace, which is where that grant does appear.
+  //   - `apply` is grantable only on a tag, and a tag's only ancestor is a
+  //     project, so `Tag.inherited_privileges.apply` is always false. Read
+  //     `direct_privileges.apply` instead.
+  //
+  // What a privilege confers is decided by the policies you load: these fields
+  // are an input to a policy, never a decision on their own.
+  // `GET /management/v1/grants/grantable-privileges` describes each name.
+  //
+  // Read these records on the objects a request decides and on the objects above
+  // them, and nowhere else. A request fetches the grants held on every object it
+  // decides — each item of a batch included — and on their ancestors, so those
+  // records say what is really held. The same request also places objects it does
+  // not decide in the store: the grantee of a grant question, and the project a
+  // grantee's role belongs to. Their records are all `false` because nothing asked
+  // what is held there, so `false` there means "not asked" rather than "not held",
+  // and a policy cannot tell the two apart.
+  //
+  // In a `forbid`, read attributes of `resource` only, for a second reason: a
+  // forbid that reads another entity is skipped when that entity is absent,
+  // which allows access.
+
+  // Grantable on the server.
+  type ServerPrivileges = {
+    describe: Bool,
+    select: Bool,
+    write: Bool,
+    create: Bool,
+    manage: Bool,
+    pass_grants: Bool,
+    manage_grants: Bool,
+  };
+
+  // Grantable on a project.
+  type ProjectPrivileges = {
+    describe: Bool,
+    select: Bool,
+    write: Bool,
+    create: Bool,
+    manage: Bool,
+    pass_grants: Bool,
+    manage_grants: Bool,
+  };
+
+  // Grantable on a warehouse.
+  type WarehousePrivileges = {
+    describe: Bool,
+    select: Bool,
+    write: Bool,
+    create: Bool,
+    manage: Bool,
+    pass_grants: Bool,
+    manage_grants: Bool,
+  };
+
+  // Grantable on a namespace.
+  type NamespacePrivileges = {
+    describe: Bool,
+    select: Bool,
+    write: Bool,
+    create: Bool,
+    manage: Bool,
+    pass_grants: Bool,
+    manage_grants: Bool,
+  };
+
+  // Grantable on a table.
+  type TablePrivileges = {
+    describe: Bool,
+    select: Bool,
+    write: Bool,
+    manage: Bool,
+    pass_grants: Bool,
+    manage_grants: Bool,
+  };
+
+  // Grantable on a view.
+  type ViewPrivileges = {
+    describe: Bool,
+    select: Bool,
+    write: Bool,
+    manage: Bool,
+    pass_grants: Bool,
+    manage_grants: Bool,
+  };
+
+  // Grantable on a generic table.
+  type GenericTablePrivileges = {
+    describe: Bool,
+    select: Bool,
+    write: Bool,
+    manage: Bool,
+    pass_grants: Bool,
+    manage_grants: Bool,
+  };
+
+  // Grantable on a tag definition.
+  type TagPrivileges = {
+    describe: Bool,
+    apply: Bool,
+    manage: Bool,
+    pass_grants: Bool,
+    manage_grants: Bool,
   };
 
   // A governance-tag definition: a project-scoped vocabulary entry that can be
@@ -165,6 +313,10 @@ namespace Lakekeeper {
     project: Project,
     // Name of the tag definition (e.g. "pii.classification").
     name: String,
+    // Privileges held here by the principal being authorized; see `Grants` above.
+    direct_privileges: TagPrivileges,
+    // Privileges the same principal holds on this object's ancestors.
+    inherited_privileges: TagPrivileges,
   };
 
   // ---------- Resource Hierarchy ----------
@@ -172,11 +324,21 @@ namespace Lakekeeper {
 
   // Server is the top-level administrative entity.
   // ID: UUID  e.g. "6e64ed7d-ace0-4a0c-9242-25da8eb237f6"
-  entity Server {};
+  entity Server {
+    // Privileges held here by the principal being authorized; see `Grants` above.
+    direct_privileges: ServerPrivileges,
+    // Always all false: the server has nothing above it.
+    inherited_privileges: ServerPrivileges,
+  };
 
   // Project is a container for warehouses.
   // ID: String (alphanumeric, hyphens, underscores)  e.g. "my-project"
-  entity Project in [Server];
+  entity Project in [Server] {
+    // Privileges held here by the principal being authorized; see `Grants` above.
+    direct_privileges: ProjectPrivileges,
+    // Privileges the same principal holds on this object's ancestors.
+    inherited_privileges: ProjectPrivileges,
+  };
 
   // Warehouse is a container for namespaces.
   // ID: UUID  e.g. "01943e3d-43c5-7a4e-b6dd-a44b6685c8c9"
@@ -189,6 +351,10 @@ namespace Lakekeeper {
     // drop bypasses the configured grace period and is irreversible immediately;
     // when false, drops are already hard deletes and `force` changes nothing.
     soft_delete_enabled: Bool,
+    // Privileges held here by the principal being authorized; see `Grants` above.
+    direct_privileges: WarehousePrivileges,
+    // Privileges the same principal holds on this object's ancestors.
+    inherited_privileges: WarehousePrivileges,
   };
 
   // Namespace can be nested within other namespaces or directly within a warehouse.
@@ -205,6 +371,10 @@ namespace Lakekeeper {
     // pending update. For properties being set during an update, see the
     // context of the UpdateNamespaceProperties action.
     properties: ResourceProperties,
+    // Privileges held here by the principal being authorized; see `Grants` above.
+    direct_privileges: NamespacePrivileges,
+    // Privileges the same principal holds on this object's ancestors.
+    inherited_privileges: NamespacePrivileges,
   };
 
   // Table entity for Iceberg tables.
@@ -222,6 +392,10 @@ namespace Lakekeeper {
     // pending update. For properties being set during an update, see the
     // context of the CommitTable action.
     properties: ResourceProperties,
+    // Privileges held here by the principal being authorized; see `Grants` above.
+    direct_privileges: TablePrivileges,
+    // Privileges the same principal holds on this object's ancestors.
+    inherited_privileges: TablePrivileges,
   };
 
   // View entity for Iceberg views.
@@ -239,6 +413,10 @@ namespace Lakekeeper {
     // pending update. For properties being set during an update, see the
     // context of the CommitView action.
     properties: ResourceProperties,
+    // Privileges held here by the principal being authorized; see `Grants` above.
+    direct_privileges: ViewPrivileges,
+    // Privileges the same principal holds on this object's ancestors.
+    inherited_privileges: ViewPrivileges,
   };
 
   // GenericTable entity for non-Iceberg ("generic") tables.
@@ -254,6 +432,10 @@ namespace Lakekeeper {
     protected: Bool,
     // Current properties of this generic table.
     properties: ResourceProperties,
+    // Privileges held here by the principal being authorized; see `Grants` above.
+    direct_privileges: GenericTablePrivileges,
+    // Privileges the same principal holds on this object's ancestors.
+    inherited_privileges: GenericTablePrivileges,
   };
 
   // ---------- Resource Properties ----------
@@ -294,18 +476,33 @@ namespace Lakekeeper {
 
   // ---------- Server Actions ----------
   action "ServerActions";
-  // ReadUserRoleAssignments — list the roles assigned to a user. A user may
-  // always read the assignments of their own identity (enforced in the
-  // authorizer, not by policy).
+  action "ServerDescribeActions" in ["ServerActions", "ServerCreateActions", "ServerModifyActions"];
+  action "ServerCreateActions" in ["ServerActions", "ServerModifyActions"];
+  action "ServerModifyActions" in ["ServerActions"];
+  // Read-only actions on the server itself.
+  //
+  //   ReadUserRoleAssignments — list the roles assigned to a user. Everyone can
+  //     always read their own assignments; that is built into the authorizer,
+  //     so you do not need a policy for it.
+  //   EvaluateCedarPolicies — try policies out against the engine without
+  //     saving them. It changes nothing, but it does show how the engine would
+  //     answer. If you would rather not offer that to everyone who can read,
+  //     you can forbid this one action and leave the rest of their access
+  //     untouched.
   action ListServerCedarEntitySources, ListCedarPoliciesFromServerSources,
-         ListServerCedarPolicySources, UpdateUsers, DeleteUsers, ListUsers,
-         ProvisionUsers, ReadUserRoleAssignments, IntrospectServerAuthorization,
-         EvaluateCedarPolicies in ["ServerActions"]
+         ListServerCedarPolicySources, ListUsers,
+         ReadUserRoleAssignments,
+         EvaluateCedarPolicies in ["ServerDescribeActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Server]
     };
-  action CreateProject in ["ServerActions"]
+  action UpdateUsers, DeleteUsers, ProvisionUsers in ["ServerModifyActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Server]
+    };
+  action CreateProject in ["ServerCreateActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Server],
@@ -321,7 +518,8 @@ namespace Lakekeeper {
 
   // ---------- Project Actions ----------
   action "ProjectActions";
-  action "ProjectDescribeActions" in ["ProjectActions", "ProjectModifyActions"];
+  action "ProjectDescribeActions" in ["ProjectActions", "ProjectCreateActions", "ProjectModifyActions"];
+  action "ProjectCreateActions" in ["ProjectActions", "ProjectModifyActions"];
   action "ProjectModifyActions" in ["ProjectActions"];
   action GetProjectMetadata, ListWarehouses, IncludeProjectInList, ListRoles,
          SearchRoles, GetProjectEndpointStatistics, GetProjectTaskQueueConfig,
@@ -330,14 +528,14 @@ namespace Lakekeeper {
       principal: [User, Role],
       resource: [Project]
     };
-  action IntrospectProjectAuthorization, DeleteProject, RenameProject,
+  action DeleteProject, RenameProject,
          ModifyProjectTaskQueueConfig,
          ControlProjectTasks in ["ProjectModifyActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Project]
     };
-  action CreateWarehouse in ["ProjectModifyActions"]
+  action CreateWarehouse in ["ProjectCreateActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Project],
@@ -347,6 +545,14 @@ namespace Lakekeeper {
         warehouse_name?: String,
       }
     };
+  // `ProjectCreateActions` is about creating places to put data: warehouses
+  // here, and namespaces, tables and views further down. Creating roles and tag
+  // definitions is not part of it — those shape how the project is governed
+  // rather than what it stores, so they live in `ProjectModifyActions` with the
+  // other administrative actions.
+  //
+  // If you want someone to create tags or roles without handing them the whole
+  // of `ProjectModifyActions`, permit the individual action instead.
   action CreateRole in ["ProjectModifyActions"]
     appliesTo {
       principal: [User, Role],
@@ -370,7 +576,17 @@ namespace Lakekeeper {
 
   // ---------- Role Actions ----------
   action "RoleActions";
-  action AssumeRole, DeleteRole, UpdateRole, ReadRole, ReadRoleMetadata, IntrospectRoleAuthorization in ["RoleActions"]
+
+  // Asking what another principal may do on a role is grant administration, not a role
+  // action: a role is not a grant resource, so there is no `RoleGrantActions` to sit in, and
+  // `ReadGrantsActions` is what the one-forbid recipe below covers.
+  action IntrospectRoleAuthorization in ["ReadGrantsActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Role]
+    };
+
+  action AssumeRole, DeleteRole, UpdateRole, ReadRole, ReadRoleMetadata in ["RoleActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Role]
@@ -409,8 +625,29 @@ namespace Lakekeeper {
   //   ReadTagAttachments      — list every target a tag definition is attached to (reverse lookup).
   //   IntrospectTagAuthorization — inspect another principal's access to this tag.
   action "TagActions";
-  action ReadTag, UpdateTag, DeleteTag, ApplyTag, RemoveTag,
-         ReadTagAttachments, IntrospectTagAuthorization in ["TagActions"]
+  action "TagDescribeActions" in ["TagActions", "TagApplyActions", "TagModifyActions"];
+  action "TagApplyActions" in ["TagActions", "TagModifyActions"];
+  action "TagModifyActions" in ["TagActions"];
+  action ReadTag in ["TagDescribeActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Tag]
+    };
+  // Attaching and detaching a tag uses the definition rather than changing it,
+  // so these have their own group. That lets you give someone the right to
+  // classify objects without also letting them rename or delete the tag.
+  //
+  // Attaching needs two keys: `ApplyTag` here, and `ManageTags` on whatever the
+  // tag is being attached to.
+  action ApplyTag, RemoveTag in ["TagApplyActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Tag]
+    };
+  // `ReadTagAttachments` sits here rather than with the read actions because it
+  // lists every object a tag is attached to. That says a good deal more about
+  // what is in the catalog than reading the tag's own definition does.
+  action UpdateTag, DeleteTag, ReadTagAttachments in ["TagModifyActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Tag]
@@ -418,7 +655,8 @@ namespace Lakekeeper {
 
   // ---------- Warehouse Actions ----------
   action "WarehouseActions";
-  action "WarehouseDescribeActions" in ["WarehouseActions", "WarehouseModifyActions"];
+  action "WarehouseDescribeActions" in ["WarehouseActions", "WarehouseCreateActions", "WarehouseModifyActions"];
+  action "WarehouseCreateActions" in ["WarehouseActions", "WarehouseModifyActions"];
   action "WarehouseModifyActions" in ["WarehouseActions"];
   action UseWarehouse, ListNamespacesInWarehouse, GetWarehouseMetadata, GetConfig,
          IncludeWarehouseInList, ListDeletedTabulars, GetTaskQueueConfig, GetAllTasks,
@@ -427,7 +665,7 @@ namespace Lakekeeper {
       principal: [User, Role],
       resource: [Warehouse]
     };
-  action IntrospectWarehouseAuthorization, DeleteWarehouse, UpdateStorage, UpdateStorageCredential,
+  action DeleteWarehouse, UpdateStorage, UpdateStorageCredential,
          DeactivateWarehouse, ActivateWarehouse,
          RenameWarehouse, ModifySoftDeletion,
          ModifyTaskQueueConfig, ControlAllTasks, SetWarehouseProtection,
@@ -436,7 +674,7 @@ namespace Lakekeeper {
       principal: [User, Role],
       resource: [Warehouse]
     };
-  action CreateNamespaceInWarehouse in ["WarehouseModifyActions"]
+  action CreateNamespaceInWarehouse in ["WarehouseCreateActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Warehouse],
@@ -448,10 +686,26 @@ namespace Lakekeeper {
         initial_namespace_properties: ResourceProperties,
       }
     };
+  // Accepting a namespace moved in from elsewhere, as a child of the warehouse
+  // root. Distinct from creating one: a create adds an *empty* child, while a
+  // move arrives carrying existing contents and the grants held on them, which
+  // this warehouse's grantees can then read. Authorized alongside
+  // `CreateNamespaceInWarehouse`, so a policy must allow both to admit a move.
+  action AcceptMovedNamespaceInWarehouse
+    appliesTo {
+      principal: [User, Role],
+      resource: [Warehouse],
+      context: {
+        // Full path the namespace is moving from, as it stands before the move.
+        // Dotted, as in `Namespace.name`.
+        source: String,
+      }
+    };
 
   // ---------- Namespace Actions ----------
   action "NamespaceActions";
-  action "NamespaceDescribeActions" in ["NamespaceActions", "NamespaceModifyActions"];
+  action "NamespaceDescribeActions" in ["NamespaceActions", "NamespaceCreateActions", "NamespaceModifyActions"];
+  action "NamespaceCreateActions" in ["NamespaceActions", "NamespaceModifyActions"];
   action "NamespaceModifyActions" in ["NamespaceActions"];
 
   action ListEverythingInNamespace, GetNamespaceMetadata, IncludeNamespaceInList,
@@ -461,11 +715,48 @@ namespace Lakekeeper {
       principal: [User, Role],
       resource: [Namespace]
     };
-  action IntrospectNamespaceAuthorization,
-         SetNamespaceProtection, ManageNamespaceTags in ["NamespaceModifyActions"]
+  action SetNamespaceProtection, ManageNamespaceTags in ["NamespaceModifyActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Namespace]
+    };
+  // Moving a namespace to a new path — re-parenting, renaming, or both. Only the
+  // source half of a move: the destination is authorized separately as
+  // `CreateNamespaceIn{Namespace,Warehouse}` plus
+  // `AcceptMovedNamespaceIn{Namespace,Warehouse}` on the parent it arrives under,
+  // so a policy allowing a move out does not by itself allow the move in.
+  //
+  // Re-parenting changes what the namespace's contents inherit — the destination
+  // subtree's grants start applying and the old parent's stop — without a grant
+  // record changing anywhere. That makes a move an act of grant administration as
+  // much as of modification, so it is in neither `NamespaceModifyActions` nor
+  // `GrantActions`: a policy has to name it, and one that wants the pair of rights
+  // together says so as a condition, which a group edge cannot express. Policies
+  // that care about where data may live should read `destination`.
+  action MoveNamespace
+    appliesTo {
+      principal: [User, Role],
+      resource: [Namespace],
+      context: {
+        // Full destination path, including the new leaf name. Dotted, as in
+        // `Namespace.name`, so `like "prod.*"` matches a destination subtree.
+        destination: String,
+        // Whether protection is overridden, as for `DeleteNamespace`.
+        force: Bool,
+      }
+    };
+  // The destination half; see `AcceptMovedNamespaceInWarehouse`. Outside
+  // `NamespaceCreateActions` for the reason `MoveNamespace` is outside
+  // `NamespaceModifyActions`: accepting a subtree changes what it inherits.
+  action AcceptMovedNamespaceInNamespace
+    appliesTo {
+      principal: [User, Role],
+      resource: [Namespace],
+      context: {
+        // Full path the namespace is moving from, as it stands before the move.
+        // Dotted, as in `Namespace.name`.
+        source: String,
+      }
     };
   action DeleteNamespace in ["NamespaceModifyActions"]
     appliesTo {
@@ -483,7 +774,7 @@ namespace Lakekeeper {
         recursive: Bool,
       }
     };
-  action CreateTable in ["NamespaceModifyActions"]
+  action CreateTable in ["NamespaceCreateActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Namespace],
@@ -498,7 +789,7 @@ namespace Lakekeeper {
         initial_table_properties: ResourceProperties,
       }
     };
-  action CreateView in ["NamespaceModifyActions"]
+  action CreateView in ["NamespaceCreateActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Namespace],
@@ -510,7 +801,7 @@ namespace Lakekeeper {
         initial_view_properties: ResourceProperties,
       }
     };
-  action CreateGenericTableInNamespace in ["NamespaceModifyActions"]
+  action CreateGenericTableInNamespace in ["NamespaceCreateActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Namespace],
@@ -531,7 +822,7 @@ namespace Lakekeeper {
         initial_generic_table_properties: ResourceProperties,
       }
     };
-  action CreateNamespaceInNamespace in ["NamespaceModifyActions"]
+  action CreateNamespaceInNamespace in ["NamespaceCreateActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Namespace],
@@ -557,8 +848,9 @@ namespace Lakekeeper {
 
   // ---------- Table Actions ----------
   action "TableActions";
-  action "TableDescribeActions" in ["TableActions", "TableSelectActions", "TableModifyActions"];
-  action "TableSelectActions" in ["TableActions", "TableModifyActions"];
+  action "TableDescribeActions" in ["TableActions", "TableSelectActions", "TableWriteActions", "TableModifyActions"];
+  action "TableSelectActions" in ["TableActions", "TableWriteActions", "TableModifyActions"];
+  action "TableWriteActions" in ["TableActions", "TableModifyActions"];
   action "TableModifyActions" in ["TableActions"];
   action GetTableMetadata, IncludeTableInList, GetTableTasks in ["TableDescribeActions"]
     appliesTo {
@@ -570,7 +862,19 @@ namespace Lakekeeper {
       principal: [User, Role],
       resource: [Table]
     };
-  action IntrospectTableAuthorization, WriteTableData, RenameTable,
+  // Writing to the table: getting write credentials, and committing the change.
+  // These are kept apart from `TableModifyActions` so you can let a loading job
+  // write data without also letting it drop, rename or unprotect the table.
+  //
+  // Committing covers schema changes too — a writer that adds a column is doing
+  // its ordinary job. Policies cannot tell the two apart, so if you need to
+  // prevent schema changes specifically, do that in the engine.
+  action WriteTableData in ["TableWriteActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Table]
+    };
+  action RenameTable,
          UndropTable, ControlTableTasks,
          SetTableProtection, ManageTableTags in ["TableModifyActions"]
     appliesTo {
@@ -590,7 +894,7 @@ namespace Lakekeeper {
         purge: Bool,
       }
     };
-  action CommitTable in ["TableModifyActions"]
+  action CommitTable in ["TableWriteActions"]
     appliesTo {
       principal: [User, Role],
       resource: [Table],
@@ -604,8 +908,9 @@ namespace Lakekeeper {
 
   // ---------- View Actions ----------
   action "ViewActions";
-  action "ViewDescribeActions" in ["ViewActions", "ViewSelectActions", "ViewModifyActions"];
-  action "ViewSelectActions" in ["ViewActions", "ViewModifyActions"];
+  action "ViewDescribeActions" in ["ViewActions", "ViewSelectActions", "ViewWriteActions", "ViewModifyActions"];
+  action "ViewSelectActions" in ["ViewActions", "ViewWriteActions", "ViewModifyActions"];
+  action "ViewWriteActions" in ["ViewActions", "ViewModifyActions"];
   action "ViewModifyActions" in ["ViewActions"];
   action GetViewMetadata, IncludeViewInList, GetViewTasks in ["ViewDescribeActions"]
     appliesTo {
@@ -617,7 +922,7 @@ namespace Lakekeeper {
       principal: [User, Role],
       resource: [View]
     };
-  action IntrospectViewAuthorization, RenameView, UndropView,
+  action RenameView, UndropView,
          ControlViewTasks, SetViewProtection, ManageViewTags in ["ViewModifyActions"]
     appliesTo {
       principal: [User, Role],
@@ -636,7 +941,10 @@ namespace Lakekeeper {
         purge: Bool,
       }
     };
-  action CommitView in ["ViewModifyActions"]
+  // Committing a new version of the view's definition. Kept apart from
+  // `ViewModifyActions` so someone can maintain the view's query without also
+  // being able to drop, rename or unprotect it.
+  action CommitView in ["ViewWriteActions"]
     appliesTo {
       principal: [User, Role],
       resource: [View],
@@ -650,8 +958,9 @@ namespace Lakekeeper {
 
   // ---------- Generic Table Actions ----------
   action "GenericTableActions";
-  action "GenericTableDescribeActions" in ["GenericTableActions", "GenericTableSelectActions", "GenericTableModifyActions"];
-  action "GenericTableSelectActions" in ["GenericTableActions", "GenericTableModifyActions"];
+  action "GenericTableDescribeActions" in ["GenericTableActions", "GenericTableSelectActions", "GenericTableWriteActions", "GenericTableModifyActions"];
+  action "GenericTableSelectActions" in ["GenericTableActions", "GenericTableWriteActions", "GenericTableModifyActions"];
+  action "GenericTableWriteActions" in ["GenericTableActions", "GenericTableModifyActions"];
   action "GenericTableModifyActions" in ["GenericTableActions"];
   action GetGenericTableMetadata, IncludeGenericTableInList,
          GetGenericTableTasks in ["GenericTableDescribeActions"]
@@ -664,11 +973,255 @@ namespace Lakekeeper {
       principal: [User, Role],
       resource: [GenericTable]
     };
-  action IntrospectGenericTableAuthorization, DropGenericTable, WriteGenericTableData,
+  // Getting write credentials for the generic table. Kept apart from
+  // `GenericTableModifyActions` so a loading job can write data without also
+  // being able to drop, rename or unprotect it.
+  action WriteGenericTableData in ["GenericTableWriteActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [GenericTable]
+    };
+  action DropGenericTable,
          RenameGenericTable, UndropGenericTable, ControlGenericTableTasks,
          SetGenericTableProtection, ManageGenericTableTags in ["GenericTableModifyActions"]
     appliesTo {
       principal: [User, Role],
       resource: [GenericTable]
+    };
+
+  // ---------- Grant Administration Actions ----------
+  // A grant is a direct (principal, privilege, resource) permission, managed
+  // through the grants API rather than written as a policy. These actions
+  // control who may hand those permissions out.
+  //
+  //   GrantActions      — every grant-administration action, on every level.
+  //   ReadGrantsActions — the read-only subset, across every level.
+  //   XGrantActions     — reading and managing grants on one level.
+  //
+  // Each level's grant group belongs to `GrantActions` alone — not to that level's
+  // `XActions` umbrella, nor to its `XModifyActions` group. So neither
+  // `action in "WarehouseActions"` nor `action in "WarehouseModifyActions"` includes
+  // grant administration; name a grant group or a leaf action. See the note above the
+  // declarations below for why.
+  //
+  // To keep grant administration with one team, a single forbid covers every
+  // level, and a forbid always wins over a permit:
+  //
+  //   forbid (principal, action in Lakekeeper::Action::"GrantActions", resource)
+  //   unless { principal in Lakekeeper::Role::"my-project/oidc~security" };
+  //
+  //   ManageXGrants — grant and revoke privileges on X. Each privilege is
+  //                   authorized on its own, even when one request covers
+  //                   several, and `context.privilege` always holds the one
+  //                   being decided:
+  //
+  //                     when { context.privilege == "select" }
+  //
+  //                   delegates exactly `select`. A permit with no privilege
+  //                   condition covers every privilege.
+  //
+  //                   `grantee` and `direction` say who would receive the
+  //                   privilege and which way it is moving. See the `Grantee`
+  //                   and `GrantDirection` types below.
+  //
+  //                   The API that lists which privileges you may administer
+  //                   here asks "may I grant this?" — direction `"grant"`, no
+  //                   grantee. A policy testing the grantee does not apply to
+  //                   that question, so read the list as a guide; every grant
+  //                   is authorized again as it is applied.
+  //   IntrospectXAuthorization — ask what another principal may do on X.
+  //   ReadXGrants   — see who holds grants on X. It also makes X itself visible
+  //                   to you, with no separate read permission needed.
+  //                   `XGrantActions` covers this alongside ManageXGrants.
+  // Who a grant would go to, or be taken away from.
+  //
+  // One of the two is set: `user` when the grant names a user, `role` when it
+  // names a role. Neither is set when the question names nobody — when the API
+  // asks which privileges you could grant here to anyone, and when a revoke
+  // names a role that no longer exists.
+  //
+  // Check that the one you want is present before reading it. Cedar's strict
+  // validation requires this, and it is also what keeps a policy written for a
+  // particular grantee from firing on a question that names none:
+  //
+  //   when {
+  //     context.grantee has role &&
+  //     context.grantee.role == Lakekeeper::Role::"my-project/oidc~analysts"
+  //   }
+  //
+  // `==` names that one role. `in` also covers the roles nested inside it:
+  //
+  //   context.grantee.role in Lakekeeper::Role::"my-project/oidc~analysts"
+  //
+  // matches a grant to `analysts` and to every role that is a member of it, at
+  // any depth. Pick whichever you mean.
+  type Grantee = {
+    user?: User,
+    role?: Role,
+  };
+
+  // Which way a grant is moving: `"grant"` when a privilege is being handed
+  // out, `"revoke"` when it is being taken away.
+  //
+  //   when { context.direction == Lakekeeper::GrantDirection::"revoke" }
+  //
+  // Misspell a direction and your policy fails validation, so you hear about
+  // it rather than quietly never matching.
+  entity GrantDirection enum ["grant", "revoke"];
+
+  // Grant administration stands outside the per-resource `<X>Actions` groups on purpose.
+  // Those groups mean "everything you can do to this object", and a customer who wrote one
+  // before grants existed did not ask to hand out access as well — group membership is
+  // conferral they cannot take back short of replacing this file. So deciding who else gets
+  // access is opt-in: name `GrantActions`, one of the per-level `<X>GrantActions`, or a leaf.
+  action "GrantActions";
+  action "ReadGrantsActions" in ["GrantActions"];
+
+  action "ServerGrantActions" in ["GrantActions"];
+  action ManageServerGrants in ["ServerGrantActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Server],
+      context: {
+        // The privilege being granted or revoked, one at a time even when the
+        // request covers several. See the section comment above.
+        privilege: String,
+        // Who would gain the privilege, or lose it on a revoke. Empty when the
+        // question names no grantee.
+        grantee: Grantee,
+        // Which way the privilege is moving.
+        direction: GrantDirection,
+      }
+    };
+  action ReadServerGrants, IntrospectServerAuthorization in ["ServerGrantActions", "ReadGrantsActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Server]
+    };
+
+  action "ProjectGrantActions" in ["GrantActions"];
+  action ManageProjectGrants in ["ProjectGrantActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Project],
+      context: {
+        // Same three terms as ManageServerGrants; see the section comment.
+        privilege: String,
+        grantee: Grantee,
+        direction: GrantDirection,
+      }
+    };
+  action ReadProjectGrants, IntrospectProjectAuthorization in ["ProjectGrantActions", "ReadGrantsActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Project]
+    };
+
+  action "WarehouseGrantActions" in ["GrantActions"];
+  action ManageWarehouseGrants in ["WarehouseGrantActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Warehouse],
+      context: {
+        // Same three terms as ManageServerGrants; see the section comment.
+        privilege: String,
+        grantee: Grantee,
+        direction: GrantDirection,
+      }
+    };
+  action ReadWarehouseGrants, IntrospectWarehouseAuthorization in ["WarehouseGrantActions", "ReadGrantsActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Warehouse]
+    };
+
+  action "NamespaceGrantActions" in ["GrantActions"];
+  action ManageNamespaceGrants in ["NamespaceGrantActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Namespace],
+      context: {
+        // Same three terms as ManageServerGrants; see the section comment.
+        privilege: String,
+        grantee: Grantee,
+        direction: GrantDirection,
+      }
+    };
+  action ReadNamespaceGrants, IntrospectNamespaceAuthorization in ["NamespaceGrantActions", "ReadGrantsActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Namespace]
+    };
+
+  action "TableGrantActions" in ["GrantActions"];
+  action ManageTableGrants in ["TableGrantActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Table],
+      context: {
+        // Same three terms as ManageServerGrants; see the section comment.
+        privilege: String,
+        grantee: Grantee,
+        direction: GrantDirection,
+      }
+    };
+  action ReadTableGrants, IntrospectTableAuthorization in ["TableGrantActions", "ReadGrantsActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Table]
+    };
+
+  action "ViewGrantActions" in ["GrantActions"];
+  action ManageViewGrants in ["ViewGrantActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [View],
+      context: {
+        // Same three terms as ManageServerGrants; see the section comment.
+        privilege: String,
+        grantee: Grantee,
+        direction: GrantDirection,
+      }
+    };
+  action ReadViewGrants, IntrospectViewAuthorization in ["ViewGrantActions", "ReadGrantsActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [View]
+    };
+
+  action "GenericTableGrantActions" in ["GrantActions"];
+  action ManageGenericTableGrants in ["GenericTableGrantActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [GenericTable],
+      context: {
+        // Same three terms as ManageServerGrants; see the section comment.
+        privilege: String,
+        grantee: Grantee,
+        direction: GrantDirection,
+      }
+    };
+  action ReadGenericTableGrants, IntrospectGenericTableAuthorization in ["GenericTableGrantActions", "ReadGrantsActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [GenericTable]
+    };
+
+  action "TagGrantActions" in ["GrantActions"];
+  action ManageTagGrants in ["TagGrantActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Tag],
+      context: {
+        // Same three terms as ManageServerGrants; see the section comment.
+        privilege: String,
+        grantee: Grantee,
+        direction: GrantDirection,
+      }
+    };
+  action ReadTagGrants, IntrospectTagAuthorization in ["TagGrantActions", "ReadGrantsActions"]
+    appliesTo {
+      principal: [User, Role],
+      resource: [Tag]
     };
 }

--- a/docs/docs/api/management-open-api-plus.yaml
+++ b/docs/docs/api/management-open-api-plus.yaml
@@ -148,6 +148,125 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/grants:
+    get:
+      tags:
+        - grant
+      summary: List Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists everything one principal holds across the project — "what does this
+        principal have here". Exactly one of `principalUser` or `principalRole` is
+        **required**; a request naming neither is refused with `MissingGrantPrincipal`
+        (400). To read every grant held on a single resource, use that resource's own
+        listing.
+
+        Grants are reported at the layer they are held: a grant a role holds is listed
+        under that role, not under the users who have the role, and a grant on an
+        ancestor is listed under the ancestor. Server grants belong to no project and are
+        not included.
+
+        Listing your own grants needs no extra permission; any other principal requires
+        the project-level grant-read permission.
+
+        **Availability depends on the configured authorizer.** This listing crosses every
+        resource in the project, which an authorizer that stores permissions per resource
+        cannot answer without reading its whole store. Those report
+        `GrantListingNotImplemented` (501) — under OpenFGA, for example. Read one
+        resource's grants from its own endpoint instead; those listings work, and page,
+        under every authorizer. `GET /info` reports the configured backend.
+      operationId: list_grants
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            List only the grants held by this user. Mutually exclusive with `principalRole`.
+            A resource's own listing accepts neither and then lists every principal's; the
+            project-wide listing requires one of the two.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            List only the grants held by this role. Mutually exclusive with `principalUser`,
+            and subject to the same requirement on the project-wide listing.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: pageToken
+          in: query
+          description: Next page token
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: Signals an upper bound of the number of results that a client will receive.
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            format: int64
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: Grants the principal holds in the project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGrantsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        '501':
+          description: Project-wide grant listing is not supported under the configured authorizer backend
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/grants/grantable-privileges:
+    get:
+      tags:
+        - grant
+      summary: Get Available Privileges [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists the privileges that may be granted, per resource type. The vocabulary
+        belongs to the configured authorizer, so it differs between deployments and a
+        name this server does not know is rejected — fetch it rather than hard-coding it.
+      operationId: get_grantable_privileges
+      responses:
+        '200':
+          description: Grantable privileges per resource type
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GrantablePrivilegesResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/info:
     get:
       tags:
@@ -1705,6 +1824,181 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/project/grants:
+    get:
+      tags:
+        - grant
+      summary: List Project Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists the grants held on the project named by `x-project-id`, or the default
+        project. Grants on resources inside the project are not included — use those
+        resources' own endpoints, or `GET /grants` for one principal's across the whole
+        project.
+
+        Supply `principalUser` or `principalRole` to narrow to one principal. Narrowing to
+        yourself requires only permission to see the project; every other listing requires
+        the project's grant-read permission.
+      operationId: list_project_grants
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            List only the grants held by this user. Mutually exclusive with `principalRole`.
+            A resource's own listing accepts neither and then lists every principal's; the
+            project-wide listing requires one of the two.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            List only the grants held by this role. Mutually exclusive with `principalUser`,
+            and subject to the same requirement on the project-wide listing.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: pageToken
+          in: query
+          description: Next page token
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: Signals an upper bound of the number of results that a client will receive.
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            format: int64
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: Grants held on the project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGrantsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+    post:
+      tags:
+        - grant
+      summary: Apply Project Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Creates the grants in `writes` and removes those in `deletes`, atomically.
+        Idempotent. Success is `204` with no body: whether an entry was already in
+        the requested state is not reported.
+      operationId: apply_project_grants
+      parameters:
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyGrantsRequest'
+        required: true
+      responses:
+        '204':
+          description: Grants applied
+        '409':
+          description: Conflict — the request was not applied and can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/project/grants/grantable-privileges:
+    get:
+      tags:
+        - grant
+      summary: Get Grantable Privileges on a project [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Every privilege this project publishes, each marked with whether the caller may
+        administer it here. Not filtered: a picker needs to show the ones it
+        cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
+        another principal's behalf, which requires authority to read this project's
+        grants.
+      operationId: get_project_grantable_privileges
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            Report which privileges this user may administer, instead of the caller. Requires
+            authority to read the resource's grants, since it discloses another principal's
+            access. Mutually exclusive with `principalRole`.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            Report which privileges this role may administer, instead of the caller. Same
+            authority requirement as `principalUser`, and mutually exclusive with it.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: This resource's privileges, each marked allowed or not
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceGrantablePrivilegesResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/project/rename:
     post:
       tags:
@@ -2460,6 +2754,10 @@ paths:
         exist first and otherwise returns `404` — provision the user (via
         `POST /user`) or create the role before assigning. Behavior is consistent
         within a deployment.
+
+        Roles from the `system` provider are provisioned, not self-service: adding a
+        member requires an instance admin (`403`), and a role may not be added as a
+        member of one (`400`) — they hold users directly.
       operationId: add_role_members
       parameters:
         - name: role_id
@@ -2575,6 +2873,10 @@ paths:
       description: |-
         Removes a single member (a user or a role) from a role. Idempotent — removing
         an absent member is a no-op and still returns `204`.
+
+        Removing a member of a `system`-provider role requires an instance admin
+        (`403`). Unlike adding, removing a role-type member is permitted, so an
+        existing nesting can be cleaned up.
       operationId: remove_role_member
       parameters:
         - name: role_id
@@ -2777,6 +3079,154 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetLakekeeperServerActionsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/server/grants:
+    get:
+      tags:
+        - grant
+      summary: List Server Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists the grants held on the server itself. Server grants belong to no project,
+        so they are the one level the project-scoped listing does not report.
+
+        Supply `principalUser` or `principalRole` to narrow to one principal. Narrowing to
+        yourself needs no permission, and is the only way to read your own server grants;
+        every other listing requires the server's grant-read permission.
+      operationId: list_server_grants
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            List only the grants held by this user. Mutually exclusive with `principalRole`.
+            A resource's own listing accepts neither and then lists every principal's; the
+            project-wide listing requires one of the two.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            List only the grants held by this role. Mutually exclusive with `principalUser`,
+            and subject to the same requirement on the project-wide listing.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: pageToken
+          in: query
+          description: Next page token
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: Signals an upper bound of the number of results that a client will receive.
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            format: int64
+      responses:
+        '200':
+          description: Grants held on the server
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGrantsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+    post:
+      tags:
+        - grant
+      summary: Apply Server Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Creates the grants in `writes` and removes those in `deletes`, atomically.
+        Idempotent. Success is `204` with no body: whether an entry was already in
+        the requested state is not reported.
+      operationId: apply_server_grants
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyGrantsRequest'
+        required: true
+      responses:
+        '204':
+          description: Grants applied
+        '409':
+          description: Conflict — the request was not applied and can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/server/grants/grantable-privileges:
+    get:
+      tags:
+        - grant
+      summary: Get Grantable Privileges on a server [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Every privilege this server publishes, each marked with whether the caller may
+        administer it here. Not filtered: a picker needs to show the ones it
+        cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
+        another principal's behalf, which requires authority to read this server's
+        grants.
+      operationId: get_server_grantable_privileges
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            Report which privileges this user may administer, instead of the caller. Requires
+            authority to read the resource's grants, since it discloses another principal's
+            access. Mutually exclusive with `principalRole`.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            Report which privileges this role may administer, instead of the caller. Same
+            authority requirement as `principalUser`, and mutually exclusive with it.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+      responses:
+        '200':
+          description: This resource's privileges, each marked allowed or not
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceGrantablePrivilegesResponse'
         4XX:
           description: ''
           content:
@@ -2987,6 +3437,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/tag-definition/{tag_definition_id}/actions:
+    get:
+      tags:
+        - tag
+      summary: Get allowed actions for a tag definition
+      operationId: get_tag_actions
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            The user to show actions for.
+            If neither user nor role is specified, shows actions for the current user.
+          required: false
+          schema:
+            type: string
+        - name: principalRole
+          in: query
+          description: |-
+            The role to show actions for.
+            If neither user nor role is specified, shows actions for the current user.
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: tag_definition_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetLakekeeperTagActionsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/tag-definition/{tag_definition_id}/attachments:
     get:
       tags:
@@ -3084,6 +3577,199 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListTagAttachmentsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/tag-definition/{tag_definition_id}/grants:
+    get:
+      tags:
+        - grant
+      summary: List Tag Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists the grants held on this tag definition — who may apply it, and who may
+        manage it. Distinct from the grants on the objects the tag is attached to.
+
+        Supply `principalUser` or `principalRole` to narrow to one principal. Narrowing to
+        yourself requires only permission to see the tag definition; every other listing
+        requires the tag definition's grant-read permission.
+      operationId: list_tag_grants
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            List only the grants held by this user. Mutually exclusive with `principalRole`.
+            A resource's own listing accepts neither and then lists every principal's; the
+            project-wide listing requires one of the two.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            List only the grants held by this role. Mutually exclusive with `principalUser`,
+            and subject to the same requirement on the project-wide listing.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: pageToken
+          in: query
+          description: Next page token
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: Signals an upper bound of the number of results that a client will receive.
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            format: int64
+        - name: tag_definition_id
+          in: path
+          description: Tag Definition ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: Grants held on the tag definition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGrantsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+    post:
+      tags:
+        - grant
+      summary: Apply Tag Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Creates the grants in `writes` and removes those in `deletes`, atomically.
+        Idempotent. Success is `204` with no body: whether an entry was already in
+        the requested state is not reported.
+      operationId: apply_tag_grants
+      parameters:
+        - name: tag_definition_id
+          in: path
+          description: Tag Definition ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyGrantsRequest'
+        required: true
+      responses:
+        '204':
+          description: Grants applied
+        '409':
+          description: Conflict — the request was not applied and can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/tag-definition/{tag_definition_id}/grants/grantable-privileges:
+    get:
+      tags:
+        - grant
+      summary: Get Grantable Privileges on a tag definition [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Every privilege this tag definition publishes, each marked with whether the caller may
+        administer it here. Not filtered: a picker needs to show the ones it
+        cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
+        another principal's behalf, which requires authority to read this tag definition's
+        grants.
+      operationId: get_tag_grantable_privileges
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            Report which privileges this user may administer, instead of the caller. Requires
+            authority to read the resource's grants, since it discloses another principal's
+            access. Mutually exclusive with `principalRole`.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            Report which privileges this role may administer, instead of the caller. Same
+            authority requirement as `principalUser`, and mutually exclusive with it.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: tag_definition_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: This resource's privileges, each marked allowed or not
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceGrantablePrivilegesResponse'
         4XX:
           description: ''
           content:
@@ -3476,6 +4162,54 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse-creation-validation:
+    post:
+      tags:
+        - warehouse
+      summary: Validate Warehouse Configuration
+      description: |-
+        Runs the checks `Create Warehouse` runs — profile syntax, name and ID
+        availability, location overlap, format-version policy, `managed-by`, and
+        physical storage access including credential vending — without creating
+        anything. No warehouse is persisted and no credential is stored.
+
+        Returns 200 whether or not the configuration is usable; inspect `valid` and
+        the per-check results. Requires the same permission as creating a warehouse.
+
+        Results are advisory and reserve nothing: a concurrent request can take a
+        name or ID between this call and the create. `warehouse-id-available` in
+        particular examines only the caller's own project, while warehouse IDs are
+        unique across the whole instance — so an ID it reports as available can
+        still be refused with `409 WarehouseIdAlreadyExists` on create.
+      operationId: validate_warehouse
+      parameters:
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateWarehouseRequest'
+        required: true
+      responses:
+        '200':
+          description: Validation ran; see `valid` and `checks` for the outcome
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateWarehouseResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/warehouse/{warehouse_id}:
     get:
       tags:
@@ -3817,6 +4551,218 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/generic-table/{generic_table_id}/grants:
+    get:
+      tags:
+        - grant
+      summary: List Generic Table Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists the grants held directly on this generic table. Grants do not inherit.
+
+        Supply `principalUser` or `principalRole` to narrow to one principal. Narrowing to
+        yourself requires only permission to see the generic table; every other listing
+        requires the generic table's grant-read permission.
+      operationId: list_generic_table_grants
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            List only the grants held by this user. Mutually exclusive with `principalRole`.
+            A resource's own listing accepts neither and then lists every principal's; the
+            project-wide listing requires one of the two.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            List only the grants held by this role. Mutually exclusive with `principalUser`,
+            and subject to the same requirement on the project-wide listing.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: pageToken
+          in: query
+          description: Next page token
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: Signals an upper bound of the number of results that a client will receive.
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            format: int64
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: generic_table_id
+          in: path
+          description: Generic Table ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: Grants held on the generic table
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGrantsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+    post:
+      tags:
+        - grant
+      summary: Apply Generic Table Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Creates the grants in `writes` and removes those in `deletes`, atomically.
+        Idempotent. Success is `204` with no body: whether an entry was already in
+        the requested state is not reported.
+      operationId: apply_generic_table_grants
+      parameters:
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: generic_table_id
+          in: path
+          description: Generic Table ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyGrantsRequest'
+        required: true
+      responses:
+        '204':
+          description: Grants applied
+        '409':
+          description: Conflict — the request was not applied and can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/generic-table/{generic_table_id}/grants/grantable-privileges:
+    get:
+      tags:
+        - grant
+      summary: Get Grantable Privileges on a generic table [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Every privilege this generic table publishes, each marked with whether the caller may
+        administer it here. Not filtered: a picker needs to show the ones it
+        cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
+        another principal's behalf, which requires authority to read this generic table's
+        grants.
+      operationId: get_generic_table_grantable_privileges
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            Report which privileges this user may administer, instead of the caller. Requires
+            authority to read the resource's grants, since it discloses another principal's
+            access. Mutually exclusive with `principalRole`.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            Report which privileges this role may administer, instead of the caller. Same
+            authority requirement as `principalUser`, and mutually exclusive with it.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: generic_table_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: This resource's privileges, each marked allowed or not
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceGrantablePrivilegesResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/warehouse/{warehouse_id}/generic-table/{generic_table_id}/protection:
     get:
       tags:
@@ -4046,6 +4992,205 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/grants:
+    get:
+      tags:
+        - grant
+      summary: List Warehouse Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists the grants held directly on this warehouse. Grants do not inherit: a
+        grant held by a role belongs to that role, and a grant on an ancestor belongs
+        to the ancestor. Use the action-check endpoints to ask what a principal may
+        effectively do.
+
+        Supply `principalUser` or `principalRole` to narrow to one principal. Narrowing to
+        yourself requires only permission to see the warehouse; every other listing
+        requires the warehouse's grant-read permission.
+      operationId: list_warehouse_grants
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            List only the grants held by this user. Mutually exclusive with `principalRole`.
+            A resource's own listing accepts neither and then lists every principal's; the
+            project-wide listing requires one of the two.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            List only the grants held by this role. Mutually exclusive with `principalUser`,
+            and subject to the same requirement on the project-wide listing.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: pageToken
+          in: query
+          description: Next page token
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: Signals an upper bound of the number of results that a client will receive.
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            format: int64
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: Grants held on the warehouse
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGrantsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+    post:
+      tags:
+        - grant
+      summary: Apply Warehouse Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Creates the grants in `writes` and removes those in `deletes`, atomically.
+        Idempotent: granting twice creates one grant, revoking a grant that is not
+        held is not an error. Which privileges are legal differs between authorizers.
+
+        Success is `204` with no body: whether an entry was already in the requested
+        state is not reported. Read the grants back, or read the `grant_created` and
+        `grant_revoked` audit records, for what changed.
+      operationId: apply_warehouse_grants
+      parameters:
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyGrantsRequest'
+        required: true
+      responses:
+        '204':
+          description: Grants applied
+        '409':
+          description: Conflict — the request was not applied and can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/grants/grantable-privileges:
+    get:
+      tags:
+        - grant
+      summary: Get Grantable Privileges on a warehouse [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Every privilege this warehouse publishes, each marked with whether the caller may
+        administer it here. Not filtered: a picker needs to show the ones it
+        cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
+        another principal's behalf, which requires authority to read this warehouse's
+        grants.
+      operationId: get_warehouse_grantable_privileges
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            Report which privileges this user may administer, instead of the caller. Requires
+            authority to read the resource's grants, since it discloses another principal's
+            access. Mutually exclusive with `principalRole`.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            Report which privileges this role may administer, instead of the caller. Same
+            authority requirement as `principalUser`, and mutually exclusive with it.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: This resource's privileges, each marked allowed or not
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceGrantablePrivilegesResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/warehouse/{warehouse_id}/managed-by:
     post:
       tags:
@@ -4125,6 +5270,286 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetLakekeeperNamespaceActionsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/namespace/{namespace_id}/grants:
+    get:
+      tags:
+        - grant
+      summary: List Namespace Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists the grants held directly on this namespace. Grants do not inherit, in
+        either direction: a child namespace's grants are its own.
+
+        Supply `principalUser` or `principalRole` to narrow to one principal. Narrowing to
+        yourself requires only permission to see the namespace; every other listing
+        requires the namespace's grant-read permission.
+      operationId: list_namespace_grants
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            List only the grants held by this user. Mutually exclusive with `principalRole`.
+            A resource's own listing accepts neither and then lists every principal's; the
+            project-wide listing requires one of the two.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            List only the grants held by this role. Mutually exclusive with `principalUser`,
+            and subject to the same requirement on the project-wide listing.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: pageToken
+          in: query
+          description: Next page token
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: Signals an upper bound of the number of results that a client will receive.
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            format: int64
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: namespace_id
+          in: path
+          description: Namespace ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: Grants held on the namespace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGrantsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+    post:
+      tags:
+        - grant
+      summary: Apply Namespace Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Creates the grants in `writes` and removes those in `deletes`, atomically.
+        Idempotent. Success is `204` with no body: whether an entry was already in
+        the requested state is not reported.
+      operationId: apply_namespace_grants
+      parameters:
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: namespace_id
+          in: path
+          description: Namespace ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyGrantsRequest'
+        required: true
+      responses:
+        '204':
+          description: Grants applied
+        '409':
+          description: Conflict — the request was not applied and can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/namespace/{namespace_id}/grants/grantable-privileges:
+    get:
+      tags:
+        - grant
+      summary: Get Grantable Privileges on a namespace [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Every privilege this namespace publishes, each marked with whether the caller may
+        administer it here. Not filtered: a picker needs to show the ones it
+        cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
+        another principal's behalf, which requires authority to read this namespace's
+        grants.
+      operationId: get_namespace_grantable_privileges
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            Report which privileges this user may administer, instead of the caller. Requires
+            authority to read the resource's grants, since it discloses another principal's
+            access. Mutually exclusive with `principalRole`.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            Report which privileges this role may administer, instead of the caller. Same
+            authority requirement as `principalUser`, and mutually exclusive with it.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: namespace_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: This resource's privileges, each marked allowed or not
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceGrantablePrivilegesResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/namespace/{namespace_id}/move:
+    post:
+      tags:
+        - warehouse
+      summary: Move a Namespace
+      description: |-
+        Moves a namespace to a new location in the warehouse's namespace hierarchy,
+        re-parenting it and/or renaming it. The request body carries the full destination path:
+        its last element is the new name, the preceding elements identify the new parent, so a
+        single-element path moves the namespace to the warehouse root. The path must not be
+        empty.
+
+        Requires grant authority at **both** ends, because re-parenting makes the namespace's
+        contents inherit the destination subtree's permissions without any assignment being
+        recorded:
+
+        - `move` on the namespace being moved,
+        - `create_namespace` **and** `accept_moved_namespace` on the destination parent (or on
+          the warehouse, when moving to the root).
+
+        Both `move` and `accept_moved_namespace` require `manage_grants` on top of the ordinary
+        write privilege (`modify` at the source, `create` at the destination). `create_namespace`
+        alone is not sufficient at the destination: it authorizes adding an *empty* child,
+        whereas a move arrives carrying existing contents and their grants.
+
+        Constraints:
+        - Namespaces that contain child namespaces cannot be moved.
+        - Moves stay within one warehouse.
+        - Protected namespaces require `force`.
+        - Rejected for warehouses whose storage layout derives physical locations from
+          namespace names or from the namespace hierarchy.
+
+        A destination equal to the namespace's current path is a no-op and returns 200, so a
+        retried request cannot fail with a spurious conflict.
+      operationId: move_namespace
+      parameters:
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: namespace_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MoveNamespaceRequest'
+        required: true
+      responses:
+        '200':
+          description: Namespace moved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MoveNamespaceResponse'
         4XX:
           description: ''
           content:
@@ -4588,6 +6013,112 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/storage/validate-access:
+    post:
+      tags:
+        - warehouse
+      summary: Validate Stored Warehouse Configuration
+      description: |-
+        Re-runs the storage checks against the configuration the warehouse is
+        currently running with, using its stored profile and stored credential.
+        Use this to find out whether a warehouse's storage access still works —
+        for example after a credential has expired or a bucket policy changed.
+      operationId: validate_storage_access
+      parameters:
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Validation ran; see `valid` and `checks` for the outcome
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateWarehouseResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/storage/validate-credential:
+    post:
+      tags:
+        - warehouse
+      summary: Validate Storage Credential
+      description: |-
+        Dry-run of `Update Storage Credential`: probes the warehouse's stored
+        storage profile with the supplied replacement credential. The stored
+        credential is left untouched.
+      operationId: validate_storage_credential
+      parameters:
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateWarehouseCredentialRequest'
+        required: true
+      responses:
+        '200':
+          description: Validation ran; see `valid` and `checks` for the outcome
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateWarehouseResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/storage/validate-profile:
+    post:
+      tags:
+        - warehouse
+      summary: Validate Storage Profile Update
+      description: |-
+        Dry-run of `Update Storage Profile`: checks that the warehouse's spec may
+        be changed, that the new profile is a permitted evolution of the current
+        one, and that the storage is reachable — without changing the warehouse.
+
+        Probes the incoming profile as supplied, before it would be merged into
+        the stored one, matching what the real update validates.
+      operationId: validate_storage_profile
+      parameters:
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateWarehouseStorageRequest'
+        required: true
+      responses:
+        '200':
+          description: Validation ran; see `valid` and `checks` for the outcome
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateWarehouseResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/warehouse/{warehouse_id}/table/{table_id}/actions:
     get:
       tags:
@@ -4631,6 +6162,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetLakekeeperTableActionsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/table/{table_id}/column-tags:
+    get:
+      tags:
+        - tag
+      summary: List All Column Tags
+      description: |-
+        Returns the governance tags on every column of the table in one call, grouped by
+        column (field-id). Columns without tags are omitted. Requires metadata access on
+        the table.
+      operationId: list_column_tags
+      parameters:
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: table_id
+          in: path
+          description: Table ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: Tags on each column of the table
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListColumnTagsResponse'
         4XX:
           description: ''
           content:
@@ -4808,6 +6385,221 @@ paths:
       responses:
         '204':
           description: Tag removed
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/table/{table_id}/grants:
+    get:
+      tags:
+        - grant
+      summary: List Table Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists the grants held directly on this table. Grants do not inherit — a grant on
+        the containing namespace or warehouse belongs to that resource, not to the table.
+        A table in the recycle bin still reports its grants, because an undrop restores
+        them.
+
+        Supply `principalUser` or `principalRole` to narrow to one principal. Narrowing to
+        yourself requires only permission to see the table; every other listing requires
+        the table's grant-read permission.
+      operationId: list_table_grants
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            List only the grants held by this user. Mutually exclusive with `principalRole`.
+            A resource's own listing accepts neither and then lists every principal's; the
+            project-wide listing requires one of the two.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            List only the grants held by this role. Mutually exclusive with `principalUser`,
+            and subject to the same requirement on the project-wide listing.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: pageToken
+          in: query
+          description: Next page token
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: Signals an upper bound of the number of results that a client will receive.
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            format: int64
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: table_id
+          in: path
+          description: Table ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: Grants held on the table
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGrantsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+    post:
+      tags:
+        - grant
+      summary: Apply Table Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Creates the grants in `writes` and removes those in `deletes`, atomically.
+        Idempotent. Success is `204` with no body: whether an entry was already in
+        the requested state is not reported.
+      operationId: apply_table_grants
+      parameters:
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: table_id
+          in: path
+          description: Table ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyGrantsRequest'
+        required: true
+      responses:
+        '204':
+          description: Grants applied
+        '409':
+          description: Conflict — the request was not applied and can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/table/{table_id}/grants/grantable-privileges:
+    get:
+      tags:
+        - grant
+      summary: Get Grantable Privileges on a table [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Every privilege this table publishes, each marked with whether the caller may
+        administer it here. Not filtered: a picker needs to show the ones it
+        cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
+        another principal's behalf, which requires authority to read this table's
+        grants.
+      operationId: get_table_grantable_privileges
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            Report which privileges this user may administer, instead of the caller. Requires
+            authority to read the resource's grants, since it discloses another principal's
+            access. Mutually exclusive with `principalRole`.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            Report which privileges this role may administer, instead of the caller. Same
+            authority requirement as `principalUser`, and mutually exclusive with it.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: table_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: This resource's privileges, each marked allowed or not
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceGrantablePrivilegesResponse'
         4XX:
           description: ''
           content:
@@ -5695,6 +7487,218 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/view/{view_id}/grants:
+    get:
+      tags:
+        - grant
+      summary: List View Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Lists the grants held directly on this view. Grants do not inherit.
+
+        Supply `principalUser` or `principalRole` to narrow to one principal. Narrowing to
+        yourself requires only permission to see the view; every other listing requires the
+        view's grant-read permission.
+      operationId: list_view_grants
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            List only the grants held by this user. Mutually exclusive with `principalRole`.
+            A resource's own listing accepts neither and then lists every principal's; the
+            project-wide listing requires one of the two.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            List only the grants held by this role. Mutually exclusive with `principalUser`,
+            and subject to the same requirement on the project-wide listing.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: pageToken
+          in: query
+          description: Next page token
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: Signals an upper bound of the number of results that a client will receive.
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            format: int64
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: view_id
+          in: path
+          description: View ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: Grants held on the view
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGrantsResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+    post:
+      tags:
+        - grant
+      summary: Apply View Grants [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Creates the grants in `writes` and removes those in `deletes`, atomically.
+        Idempotent. Success is `204` with no body: whether an entry was already in
+        the requested state is not reported.
+      operationId: apply_view_grants
+      parameters:
+        - name: warehouse_id
+          in: path
+          description: Warehouse ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: view_id
+          in: path
+          description: View ID
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplyGrantsRequest'
+        required: true
+      responses:
+        '204':
+          description: Grants applied
+        '409':
+          description: Conflict — the request was not applied and can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+  /management/v1/warehouse/{warehouse_id}/view/{view_id}/grants/grantable-privileges:
+    get:
+      tags:
+        - grant
+      summary: Get Grantable Privileges on a view [Preview]
+      description: |-
+        This API may change in a backward-incompatible way in a future release.
+
+        Every privilege this view publishes, each marked with whether the caller may
+        administer it here. Not filtered: a picker needs to show the ones it
+        cannot offer, not omit them. Pass `principalUser` or `principalRole` to ask on
+        another principal's behalf, which requires authority to read this view's
+        grants.
+      operationId: get_view_grantable_privileges
+      parameters:
+        - name: principalUser
+          in: query
+          description: |-
+            Report which privileges this user may administer, instead of the caller. Requires
+            authority to read the resource's grants, since it discloses another principal's
+            access. Mutually exclusive with `principalRole`.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+        - name: principalRole
+          in: query
+          description: |-
+            Report which privileges this role may administer, instead of the caller. Same
+            authority requirement as `principalUser`, and mutually exclusive with it.
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: uuid
+        - name: warehouse_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: view_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: x-project-id
+          in: header
+          description: Project ID (optional; falls back to the default project if not provided)
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+      responses:
+        '200':
+          description: This resource's privileges, each marked allowed or not
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceGrantablePrivilegesResponse'
+        4XX:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
   /management/v1/warehouse/{warehouse_id}/view/{view_id}/protection:
     get:
       tags:
@@ -6055,6 +8059,36 @@ components:
             - string
             - 'null'
           description: Value the tag carries on this target
+    ApplyGrantsRequest:
+      type: object
+      description: |-
+        A grant diff: create `writes`, remove `deletes`.
+
+        Applied atomically, and safe to retry: applying the same diff twice has the same
+        effect as applying it once. The same entry may not appear in both lists — that is
+        rejected rather than resolved, because either reading of it would be a guess.
+
+        Unknown fields are rejected: a misspelled `deletes` would otherwise silently apply
+        the writes and drop the revocations.
+
+        At least one entry is required, and `writes` and `deletes` together may not exceed
+        100. Neither rule is expressible as a per-field schema constraint — a `maxItems` on
+        each array would say 200 are acceptable — so both are stated here and enforced by
+        the server.
+      properties:
+        deletes:
+          type: array
+          items:
+            $ref: '#/components/schemas/GrantEntry'
+          description: Grants to remove. Counts against the shared 100-entry limit with `writes`.
+          maxItems: 100
+        writes:
+          type: array
+          items:
+            $ref: '#/components/schemas/GrantEntry'
+          description: Grants to create. Counts against the shared 100-entry limit with `deletes`.
+          maxItems: 100
+      additionalProperties: false
     AzCredential:
       oneOf:
         - type: object
@@ -6164,6 +8198,7 @@ components:
     CatalogActionCheckOperation:
       oneOf:
         - type: object
+          title: CatalogActionCheckOperationServer
           required:
             - server
           properties:
@@ -6175,6 +8210,7 @@ components:
                 action:
                   $ref: '#/components/schemas/LakekeeperServerAction'
         - type: object
+          title: CatalogActionCheckOperationProject
           required:
             - project
           properties:
@@ -6191,6 +8227,7 @@ components:
                     - 'null'
                   format: uuid
         - type: object
+          title: CatalogActionCheckOperationWarehouse
           required:
             - warehouse
           properties:
@@ -6206,6 +8243,7 @@ components:
                   type: string
                   format: uuid
         - type: object
+          title: CatalogActionCheckOperationNamespace
           required:
             - namespace
           properties:
@@ -6219,6 +8257,7 @@ components:
                     action:
                       $ref: '#/components/schemas/LakekeeperNamespaceAction'
         - type: object
+          title: CatalogActionCheckOperationTable
           required:
             - table
           properties:
@@ -6232,6 +8271,7 @@ components:
                     action:
                       $ref: '#/components/schemas/LakekeeperTableAction'
         - type: object
+          title: CatalogActionCheckOperationView
           required:
             - view
           properties:
@@ -6245,6 +8285,7 @@ components:
                     action:
                       $ref: '#/components/schemas/LakekeeperViewAction'
         - type: object
+          title: CatalogActionCheckOperationGenericTable
           required:
             - generic-table
           properties:
@@ -6406,6 +8447,7 @@ components:
           enum:
             - server
         - type: object
+          title: CedarResolveResourceProject
           required:
             - project
           properties:
@@ -6418,6 +8460,7 @@ components:
                     - 'null'
                   description: Project ID. If not specified, the ambient project from the request header is used.
         - type: object
+          title: CedarResolveResourceWarehouse
           required:
             - warehouse
           properties:
@@ -6430,6 +8473,7 @@ components:
                   type: string
                   format: uuid
         - type: object
+          title: CedarResolveResourceNamespace
           required:
             - namespace
           properties:
@@ -6437,6 +8481,7 @@ components:
               allOf:
                 - $ref: '#/components/schemas/NamespaceIdentOrUuid'
         - type: object
+          title: CedarResolveResourceTable
           required:
             - table
           properties:
@@ -6444,6 +8489,7 @@ components:
               allOf:
                 - $ref: '#/components/schemas/TabularIdentOrUuid'
         - type: object
+          title: CedarResolveResourceView
           required:
             - view
           properties:
@@ -6451,6 +8497,7 @@ components:
               allOf:
                 - $ref: '#/components/schemas/TabularIdentOrUuid'
         - type: object
+          title: CedarResolveResourceGenericTable
           required:
             - generic-table
           properties:
@@ -6571,29 +8618,39 @@ components:
             is: false
     CedarSourceConfig:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/CedarFileSourceConfig'
-            - type: object
-              required:
-                - source-type
-              properties:
-                source-type:
-                  type: string
-                  enum:
-                    - file
-        - allOf:
-            - $ref: '#/components/schemas/CedarKubernetesConfigMapSourceConfig'
-            - type: object
-              required:
-                - source-type
-              properties:
-                source-type:
-                  type: string
-                  enum:
-                    - kubernetes-config-map
+        - $ref: '#/components/schemas/CedarSourceConfigFile'
+        - $ref: '#/components/schemas/CedarSourceConfigKubernetesConfigMap'
+      discriminator:
+        propertyName: source-type
+        mapping:
+          file: '#/components/schemas/CedarSourceConfigFile'
+          kubernetes-config-map: '#/components/schemas/CedarSourceConfigKubernetesConfigMap'
+    CedarSourceConfigFile:
+      allOf:
+        - $ref: '#/components/schemas/CedarFileSourceConfig'
+        - type: object
+          required:
+            - source-type
+          properties:
+            source-type:
+              type: string
+              enum:
+                - file
+    CedarSourceConfigKubernetesConfigMap:
+      allOf:
+        - $ref: '#/components/schemas/CedarKubernetesConfigMapSourceConfig'
+        - type: object
+          required:
+            - source-type
+          properties:
+            source-type:
+              type: string
+              enum:
+                - kubernetes-config-map
     CheckOperation:
       oneOf:
         - type: object
+          title: CheckOperationServer
           required:
             - server
           properties:
@@ -6605,6 +8662,7 @@ components:
                 action:
                   $ref: '#/components/schemas/ServerAction'
         - type: object
+          title: CheckOperationProject
           required:
             - project
           properties:
@@ -6621,6 +8679,7 @@ components:
                     - 'null'
                   format: uuid
         - type: object
+          title: CheckOperationWarehouse
           required:
             - warehouse
           properties:
@@ -6636,6 +8695,7 @@ components:
                   type: string
                   format: uuid
         - type: object
+          title: CheckOperationNamespace
           required:
             - namespace
           properties:
@@ -6649,6 +8709,7 @@ components:
                     action:
                       $ref: '#/components/schemas/NamespaceAction'
         - type: object
+          title: CheckOperationTable
           required:
             - table
           properties:
@@ -6662,6 +8723,7 @@ components:
                     action:
                       $ref: '#/components/schemas/TableAction'
         - type: object
+          title: CheckOperationView
           required:
             - view
           properties:
@@ -6675,6 +8737,7 @@ components:
                     action:
                       $ref: '#/components/schemas/ViewAction'
         - type: object
+          title: CheckOperationGenericTable
           required:
             - generic-table
           properties:
@@ -6710,6 +8773,28 @@ components:
         allowed:
           type: boolean
           description: Whether the action is allowed.
+    ColumnTags:
+      type: object
+      description: |-
+        A column and the governance tags attached directly to it. The column is identified
+        by Iceberg field-id only; resolve it to a name against the table metadata client-side
+        (field-ids are stable across schema evolution, names are not).
+      required:
+        - field-id
+        - tags
+      properties:
+        field-id:
+          type: integer
+          format: int32
+          description: Iceberg field-id of the column.
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/TargetTag'
+          description: |-
+            Tags attached directly to this column. Always non-empty — a column with no tags
+            is omitted from the response entirely.
+          minItems: 1
     ConsoleInfo:
       type: object
       description: Information about the UI (console) shipped with this binary.
@@ -6733,53 +8818,68 @@ components:
           description: SemVer of the console crate.
     ControlTaskAction:
       oneOf:
-        - type: object
-          description: Stop the task gracefully. The task will be retried.
-          required:
-            - action-type
-          properties:
-            action-type:
-              type: string
-              enum:
-                - stop
-        - type: object
-          description: Cancel the task permanently. The task is not retried.
-          required:
-            - action-type
-          properties:
-            action-type:
-              type: string
-              enum:
-                - cancel
-        - type: object
-          description: |-
-            Run the task immediately, moving the `scheduled_for` time to now.
-            Affects only tasks in `Scheduled` or `Stopping` state.
-          required:
-            - action-type
-          properties:
-            action-type:
-              type: string
-              enum:
-                - run-now
-        - type: object
-          description: |-
-            Run the task at the specified time, moving the `scheduled_for` time to the provided timestamp.
-            Affects only tasks in `Scheduled` or `Stopping` state.
-            Timestamps must be in RFC 3339 format.
-          required:
-            - scheduled-for
-            - action-type
-          properties:
-            action-type:
-              type: string
-              enum:
-                - run-at
-            scheduled-for:
-              type: string
-              format: date-time
-              description: The time to run the task at
-              example: 2025-12-31T23:59:59Z
+        - $ref: '#/components/schemas/ControlTaskActionStop'
+        - $ref: '#/components/schemas/ControlTaskActionCancel'
+        - $ref: '#/components/schemas/ControlTaskActionRunNow'
+        - $ref: '#/components/schemas/ControlTaskActionRunAt'
+      discriminator:
+        propertyName: action-type
+        mapping:
+          cancel: '#/components/schemas/ControlTaskActionCancel'
+          run-at: '#/components/schemas/ControlTaskActionRunAt'
+          run-now: '#/components/schemas/ControlTaskActionRunNow'
+          stop: '#/components/schemas/ControlTaskActionStop'
+    ControlTaskActionCancel:
+      type: object
+      description: Cancel the task permanently. The task is not retried.
+      required:
+        - action-type
+      properties:
+        action-type:
+          type: string
+          enum:
+            - cancel
+    ControlTaskActionRunAt:
+      type: object
+      description: |-
+        Run the task at the specified time, moving the `scheduled_for` time to the provided timestamp.
+        Affects only tasks in `Scheduled` or `Stopping` state.
+        Timestamps must be in RFC 3339 format.
+      required:
+        - scheduled-for
+        - action-type
+      properties:
+        action-type:
+          type: string
+          enum:
+            - run-at
+        scheduled-for:
+          type: string
+          format: date-time
+          description: The time to run the task at
+          example: 2025-12-31T23:59:59Z
+    ControlTaskActionRunNow:
+      type: object
+      description: |-
+        Run the task immediately, moving the `scheduled_for` time to now.
+        Affects only tasks in `Scheduled` or `Stopping` state.
+      required:
+        - action-type
+      properties:
+        action-type:
+          type: string
+          enum:
+            - run-now
+    ControlTaskActionStop:
+      type: object
+      description: Stop the task gracefully. The task will be retried.
+      required:
+        - action-type
+      properties:
+        action-type:
+          type: string
+          enum:
+            - stop
     ControlTasksRequest:
       type: object
       required:
@@ -6976,6 +9076,17 @@ components:
         storage-profile:
           $ref: '#/components/schemas/StorageProfile'
           description: Storage profile to use for the warehouse.
+        warehouse-id:
+          type:
+            - string
+            - 'null'
+          format: uuid
+          description: |-
+            Request a specific warehouse ID - optional.
+            If not provided, a new warehouse ID will be generated (recommended).
+            Warehouse IDs are unique across the whole Lakekeeper instance, not just
+            within a project. If you do provide one, prefer a UUIDv7, so that IDs
+            sort by creation time.
         warehouse-name:
           type: string
           description: |-
@@ -7028,57 +9139,9 @@ components:
           description: Warehouse ID where the tabular is stored
     EndpointMode:
       oneOf:
-        - type: object
-          description: |-
-            Use the global `OneLake` endpoint `onelake.dfs.fabric.microsoft.com`. Default.
-
-            Also the correct choice for tenant-level private link — tenant PE
-            only changes DNS resolution, not the URL Lakekeeper constructs.
-          required:
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - default
-        - type: object
-          description: |-
-            Use a region-pinned endpoint `<region>-onelake.dfs.fabric.microsoft.com`.
-            Use this when data residency requires the request to stay within a
-            specific Azure region.
-          required:
-            - region
-            - type
-          properties:
-            region:
-              type: string
-              description: |-
-                Azure region slug, e.g. `westus`, `centralus`, `northeurope`.
-                Trimmed and lowercased at validation time, then pattern-checked to
-                match the Azure region-slug shape (lowercase ASCII letter followed
-                by lowercase letters or digits) so a stray `.` or `-` can't smuggle
-                an extra host segment into the resolved DFS host. An unknown but
-                well-shaped slug still surfaces as a DNS-resolution failure at
-                access time. See `normalize_endpoint_mode` for the exact rule.
-            type:
-              type: string
-              enum:
-                - regional
-        - type: object
-          description: |-
-            Use a workspace-scoped private-link endpoint
-            `<workspaceId>.z<xy>.dfs.fabric.microsoft.com`. The host is computed
-            from the workspace ID at runtime; users only opt in via this variant.
-
-            For *tenant*-level private link, stay on [`Default`] — the global
-            onelake FQDN is what gets routed through a tenant PE.
-          required:
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - workspace-private-link
+        - $ref: '#/components/schemas/EndpointModeDefault'
+        - $ref: '#/components/schemas/EndpointModeRegional'
+        - $ref: '#/components/schemas/EndpointModeWorkspacePrivateLink'
       description: |-
         How Lakekeeper connects to the `OneLake` DFS endpoint.
 
@@ -7095,6 +9158,66 @@ components:
           `<wsId>.z<xy>.dfs.fabric.microsoft.com` FQDN routed via a
           workspace-scoped PE. Lakekeeper needs to build that FQDN — use
           [`WorkspacePrivateLink`].
+      discriminator:
+        propertyName: type
+        mapping:
+          default: '#/components/schemas/EndpointModeDefault'
+          regional: '#/components/schemas/EndpointModeRegional'
+          workspace-private-link: '#/components/schemas/EndpointModeWorkspacePrivateLink'
+    EndpointModeDefault:
+      type: object
+      description: |-
+        Use the global `OneLake` endpoint `onelake.dfs.fabric.microsoft.com`. Default.
+
+        Also the correct choice for tenant-level private link — tenant PE
+        only changes DNS resolution, not the URL Lakekeeper constructs.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - default
+    EndpointModeRegional:
+      type: object
+      description: |-
+        Use a region-pinned endpoint `<region>-onelake.dfs.fabric.microsoft.com`.
+        Use this when data residency requires the request to stay within a
+        specific Azure region.
+      required:
+        - region
+        - type
+      properties:
+        region:
+          type: string
+          description: |-
+            Azure region slug, e.g. `westus`, `centralus`, `northeurope`.
+            Trimmed and lowercased at validation time, then pattern-checked to
+            match the Azure region-slug shape (lowercase ASCII letter followed
+            by lowercase letters or digits) so a stray `.` or `-` can't smuggle
+            an extra host segment into the resolved DFS host. An unknown but
+            well-shaped slug still surfaces as a DNS-resolution failure at
+            access time. See `normalize_endpoint_mode` for the exact rule.
+        type:
+          type: string
+          enum:
+            - regional
+    EndpointModeWorkspacePrivateLink:
+      type: object
+      description: |-
+        Use a workspace-scoped private-link endpoint
+        `<workspaceId>.z<xy>.dfs.fabric.microsoft.com`. The host is computed
+        from the workspace ID at runtime; users only opt in via this variant.
+
+        For *tenant*-level private link, stay on [`Default`] — the global
+        onelake FQDN is what gets routed through a tenant PE.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - workspace-private-link
     EndpointStatistic:
       type: object
       required:
@@ -7417,78 +9540,107 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
         - change_ownership
     GenericTableAssignment:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - ownership
-          title: GenericTableAssignmentOwnership
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - pass_grants
-          title: GenericTableAssignmentPassGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - manage_grants
-          title: GenericTableAssignmentManageGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - describe
-          title: GenericTableAssignmentDescribe
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - select
-          title: GenericTableAssignmentSelect
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - modify
-          title: GenericTableAssignmentModify
+        - $ref: '#/components/schemas/GenericTableAssignmentOwnership'
+        - $ref: '#/components/schemas/GenericTableAssignmentPassGrants'
+        - $ref: '#/components/schemas/GenericTableAssignmentManageGrants'
+        - $ref: '#/components/schemas/GenericTableAssignmentDescribe'
+        - $ref: '#/components/schemas/GenericTableAssignmentSelect'
+        - $ref: '#/components/schemas/GenericTableAssignmentModify'
+        - $ref: '#/components/schemas/GenericTableAssignmentManageTags'
+      discriminator:
+        propertyName: type
+        mapping:
+          describe: '#/components/schemas/GenericTableAssignmentDescribe'
+          manage_grants: '#/components/schemas/GenericTableAssignmentManageGrants'
+          manage_tags: '#/components/schemas/GenericTableAssignmentManageTags'
+          modify: '#/components/schemas/GenericTableAssignmentModify'
+          ownership: '#/components/schemas/GenericTableAssignmentOwnership'
+          pass_grants: '#/components/schemas/GenericTableAssignmentPassGrants'
+          select: '#/components/schemas/GenericTableAssignmentSelect'
+    GenericTableAssignmentDescribe:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - describe
+    GenericTableAssignmentManageGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_grants
+    GenericTableAssignmentManageTags:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_tags
+    GenericTableAssignmentModify:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - modify
+    GenericTableAssignmentOwnership:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - ownership
+    GenericTableAssignmentPassGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - pass_grants
+    GenericTableAssignmentSelect:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - select
     GenericTableRelation:
       type: string
       enum:
@@ -7498,6 +9650,7 @@ components:
         - describe
         - select
         - modify
+        - manage_tags
     GetCedarPoliciesResponse:
       type: object
       required:
@@ -7639,6 +9792,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LakekeeperTableActionKind'
+    GetLakekeeperTagActionsResponse:
+      type: object
+      required:
+        - allowed-actions
+      properties:
+        allowed-actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/LakekeeperTagAction'
     GetLakekeeperUserActionsResponse:
       type: object
       required:
@@ -8091,6 +10253,249 @@ components:
           type: string
           format: uuid
           description: ID of the warehouse.
+    GrantEntry:
+      type: object
+      description: |-
+        One entry of a grant diff.
+
+        Unknown fields are rejected so that feeding a `GrantResponse` from a listing
+        straight back into an apply fails loudly instead of silently dropping its
+        `resource` — which would apply the grant to whatever resource the endpoint names.
+      required:
+        - privilege
+        - principal
+      properties:
+        principal:
+          $ref: '#/components/schemas/UserOrRole'
+        privilege:
+          type: string
+          description: |-
+            A privilege from the authorizer's grantable vocabulary. Which values are legal
+            differs between authorizers and is published by the server.
+          maxLength: 256
+          minLength: 1
+      additionalProperties: false
+    GrantResourceGenericTable:
+      type: object
+      required:
+        - warehouse-id
+        - generic-table-id
+        - type
+      properties:
+        generic-table-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - generic-table
+        warehouse-id:
+          type: string
+          format: uuid
+    GrantResourceNamespace:
+      type: object
+      required:
+        - warehouse-id
+        - namespace-id
+        - type
+      properties:
+        namespace-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - namespace
+        warehouse-id:
+          type: string
+          format: uuid
+    GrantResourceProject:
+      type: object
+      required:
+        - project-id
+        - type
+      properties:
+        project-id:
+          type: string
+        type:
+          type: string
+          enum:
+            - project
+    GrantResourceResponse:
+      oneOf:
+        - $ref: '#/components/schemas/GrantResourceServer'
+        - $ref: '#/components/schemas/GrantResourceProject'
+        - $ref: '#/components/schemas/GrantResourceWarehouse'
+        - $ref: '#/components/schemas/GrantResourceNamespace'
+        - $ref: '#/components/schemas/GrantResourceTable'
+        - $ref: '#/components/schemas/GrantResourceView'
+        - $ref: '#/components/schemas/GrantResourceGenericTable'
+        - $ref: '#/components/schemas/GrantResourceTag'
+      description: |-
+        The resource a grant is held on, as it appears in a response.
+
+        `type` carries the same spelling as `ResourceType`, which is also the URL segment
+        that addresses the resource — so a client can look a listed grant up in the
+        vocabulary, or build a request path from it, without a translation table.
+      discriminator:
+        propertyName: type
+        mapping:
+          generic-table: '#/components/schemas/GrantResourceGenericTable'
+          namespace: '#/components/schemas/GrantResourceNamespace'
+          project: '#/components/schemas/GrantResourceProject'
+          server: '#/components/schemas/GrantResourceServer'
+          table: '#/components/schemas/GrantResourceTable'
+          tag-definition: '#/components/schemas/GrantResourceTag'
+          view: '#/components/schemas/GrantResourceView'
+          warehouse: '#/components/schemas/GrantResourceWarehouse'
+    GrantResourceServer:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - server
+    GrantResourceTable:
+      type: object
+      required:
+        - warehouse-id
+        - table-id
+        - type
+      properties:
+        table-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - table
+        warehouse-id:
+          type: string
+          format: uuid
+    GrantResourceTag:
+      type: object
+      description: |-
+        Spelled `tag-definition`, as everywhere else. `kebab-case` alone would render it
+        `tag`, which matches neither `ResourceType` nor the URL segment.
+      required:
+        - tag-definition-id
+        - type
+      properties:
+        tag-definition-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - tag-definition
+    GrantResourceView:
+      type: object
+      required:
+        - warehouse-id
+        - view-id
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - view
+        view-id:
+          type: string
+          format: uuid
+        warehouse-id:
+          type: string
+          format: uuid
+    GrantResourceWarehouse:
+      type: object
+      required:
+        - warehouse-id
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - warehouse
+        warehouse-id:
+          type: string
+          format: uuid
+    GrantResponse:
+      type: object
+      description: One grant in a listing.
+      required:
+        - principal
+        - resource
+        - privilege
+        - recognized
+      properties:
+        created-at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        principal:
+          $ref: '#/components/schemas/UserOrRole'
+        privilege:
+          type: string
+        recognized:
+          type: boolean
+          description: |-
+            Whether `privilege` is still in the authorizer's vocabulary. Where grants live
+            in the catalog, a `false` value is surfaced rather than hidden: the grant
+            enforces nothing today but is still there, and can still be revoked. An
+            authorizer that owns its grants may instead omit unrecognized grants from
+            listings entirely, so `false` never appears there — see its documentation.
+        resource:
+          $ref: '#/components/schemas/GrantResourceResponse'
+    GrantablePrivilege:
+      type: object
+      description: One privilege of a resource's vocabulary, and whether the principal may grant it.
+      required:
+        - privilege
+        - allowed
+      properties:
+        allowed:
+          type: boolean
+          description: |-
+            Whether the principal may grant this privilege here. Advisory: an apply checks
+            each of its entries on its own.
+
+            Granting only. Revoking is authorized separately and may be refused where this
+            says `true` — under the OpenFGA authorizer, delegated grant authority
+            (`pass_grants`) hands a privilege out without taking it back. There is no
+            discovery question for the revoke direction; a removal is authorized as it is
+            applied.
+        privilege:
+          $ref: '#/components/schemas/PrivilegeDescriptor'
+          description: |-
+            The privilege itself: static vocabulary, identical for every caller, and the same
+            object `GET /management/v1/grants/grantable-privileges` publishes. Nested rather
+            than flattened so the cacheable description and the per-caller decision below stay
+            distinct — and so a new descriptor field can never collide with `allowed`.
+    GrantablePrivilegesResponse:
+      type: object
+      description: |-
+        The privileges this server's authorizer will accept, per resource type.
+
+        Which privileges exist is decided by the configured authorizer, not by the API, so
+        this endpoint is the only reliable way to learn them: sending a name the authorizer
+        does not know is a 400.
+      required:
+        - privileges
+      properties:
+        privileges:
+          type: object
+          description: |-
+            Keyed by resource type. Every resource type the API knows is present, so an
+            empty list distinguishes "nothing is grantable here" from "unknown type" — an
+            authorizer that manages no grants reports every list empty.
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/PrivilegeDescriptor'
+          propertyNames:
+            type: string
     IcebergErrorResponse:
       type: object
       description: JSON wrapper for all error responses (non-2xx)
@@ -8101,1715 +10506,2642 @@ components:
           $ref: '#/components/schemas/ErrorModel'
     LakekeeperGenericTableAction:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - drop
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - read_data
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - write_data
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - rename
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - undrop
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - control_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_protection
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_tags
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionDrop'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionReadData'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionWriteData'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionRename'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionUndrop'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionGetTasks'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionControlTasks'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionSetProtection'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionManageTags'
+        - $ref: '#/components/schemas/LakekeeperGenericTableActionReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          control_tasks: '#/components/schemas/LakekeeperGenericTableActionControlTasks'
+          drop: '#/components/schemas/LakekeeperGenericTableActionDrop'
+          get_metadata: '#/components/schemas/LakekeeperGenericTableActionGetMetadata'
+          get_tasks: '#/components/schemas/LakekeeperGenericTableActionGetTasks'
+          include_in_list: '#/components/schemas/LakekeeperGenericTableActionIncludeInList'
+          manage_tags: '#/components/schemas/LakekeeperGenericTableActionManageTags'
+          read_data: '#/components/schemas/LakekeeperGenericTableActionReadData'
+          read_grants: '#/components/schemas/LakekeeperGenericTableActionReadGrants'
+          rename: '#/components/schemas/LakekeeperGenericTableActionRename'
+          set_protection: '#/components/schemas/LakekeeperGenericTableActionSetProtection'
+          undrop: '#/components/schemas/LakekeeperGenericTableActionUndrop'
+          write_data: '#/components/schemas/LakekeeperGenericTableActionWriteData'
+    LakekeeperGenericTableActionControlTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - control_tasks
+    LakekeeperGenericTableActionDrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - drop
+    LakekeeperGenericTableActionGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperGenericTableActionGetTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_tasks
+    LakekeeperGenericTableActionIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
+    LakekeeperGenericTableActionManageTags:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_tags
+    LakekeeperGenericTableActionReadData:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_data
+    LakekeeperGenericTableActionReadGrants:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperGenericTableActionRename:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - rename
+    LakekeeperGenericTableActionSetProtection:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_protection
+    LakekeeperGenericTableActionUndrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - undrop
+    LakekeeperGenericTableActionWriteData:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - write_data
     LakekeeperNamespaceAction:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_table
-            name:
-              type:
-                - string
-                - 'null'
-              description: Name of the table to create.
-            properties:
-              type: object
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-            table_id:
-              type:
-                - string
-                - 'null'
-              format: uuid
-              description: Table ID, if externally provided (e.g. via register).
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_view
-            name:
-              type:
-                - string
-                - 'null'
-              description: Name of the view to create.
-            properties:
-              type: object
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_namespace
-            name:
-              type:
-                - string
-                - 'null'
-              description: Name of the namespace to create.
-            properties:
-              type: object
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete
-            force:
-              type: boolean
-              description: |-
-                Whether the warehouse-configured soft-deletion is bypassed, i.e.
-                contained tabulars are hard-deleted immediately instead of being
-                recoverable for the configured grace period.
-            purge:
-              type: boolean
-              description: Whether the underlying data/metadata files are physically purged.
-            recursive:
-              type: boolean
-              description: |-
-                Whether the drop recurses into child namespaces, tables and views,
-                deleting the entire subtree rooted at this namespace.
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update_properties
-            removed_properties:
-              type: array
-              items:
-                type: string
-            updated_properties:
-              type: object
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_tables
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_views
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_namespaces
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_everything
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_protection
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_generic_table
-            base_location:
-              type:
-                - string
-                - 'null'
-              description: |-
-                User-supplied base location override — primary lever for
-                path-based authorization policy.
-            format:
-              type:
-                - string
-                - 'null'
-              description: |-
-                Generic table format (e.g. "lance", "delta") — primary lever for
-                format-based authorization policy.
-            generic_table_id:
-              type:
-                - string
-                - 'null'
-              format: uuid
-              description: Generic table ID, if externally provided.
-            name:
-              type:
-                - string
-                - 'null'
-              description: Name of the generic table to create.
-            properties:
-              type: object
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_generic_tables
-        - type: object
-          description: Attach/detach governance tags on this namespace.
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_tags
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionCreateTable'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionCreateView'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionCreateNamespace'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionDelete'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionUpdateProperties'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionListTables'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionListViews'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionListNamespaces'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionListEverything'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionSetProtection'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionCreateGenericTable'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionListGenericTables'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionManageTags'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionMove'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionAcceptMovedNamespace'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          accept_moved_namespace: '#/components/schemas/LakekeeperNamespaceActionAcceptMovedNamespace'
+          create_generic_table: '#/components/schemas/LakekeeperNamespaceActionCreateGenericTable'
+          create_namespace: '#/components/schemas/LakekeeperNamespaceActionCreateNamespace'
+          create_table: '#/components/schemas/LakekeeperNamespaceActionCreateTable'
+          create_view: '#/components/schemas/LakekeeperNamespaceActionCreateView'
+          delete: '#/components/schemas/LakekeeperNamespaceActionDelete'
+          get_metadata: '#/components/schemas/LakekeeperNamespaceActionGetMetadata'
+          include_in_list: '#/components/schemas/LakekeeperNamespaceActionIncludeInList'
+          list_everything: '#/components/schemas/LakekeeperNamespaceActionListEverything'
+          list_generic_tables: '#/components/schemas/LakekeeperNamespaceActionListGenericTables'
+          list_namespaces: '#/components/schemas/LakekeeperNamespaceActionListNamespaces'
+          list_tables: '#/components/schemas/LakekeeperNamespaceActionListTables'
+          list_views: '#/components/schemas/LakekeeperNamespaceActionListViews'
+          manage_tags: '#/components/schemas/LakekeeperNamespaceActionManageTags'
+          move: '#/components/schemas/LakekeeperNamespaceActionMove'
+          read_grants: '#/components/schemas/LakekeeperNamespaceActionReadGrants'
+          set_protection: '#/components/schemas/LakekeeperNamespaceActionSetProtection'
+          update_properties: '#/components/schemas/LakekeeperNamespaceActionUpdateProperties'
+    LakekeeperNamespaceActionAcceptMovedNamespace:
+      type: object
+      description: |-
+        Accept a namespace being moved in from elsewhere as a child of this entity.
+
+        Distinct from `CreateNamespace`: creating adds an *empty* child, so exposing it to
+        this subtree's grantees exposes nothing. A move arrives carrying existing contents
+        and their direct grants, which is why this is gated on grant authority in addition to
+        `create` — without it, a namespace could be populated and granted somewhere
+        permissive and then moved into a `managed_access` subtree, smuggling grants past the
+        control that subtree exists to enforce.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - accept_moved_namespace
+        source:
+          type: array
+          items:
+            type: string
+          description: Path the namespace is being moved from.
+    LakekeeperNamespaceActionCreateGenericTable:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_generic_table
+        base_location:
+          type:
+            - string
+            - 'null'
+          description: |-
+            User-supplied base location override — primary lever for
+            path-based authorization policy.
+        format:
+          type:
+            - string
+            - 'null'
+          description: |-
+            Generic table format (e.g. "lance", "delta") — primary lever for
+            format-based authorization policy.
+        generic_table_id:
+          type:
+            - string
+            - 'null'
+          format: uuid
+          description: Generic table ID, if externally provided.
+        name:
+          type:
+            - string
+            - 'null'
+          description: Name of the generic table to create.
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+    LakekeeperNamespaceActionCreateNamespace:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_namespace
+        name:
+          type:
+            - string
+            - 'null'
+          description: Name of the namespace to create.
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+    LakekeeperNamespaceActionCreateTable:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_table
+        name:
+          type:
+            - string
+            - 'null'
+          description: Name of the table to create.
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+        table_id:
+          type:
+            - string
+            - 'null'
+          format: uuid
+          description: Table ID, if externally provided (e.g. via register).
+    LakekeeperNamespaceActionCreateView:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_view
+        name:
+          type:
+            - string
+            - 'null'
+          description: Name of the view to create.
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+    LakekeeperNamespaceActionDelete:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete
+        force:
+          type: boolean
+          description: |-
+            Whether the warehouse-configured soft-deletion is bypassed, i.e.
+            contained tabulars are hard-deleted immediately instead of being
+            recoverable for the configured grace period.
+        purge:
+          type: boolean
+          description: Whether the underlying data/metadata files are physically purged.
+        recursive:
+          type: boolean
+          description: |-
+            Whether the drop recurses into child namespaces, tables and views,
+            deleting the entire subtree rooted at this namespace.
+    LakekeeperNamespaceActionGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperNamespaceActionIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
     LakekeeperNamespaceActionKind:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_table
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_view
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_namespace
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update_properties
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_tables
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_views
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_namespaces
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_everything
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_protection
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_generic_table
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_generic_tables
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_tags
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindCreateTable'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindCreateView'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindCreateNamespace'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindDelete'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindUpdateProperties'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindListTables'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindListViews'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindListNamespaces'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindListEverything'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindSetProtection'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindCreateGenericTable'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindListGenericTables'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindManageTags'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindMove'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindAcceptMovedNamespace'
+        - $ref: '#/components/schemas/LakekeeperNamespaceActionKindReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          accept_moved_namespace: '#/components/schemas/LakekeeperNamespaceActionKindAcceptMovedNamespace'
+          create_generic_table: '#/components/schemas/LakekeeperNamespaceActionKindCreateGenericTable'
+          create_namespace: '#/components/schemas/LakekeeperNamespaceActionKindCreateNamespace'
+          create_table: '#/components/schemas/LakekeeperNamespaceActionKindCreateTable'
+          create_view: '#/components/schemas/LakekeeperNamespaceActionKindCreateView'
+          delete: '#/components/schemas/LakekeeperNamespaceActionKindDelete'
+          get_metadata: '#/components/schemas/LakekeeperNamespaceActionKindGetMetadata'
+          include_in_list: '#/components/schemas/LakekeeperNamespaceActionKindIncludeInList'
+          list_everything: '#/components/schemas/LakekeeperNamespaceActionKindListEverything'
+          list_generic_tables: '#/components/schemas/LakekeeperNamespaceActionKindListGenericTables'
+          list_namespaces: '#/components/schemas/LakekeeperNamespaceActionKindListNamespaces'
+          list_tables: '#/components/schemas/LakekeeperNamespaceActionKindListTables'
+          list_views: '#/components/schemas/LakekeeperNamespaceActionKindListViews'
+          manage_tags: '#/components/schemas/LakekeeperNamespaceActionKindManageTags'
+          move: '#/components/schemas/LakekeeperNamespaceActionKindMove'
+          read_grants: '#/components/schemas/LakekeeperNamespaceActionKindReadGrants'
+          set_protection: '#/components/schemas/LakekeeperNamespaceActionKindSetProtection'
+          update_properties: '#/components/schemas/LakekeeperNamespaceActionKindUpdateProperties'
+    LakekeeperNamespaceActionKindAcceptMovedNamespace:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - accept_moved_namespace
+    LakekeeperNamespaceActionKindCreateGenericTable:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_generic_table
+    LakekeeperNamespaceActionKindCreateNamespace:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_namespace
+    LakekeeperNamespaceActionKindCreateTable:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_table
+    LakekeeperNamespaceActionKindCreateView:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_view
+    LakekeeperNamespaceActionKindDelete:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete
+    LakekeeperNamespaceActionKindGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperNamespaceActionKindIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
+    LakekeeperNamespaceActionKindListEverything:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_everything
+    LakekeeperNamespaceActionKindListGenericTables:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_generic_tables
+    LakekeeperNamespaceActionKindListNamespaces:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_namespaces
+    LakekeeperNamespaceActionKindListTables:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_tables
+    LakekeeperNamespaceActionKindListViews:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_views
+    LakekeeperNamespaceActionKindManageTags:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_tags
+    LakekeeperNamespaceActionKindMove:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - move
+    LakekeeperNamespaceActionKindReadGrants:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperNamespaceActionKindSetProtection:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_protection
+    LakekeeperNamespaceActionKindUpdateProperties:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update_properties
+    LakekeeperNamespaceActionListEverything:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_everything
+    LakekeeperNamespaceActionListGenericTables:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_generic_tables
+    LakekeeperNamespaceActionListNamespaces:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_namespaces
+    LakekeeperNamespaceActionListTables:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_tables
+    LakekeeperNamespaceActionListViews:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_views
+    LakekeeperNamespaceActionManageTags:
+      type: object
+      description: Attach/detach governance tags on this namespace.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_tags
+    LakekeeperNamespaceActionMove:
+      type: object
+      description: |-
+        Move this namespace to a new path, re-parenting and/or renaming it.
+
+        Gated on grant-level authority *in addition to* plain write access. Re-parenting a
+        namespace re-issues every privilege the destination subtree confers onto the
+        namespace's contents, with no assignment record anywhere — so the actor must
+        already be able to grant on the namespace being moved. Inside a `managed_access`
+        subtree ownership does not confer that, which is precisely the case where moving
+        out would otherwise defeat the control.
+
+        Only the source half of a move's authorization; the destination is gated by
+        `CreateNamespace` plus `AcceptMovedNamespace`.
+      required:
+        - destination
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - move
+        destination:
+          type: array
+          items:
+            type: string
+          description: Full destination path, including the new leaf name.
+        force:
+          type: boolean
+          description: Whether protection is overridden, as for `Delete`.
+    LakekeeperNamespaceActionReadGrants:
+      type: object
+      description: Can list the grants held on this namespace.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperNamespaceActionSetProtection:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_protection
+    LakekeeperNamespaceActionUpdateProperties:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update_properties
+        removed_properties:
+          type: array
+          items:
+            type: string
+        updated_properties:
+          type: object
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
     LakekeeperProjectAction:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_warehouse
-            name:
-              type:
-                - string
-                - 'null'
-              description: Name of the warehouse to create.
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - rename
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_warehouses
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_role
-            name:
-              type:
-                - string
-                - 'null'
-              description: Name of the role to create.
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_roles
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - search_roles
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_endpoint_statistics
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - modify_task_queue_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_task_queue_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_project_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - control_project_tasks
-        - type: object
-          description: Create a new governance tag definition in this project.
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_tag
-            name:
-              type:
-                - string
-                - 'null'
-              description: Name of the tag to create.
-        - type: object
-          description: List tag definitions in this project.
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_tags
+        - $ref: '#/components/schemas/LakekeeperProjectActionCreateWarehouse'
+        - $ref: '#/components/schemas/LakekeeperProjectActionDelete'
+        - $ref: '#/components/schemas/LakekeeperProjectActionRename'
+        - $ref: '#/components/schemas/LakekeeperProjectActionGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperProjectActionListWarehouses'
+        - $ref: '#/components/schemas/LakekeeperProjectActionIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperProjectActionCreateRole'
+        - $ref: '#/components/schemas/LakekeeperProjectActionListRoles'
+        - $ref: '#/components/schemas/LakekeeperProjectActionSearchRoles'
+        - $ref: '#/components/schemas/LakekeeperProjectActionGetEndpointStatistics'
+        - $ref: '#/components/schemas/LakekeeperProjectActionModifyTaskQueueConfig'
+        - $ref: '#/components/schemas/LakekeeperProjectActionGetTaskQueueConfig'
+        - $ref: '#/components/schemas/LakekeeperProjectActionGetProjectTasks'
+        - $ref: '#/components/schemas/LakekeeperProjectActionControlProjectTasks'
+        - $ref: '#/components/schemas/LakekeeperProjectActionCreateTag'
+        - $ref: '#/components/schemas/LakekeeperProjectActionListTags'
+        - $ref: '#/components/schemas/LakekeeperProjectActionReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          control_project_tasks: '#/components/schemas/LakekeeperProjectActionControlProjectTasks'
+          create_role: '#/components/schemas/LakekeeperProjectActionCreateRole'
+          create_tag: '#/components/schemas/LakekeeperProjectActionCreateTag'
+          create_warehouse: '#/components/schemas/LakekeeperProjectActionCreateWarehouse'
+          delete: '#/components/schemas/LakekeeperProjectActionDelete'
+          get_endpoint_statistics: '#/components/schemas/LakekeeperProjectActionGetEndpointStatistics'
+          get_metadata: '#/components/schemas/LakekeeperProjectActionGetMetadata'
+          get_project_tasks: '#/components/schemas/LakekeeperProjectActionGetProjectTasks'
+          get_task_queue_config: '#/components/schemas/LakekeeperProjectActionGetTaskQueueConfig'
+          include_in_list: '#/components/schemas/LakekeeperProjectActionIncludeInList'
+          list_roles: '#/components/schemas/LakekeeperProjectActionListRoles'
+          list_tags: '#/components/schemas/LakekeeperProjectActionListTags'
+          list_warehouses: '#/components/schemas/LakekeeperProjectActionListWarehouses'
+          modify_task_queue_config: '#/components/schemas/LakekeeperProjectActionModifyTaskQueueConfig'
+          read_grants: '#/components/schemas/LakekeeperProjectActionReadGrants'
+          rename: '#/components/schemas/LakekeeperProjectActionRename'
+          search_roles: '#/components/schemas/LakekeeperProjectActionSearchRoles'
+    LakekeeperProjectActionControlProjectTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - control_project_tasks
+    LakekeeperProjectActionCreateRole:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_role
+        name:
+          type:
+            - string
+            - 'null'
+          description: Name of the role to create.
+    LakekeeperProjectActionCreateTag:
+      type: object
+      description: Create a new governance tag definition in this project.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_tag
+        name:
+          type:
+            - string
+            - 'null'
+          description: Name of the tag to create.
+    LakekeeperProjectActionCreateWarehouse:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_warehouse
+        name:
+          type:
+            - string
+            - 'null'
+          description: Name of the warehouse to create.
+    LakekeeperProjectActionDelete:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete
+    LakekeeperProjectActionGetEndpointStatistics:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_endpoint_statistics
+    LakekeeperProjectActionGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperProjectActionGetProjectTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_project_tasks
+    LakekeeperProjectActionGetTaskQueueConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_task_queue_config
+    LakekeeperProjectActionIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
     LakekeeperProjectActionKind:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_warehouse
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - rename
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_warehouses
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_role
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_roles
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - search_roles
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_endpoint_statistics
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - modify_task_queue_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_task_queue_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_project_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - control_project_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_tag
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_tags
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindCreateWarehouse'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindDelete'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindRename'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindListWarehouses'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindCreateRole'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindListRoles'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindSearchRoles'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindGetEndpointStatistics'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindModifyTaskQueueConfig'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindGetTaskQueueConfig'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindGetProjectTasks'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindControlProjectTasks'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindCreateTag'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindListTags'
+        - $ref: '#/components/schemas/LakekeeperProjectActionKindReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          control_project_tasks: '#/components/schemas/LakekeeperProjectActionKindControlProjectTasks'
+          create_role: '#/components/schemas/LakekeeperProjectActionKindCreateRole'
+          create_tag: '#/components/schemas/LakekeeperProjectActionKindCreateTag'
+          create_warehouse: '#/components/schemas/LakekeeperProjectActionKindCreateWarehouse'
+          delete: '#/components/schemas/LakekeeperProjectActionKindDelete'
+          get_endpoint_statistics: '#/components/schemas/LakekeeperProjectActionKindGetEndpointStatistics'
+          get_metadata: '#/components/schemas/LakekeeperProjectActionKindGetMetadata'
+          get_project_tasks: '#/components/schemas/LakekeeperProjectActionKindGetProjectTasks'
+          get_task_queue_config: '#/components/schemas/LakekeeperProjectActionKindGetTaskQueueConfig'
+          include_in_list: '#/components/schemas/LakekeeperProjectActionKindIncludeInList'
+          list_roles: '#/components/schemas/LakekeeperProjectActionKindListRoles'
+          list_tags: '#/components/schemas/LakekeeperProjectActionKindListTags'
+          list_warehouses: '#/components/schemas/LakekeeperProjectActionKindListWarehouses'
+          modify_task_queue_config: '#/components/schemas/LakekeeperProjectActionKindModifyTaskQueueConfig'
+          read_grants: '#/components/schemas/LakekeeperProjectActionKindReadGrants'
+          rename: '#/components/schemas/LakekeeperProjectActionKindRename'
+          search_roles: '#/components/schemas/LakekeeperProjectActionKindSearchRoles'
+    LakekeeperProjectActionKindControlProjectTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - control_project_tasks
+    LakekeeperProjectActionKindCreateRole:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_role
+    LakekeeperProjectActionKindCreateTag:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_tag
+    LakekeeperProjectActionKindCreateWarehouse:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_warehouse
+    LakekeeperProjectActionKindDelete:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete
+    LakekeeperProjectActionKindGetEndpointStatistics:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_endpoint_statistics
+    LakekeeperProjectActionKindGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperProjectActionKindGetProjectTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_project_tasks
+    LakekeeperProjectActionKindGetTaskQueueConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_task_queue_config
+    LakekeeperProjectActionKindIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
+    LakekeeperProjectActionKindListRoles:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_roles
+    LakekeeperProjectActionKindListTags:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_tags
+    LakekeeperProjectActionKindListWarehouses:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_warehouses
+    LakekeeperProjectActionKindModifyTaskQueueConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - modify_task_queue_config
+    LakekeeperProjectActionKindReadGrants:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperProjectActionKindRename:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - rename
+    LakekeeperProjectActionKindSearchRoles:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - search_roles
+    LakekeeperProjectActionListRoles:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_roles
+    LakekeeperProjectActionListTags:
+      type: object
+      description: List tag definitions in this project.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_tags
+    LakekeeperProjectActionListWarehouses:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_warehouses
+    LakekeeperProjectActionModifyTaskQueueConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - modify_task_queue_config
+    LakekeeperProjectActionReadGrants:
+      type: object
+      description: Can list the grants held on this project.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperProjectActionRename:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - rename
+    LakekeeperProjectActionSearchRoles:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - search_roles
     LakekeeperRoleActionKind:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - read
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - read_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_role_assignments
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - read_role_assignments
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update_source_system
+        - $ref: '#/components/schemas/LakekeeperRoleActionKindRead'
+        - $ref: '#/components/schemas/LakekeeperRoleActionKindReadMetadata'
+        - $ref: '#/components/schemas/LakekeeperRoleActionKindDelete'
+        - $ref: '#/components/schemas/LakekeeperRoleActionKindUpdate'
+        - $ref: '#/components/schemas/LakekeeperRoleActionKindManageRoleAssignments'
+        - $ref: '#/components/schemas/LakekeeperRoleActionKindReadRoleAssignments'
+        - $ref: '#/components/schemas/LakekeeperRoleActionKindUpdateSourceSystem'
+      discriminator:
+        propertyName: action
+        mapping:
+          delete: '#/components/schemas/LakekeeperRoleActionKindDelete'
+          manage_role_assignments: '#/components/schemas/LakekeeperRoleActionKindManageRoleAssignments'
+          read: '#/components/schemas/LakekeeperRoleActionKindRead'
+          read_metadata: '#/components/schemas/LakekeeperRoleActionKindReadMetadata'
+          read_role_assignments: '#/components/schemas/LakekeeperRoleActionKindReadRoleAssignments'
+          update: '#/components/schemas/LakekeeperRoleActionKindUpdate'
+          update_source_system: '#/components/schemas/LakekeeperRoleActionKindUpdateSourceSystem'
+    LakekeeperRoleActionKindDelete:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete
+    LakekeeperRoleActionKindManageRoleAssignments:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_role_assignments
+    LakekeeperRoleActionKindRead:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read
+    LakekeeperRoleActionKindReadMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_metadata
+    LakekeeperRoleActionKindReadRoleAssignments:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_role_assignments
+    LakekeeperRoleActionKindUpdate:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update
+    LakekeeperRoleActionKindUpdateSourceSystem:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update_source_system
     LakekeeperServerAction:
       oneOf:
-        - type: object
-          description: Can create items inside the server (can create Warehouses).
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_project
-            name:
-              type:
-                - string
-                - 'null'
-              description: Name of the project to create.
-            project_id:
-              type:
-                - string
-                - 'null'
-              description: Project ID, if externally provided.
-        - type: object
-          description: Can update all users on this server.
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update_users
-        - type: object
-          description: Can delete all users on this server.
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete_users
-        - type: object
-          description: Can List all users on this server.
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_users
-        - type: object
-          description: Can provision user
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - provision_users
+        - $ref: '#/components/schemas/LakekeeperServerActionCreateProject'
+        - $ref: '#/components/schemas/LakekeeperServerActionUpdateUsers'
+        - $ref: '#/components/schemas/LakekeeperServerActionDeleteUsers'
+        - $ref: '#/components/schemas/LakekeeperServerActionListUsers'
+        - $ref: '#/components/schemas/LakekeeperServerActionProvisionUsers'
+        - $ref: '#/components/schemas/LakekeeperServerActionReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          create_project: '#/components/schemas/LakekeeperServerActionCreateProject'
+          delete_users: '#/components/schemas/LakekeeperServerActionDeleteUsers'
+          list_users: '#/components/schemas/LakekeeperServerActionListUsers'
+          provision_users: '#/components/schemas/LakekeeperServerActionProvisionUsers'
+          read_grants: '#/components/schemas/LakekeeperServerActionReadGrants'
+          update_users: '#/components/schemas/LakekeeperServerActionUpdateUsers'
+    LakekeeperServerActionCreateProject:
+      type: object
+      description: Can create items inside the server (can create Warehouses).
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_project
+        name:
+          type:
+            - string
+            - 'null'
+          description: Name of the project to create.
+        project_id:
+          type:
+            - string
+            - 'null'
+          description: Project ID, if externally provided.
+    LakekeeperServerActionDeleteUsers:
+      type: object
+      description: Can delete all users on this server.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete_users
     LakekeeperServerActionKind:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_project
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update_users
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete_users
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_users
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - provision_users
+        - $ref: '#/components/schemas/LakekeeperServerActionKindCreateProject'
+        - $ref: '#/components/schemas/LakekeeperServerActionKindUpdateUsers'
+        - $ref: '#/components/schemas/LakekeeperServerActionKindDeleteUsers'
+        - $ref: '#/components/schemas/LakekeeperServerActionKindListUsers'
+        - $ref: '#/components/schemas/LakekeeperServerActionKindProvisionUsers'
+        - $ref: '#/components/schemas/LakekeeperServerActionKindReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          create_project: '#/components/schemas/LakekeeperServerActionKindCreateProject'
+          delete_users: '#/components/schemas/LakekeeperServerActionKindDeleteUsers'
+          list_users: '#/components/schemas/LakekeeperServerActionKindListUsers'
+          provision_users: '#/components/schemas/LakekeeperServerActionKindProvisionUsers'
+          read_grants: '#/components/schemas/LakekeeperServerActionKindReadGrants'
+          update_users: '#/components/schemas/LakekeeperServerActionKindUpdateUsers'
+    LakekeeperServerActionKindCreateProject:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_project
+    LakekeeperServerActionKindDeleteUsers:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete_users
+    LakekeeperServerActionKindListUsers:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_users
+    LakekeeperServerActionKindProvisionUsers:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - provision_users
+    LakekeeperServerActionKindReadGrants:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperServerActionKindUpdateUsers:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update_users
+    LakekeeperServerActionListUsers:
+      type: object
+      description: Can List all users on this server.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_users
+    LakekeeperServerActionProvisionUsers:
+      type: object
+      description: Can provision user
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - provision_users
+    LakekeeperServerActionReadGrants:
+      type: object
+      description: Can list the grants held on this server.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperServerActionUpdateUsers:
+      type: object
+      description: Can update all users on this server.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update_users
     LakekeeperTableAction:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - drop
-            force:
-              type: boolean
-              description: |-
-                Whether the warehouse-configured soft-deletion is bypassed, i.e. the
-                table is hard-deleted immediately instead of being recoverable for the
-                configured grace period. Extra destructive — irreversible right away.
-            purge:
-              type: boolean
-              description: Whether the underlying data files are physically purged from storage.
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - write_data
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - read_data
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - commit
-            removed_properties:
-              type: array
-              items:
-                type: string
-            target_refs:
-              type: array
-              items:
-                type: string
-              description: |-
-                The branch and tag names this commit creates, moves, or removes.
-                Empty when the commit targets no ref by name.
-              uniqueItems: true
-            update_kinds:
-              type: array
-              items:
-                $ref: '#/components/schemas/TableUpdateKind'
-              description: The kinds of metadata updates this commit contains.
-              uniqueItems: true
-            updated_properties:
-              type: object
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - rename
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - undrop
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - control_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_protection
-        - type: object
-          description: Attach/detach governance tags on this table.
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_tags
+        - $ref: '#/components/schemas/LakekeeperTableActionDrop'
+        - $ref: '#/components/schemas/LakekeeperTableActionWriteData'
+        - $ref: '#/components/schemas/LakekeeperTableActionReadData'
+        - $ref: '#/components/schemas/LakekeeperTableActionGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperTableActionCommit'
+        - $ref: '#/components/schemas/LakekeeperTableActionRename'
+        - $ref: '#/components/schemas/LakekeeperTableActionIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperTableActionUndrop'
+        - $ref: '#/components/schemas/LakekeeperTableActionGetTasks'
+        - $ref: '#/components/schemas/LakekeeperTableActionControlTasks'
+        - $ref: '#/components/schemas/LakekeeperTableActionSetProtection'
+        - $ref: '#/components/schemas/LakekeeperTableActionManageTags'
+        - $ref: '#/components/schemas/LakekeeperTableActionReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          commit: '#/components/schemas/LakekeeperTableActionCommit'
+          control_tasks: '#/components/schemas/LakekeeperTableActionControlTasks'
+          drop: '#/components/schemas/LakekeeperTableActionDrop'
+          get_metadata: '#/components/schemas/LakekeeperTableActionGetMetadata'
+          get_tasks: '#/components/schemas/LakekeeperTableActionGetTasks'
+          include_in_list: '#/components/schemas/LakekeeperTableActionIncludeInList'
+          manage_tags: '#/components/schemas/LakekeeperTableActionManageTags'
+          read_data: '#/components/schemas/LakekeeperTableActionReadData'
+          read_grants: '#/components/schemas/LakekeeperTableActionReadGrants'
+          rename: '#/components/schemas/LakekeeperTableActionRename'
+          set_protection: '#/components/schemas/LakekeeperTableActionSetProtection'
+          undrop: '#/components/schemas/LakekeeperTableActionUndrop'
+          write_data: '#/components/schemas/LakekeeperTableActionWriteData'
+    LakekeeperTableActionCommit:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - commit
+        removed_properties:
+          type: array
+          items:
+            type: string
+        target_refs:
+          type: array
+          items:
+            type: string
+          description: |-
+            The branch and tag names this commit creates, moves, or removes.
+            Empty when the commit targets no ref by name.
+          uniqueItems: true
+        update_kinds:
+          type: array
+          items:
+            $ref: '#/components/schemas/TableUpdateKind'
+          description: The kinds of metadata updates this commit contains.
+          uniqueItems: true
+        updated_properties:
+          type: object
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+    LakekeeperTableActionControlTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - control_tasks
+    LakekeeperTableActionDrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - drop
+        force:
+          type: boolean
+          description: |-
+            Whether the warehouse-configured soft-deletion is bypassed, i.e. the
+            table is hard-deleted immediately instead of being recoverable for the
+            configured grace period. Extra destructive — irreversible right away.
+        purge:
+          type: boolean
+          description: Whether the underlying data files are physically purged from storage.
+    LakekeeperTableActionGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperTableActionGetTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_tasks
+    LakekeeperTableActionIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
     LakekeeperTableActionKind:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - drop
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - write_data
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - read_data
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - commit
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - rename
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - undrop
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - control_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_protection
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_tags
+        - $ref: '#/components/schemas/LakekeeperTableActionKindDrop'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindWriteData'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindReadData'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindCommit'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindRename'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindUndrop'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindGetTasks'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindControlTasks'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindSetProtection'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindManageTags'
+        - $ref: '#/components/schemas/LakekeeperTableActionKindReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          commit: '#/components/schemas/LakekeeperTableActionKindCommit'
+          control_tasks: '#/components/schemas/LakekeeperTableActionKindControlTasks'
+          drop: '#/components/schemas/LakekeeperTableActionKindDrop'
+          get_metadata: '#/components/schemas/LakekeeperTableActionKindGetMetadata'
+          get_tasks: '#/components/schemas/LakekeeperTableActionKindGetTasks'
+          include_in_list: '#/components/schemas/LakekeeperTableActionKindIncludeInList'
+          manage_tags: '#/components/schemas/LakekeeperTableActionKindManageTags'
+          read_data: '#/components/schemas/LakekeeperTableActionKindReadData'
+          read_grants: '#/components/schemas/LakekeeperTableActionKindReadGrants'
+          rename: '#/components/schemas/LakekeeperTableActionKindRename'
+          set_protection: '#/components/schemas/LakekeeperTableActionKindSetProtection'
+          undrop: '#/components/schemas/LakekeeperTableActionKindUndrop'
+          write_data: '#/components/schemas/LakekeeperTableActionKindWriteData'
+    LakekeeperTableActionKindCommit:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - commit
+    LakekeeperTableActionKindControlTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - control_tasks
+    LakekeeperTableActionKindDrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - drop
+    LakekeeperTableActionKindGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperTableActionKindGetTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_tasks
+    LakekeeperTableActionKindIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
+    LakekeeperTableActionKindManageTags:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_tags
+    LakekeeperTableActionKindReadData:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_data
+    LakekeeperTableActionKindReadGrants:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperTableActionKindRename:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - rename
+    LakekeeperTableActionKindSetProtection:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_protection
+    LakekeeperTableActionKindUndrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - undrop
+    LakekeeperTableActionKindWriteData:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - write_data
+    LakekeeperTableActionManageTags:
+      type: object
+      description: Attach/detach governance tags on this table.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_tags
+    LakekeeperTableActionReadData:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_data
+    LakekeeperTableActionReadGrants:
+      type: object
+      description: Can list the grants held on this table.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperTableActionRename:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - rename
+    LakekeeperTableActionSetProtection:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_protection
+    LakekeeperTableActionUndrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - undrop
+    LakekeeperTableActionWriteData:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - write_data
+    LakekeeperTagAction:
+      oneOf:
+        - $ref: '#/components/schemas/LakekeeperTagActionRead'
+        - $ref: '#/components/schemas/LakekeeperTagActionUpdate'
+        - $ref: '#/components/schemas/LakekeeperTagActionDelete'
+        - $ref: '#/components/schemas/LakekeeperTagActionApply'
+        - $ref: '#/components/schemas/LakekeeperTagActionRemove'
+        - $ref: '#/components/schemas/LakekeeperTagActionReadAttachments'
+        - $ref: '#/components/schemas/LakekeeperTagActionReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          apply: '#/components/schemas/LakekeeperTagActionApply'
+          delete: '#/components/schemas/LakekeeperTagActionDelete'
+          read: '#/components/schemas/LakekeeperTagActionRead'
+          read_attachments: '#/components/schemas/LakekeeperTagActionReadAttachments'
+          read_grants: '#/components/schemas/LakekeeperTagActionReadGrants'
+          remove: '#/components/schemas/LakekeeperTagActionRemove'
+          update: '#/components/schemas/LakekeeperTagActionUpdate'
+    LakekeeperTagActionApply:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - apply
+    LakekeeperTagActionDelete:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete
+    LakekeeperTagActionRead:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read
+    LakekeeperTagActionReadAttachments:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_attachments
+    LakekeeperTagActionReadGrants:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperTagActionRemove:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - remove
+    LakekeeperTagActionUpdate:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update
     LakekeeperUserAction:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - read
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - read_role_assignments
+        - $ref: '#/components/schemas/LakekeeperUserActionRead'
+        - $ref: '#/components/schemas/LakekeeperUserActionUpdate'
+        - $ref: '#/components/schemas/LakekeeperUserActionDelete'
+        - $ref: '#/components/schemas/LakekeeperUserActionReadRoleAssignments'
+      discriminator:
+        propertyName: action
+        mapping:
+          delete: '#/components/schemas/LakekeeperUserActionDelete'
+          read: '#/components/schemas/LakekeeperUserActionRead'
+          read_role_assignments: '#/components/schemas/LakekeeperUserActionReadRoleAssignments'
+          update: '#/components/schemas/LakekeeperUserActionUpdate'
+    LakekeeperUserActionDelete:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete
+    LakekeeperUserActionRead:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read
+    LakekeeperUserActionReadRoleAssignments:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_role_assignments
+    LakekeeperUserActionUpdate:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update
     LakekeeperViewAction:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - drop
-            force:
-              type: boolean
-              description: |-
-                Whether the warehouse-configured soft-deletion is bypassed, i.e. the
-                view is hard-deleted immediately instead of being recoverable for the
-                configured grace period. Extra destructive — irreversible right away.
-            purge:
-              type: boolean
-              description: Whether the underlying metadata files are physically purged from storage.
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - select
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - commit
-            removed_properties:
-              type: array
-              items:
-                type: string
-            updated_properties:
-              type: object
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - rename
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - undrop
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - control_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_protection
-        - type: object
-          description: Attach/detach governance tags on this view.
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_tags
+        - $ref: '#/components/schemas/LakekeeperViewActionDrop'
+        - $ref: '#/components/schemas/LakekeeperViewActionGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperViewActionSelect'
+        - $ref: '#/components/schemas/LakekeeperViewActionCommit'
+        - $ref: '#/components/schemas/LakekeeperViewActionIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperViewActionRename'
+        - $ref: '#/components/schemas/LakekeeperViewActionUndrop'
+        - $ref: '#/components/schemas/LakekeeperViewActionGetTasks'
+        - $ref: '#/components/schemas/LakekeeperViewActionControlTasks'
+        - $ref: '#/components/schemas/LakekeeperViewActionSetProtection'
+        - $ref: '#/components/schemas/LakekeeperViewActionManageTags'
+        - $ref: '#/components/schemas/LakekeeperViewActionReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          commit: '#/components/schemas/LakekeeperViewActionCommit'
+          control_tasks: '#/components/schemas/LakekeeperViewActionControlTasks'
+          drop: '#/components/schemas/LakekeeperViewActionDrop'
+          get_metadata: '#/components/schemas/LakekeeperViewActionGetMetadata'
+          get_tasks: '#/components/schemas/LakekeeperViewActionGetTasks'
+          include_in_list: '#/components/schemas/LakekeeperViewActionIncludeInList'
+          manage_tags: '#/components/schemas/LakekeeperViewActionManageTags'
+          read_grants: '#/components/schemas/LakekeeperViewActionReadGrants'
+          rename: '#/components/schemas/LakekeeperViewActionRename'
+          select: '#/components/schemas/LakekeeperViewActionSelect'
+          set_protection: '#/components/schemas/LakekeeperViewActionSetProtection'
+          undrop: '#/components/schemas/LakekeeperViewActionUndrop'
+    LakekeeperViewActionCommit:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - commit
+        removed_properties:
+          type: array
+          items:
+            type: string
+        updated_properties:
+          type: object
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+    LakekeeperViewActionControlTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - control_tasks
+    LakekeeperViewActionDrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - drop
+        force:
+          type: boolean
+          description: |-
+            Whether the warehouse-configured soft-deletion is bypassed, i.e. the
+            view is hard-deleted immediately instead of being recoverable for the
+            configured grace period. Extra destructive — irreversible right away.
+        purge:
+          type: boolean
+          description: Whether the underlying metadata files are physically purged from storage.
+    LakekeeperViewActionGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperViewActionGetTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_tasks
+    LakekeeperViewActionIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
     LakekeeperViewActionKind:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - drop
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - select
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - commit
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - rename
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - undrop
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - control_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_protection
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_tags
+        - $ref: '#/components/schemas/LakekeeperViewActionKindDrop'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindSelect'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindCommit'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindRename'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindUndrop'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindGetTasks'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindControlTasks'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindSetProtection'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindManageTags'
+        - $ref: '#/components/schemas/LakekeeperViewActionKindReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          commit: '#/components/schemas/LakekeeperViewActionKindCommit'
+          control_tasks: '#/components/schemas/LakekeeperViewActionKindControlTasks'
+          drop: '#/components/schemas/LakekeeperViewActionKindDrop'
+          get_metadata: '#/components/schemas/LakekeeperViewActionKindGetMetadata'
+          get_tasks: '#/components/schemas/LakekeeperViewActionKindGetTasks'
+          include_in_list: '#/components/schemas/LakekeeperViewActionKindIncludeInList'
+          manage_tags: '#/components/schemas/LakekeeperViewActionKindManageTags'
+          read_grants: '#/components/schemas/LakekeeperViewActionKindReadGrants'
+          rename: '#/components/schemas/LakekeeperViewActionKindRename'
+          select: '#/components/schemas/LakekeeperViewActionKindSelect'
+          set_protection: '#/components/schemas/LakekeeperViewActionKindSetProtection'
+          undrop: '#/components/schemas/LakekeeperViewActionKindUndrop'
+    LakekeeperViewActionKindCommit:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - commit
+    LakekeeperViewActionKindControlTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - control_tasks
+    LakekeeperViewActionKindDrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - drop
+    LakekeeperViewActionKindGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperViewActionKindGetTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_tasks
+    LakekeeperViewActionKindIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
+    LakekeeperViewActionKindManageTags:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_tags
+    LakekeeperViewActionKindReadGrants:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperViewActionKindRename:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - rename
+    LakekeeperViewActionKindSelect:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - select
+    LakekeeperViewActionKindSetProtection:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_protection
+    LakekeeperViewActionKindUndrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - undrop
+    LakekeeperViewActionManageTags:
+      type: object
+      description: Attach/detach governance tags on this view.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_tags
+    LakekeeperViewActionReadGrants:
+      type: object
+      description: Can list the grants held on this view.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperViewActionRename:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - rename
+    LakekeeperViewActionSelect:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - select
+    LakekeeperViewActionSetProtection:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_protection
+    LakekeeperViewActionUndrop:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - undrop
     LakekeeperWarehouseAction:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_namespace
-            name:
-              type:
-                - string
-                - 'null'
-              description: Name of the namespace to create.
-            properties:
-              type: object
-              additionalProperties:
-                type: string
-              propertyNames:
-                type: string
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update_storage
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update_storage_credential
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_namespaces
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_everything
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - use
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - deactivate
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - activate
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - rename
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_deleted_tabulars
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - modify_soft_deletion
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_task_queue_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - modify_task_queue_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_all_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - control_all_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_protection
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_format_version_policy
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_endpoint_statistics
-        - type: object
-          description: Attach/detach governance tags on this warehouse.
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_tags
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionCreateNamespace'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionDelete'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionUpdateStorage'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionGetConfig'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionListNamespaces'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionListEverything'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionUse'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionDeactivate'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionActivate'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionRename'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionListDeletedTabulars'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionModifySoftDeletion'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionGetTaskQueueConfig'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionModifyTaskQueueConfig'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionGetAllTasks'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionControlAllTasks'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionSetProtection'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionSetFormatVersionPolicy'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionGetEndpointStatistics'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionManageTags'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionAcceptMovedNamespace'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          accept_moved_namespace: '#/components/schemas/LakekeeperWarehouseActionAcceptMovedNamespace'
+          activate: '#/components/schemas/LakekeeperWarehouseActionActivate'
+          control_all_tasks: '#/components/schemas/LakekeeperWarehouseActionControlAllTasks'
+          create_namespace: '#/components/schemas/LakekeeperWarehouseActionCreateNamespace'
+          deactivate: '#/components/schemas/LakekeeperWarehouseActionDeactivate'
+          delete: '#/components/schemas/LakekeeperWarehouseActionDelete'
+          get_all_tasks: '#/components/schemas/LakekeeperWarehouseActionGetAllTasks'
+          get_config: '#/components/schemas/LakekeeperWarehouseActionGetConfig'
+          get_endpoint_statistics: '#/components/schemas/LakekeeperWarehouseActionGetEndpointStatistics'
+          get_metadata: '#/components/schemas/LakekeeperWarehouseActionGetMetadata'
+          get_task_queue_config: '#/components/schemas/LakekeeperWarehouseActionGetTaskQueueConfig'
+          include_in_list: '#/components/schemas/LakekeeperWarehouseActionIncludeInList'
+          list_deleted_tabulars: '#/components/schemas/LakekeeperWarehouseActionListDeletedTabulars'
+          list_everything: '#/components/schemas/LakekeeperWarehouseActionListEverything'
+          list_namespaces: '#/components/schemas/LakekeeperWarehouseActionListNamespaces'
+          manage_tags: '#/components/schemas/LakekeeperWarehouseActionManageTags'
+          modify_soft_deletion: '#/components/schemas/LakekeeperWarehouseActionModifySoftDeletion'
+          modify_task_queue_config: '#/components/schemas/LakekeeperWarehouseActionModifyTaskQueueConfig'
+          read_grants: '#/components/schemas/LakekeeperWarehouseActionReadGrants'
+          rename: '#/components/schemas/LakekeeperWarehouseActionRename'
+          set_format_version_policy: '#/components/schemas/LakekeeperWarehouseActionSetFormatVersionPolicy'
+          set_protection: '#/components/schemas/LakekeeperWarehouseActionSetProtection'
+          update_storage: '#/components/schemas/LakekeeperWarehouseActionUpdateStorage'
+          use: '#/components/schemas/LakekeeperWarehouseActionUse'
+    LakekeeperWarehouseActionAcceptMovedNamespace:
+      type: object
+      description: |-
+        Accept a namespace being moved in from elsewhere as a child of this entity.
+
+        Distinct from `CreateNamespace`: creating adds an *empty* child, so exposing it to
+        this subtree's grantees exposes nothing. A move arrives carrying existing contents
+        and their direct grants, which is why this is gated on grant authority in addition to
+        `create` — without it, a namespace could be populated and granted somewhere
+        permissive and then moved into a `managed_access` subtree, smuggling grants past the
+        control that subtree exists to enforce.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - accept_moved_namespace
+        source:
+          type: array
+          items:
+            type: string
+          description: Path the namespace is being moved from.
+    LakekeeperWarehouseActionActivate:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - activate
+    LakekeeperWarehouseActionControlAllTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - control_all_tasks
+    LakekeeperWarehouseActionCreateNamespace:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_namespace
+        name:
+          type:
+            - string
+            - 'null'
+          description: Name of the namespace to create.
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+          propertyNames:
+            type: string
+    LakekeeperWarehouseActionDeactivate:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - deactivate
+    LakekeeperWarehouseActionDelete:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete
+    LakekeeperWarehouseActionGetAllTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_all_tasks
+    LakekeeperWarehouseActionGetConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_config
+    LakekeeperWarehouseActionGetEndpointStatistics:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_endpoint_statistics
+    LakekeeperWarehouseActionGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperWarehouseActionGetTaskQueueConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_task_queue_config
+    LakekeeperWarehouseActionIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
     LakekeeperWarehouseActionKind:
       oneOf:
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - create_namespace
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - delete
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update_storage
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - update_storage_credential
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_metadata
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_namespaces
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_everything
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - use
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - include_in_list
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - deactivate
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - activate
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - rename
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - list_deleted_tabulars
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - modify_soft_deletion
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_task_queue_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - modify_task_queue_config
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_all_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - control_all_tasks
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_protection
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - set_format_version_policy
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - get_endpoint_statistics
-        - type: object
-          required:
-            - action
-          properties:
-            action:
-              type: string
-              enum:
-                - manage_tags
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindCreateNamespace'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindDelete'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindUpdateStorage'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindGetMetadata'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindGetConfig'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindListNamespaces'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindListEverything'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindUse'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindIncludeInList'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindDeactivate'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindActivate'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindRename'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindListDeletedTabulars'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindModifySoftDeletion'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindGetTaskQueueConfig'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindModifyTaskQueueConfig'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindGetAllTasks'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindControlAllTasks'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindSetProtection'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindSetFormatVersionPolicy'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindGetEndpointStatistics'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindManageTags'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindAcceptMovedNamespace'
+        - $ref: '#/components/schemas/LakekeeperWarehouseActionKindReadGrants'
+      discriminator:
+        propertyName: action
+        mapping:
+          accept_moved_namespace: '#/components/schemas/LakekeeperWarehouseActionKindAcceptMovedNamespace'
+          activate: '#/components/schemas/LakekeeperWarehouseActionKindActivate'
+          control_all_tasks: '#/components/schemas/LakekeeperWarehouseActionKindControlAllTasks'
+          create_namespace: '#/components/schemas/LakekeeperWarehouseActionKindCreateNamespace'
+          deactivate: '#/components/schemas/LakekeeperWarehouseActionKindDeactivate'
+          delete: '#/components/schemas/LakekeeperWarehouseActionKindDelete'
+          get_all_tasks: '#/components/schemas/LakekeeperWarehouseActionKindGetAllTasks'
+          get_config: '#/components/schemas/LakekeeperWarehouseActionKindGetConfig'
+          get_endpoint_statistics: '#/components/schemas/LakekeeperWarehouseActionKindGetEndpointStatistics'
+          get_metadata: '#/components/schemas/LakekeeperWarehouseActionKindGetMetadata'
+          get_task_queue_config: '#/components/schemas/LakekeeperWarehouseActionKindGetTaskQueueConfig'
+          include_in_list: '#/components/schemas/LakekeeperWarehouseActionKindIncludeInList'
+          list_deleted_tabulars: '#/components/schemas/LakekeeperWarehouseActionKindListDeletedTabulars'
+          list_everything: '#/components/schemas/LakekeeperWarehouseActionKindListEverything'
+          list_namespaces: '#/components/schemas/LakekeeperWarehouseActionKindListNamespaces'
+          manage_tags: '#/components/schemas/LakekeeperWarehouseActionKindManageTags'
+          modify_soft_deletion: '#/components/schemas/LakekeeperWarehouseActionKindModifySoftDeletion'
+          modify_task_queue_config: '#/components/schemas/LakekeeperWarehouseActionKindModifyTaskQueueConfig'
+          read_grants: '#/components/schemas/LakekeeperWarehouseActionKindReadGrants'
+          rename: '#/components/schemas/LakekeeperWarehouseActionKindRename'
+          set_format_version_policy: '#/components/schemas/LakekeeperWarehouseActionKindSetFormatVersionPolicy'
+          set_protection: '#/components/schemas/LakekeeperWarehouseActionKindSetProtection'
+          update_storage: '#/components/schemas/LakekeeperWarehouseActionKindUpdateStorage'
+          use: '#/components/schemas/LakekeeperWarehouseActionKindUse'
+    LakekeeperWarehouseActionKindAcceptMovedNamespace:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - accept_moved_namespace
+    LakekeeperWarehouseActionKindActivate:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - activate
+    LakekeeperWarehouseActionKindControlAllTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - control_all_tasks
+    LakekeeperWarehouseActionKindCreateNamespace:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - create_namespace
+    LakekeeperWarehouseActionKindDeactivate:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - deactivate
+    LakekeeperWarehouseActionKindDelete:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - delete
+    LakekeeperWarehouseActionKindGetAllTasks:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_all_tasks
+    LakekeeperWarehouseActionKindGetConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_config
+    LakekeeperWarehouseActionKindGetEndpointStatistics:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_endpoint_statistics
+    LakekeeperWarehouseActionKindGetMetadata:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_metadata
+    LakekeeperWarehouseActionKindGetTaskQueueConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - get_task_queue_config
+    LakekeeperWarehouseActionKindIncludeInList:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - include_in_list
+    LakekeeperWarehouseActionKindListDeletedTabulars:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_deleted_tabulars
+    LakekeeperWarehouseActionKindListEverything:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_everything
+    LakekeeperWarehouseActionKindListNamespaces:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_namespaces
+    LakekeeperWarehouseActionKindManageTags:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_tags
+    LakekeeperWarehouseActionKindModifySoftDeletion:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - modify_soft_deletion
+    LakekeeperWarehouseActionKindModifyTaskQueueConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - modify_task_queue_config
+    LakekeeperWarehouseActionKindReadGrants:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperWarehouseActionKindRename:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - rename
+    LakekeeperWarehouseActionKindSetFormatVersionPolicy:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_format_version_policy
+    LakekeeperWarehouseActionKindSetProtection:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_protection
+    LakekeeperWarehouseActionKindUpdateStorage:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update_storage
+    LakekeeperWarehouseActionKindUse:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - use
+    LakekeeperWarehouseActionListDeletedTabulars:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_deleted_tabulars
+    LakekeeperWarehouseActionListEverything:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_everything
+    LakekeeperWarehouseActionListNamespaces:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - list_namespaces
+    LakekeeperWarehouseActionManageTags:
+      type: object
+      description: Attach/detach governance tags on this warehouse.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - manage_tags
+    LakekeeperWarehouseActionModifySoftDeletion:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - modify_soft_deletion
+    LakekeeperWarehouseActionModifyTaskQueueConfig:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - modify_task_queue_config
+    LakekeeperWarehouseActionReadGrants:
+      type: object
+      description: Can list the grants held on this warehouse.
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - read_grants
+    LakekeeperWarehouseActionRename:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - rename
+    LakekeeperWarehouseActionSetFormatVersionPolicy:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_format_version_policy
+    LakekeeperWarehouseActionSetProtection:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - set_protection
+    LakekeeperWarehouseActionUpdateStorage:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - update_storage
+    LakekeeperWarehouseActionUse:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - use
     LicenseStatus:
       type: object
       description: Status of license validation
@@ -9928,6 +13260,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CedarPolicySourceInfo'
+    ListColumnTagsResponse:
+      type: object
+      description: |-
+        Every column of a table that carries at least one tag, each with its direct tags;
+        columns without tags are omitted. Column tags are never inherited, so this is a
+        direct-only listing (no effective view).
+      required:
+        - columns
+      properties:
+        columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/ColumnTags'
     ListDeletedTabularsResponse:
       type: object
       required:
@@ -9943,6 +13288,32 @@ components:
           items:
             $ref: '#/components/schemas/DeletedTabularResponse'
           description: List of tabulars
+    ListGrantsResponse:
+      type: object
+      description: |-
+        A page of grants.
+
+        The order is **unspecified** and differs by authorizer, so do not rely on it. Use the
+        page token to walk a listing, and sort client-side if you need a stable presentation.
+      required:
+        - grants
+      properties:
+        grants:
+          type: array
+          items:
+            $ref: '#/components/schemas/GrantResponse'
+        next-page-token:
+          type:
+            - string
+            - 'null'
+          description: |-
+            Present when another page may follow. Follow the token until it is **absent**:
+            depending on the authorizer, a page can come back short or even empty while
+            more grants remain, so neither a short page nor an empty one signals the end.
+
+            The project-scoped listing pages like the rest, but only where grants live in
+            the catalog. An authorizer that owns its grants may not implement that listing
+            at all — see its `501` response.
     ListProjectTasksRequest:
       type: object
       properties:
@@ -10211,6 +13582,52 @@ components:
       enum:
         - self-managed
         - instance-admin
+    MoveNamespaceRequest:
+      type: object
+      description: Request to move a namespace to a new location in the hierarchy.
+      required:
+        - destination
+      properties:
+        destination:
+          type: array
+          items:
+            type: string
+          description: |-
+            Full new path of the namespace, including its new name as the last element.
+
+            The preceding elements identify the new parent; a single-element destination moves the
+            namespace to the warehouse root. Must not be empty. Renaming in place is expressed by
+            keeping the same parent and changing only the last element. Mirrors the `destination`
+            of Iceberg REST rename-table request.
+
+            A destination equal to the namespace's current path succeeds without changing
+            anything, so retrying a request that already went through is safe.
+        force:
+          type: boolean
+          description: Move the namespace even if it is protected.
+      additionalProperties: false
+    MoveNamespaceResponse:
+      type: object
+      description: The namespace after a successful move.
+      required:
+        - namespace
+        - namespace-id
+      properties:
+        namespace:
+          type: array
+          items:
+            type: string
+          description: The namespace's new path.
+        namespace-id:
+          type: string
+          format: uuid
+          description: Unchanged by the move; returned so callers can confirm identity.
+        parent-namespace-id:
+          type:
+            - string
+            - 'null'
+          format: uuid
+          description: Id of the new parent namespace, or `null` if the namespace is now top-level.
     NamespaceAction:
       type: string
       enum:
@@ -10219,6 +13636,8 @@ components:
         - create_generic_table
         - create_namespace
         - delete
+        - move
+        - accept_moved_namespace
         - update_properties
         - get_metadata
         - read_assignments
@@ -10228,89 +13647,121 @@ components:
         - grant_select
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - set_protection
     NamespaceAssignment:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - ownership
-          title: NamespaceAssignmentOwnership
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - pass_grants
-          title: NamespaceAssignmentPassGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - manage_grants
-          title: NamespaceAssignmentManageGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - describe
-          title: NamespaceAssignmentDescribe
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - select
-          title: NamespaceAssignmentSelect
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - create
-          title: NamespaceAssignmentCreate
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - modify
-          title: NamespaceAssignmentModify
+        - $ref: '#/components/schemas/NamespaceAssignmentOwnership'
+        - $ref: '#/components/schemas/NamespaceAssignmentPassGrants'
+        - $ref: '#/components/schemas/NamespaceAssignmentManageGrants'
+        - $ref: '#/components/schemas/NamespaceAssignmentDescribe'
+        - $ref: '#/components/schemas/NamespaceAssignmentSelect'
+        - $ref: '#/components/schemas/NamespaceAssignmentCreate'
+        - $ref: '#/components/schemas/NamespaceAssignmentModify'
+        - $ref: '#/components/schemas/NamespaceAssignmentManageTags'
+      discriminator:
+        propertyName: type
+        mapping:
+          create: '#/components/schemas/NamespaceAssignmentCreate'
+          describe: '#/components/schemas/NamespaceAssignmentDescribe'
+          manage_grants: '#/components/schemas/NamespaceAssignmentManageGrants'
+          manage_tags: '#/components/schemas/NamespaceAssignmentManageTags'
+          modify: '#/components/schemas/NamespaceAssignmentModify'
+          ownership: '#/components/schemas/NamespaceAssignmentOwnership'
+          pass_grants: '#/components/schemas/NamespaceAssignmentPassGrants'
+          select: '#/components/schemas/NamespaceAssignmentSelect'
+    NamespaceAssignmentCreate:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - create
+    NamespaceAssignmentDescribe:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - describe
+    NamespaceAssignmentManageGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_grants
+    NamespaceAssignmentManageTags:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_tags
+    NamespaceAssignmentModify:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - modify
+    NamespaceAssignmentOwnership:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - ownership
+    NamespaceAssignmentPassGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - pass_grants
+    NamespaceAssignmentSelect:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - select
     NamespaceIdentOrUuid:
       oneOf:
         - type: object
+          title: NamespaceIdentOrUuidById
           required:
             - namespace-id
             - warehouse-id
@@ -10322,6 +13773,7 @@ components:
               type: string
               format: uuid
         - type: object
+          title: NamespaceIdentOrUuidByName
           required:
             - namespace
             - warehouse-id
@@ -10344,6 +13796,7 @@ components:
         - select
         - create
         - modify
+        - manage_tags
     OneLakeProfile:
       type: object
       description: |-
@@ -10407,6 +13860,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -10421,11 +13875,13 @@ components:
         - grant_select
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
     OpenFGAProjectAction:
       type: string
       enum:
         - read_assignments
         - grant_role_creator
+        - grant_tag_creator
         - grant_create
         - grant_describe
         - grant_modify
@@ -10451,6 +13907,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -10461,6 +13918,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -10475,7 +13933,45 @@ components:
         - grant_select
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - change_ownership
+    PrivilegeDescriptor:
+      type: object
+      description: One grantable privilege, as published by an authorizer for discovery.
+      required:
+        - name
+        - display-name
+        - resource-type
+      properties:
+        category:
+          type:
+            - string
+            - 'null'
+          description: |-
+            Which group of privileges this one belongs to, so a picker can lay out columns
+            instead of one long list.
+
+            Authorizer-supplied and open, because the vocabulary it groups is too. Treat an
+            unrecognized value as its own group rather than an error, and `null` as
+            ungrouped. Lakekeeper's own authorizers use `metadata`, `read`, `write`,
+            `create`, `security` and `administration`; a client that wants a fixed column
+            order should key off those and fall back for anything else.
+        description:
+          type:
+            - string
+            - 'null'
+          description: |-
+            What the privilege permits, when the authorizer supplies an explanation.
+            `null` rather than a guess: a wrong description of a permission is worse than
+            none, so an authorizer that has not written one reports nothing.
+        display-name:
+          type: string
+          description: Short human-readable label for pickers.
+        name:
+          type: string
+          description: The name to send back in a grant request.
+        resource-type:
+          $ref: '#/components/schemas/ResourceType'
     ProjectAction:
       type: string
       enum:
@@ -10488,6 +13984,7 @@ components:
         - search_roles
         - read_assignments
         - grant_role_creator
+        - grant_tag_creator
         - grant_create
         - grant_describe
         - grant_modify
@@ -10498,94 +13995,126 @@ components:
         - get_endpoint_statistics
     ProjectAssignment:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - project_admin
-          title: ProjectAssignmentProjectAdmin
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - security_admin
-          title: ProjectAssignmentSecurityAdmin
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - data_admin
-          title: ProjectAssignmentDataAdmin
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - role_creator
-          title: ProjectAssignmentRoleCreator
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - describe
-          title: ProjectAssignmentDescribe
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - select
-          title: ProjectAssignmentSelect
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - create
-          title: ProjectAssignmentCreate
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - modify
-          title: ProjectAssignmentModify
+        - $ref: '#/components/schemas/ProjectAssignmentProjectAdmin'
+        - $ref: '#/components/schemas/ProjectAssignmentSecurityAdmin'
+        - $ref: '#/components/schemas/ProjectAssignmentDataAdmin'
+        - $ref: '#/components/schemas/ProjectAssignmentRoleCreator'
+        - $ref: '#/components/schemas/ProjectAssignmentTagCreator'
+        - $ref: '#/components/schemas/ProjectAssignmentDescribe'
+        - $ref: '#/components/schemas/ProjectAssignmentSelect'
+        - $ref: '#/components/schemas/ProjectAssignmentCreate'
+        - $ref: '#/components/schemas/ProjectAssignmentModify'
+      discriminator:
+        propertyName: type
+        mapping:
+          create: '#/components/schemas/ProjectAssignmentCreate'
+          data_admin: '#/components/schemas/ProjectAssignmentDataAdmin'
+          describe: '#/components/schemas/ProjectAssignmentDescribe'
+          modify: '#/components/schemas/ProjectAssignmentModify'
+          project_admin: '#/components/schemas/ProjectAssignmentProjectAdmin'
+          role_creator: '#/components/schemas/ProjectAssignmentRoleCreator'
+          security_admin: '#/components/schemas/ProjectAssignmentSecurityAdmin'
+          select: '#/components/schemas/ProjectAssignmentSelect'
+          tag_creator: '#/components/schemas/ProjectAssignmentTagCreator'
+    ProjectAssignmentCreate:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - create
+    ProjectAssignmentDataAdmin:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - data_admin
+    ProjectAssignmentDescribe:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - describe
+    ProjectAssignmentModify:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - modify
+    ProjectAssignmentProjectAdmin:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - project_admin
+    ProjectAssignmentRoleCreator:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - role_creator
+    ProjectAssignmentSecurityAdmin:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - security_admin
+    ProjectAssignmentSelect:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - select
+    ProjectAssignmentTagCreator:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - tag_creator
     ProjectRelation:
       type: string
       enum:
@@ -10593,6 +14122,7 @@ components:
         - security_admin
         - data_admin
         - role_creator
+        - tag_creator
         - describe
         - select
         - create
@@ -10823,6 +14353,54 @@ components:
           type: integer
           description: Total number of entities resolved.
           minimum: 0
+    ResourceGrantablePrivilegesResponse:
+      type: object
+      description: |-
+        This resource's whole vocabulary, each entry marked with whether the principal may
+        grant it.
+
+        The deployment-wide vocabulary answers "what does this server understand"; this
+        answers "what may I do here", which is the question a grant dialog asks. Grant
+        authority is a right of its own, invisible to action introspection, so neither
+        `.../actions` nor the vocabulary can substitute for it.
+
+        Deliberately **not** filtered to the permitted subset — unlike `allowed-actions` on
+        the action-introspection endpoints. A picker chooses from a closed, published set, so
+        a silently shortened list reads as a missing privilege rather than a withheld one;
+        the caller needs to render `ownership` greyed out, not to wonder where it went.
+        Nothing is disclosed by listing them: the same names are public at
+        `/management/v1/grants/grantable-privileges`.
+      required:
+        - privileges
+      properties:
+        privileges:
+          type: array
+          items:
+            $ref: '#/components/schemas/GrantablePrivilege'
+          description: Every privilege this resource level publishes, in the authorizer's own order.
+    ResourceType:
+      type: string
+      description: |-
+        The kinds of resource a grant can be held on.
+
+        Every value is also the URL segment that addresses that kind of resource, so a
+        client can build request paths straight from a vocabulary response. Kept link-free:
+        this doc comment is published verbatim in the `OpenAPI` description, where an
+        intra-doc link would render as a raw Rust module path.
+
+        This is the vocabulary the API speaks. A store is free to persist a coarser one —
+        tables, views and generic tables are one kind to a catalog that already records
+        which of the three an id refers to — so this deliberately carries no storage
+        mapping.
+      enum:
+        - server
+        - project
+        - warehouse
+        - namespace
+        - table
+        - view
+        - generic-table
+        - tag-definition
     Role:
       type: object
       required:
@@ -10882,97 +14460,122 @@ components:
         - read_assignments
     RoleAssignment:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - assignee
-          title: RoleAssignmentAssignee
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - ownership
-          title: RoleAssignmentOwnership
+        - $ref: '#/components/schemas/RoleAssignmentAssignee'
+        - $ref: '#/components/schemas/RoleAssignmentOwnership'
+      discriminator:
+        propertyName: type
+        mapping:
+          assignee: '#/components/schemas/RoleAssignmentAssignee'
+          ownership: '#/components/schemas/RoleAssignmentOwnership'
+    RoleAssignmentAssignee:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - assignee
+    RoleAssignmentOwnership:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - ownership
     RoleMember:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserMembership'
-              description: A user assigned to the role.
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - user
-          description: A user assigned to the role.
-        - allOf:
-            - $ref: '#/components/schemas/RoleMembership'
-              description: Another role that is a member of the role.
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - role
-          description: Another role that is a member of the role.
+        - $ref: '#/components/schemas/RoleMemberUser'
+        - $ref: '#/components/schemas/RoleMemberRole'
       description: |-
         A member of a role, returned by `GET /role/{id}/members`. Discriminated by
         `type`: a `user` (direct user→role assignment) or a `role` (role→role edge).
         Identity is hydrated; for requests and add confirmations use the
         un-hydrated [`RoleMemberRef`] instead.
+      discriminator:
+        propertyName: type
+        mapping:
+          role: '#/components/schemas/RoleMemberRole'
+          user: '#/components/schemas/RoleMemberUser'
     RoleMemberRef:
       oneOf:
-        - type: object
-          description: A user, by `IdP` subject id.
-          required:
-            - id
-            - type
-          properties:
-            id:
-              type: string
-            type:
-              type: string
-              enum:
-                - user
-        - type: object
-          description: A role, by id.
-          required:
-            - id
-            - type
-          properties:
-            id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - role
+        - $ref: '#/components/schemas/RoleMemberRefUser'
+        - $ref: '#/components/schemas/RoleMemberRefRole'
       description: |-
         An identity reference to a role member — a `user` or a `role`, by typed id.
         Sent in `POST /role/{id}/members` requests and echoed by the add confirmation
         (remove returns `204` with no body). Unlike [`RoleMember`] it is never hydrated
         (no display name): it names *which* principal, not its display identity.
+      discriminator:
+        propertyName: type
+        mapping:
+          role: '#/components/schemas/RoleMemberRefRole'
+          user: '#/components/schemas/RoleMemberRefUser'
+    RoleMemberRefRole:
+      type: object
+      description: A role, by id.
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - role
+    RoleMemberRefUser:
+      type: object
+      description: A user, by `IdP` subject id.
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum:
+            - user
+    RoleMemberRole:
+      allOf:
+        - $ref: '#/components/schemas/RoleMembership'
+          description: Another role that is a member of the role.
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - role
+      description: Another role that is a member of the role.
     RoleMemberType:
       type: string
       description: Kind of a role member. Serializes as `"user"` / `"role"`.
       enum:
         - user
         - role
+    RoleMemberUser:
+      allOf:
+        - $ref: '#/components/schemas/UserMembership'
+          description: A user assigned to the role.
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - user
+      description: A user assigned to the role.
     RoleMembership:
       type: object
       description: |-
@@ -11090,6 +14693,7 @@ components:
                   type: string
                   enum:
                     - access-key
+          title: S3CredentialAccessKey
           description: Authenticate to AWS using access-key and secret-key.
         - allOf:
             - $ref: '#/components/schemas/S3AwsSystemIdentityCredential'
@@ -11104,6 +14708,7 @@ components:
                   type: string
                   enum:
                     - aws-system-identity
+          title: S3CredentialAwsSystemIdentity
           description: |-
             Authenticate to AWS using the identity configured on the system
              that runs lakekeeper. The AWS SDK is used to load the credentials.
@@ -11117,6 +14722,7 @@ components:
                   type: string
                   enum:
                     - cloudflare-r2
+          title: S3CredentialCloudflareR2
         - allOf:
             - $ref: '#/components/schemas/S3AccessKeyCredential'
               description: |-
@@ -11133,6 +14739,7 @@ components:
                   type: string
                   enum:
                     - aliyun-oss
+          title: S3CredentialAliyunOss
           description: |-
             **Beta:** Alibaba Cloud OSS support is in beta. The API and behavior may change in a
             future release.
@@ -11487,28 +15094,35 @@ components:
         - read_assignments
     ServerAssignment:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - admin
-          title: ServerAssignmentAdmin
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - operator
-          title: ServerAssignmentOperator
+        - $ref: '#/components/schemas/ServerAssignmentAdmin'
+        - $ref: '#/components/schemas/ServerAssignmentOperator'
+      discriminator:
+        propertyName: type
+        mapping:
+          admin: '#/components/schemas/ServerAssignmentAdmin'
+          operator: '#/components/schemas/ServerAssignmentOperator'
+    ServerAssignmentAdmin:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - admin
+    ServerAssignmentOperator:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - operator
     ServerInfo:
       type: object
       required:
@@ -11696,6 +15310,118 @@ components:
     SoftDeletionQueueConfig:
       type: object
       description: Warehouse-specific configuration for the soft-deletion (tabular expiration) queue.
+    StackitAccessKeyCredential:
+      type: object
+      title: StackitCredentialAccessKey
+      required:
+        - access-key-id
+        - secret-access-key
+      properties:
+        access-key-id:
+          type: string
+          description: Access key ID of a key created in the STACKIT credentials group.
+        secret-access-key:
+          type: string
+          description: Secret shown once when the access key was created.
+    StackitCredential:
+      oneOf:
+        - allOf:
+            - $ref: '#/components/schemas/StackitAccessKeyCredential'
+              description: Access key and secret, created inside a STACKIT credentials group.
+            - type: object
+              required:
+                - credential-type
+              properties:
+                credential-type:
+                  type: string
+                  enum:
+                    - access-key
+          title: StackitCredentialAccessKey
+          description: Access key and secret, created inside a STACKIT credentials group.
+      description: |-
+        Credentials for STACKIT Object Storage.
+
+        Its own enum rather than a reuse of `S3Credential`, so STACKIT can gain
+        authentication methods without inheriting AWS-only ones.
+    StackitCredentialType:
+      type: string
+      description: The type of STACKIT credential.
+      enum:
+        - access-key
+    StackitProfile:
+      type: object
+      description: Storage profile for STACKIT Object Storage.
+      required:
+        - bucket
+        - region
+      properties:
+        bucket:
+          type: string
+          description: |-
+            Name of the STACKIT bucket.
+
+            Must not contain `.`: STACKIT addresses buckets as a subdomain of the
+            endpoint, and its wildcard certificate covers only a single label.
+        credentials-group-urn:
+          type:
+            - string
+            - 'null'
+          description: |-
+            URN of the STACKIT credentials group to assume when vending credentials,
+            e.g. `urn:sgws:identity::87066461224079950546:group/credentials-group-a1b2c3`.
+
+            Copy it verbatim from the credentials group; it is not derivable.
+            Required when `sts-enabled` is true, optional otherwise — but validated
+            whenever it is present.
+        endpoint:
+          type:
+            - string
+            - 'null'
+          format: uri
+          description: |-
+            Endpoint override. Normally omitted — the endpoint is derived from
+            `region`.
+
+            Set this only for a STACKIT endpoint outside the public naming scheme,
+            which STACKIT hands out per customer. Such an endpoint is a distinct
+            storage tenant, not another route to the same bucket, so it is immutable
+            once the warehouse exists.
+        key-prefix:
+          type:
+            - string
+            - 'null'
+          description: Subpath within the bucket to use.
+        push-s3-delete-disabled:
+          type: boolean
+          description: |-
+            Push `s3.delete-enabled=false` to clients, discouraging Spark from
+            deleting files directly and bypassing soft-deletion. Defaults to true.
+        region:
+          type: string
+          description: STACKIT region, e.g. `eu01`.
+        remote-signing-enabled:
+          type: boolean
+          description: |-
+            Allow clients to have Lakekeeper sign their S3 requests. Defaults to
+            enabled, and is the only client path when `sts-enabled` is false.
+        storage-layout:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/StorageLayout'
+              description: Storage layout for namespace and tabular paths.
+        sts-enabled:
+          type: boolean
+          description: |-
+            Vend temporary downscoped credentials via STS. Defaults to enabled.
+
+            Requires `credentials-group-urn`, and requires the credentials group to
+            carry a trust policy allowing `sts:AssumeRole`. Disable it to fall back
+            to remote signing on storage that predates `StorageGRID` 12.0.
+        sts-token-validity-seconds:
+          type: integer
+          format: int64
+          description: Validity of vended credentials in seconds. Defaults to 3600.
+          minimum: 0
     StorageCredential:
       oneOf:
         - allOf:
@@ -11735,6 +15461,45 @@ components:
                 "credential-type": "access-key",
                 "access-key-id": "minio-root-user",
                 "secret-access-key": "minio-root-password"
+              }"#).unwrap();
+            ```
+        - allOf:
+            - $ref: '#/components/schemas/StackitCredential'
+              description: |-
+                Credentials for STACKIT Object Storage.
+
+                Example payload:
+
+                ```
+                use lakekeeper::service::storage::StorageCredential;
+                let cred: StorageCredential = serde_json::from_str(r#"{
+                    "type": "stackit",
+                    "credential-type": "access-key",
+                    "access-key-id": "...",
+                    "secret-access-key": "..."
+                  }"#).unwrap();
+                ```
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - stackit
+          title: StorageCredentialStackit
+          description: |-
+            Credentials for STACKIT Object Storage.
+
+            Example payload:
+
+            ```
+            use lakekeeper::service::storage::StorageCredential;
+            let cred: StorageCredential = serde_json::from_str(r#"{
+                "type": "stackit",
+                "credential-type": "access-key",
+                "access-key-id": "...",
+                "secret-access-key": "..."
               }"#).unwrap();
             ```
         - allOf:
@@ -11842,80 +15607,83 @@ components:
       description: Storage secret for a warehouse.
     StorageCredentialType:
       oneOf:
-        - type: object
-          description: S3 credential type
-          required:
-            - credential-type
-            - type
-          properties:
-            credential-type:
-              $ref: '#/components/schemas/S3CredentialType'
-              description: S3 credential type
-            type:
-              type: string
-              enum:
-                - s3
-        - type: object
-          description: Azure credential type
-          required:
-            - credential-type
-            - type
-          properties:
-            credential-type:
-              $ref: '#/components/schemas/AzCredentialType'
-              description: Azure credential type
-            type:
-              type: string
-              enum:
-                - az
-        - type: object
-          description: GCS credential type
-          required:
-            - credential-type
-            - type
-          properties:
-            credential-type:
-              $ref: '#/components/schemas/GcsCredentialType'
-              description: GCS credential type
-            type:
-              type: string
-              enum:
-                - gcs
+        - $ref: '#/components/schemas/StorageCredentialTypeS3'
+        - $ref: '#/components/schemas/StorageCredentialTypeAz'
+        - $ref: '#/components/schemas/StorageCredentialTypeGcs'
+        - $ref: '#/components/schemas/StorageCredentialTypeStackit'
       description: |-
         The type of storage credential configured for a warehouse, without secret values.
 
         This is returned in API responses so clients know which credential type
         was selected (e.g. to restore radio button state in the UI).
+      discriminator:
+        propertyName: type
+        mapping:
+          az: '#/components/schemas/StorageCredentialTypeAz'
+          gcs: '#/components/schemas/StorageCredentialTypeGcs'
+          s3: '#/components/schemas/StorageCredentialTypeS3'
+          stackit: '#/components/schemas/StorageCredentialTypeStackit'
+    StorageCredentialTypeAz:
+      type: object
+      description: Azure credential type
+      required:
+        - credential-type
+        - type
+      properties:
+        credential-type:
+          $ref: '#/components/schemas/AzCredentialType'
+          description: Azure credential type
+        type:
+          type: string
+          enum:
+            - az
+    StorageCredentialTypeGcs:
+      type: object
+      description: GCS credential type
+      required:
+        - credential-type
+        - type
+      properties:
+        credential-type:
+          $ref: '#/components/schemas/GcsCredentialType'
+          description: GCS credential type
+        type:
+          type: string
+          enum:
+            - gcs
+    StorageCredentialTypeS3:
+      type: object
+      description: S3 credential type
+      required:
+        - credential-type
+        - type
+      properties:
+        credential-type:
+          $ref: '#/components/schemas/S3CredentialType'
+          description: S3 credential type
+        type:
+          type: string
+          enum:
+            - s3
+    StorageCredentialTypeStackit:
+      type: object
+      description: STACKIT credential type
+      required:
+        - credential-type
+        - type
+      properties:
+        credential-type:
+          $ref: '#/components/schemas/StackitCredentialType'
+          description: STACKIT credential type
+        type:
+          type: string
+          enum:
+            - stackit
     StorageLayout:
       oneOf:
-        - type: object
-          required:
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - default
-        - allOf:
-            - $ref: '#/components/schemas/StorageLayoutFlat'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - tabular-only
-        - allOf:
-            - $ref: '#/components/schemas/StorageLayoutFullHierarchy'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - full-hierarchy
+        - $ref: '#/components/schemas/StorageLayoutDefault'
+        - $ref: '#/components/schemas/StorageLayoutTabularOnly'
+        - $ref: '#/components/schemas/StorageLayoutFullHierarchyVariant'
       description: |-
         Controls how namespace and tabular paths are constructed under the warehouse base location.
 
@@ -11933,6 +15701,21 @@ components:
         type: full-hierarchy
         namespace: '{name}-{uuid}'
         tabular: '{name}-{uuid}'
+      discriminator:
+        propertyName: type
+        mapping:
+          default: '#/components/schemas/StorageLayoutDefault'
+          full-hierarchy: '#/components/schemas/StorageLayoutFullHierarchyVariant'
+          tabular-only: '#/components/schemas/StorageLayoutTabularOnly'
+    StorageLayoutDefault:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - default
     StorageLayoutFlat:
       type: object
       description: |-
@@ -11965,77 +15748,129 @@ components:
       example:
         namespace: '{name}-{uuid}'
         tabular: '{name}-{uuid}'
+    StorageLayoutFullHierarchyVariant:
+      allOf:
+        - $ref: '#/components/schemas/StorageLayoutFullHierarchy'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - full-hierarchy
     StorageLayoutNamespaceTemplate:
       type: string
       description: 'Template string for namespace path segments. Placeholders {uuid} and {name} (with curly braces) will be replaced with the actual namespace UUID and name respectively. The {name} value is percent-encoded (URL percent-encoding) so spaces and special characters are escaped (e.g. "my name" becomes "my%20name"). The {uuid} value is inserted as-is without encoding. Example: "{name}-{uuid}" for a namespace named "my ns" renders to "my%20ns-550e8400-e29b-41d4-a716-446655440001".'
       example: '{uuid}'
+    StorageLayoutTabularOnly:
+      allOf:
+        - $ref: '#/components/schemas/StorageLayoutFlat'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - tabular-only
     StorageLayoutTabularTemplate:
       type: string
       description: 'Template string for tabular names. Placeholders {uuid} and {name} (with curly braces) will be replaced with the actual tabular UUID and name respectively. The {name} value is percent-encoded (URL percent-encoding) so spaces and special characters are escaped (e.g. "my tabular" becomes "my%20tabular"). The {uuid} value is inserted as-is without encoding. Example: "{name}-{uuid}" for a tabular named "my tabular" renders to "my%20tabular-550e8400-e29b-41d4-a716-446655440002".'
       example: '{uuid}'
     StorageProfile:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/AdlsProfile'
-              description: |-
-                Generic Azure Data Lake Storage Gen2 profile. Speaks ADLS Gen2 against
-                any storage account.
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - adls
-          title: StorageProfileAdls
+        - $ref: '#/components/schemas/StorageProfileAdls'
+        - $ref: '#/components/schemas/StorageProfileOneLake'
+        - $ref: '#/components/schemas/StorageProfileS3'
+        - $ref: '#/components/schemas/StorageProfileStackit'
+        - $ref: '#/components/schemas/StorageProfileGcs'
+      description: Storage profile for a warehouse.
+      discriminator:
+        propertyName: type
+        mapping:
+          adls: '#/components/schemas/StorageProfileAdls'
+          gcs: '#/components/schemas/StorageProfileGcs'
+          onelake: '#/components/schemas/StorageProfileOneLake'
+          s3: '#/components/schemas/StorageProfileS3'
+          stackit: '#/components/schemas/StorageProfileStackit'
+    StorageProfileAdls:
+      allOf:
+        - $ref: '#/components/schemas/AdlsProfile'
           description: |-
             Generic Azure Data Lake Storage Gen2 profile. Speaks ADLS Gen2 against
             any storage account.
-        - allOf:
-            - $ref: '#/components/schemas/OneLakeProfile'
-              description: |-
-                `OneLake` (Microsoft Fabric) profile. Knows how to construct `OneLake`
-                URLs from workspace + lakehouse IDs and how to derive the
-                workspace-private-link endpoint host.
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - onelake
-          title: StorageProfileOneLake
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - adls
+      description: |-
+        Generic Azure Data Lake Storage Gen2 profile. Speaks ADLS Gen2 against
+        any storage account.
+    StorageProfileGcs:
+      allOf:
+        - $ref: '#/components/schemas/GcsProfile'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - gcs
+    StorageProfileOneLake:
+      allOf:
+        - $ref: '#/components/schemas/OneLakeProfile'
           description: |-
             `OneLake` (Microsoft Fabric) profile. Knows how to construct `OneLake`
             URLs from workspace + lakehouse IDs and how to derive the
             workspace-private-link endpoint host.
-        - allOf:
-            - $ref: '#/components/schemas/S3Profile'
-              description: S3 storage profile
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - s3
-          title: StorageProfileS3
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - onelake
+      description: |-
+        `OneLake` (Microsoft Fabric) profile. Knows how to construct `OneLake`
+        URLs from workspace + lakehouse IDs and how to derive the
+        workspace-private-link endpoint host.
+    StorageProfileS3:
+      allOf:
+        - $ref: '#/components/schemas/S3Profile'
           description: S3 storage profile
-        - allOf:
-            - $ref: '#/components/schemas/GcsProfile'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - gcs
-          title: StorageProfileGcs
-      description: Storage profile for a warehouse.
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - s3
+      description: S3 storage profile
+    StorageProfileStackit:
+      allOf:
+        - $ref: '#/components/schemas/StackitProfile'
+          description: |-
+            STACKIT Object Storage. S3 over `NetApp` `StorageGRID`, with a reduced knob
+            set and STACKIT's own endpoint derivation and credentials-group STS.
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - stackit
+      description: |-
+        STACKIT Object Storage. S3 over `NetApp` `StorageGRID`, with a reduced knob
+        set and STACKIT's own endpoint derivation and credentials-group STS.
     TableAction:
       type: string
       enum:
@@ -12048,6 +15883,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -12057,72 +15893,100 @@ components:
         - set_protection
     TableAssignment:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - ownership
-          title: TableAssignmentOwnership
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - pass_grants
-          title: TableAssignmentPassGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - manage_grants
-          title: TableAssignmentManageGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - describe
-          title: TableAssignmentDescribe
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - select
-          title: TableAssignmentSelect
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - modify
-          title: TableAssignmentModify
+        - $ref: '#/components/schemas/TableAssignmentOwnership'
+        - $ref: '#/components/schemas/TableAssignmentPassGrants'
+        - $ref: '#/components/schemas/TableAssignmentManageGrants'
+        - $ref: '#/components/schemas/TableAssignmentDescribe'
+        - $ref: '#/components/schemas/TableAssignmentSelect'
+        - $ref: '#/components/schemas/TableAssignmentModify'
+        - $ref: '#/components/schemas/TableAssignmentManageTags'
+      discriminator:
+        propertyName: type
+        mapping:
+          describe: '#/components/schemas/TableAssignmentDescribe'
+          manage_grants: '#/components/schemas/TableAssignmentManageGrants'
+          manage_tags: '#/components/schemas/TableAssignmentManageTags'
+          modify: '#/components/schemas/TableAssignmentModify'
+          ownership: '#/components/schemas/TableAssignmentOwnership'
+          pass_grants: '#/components/schemas/TableAssignmentPassGrants'
+          select: '#/components/schemas/TableAssignmentSelect'
+    TableAssignmentDescribe:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - describe
+    TableAssignmentManageGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_grants
+    TableAssignmentManageTags:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_tags
+    TableAssignmentModify:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - modify
+    TableAssignmentOwnership:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - ownership
+    TableAssignmentPassGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - pass_grants
+    TableAssignmentSelect:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - select
     TableRelation:
       type: string
       enum:
@@ -12132,6 +15996,7 @@ components:
         - describe
         - select
         - modify
+        - manage_tags
     TableUpdateKind:
       type: string
       description: |-
@@ -12163,31 +16028,39 @@ components:
         - remove-encryption-key
     TabularDeleteProfile:
       oneOf:
-        - type: object
-          title: TabularDeleteProfileHard
-          required:
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - hard
-        - type: object
-          title: TabularDeleteProfileSoft
-          required:
-            - expiration-seconds
-            - type
-          properties:
-            expiration-seconds:
-              type: integer
-              format: int64
-            type:
-              type: string
-              enum:
-                - soft
+        - $ref: '#/components/schemas/TabularDeleteProfileHard'
+        - $ref: '#/components/schemas/TabularDeleteProfileSoft'
+      discriminator:
+        propertyName: type
+        mapping:
+          hard: '#/components/schemas/TabularDeleteProfileHard'
+          soft: '#/components/schemas/TabularDeleteProfileSoft'
+    TabularDeleteProfileHard:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - hard
+    TabularDeleteProfileSoft:
+      type: object
+      required:
+        - expiration-seconds
+        - type
+      properties:
+        expiration-seconds:
+          type: integer
+          format: int64
+        type:
+          type: string
+          enum:
+            - soft
     TabularIdentOrUuid:
       oneOf:
         - type: object
+          title: TabularIdentOrUuidById
           required:
             - warehouse-id
             - table-id
@@ -12199,6 +16072,7 @@ components:
               type: string
               format: uuid
         - type: object
+          title: TabularIdentOrUuidByName
           required:
             - namespace
             - table
@@ -12221,42 +16095,54 @@ components:
         accepted as input aliases for client ergonomics.
     TabularIdentUuid:
       oneOf:
-        - type: object
-          required:
-            - id
-            - type
-          properties:
-            id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - table
-        - type: object
-          required:
-            - id
-            - type
-          properties:
-            id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - view
-        - type: object
-          required:
-            - id
-            - type
-          properties:
-            id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - generic-table
+        - $ref: '#/components/schemas/TabularIdentUuidTable'
+        - $ref: '#/components/schemas/TabularIdentUuidView'
+        - $ref: '#/components/schemas/TabularIdentUuidGenericTable'
+      discriminator:
+        propertyName: type
+        mapping:
+          generic-table: '#/components/schemas/TabularIdentUuidGenericTable'
+          table: '#/components/schemas/TabularIdentUuidTable'
+          view: '#/components/schemas/TabularIdentUuidView'
+    TabularIdentUuidGenericTable:
+      type: object
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - generic-table
+    TabularIdentUuidTable:
+      type: object
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - table
+    TabularIdentUuidView:
+      type: object
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - view
     TabularType:
       type: string
       description: Type of tabular
@@ -12266,28 +16152,35 @@ components:
         - generic-table
     TagAssignment:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - ownership
-          title: TagAssignmentOwnership
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - apply
-          title: TagAssignmentApply
+        - $ref: '#/components/schemas/TagAssignmentOwnership'
+        - $ref: '#/components/schemas/TagAssignmentApply'
+      discriminator:
+        propertyName: type
+        mapping:
+          apply: '#/components/schemas/TagAssignmentApply'
+          ownership: '#/components/schemas/TagAssignmentOwnership'
+    TagAssignmentApply:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - apply
+    TagAssignmentOwnership:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - ownership
     TagAttachment:
       type: object
       description: One target a tag definition is attached to (reverse lookup).
@@ -12319,106 +16212,127 @@ components:
           description: Value the tag carries on this target
     TagAttachmentTarget:
       oneOf:
-        - type: object
-          required:
-            - warehouse-id
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - warehouse
-            warehouse-id:
-              type: string
-              format: uuid
-        - type: object
-          required:
-            - warehouse-id
-            - namespace-id
-            - type
-          properties:
-            namespace-id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - namespace
-            warehouse-id:
-              type: string
-              format: uuid
-        - type: object
-          required:
-            - warehouse-id
-            - table-id
-            - type
-          properties:
-            table-id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - table
-            warehouse-id:
-              type: string
-              format: uuid
-        - type: object
-          required:
-            - warehouse-id
-            - view-id
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - view
-            view-id:
-              type: string
-              format: uuid
-            warehouse-id:
-              type: string
-              format: uuid
-        - type: object
-          required:
-            - warehouse-id
-            - generic-table-id
-            - type
-          properties:
-            generic-table-id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - generic-table
-            warehouse-id:
-              type: string
-              format: uuid
-        - type: object
-          required:
-            - warehouse-id
-            - table-id
-            - field-id
-            - type
-          properties:
-            field-id:
-              type: integer
-              format: int32
-              description: Iceberg field-id of the column within the table's schema.
-            table-id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - column
-            warehouse-id:
-              type: string
-              format: uuid
+        - $ref: '#/components/schemas/TagAttachmentTargetWarehouse'
+        - $ref: '#/components/schemas/TagAttachmentTargetNamespace'
+        - $ref: '#/components/schemas/TagAttachmentTargetTable'
+        - $ref: '#/components/schemas/TagAttachmentTargetView'
+        - $ref: '#/components/schemas/TagAttachmentTargetGenericTable'
+        - $ref: '#/components/schemas/TagAttachmentTargetColumn'
       description: |-
         The object a tag is attached to in a reverse-lookup listing. `type`
         discriminates the target kind; columns are addressed by Iceberg field-id.
+      discriminator:
+        propertyName: type
+        mapping:
+          column: '#/components/schemas/TagAttachmentTargetColumn'
+          generic-table: '#/components/schemas/TagAttachmentTargetGenericTable'
+          namespace: '#/components/schemas/TagAttachmentTargetNamespace'
+          table: '#/components/schemas/TagAttachmentTargetTable'
+          view: '#/components/schemas/TagAttachmentTargetView'
+          warehouse: '#/components/schemas/TagAttachmentTargetWarehouse'
+    TagAttachmentTargetColumn:
+      type: object
+      required:
+        - warehouse-id
+        - table-id
+        - field-id
+        - type
+      properties:
+        field-id:
+          type: integer
+          format: int32
+          description: Iceberg field-id of the column within the table's schema.
+        table-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - column
+        warehouse-id:
+          type: string
+          format: uuid
+    TagAttachmentTargetGenericTable:
+      type: object
+      required:
+        - warehouse-id
+        - generic-table-id
+        - type
+      properties:
+        generic-table-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - generic-table
+        warehouse-id:
+          type: string
+          format: uuid
+    TagAttachmentTargetNamespace:
+      type: object
+      required:
+        - warehouse-id
+        - namespace-id
+        - type
+      properties:
+        namespace-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - namespace
+        warehouse-id:
+          type: string
+          format: uuid
+    TagAttachmentTargetTable:
+      type: object
+      required:
+        - warehouse-id
+        - table-id
+        - type
+      properties:
+        table-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - table
+        warehouse-id:
+          type: string
+          format: uuid
+    TagAttachmentTargetView:
+      type: object
+      required:
+        - warehouse-id
+        - view-id
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - view
+        view-id:
+          type: string
+          format: uuid
+        warehouse-id:
+          type: string
+          format: uuid
+    TagAttachmentTargetWarehouse:
+      type: object
+      required:
+        - warehouse-id
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - warehouse
+        warehouse-id:
+          type: string
+          format: uuid
     TagDefinition:
       type: object
       required:
@@ -12469,37 +16383,46 @@ components:
           description: How values of this definition are constrained
     TagInheritanceSource:
       oneOf:
-        - type: object
-          required:
-            - warehouse-id
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - warehouse
-            warehouse-id:
-              type: string
-              format: uuid
-        - type: object
-          required:
-            - warehouse-id
-            - namespace-id
-            - type
-          properties:
-            namespace-id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - namespace
-            warehouse-id:
-              type: string
-              format: uuid
+        - $ref: '#/components/schemas/TagInheritanceSourceWarehouse'
+        - $ref: '#/components/schemas/TagInheritanceSourceNamespace'
       description: |-
         The ancestor an inherited effective tag is attached to. Restricted to the levels
         that can actually be ancestors (warehouse / namespace).
+      discriminator:
+        propertyName: type
+        mapping:
+          namespace: '#/components/schemas/TagInheritanceSourceNamespace'
+          warehouse: '#/components/schemas/TagInheritanceSourceWarehouse'
+    TagInheritanceSourceNamespace:
+      type: object
+      required:
+        - warehouse-id
+        - namespace-id
+        - type
+      properties:
+        namespace-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - namespace
+        warehouse-id:
+          type: string
+          format: uuid
+    TagInheritanceSourceWarehouse:
+      type: object
+      required:
+        - warehouse-id
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - warehouse
+        warehouse-id:
+          type: string
+          format: uuid
     TagRelation:
       type: string
       description: |-
@@ -12658,53 +16581,62 @@ components:
         - FAILED
     TimeWindowSelector:
       oneOf:
-        - type: object
-          required:
-            - end
-            - interval
-            - type
-          properties:
-            end:
-              type: string
-              format: date-time
-              description: |-
-                End timestamp of the time window
-                Specify
-              example: 2023-12-31T23:59:59Z
-            interval:
-              type: string
-              description: |-
-                Duration/span of the time window
+        - $ref: '#/components/schemas/TimeWindowSelectorWindow'
+        - $ref: '#/components/schemas/TimeWindowSelectorPageToken'
+      discriminator:
+        propertyName: type
+        mapping:
+          page-token: '#/components/schemas/TimeWindowSelectorPageToken'
+          window: '#/components/schemas/TimeWindowSelectorWindow'
+    TimeWindowSelectorPageToken:
+      type: object
+      required:
+        - token
+        - type
+      properties:
+        token:
+          type: string
+          description: |-
+            Opaque Token from previous response for paginating through time windows
 
-                The returned statistics will be for the time window from `end` - `interval` to `end`.
-                Specify a ISO8601 duration string, e.g. `PT1H` for 1 hour, `P1D` for 1 day.
-              example: P1D
-            type:
-              type: string
-              enum:
-                - window
-          example:
-            type: window
-            end: 2023-12-31T23:59:59Z
-            interval: P1D
-        - type: object
-          required:
-            - token
-            - type
-          properties:
-            token:
-              type: string
-              description: |-
-                Opaque Token from previous response for paginating through time windows
+            Use the `next_page_token` or `previous_page_token` from a previous response
+        type:
+          type: string
+          enum:
+            - page-token
+      example:
+        type: page-token
+        token: xyz
+    TimeWindowSelectorWindow:
+      type: object
+      required:
+        - end
+        - interval
+        - type
+      properties:
+        end:
+          type: string
+          format: date-time
+          description: |-
+            End timestamp of the time window
+            Specify
+          example: 2023-12-31T23:59:59Z
+        interval:
+          type: string
+          description: |-
+            Duration/span of the time window
 
-                Use the `next_page_token` or `previous_page_token` from a previous response
-            type:
-              type: string
-              enum:
-                - page-token
-          example:
-            type: page-token
-            token: xyz
+            The returned statistics will be for the time window from `end` - `interval` to `end`.
+            Specify a ISO8601 duration string, e.g. `PT1H` for 1 hour, `P1D` for 1 day.
+          example: P1D
+        type:
+          type: string
+          enum:
+            - window
+      example:
+        type: window
+        end: 2023-12-31T23:59:59Z
+        interval: P1D
     TopLevelFolder:
       type: string
       description: |-
@@ -13033,33 +16965,125 @@ components:
                 Whether the principal is a human or an application; `null` when the user
                 is assigned but not provisioned in the catalog (the id is all that's known).
     UserOrRole:
-      oneOf:
-        - type: object
-          title: UserOrRoleUser
-          description: Id of the user
-          required:
-            - user
-          properties:
-            user:
-              type: string
-              description: Id of the user
-        - type: object
-          title: UserOrRoleRole
+      type: object
+      description: |-
+        Identifies a user or a role
+
+        Exactly one of `user` and `role` must be set. The server rejects a payload that names
+        both, and one that names neither.
+
+        The schema does not express that: both properties are optional on a single object, so
+        `{}` and `{"user": ..., "role": ...}` are schema-valid and are refused at runtime
+        instead. Clients must enforce the choice themselves. The shape is deliberate — a
+        `oneOf` here cannot be composed by code generators, because the `*Assignment` schemas
+        embed this type and generators flatten the union into a struct that requires both
+        properties.
+      properties:
+        role:
+          type: string
+          format: uuid
           description: Id of the role
-          required:
-            - role
-          properties:
-            role:
-              type: string
-              format: uuid
-              description: Id of the role
-      description: Identifies a user or a role
+        user:
+          type: string
+          description: Id of the user
     UserType:
       type: string
       description: Type of a User
       enum:
         - human
         - application
+    ValidateWarehouseResponse:
+      type: object
+      description: |-
+        Outcome of validating a warehouse configuration.
+
+        Returned with HTTP 200 whether or not the configuration is usable — a failing
+        check is a result, not a request error. Only authorization and malformed
+        bodies produce a 4xx.
+      required:
+        - valid
+        - checks
+      properties:
+        checks:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationCheck'
+          description: |-
+            Every check that was considered, in execution order — passed, failed and
+            skipped alike, so the caller can see what was and was not covered.
+        valid:
+          type: boolean
+          description: True when no check failed. Skipped checks do not make a configuration invalid.
+    ValidationCheck:
+      type: object
+      required:
+        - name
+        - status
+      properties:
+        duration-ms:
+          type:
+            - integer
+            - 'null'
+          format: int64
+          description: Wall-clock duration of the check. Absent for skipped checks.
+          minimum: 0
+        error:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/ErrorModel'
+              description: What went wrong. Only set for `failed`.
+        name:
+          $ref: '#/components/schemas/ValidationCheckName'
+        reason:
+          type:
+            - string
+            - 'null'
+          description: Why the check was skipped. Only set for `skipped`.
+        status:
+          $ref: '#/components/schemas/ValidationCheckStatus'
+    ValidationCheckName:
+      type: string
+      description: |-
+        A single check performed against a warehouse configuration.
+
+        Each name is a claim about the configuration that is true exactly when the
+        check's `status` is `passed`. A check that asserts a property of a subject is
+        named `<subject>-<predicate>`, the predicate an adjective or past participle;
+        a check that exercises an operation is named after the operation. A check is
+        never named after the failure it detects — a requirement that is naturally
+        negative is stated as the positive property that must hold.
+
+        These are stable wire identifiers. Adding a value is a breaking change for
+        generated clients, which reject unknown enum values, so new checks ship in a
+        release that clients must upgrade to.
+      enum:
+        - profile-well-formed
+        - profile-compatible
+        - warehouse-name-valid
+        - warehouse-id-available
+        - location-exclusive
+        - spec-mutable
+        - format-version-policy-consistent
+        - managed-by-allowed
+        - storage-client-initialized
+        - lakekeeper-read-write
+        - vended-credentials-issued
+        - vended-credentials-read-write
+        - vended-credentials-scope-enforced
+        - cleanup
+    ValidationCheckStatus:
+      type: string
+      description: |-
+        The outcome of a single check.
+
+        `passed` and `failed` are verdicts about the configuration. `skipped` is not
+        a verdict: the check did not apply, or a prerequisite failed, and `reason`
+        says which. Skipped checks never make a configuration invalid, so a report
+        can be `valid` with nothing actually verified — read the individual checks.
+      enum:
+        - passed
+        - failed
+        - skipped
     ViewAction:
       type: string
       enum:
@@ -13071,6 +17095,7 @@ components:
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - grant_describe
         - grant_select
         - grant_modify
@@ -13080,72 +17105,100 @@ components:
         - set_protection
     ViewAssignment:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - ownership
-          title: ViewAssignmentOwnership
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - pass_grants
-          title: ViewAssignmentPassGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - manage_grants
-          title: ViewAssignmentManageGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - describe
-          title: ViewAssignmentDescribe
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - select
-          title: ViewAssignmentSelect
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - modify
-          title: ViewAssignmentModify
+        - $ref: '#/components/schemas/ViewAssignmentOwnership'
+        - $ref: '#/components/schemas/ViewAssignmentPassGrants'
+        - $ref: '#/components/schemas/ViewAssignmentManageGrants'
+        - $ref: '#/components/schemas/ViewAssignmentDescribe'
+        - $ref: '#/components/schemas/ViewAssignmentSelect'
+        - $ref: '#/components/schemas/ViewAssignmentModify'
+        - $ref: '#/components/schemas/ViewAssignmentManageTags'
+      discriminator:
+        propertyName: type
+        mapping:
+          describe: '#/components/schemas/ViewAssignmentDescribe'
+          manage_grants: '#/components/schemas/ViewAssignmentManageGrants'
+          manage_tags: '#/components/schemas/ViewAssignmentManageTags'
+          modify: '#/components/schemas/ViewAssignmentModify'
+          ownership: '#/components/schemas/ViewAssignmentOwnership'
+          pass_grants: '#/components/schemas/ViewAssignmentPassGrants'
+          select: '#/components/schemas/ViewAssignmentSelect'
+    ViewAssignmentDescribe:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - describe
+    ViewAssignmentManageGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_grants
+    ViewAssignmentManageTags:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_tags
+    ViewAssignmentModify:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - modify
+    ViewAssignmentOwnership:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - ownership
+    ViewAssignmentPassGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - pass_grants
+    ViewAssignmentSelect:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - select
     ViewRelation:
       type: string
       enum:
@@ -13155,10 +17208,12 @@ components:
         - describe
         - select
         - modify
+        - manage_tags
     WarehouseAction:
       type: string
       enum:
         - create_namespace
+        - accept_moved_namespace
         - delete
         - modify_storage
         - modify_storage_credential
@@ -13177,6 +17232,7 @@ components:
         - grant_select
         - grant_pass_grants
         - grant_manage_grants
+        - grant_manage_tags
         - change_ownership
         - get_all_tasks
         - control_all_tasks
@@ -13185,116 +17241,158 @@ components:
         - get_endpoint_statistics
     WarehouseAssignment:
       oneOf:
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - ownership
-          title: WarehouseAssignmentOwnership
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - pass_grants
-          title: WarehouseAssignmentPassGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - manage_grants
-          title: WarehouseAssignmentManageGrants
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - describe
-          title: WarehouseAssignmentDescribe
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - select
-          title: WarehouseAssignmentSelect
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - create
-          title: WarehouseAssignmentCreate
-        - allOf:
-            - $ref: '#/components/schemas/UserOrRole'
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - modify
-          title: WarehouseAssignmentModify
+        - $ref: '#/components/schemas/WarehouseAssignmentOwnership'
+        - $ref: '#/components/schemas/WarehouseAssignmentPassGrants'
+        - $ref: '#/components/schemas/WarehouseAssignmentManageGrants'
+        - $ref: '#/components/schemas/WarehouseAssignmentDescribe'
+        - $ref: '#/components/schemas/WarehouseAssignmentSelect'
+        - $ref: '#/components/schemas/WarehouseAssignmentCreate'
+        - $ref: '#/components/schemas/WarehouseAssignmentModify'
+        - $ref: '#/components/schemas/WarehouseAssignmentManageTags'
+      discriminator:
+        propertyName: type
+        mapping:
+          create: '#/components/schemas/WarehouseAssignmentCreate'
+          describe: '#/components/schemas/WarehouseAssignmentDescribe'
+          manage_grants: '#/components/schemas/WarehouseAssignmentManageGrants'
+          manage_tags: '#/components/schemas/WarehouseAssignmentManageTags'
+          modify: '#/components/schemas/WarehouseAssignmentModify'
+          ownership: '#/components/schemas/WarehouseAssignmentOwnership'
+          pass_grants: '#/components/schemas/WarehouseAssignmentPassGrants'
+          select: '#/components/schemas/WarehouseAssignmentSelect'
+    WarehouseAssignmentCreate:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - create
+    WarehouseAssignmentDescribe:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - describe
+    WarehouseAssignmentManageGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_grants
+    WarehouseAssignmentManageTags:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - manage_tags
+    WarehouseAssignmentModify:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - modify
+    WarehouseAssignmentOwnership:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - ownership
+    WarehouseAssignmentPassGrants:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - pass_grants
+    WarehouseAssignmentSelect:
+      allOf:
+        - $ref: '#/components/schemas/UserOrRole'
+        - type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - select
     WarehouseFilter:
       oneOf:
-        - type: object
-          description: Filter for a specific warehouse
-          required:
-            - id
-            - type
-          properties:
-            id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - warehouse-id
-        - type: object
-          description: Filter for items that are not associated with a warehouse
-          required:
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - unmapped
-        - type: object
-          description: Return all items in the current project, regardless of warehouse association
-          required:
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - all
+        - $ref: '#/components/schemas/WarehouseFilterWarehouseId'
+        - $ref: '#/components/schemas/WarehouseFilterUnmapped'
+        - $ref: '#/components/schemas/WarehouseFilterAll'
+      discriminator:
+        propertyName: type
+        mapping:
+          all: '#/components/schemas/WarehouseFilterAll'
+          unmapped: '#/components/schemas/WarehouseFilterUnmapped'
+          warehouse-id: '#/components/schemas/WarehouseFilterWarehouseId'
+    WarehouseFilterAll:
+      type: object
+      description: Return all items in the current project, regardless of warehouse association
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - all
+    WarehouseFilterUnmapped:
+      type: object
+      description: Filter for items that are not associated with a warehouse
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - unmapped
+    WarehouseFilterWarehouseId:
+      type: object
+      description: Filter for a specific warehouse
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - warehouse-id
     WarehouseRelation:
       type: string
       enum:
@@ -13305,6 +17403,7 @@ components:
         - select
         - create
         - modify
+        - manage_tags
     WarehouseStatistics:
       type: object
       required:
@@ -13362,94 +17461,121 @@ components:
         - inactive
     WarehouseTaskEntityFilter:
       oneOf:
-        - type: object
-          description: Get tasks for a specific table
-          required:
-            - table-id
-            - type
-          properties:
-            table-id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - table
-        - type: object
-          description: Get tasks for a specific view
-          required:
-            - view-id
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - view
-            view-id:
-              type: string
-              format: uuid
-        - type: object
-          description: Get tasks for a specific generic table
-          required:
-            - generic-table-id
-            - type
-          properties:
-            generic-table-id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - generic-table
-        - type: object
-          description: |-
-            Get Warehouse-level tasks which are not associated with a specific entity
-            inside the warehouse
-          required:
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - warehouse
+        - $ref: '#/components/schemas/WarehouseTaskEntityFilterTable'
+        - $ref: '#/components/schemas/WarehouseTaskEntityFilterView'
+        - $ref: '#/components/schemas/WarehouseTaskEntityFilterGenericTable'
+        - $ref: '#/components/schemas/WarehouseTaskEntityFilterWarehouse'
+      discriminator:
+        propertyName: type
+        mapping:
+          generic-table: '#/components/schemas/WarehouseTaskEntityFilterGenericTable'
+          table: '#/components/schemas/WarehouseTaskEntityFilterTable'
+          view: '#/components/schemas/WarehouseTaskEntityFilterView'
+          warehouse: '#/components/schemas/WarehouseTaskEntityFilterWarehouse'
+    WarehouseTaskEntityFilterGenericTable:
+      type: object
+      description: Get tasks for a specific generic table
+      required:
+        - generic-table-id
+        - type
+      properties:
+        generic-table-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - generic-table
+    WarehouseTaskEntityFilterTable:
+      type: object
+      description: Get tasks for a specific table
+      required:
+        - table-id
+        - type
+      properties:
+        table-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - table
+    WarehouseTaskEntityFilterView:
+      type: object
+      description: Get tasks for a specific view
+      required:
+        - view-id
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - view
+        view-id:
+          type: string
+          format: uuid
+    WarehouseTaskEntityFilterWarehouse:
+      type: object
+      description: |-
+        Get Warehouse-level tasks which are not associated with a specific entity
+        inside the warehouse
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - warehouse
     WarehouseTaskEntityId:
       oneOf:
-        - type: object
-          required:
-            - table-id
-            - type
-          properties:
-            table-id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - table
-        - type: object
-          required:
-            - view-id
-            - type
-          properties:
-            type:
-              type: string
-              enum:
-                - view
-            view-id:
-              type: string
-              format: uuid
-        - type: object
-          required:
-            - generic-table-id
-            - type
-          properties:
-            generic-table-id:
-              type: string
-              format: uuid
-            type:
-              type: string
-              enum:
-                - generic-table
+        - $ref: '#/components/schemas/WarehouseTaskEntityIdTable'
+        - $ref: '#/components/schemas/WarehouseTaskEntityIdView'
+        - $ref: '#/components/schemas/WarehouseTaskEntityIdGenericTable'
+      discriminator:
+        propertyName: type
+        mapping:
+          generic-table: '#/components/schemas/WarehouseTaskEntityIdGenericTable'
+          table: '#/components/schemas/WarehouseTaskEntityIdTable'
+          view: '#/components/schemas/WarehouseTaskEntityIdView'
+    WarehouseTaskEntityIdGenericTable:
+      type: object
+      required:
+        - generic-table-id
+        - type
+      properties:
+        generic-table-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - generic-table
+    WarehouseTaskEntityIdTable:
+      type: object
+      required:
+        - table-id
+        - type
+      properties:
+        table-id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - table
+    WarehouseTaskEntityIdView:
+      type: object
+      required:
+        - view-id
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - view
+        view-id:
+          type: string
+          format: uuid
     WarehouseTaskInfo:
       type: object
       required:
@@ -13571,6 +17697,8 @@ tags:
     description: Manage Roles
   - name: tag
     description: '**[Preview]** Manage governance tags. This API is in preview and may change in a backward-incompatible way in a future release.'
+  - name: grant
+    description: '**[Preview]** Manage grants: which principal holds which privilege on which resource. This API is in preview and may change in a backward-incompatible way in a future release.'
   - name: permissions-openfga
     description: Authorization and permissions management using OpenFGA
   - name: permissions-cedar

--- a/site/docs/about/enterprise-release-notes.md
+++ b/site/docs/about/enterprise-release-notes.md
@@ -4,6 +4,51 @@ description: "Release notes for Lakekeeper+, the commercial distribution, coveri
 
 # Lakekeeper+ Release Notes
 
+## Unreleased
+
+### Features
+- **Cedar: grants decide access.** Privileges granted in the catalog now reach Cedar policies. Every resource entity carries `direct_privileges` (granted on it) and `inherited_privileges` (granted above it), so a policy can read `resource.direct_privileges.select`. `GET /management/v1/grants/grantable-privileges` lists the grantable names per resource type. A grant on the server is in no project, so Cedar reads the caller's roles from every project when one decides a request.
+
+### Breaking Changes
+- **Admission gate: `idp_id` must name a provider the server authenticates.** Startup checks it against the configured authenticators and refuses to start when it matches none, naming what is available. An id matching nothing governs nobody: every request counts as being from another IdP and is admitted untouched, while the gate makes no upstream call and so still reports itself healthy. A deployment whose `idp_id` has a typo has not been enforcing anything.
+- **Admission gate: unknown configuration keys are refused.** A misspelled key under `admission_enforce` — `cache_ttl_sec` for `cache_ttl_secs`, `role_source` for `role_source_id` — previously applied its default silently. Startup now names it and stops. Check your configuration against the documented keys before upgrading.
+- **Admission gate: a request with no authenticated principal is rejected.** It reaches the gate only if the authentication middleware changes, and a gate that cannot see who is calling cannot enforce anything.
+- **OpenFGA: revoking a privilege requires `manage_grants`.** `pass_grants` means handing others the privileges you hold; taking one back is administration. Both directions previously asked the same relation, so a holder of `pass_grants` plus a privilege could clear every other principal's copy of it, logged as ordinary grant administration. Applies to both the `/grants` diff and the older `/permissions/{type}/{id}/assignments` deletes.
+- **OpenFGA: membership of a `system`-provider role requires an instance admin.** Membership of a catalog-managed system role is provisioning, not self-service, and role-type members are rejected on them — closing the path where a role conferring `ManageRoleAssignments` could appoint more of its own members. Removing an existing role-type member remains available to instance admins. Ordinary and `lakekeeper`-provider roles are unaffected.
+- **Cedar: seeing another principal's access needs its own grant.** `Introspect<X>Authorization` left `ServerActions`, `RoleActions` and the `<X>ModifyActions` groups, and is now in `ReadGrantsActions` and the level's `<X>GrantActions`. Policies granting those older groups no longer confer it; grant `Read<X>Grants`, or name the action, where you want it.
+- **Cedar: requests must name the project their resources are in.** Addressing a warehouse outside the project in `x-project-id` — or outside the default project, if the header is absent — now returns 400. One request cannot span two projects. Single-project deployments are unaffected.
+- **Cedar: a replaced schema file must declare the privilege records.** With `LAKEKEEPER__CEDAR__SCHEMA_FILE` set, startup fails unless every resource entity declares `direct_privileges` and `inherited_privileges`, naming what is missing.
+- **Cedar: external entity files must declare the privilege records.** Entity JSON is validated against the schema, so a resource entity without both records fails to load and the server does not start.
+- **Cedar: with externally managed identity, the entity file must declare every principal a request names.** Under `LAKEKEEPER__CEDAR__EXTERNALLY_MANAGED_USER_AND_ROLES`, a request naming a user or role your file omits is refused rather than answered — Cedar skips policies about entities it cannot find, which can turn a `forbid` into an allow. Declare everyone you authenticate, every role callers assume or manage, and the roles those sit inside.
+
+### Upgrade Notes
+- **Cedar, multi-project deployments: check that clients send `x-project-id`.** Before this release a request could be answered using a different project's roles, so a policy meant to deny could permit. If your clients omitted the header, treat past cross-project decisions as unreliable.
+- **Cedar with externally managed identity: grant users, not roles.** A grant held by a user applies. One held by a role does not, because your entity file owns role membership — and the role nesting a `forbid` on a parent role reads. Authorization in this mode now reads the catalog for grants, where it previously read nothing.
+
+
+## v0.13.5 (2026-08-26)
+
+_Based on Lakekeeper OSS v0.13.3._
+
+### Highlights
+- **Improved memory behaviour on long-running instances.** Conditions that could, under some circumstances, prevent freed memory from being returned to the OS are addressed.
+
+### Features
+- **New memory metrics.** `lakekeeper_jemalloc_*` separates live heap from memory the allocator is holding back; `lakekeeper_http_connections` reports open connections.
+- **The table maintenance cache reports what it holds:** `lakekeeper_cache_weighted_bytes{cache_type="table_metadata"}` and `lakekeeper_cache_instances`, with hits and misses in the shared `lakekeeper_cache_*` series.
+
+### Bug Fixes
+- **Transparent huge pages could prevent freed memory from being returned to the OS.** On nodes with `THP=always`, the default on common EKS AMIs, resident memory could grow for the life of the process.
+- **The manifest cache under-counted its entries**, so under some circumstances its 128 MiB budget did not bind during table maintenance.
+- **The UI asset cache keyed on an unvalidated header**, so variants of `x-forwarded-prefix` could each add an entry to a cache with no expiry.
+- **Allocator metrics now report on every serving path**, including `LAKEKEEPER__DEBUG__AUTO_SERVE`. Memory behaviour itself was unaffected.
+
+### Upgrade Notes
+- **Idle HTTP connections now close after 75 seconds** and carry TCP keepalive probes. Standard Iceberg and S3 clients retry; previously a connection whose peer had vanished could be held for the life of the process.
+- **Request headers above 64 KiB are rejected with 431.** Request bodies are unaffected.
+- **Shutdown drains for at most 10 seconds** before abandoning connections still open.
+- **Unmatched request paths report `endpoint="unmatched"` in metrics** instead of each creating a permanent series. Dashboards that group by raw path lose those values.
+
 ## v0.13.4 (2026-08-14)
 
 _Based on Lakekeeper OSS v0.13.3._


### PR DESCRIPTION
This PR automatically syncs documentation files from the lakekeeper plus repository.

## Changes
- management-open-api-plus.yaml: ✓ Updated
- lakekeeper.cedarschema: ✓ Updated
- enterprise-release-notes.md: ✓ Updated

Source commit: `c6a3710047cc5f48beb201fff5e6ba4b6e41ed70`
Generated by [workflow run](https://github.com/vakamo-labs/lakekeeper-enterprise/actions/runs/33053602869)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added grant management and grant visibility actions across resource types.
  * Added support for moving namespaces and accepting moved namespaces.
  * Added direct and inherited privilege information for resources.
  * Refined authorization action categories for creating, writing, tagging, and inspecting resources.

* **Documentation**
  * Added unreleased Cedar and admission-gate authorization notes.
  * Added v0.13.5 release notes covering authorization, validation, metrics, and connection handling updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->