### PR TITLE
fix: limit connection lifetimes (#1990)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,3 +9,19 @@ rustflags = ["--cfg", "tracing_unstable", "--cfg", "tokio_unstable"]
 # cache against the live database.
 [env]
 SQLX_OFFLINE = "true"
+
+# Compile `thp:never` into jemalloc (applied as its `--with-malloc-conf`).
+#
+# Transparent huge pages defeat jemalloc's page release: it frees at 4 KiB
+# granularity with MADV_DONTNEED, but a 2 MiB huge page cannot be partially
+# freed, so one live page anywhere inside keeps all 2 MiB resident. On a node
+# with THP=always (common on EKS AMIs) a replica's RSS ratchets up permanently
+# and only a restart recovers it, while jemalloc's own `stats.resident`
+# under-reports real residency because it tracks its logical 4 KiB view.
+# Measured: AnonHugePages 286 MiB -> 0, settled RSS -68%, throughput +1.9%.
+#
+# A build variable, so the setting travels inside every binary built from this
+# tree, including `cargo install` and direct `cargo build` runs. jemalloc reads
+# `--with-malloc-conf` first and `MALLOC_CONF` last, so an operator can override
+# it at runtime with `_RJEM_MALLOC_CONF`.
+JEMALLOC_SYS_WITH_MALLOC_CONF = "thp:never"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Clippy runs with multiple feature flag combinations — don't just run `cargo cl
 | Crate | Path | Purpose |
 |-------|------|---------|
 | lakekeeper | crates/lakekeeper | Core catalog logic |
+| lakekeeper-alloc | crates/alloc | Allocator configuration and observability |
 | lakekeeper-bin | crates/lakekeeper-bin | Server binary |
 | lakekeeper-io | crates/io | Storage I/O (S3, GCS, Azure, etc.) |
 | iceberg-ext | crates/iceberg-ext | Iceberg format extensions |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3840,6 +3840,7 @@ dependencies = [
  "hostname",
  "http 1.4.1",
  "http-body-util",
+ "hyper-util",
  "iceberg",
  "iceberg-ext",
  "iso8601",
@@ -3863,6 +3864,7 @@ dependencies = [
  "serde_norway",
  "serde_urlencoded",
  "similar",
+ "socket2",
  "sqlx",
  "strum",
  "strum_macros",
@@ -3888,6 +3890,17 @@ dependencies = [
  "valuable",
  "veil",
  "xxhash-rust",
+]
+
+[[package]]
+name = "lakekeeper-alloc"
+version = "0.13.3"
+dependencies = [
+ "axum-prometheus",
+ "serde_json",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3930,6 +3943,7 @@ dependencies = [
  "figment",
  "http 1.4.1",
  "lakekeeper",
+ "lakekeeper-alloc",
  "lakekeeper-authz-openfga",
  "lakekeeper-console",
  "lakekeeper-events-kafka",
@@ -7099,6 +7113,17 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float 2.10.1",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/alloc",
     "crates/authz-openfga",
     "crates/iceberg-ext",
     "crates/io",
@@ -109,6 +110,12 @@ heck = "0.5.0"
 hostname = "0.4.0"
 http = "1.3.1"
 http-body-util = "^0.1"
+hyper-util = { version = "0.1.20", features = [
+    "server-auto",
+    "server-graceful",
+    "service",
+    "tokio",
+] }
 iceberg = { git = "https://github.com/lakekeeper/iceberg-rust.git", rev = "2056f3e4d53129039f2229f3b326aa538289be27" }
 iso8601 = "0.6.2"
 itertools = "0.14.0"
@@ -158,6 +165,8 @@ serde_norway = "0.9.42"
 serde_urlencoded = "0.7.1"
 serde_with = "^3.4"
 similar = "3.0.0"
+# `all` gates `TcpKeepalive::with_retries`, used by the HTTP accept loop.
+socket2 = { version = "0.6", features = ["all"] }
 sqlx = { version = "0.9.0", default-features = false, features = [
     "runtime-tokio",
     "tls-rustls",
@@ -172,6 +181,7 @@ strum = { version = "0.27.0", features = ["derive"] }
 strum_macros = "0.27.0"
 tempfile = "3.20"
 thiserror = "2.0.0"
+tikv-jemalloc-ctl = "0.6"
 tikv-jemallocator = { version = "0.6" }
 time = "0.3.36"
 tokio = { version = "1.41", default-features = false, features = [

--- a/crates/alloc/Cargo.toml
+++ b/crates/alloc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "lakekeeper-alloc"
+description = "Allocator configuration and observability for the Lakekeeper binaries"
+resolver = "2"
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+
+[target.'cfg(all(target_os = "linux", not(target_env = "msvc")))'.dependencies]
+axum-prometheus = { workspace = true }
+serde_json = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true, features = ["stats", "use_std"] }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/crates/alloc/src/lib.rs
+++ b/crates/alloc/src/lib.rs
@@ -1,0 +1,77 @@
+//! Allocator configuration and observability, shared by every Lakekeeper binary.
+//!
+//! This crate exists for one reason: it is the **only** crate permitted to use
+//! `unsafe`, so that the binaries can keep `#![forbid(unsafe_code)]`. The single
+//! use is [`MALLOC_CONF`], which defines a symbol jemalloc reads before `main`.
+//!
+//! Depend on it from binaries only, never from the `lakekeeper` library — a
+//! library must not impose allocator behaviour on downstream consumers.
+#![warn(missing_debug_implementations, rust_2018_idioms, clippy::pedantic)]
+// See `MALLOC_CONF`. No `unsafe` blocks and no unsafe operations are used; the
+// single exception is one `unsafe` *attribute*, which asserts that the exported
+// symbol matches the type jemalloc declares for it.
+#![allow(unsafe_code)]
+
+#[cfg(all(target_os = "linux", not(target_env = "msvc")))]
+mod stats;
+#[cfg(all(target_os = "linux", not(target_env = "msvc")))]
+pub use stats::{log_effective_config, run};
+
+/// jemalloc's `thp` option and `/proc/self/smaps_rollup` are Linux-only, so
+/// these are no-ops elsewhere. Callers stay free of `cfg`.
+#[cfg(not(all(target_os = "linux", not(target_env = "msvc"))))]
+pub fn log_effective_config() {}
+
+/// See [`log_effective_config`].
+#[cfg(not(all(target_os = "linux", not(target_env = "msvc"))))]
+pub async fn run(_interval: std::time::Duration) {}
+
+/// jemalloc run-time options, compiled into the binary.
+///
+/// `thp:never` is the important one. Transparent huge pages defeat jemalloc's
+/// page release: it frees at 4 `KiB` granularity with `MADV_DONTNEED`, but a 2 `MiB`
+/// huge page cannot be *partially* freed, so a single live page anywhere inside
+/// one keeps the whole 2 `MiB` resident. On a node with `THP=always` (the default
+/// on common EKS AMIs) a replica's RSS therefore ratchets upward permanently and
+/// only a restart recovers it, while jemalloc's own `stats.resident`
+/// under-reports real residency because it tracks its logical 4 `KiB` view.
+/// Measured on a commit-heavy workload: `AnonHugePages` 286 `MiB` -> 0, settled
+/// RSS -68%, throughput +1.9% (i.e. no cost — the workload is I/O-bound with a
+/// ~30 `MiB` live heap, so it gains nothing from huge pages).
+///
+/// jemalloc reads options from `--with-malloc-conf`, then this symbol, then
+/// `/etc/malloc.conf`, then `MALLOC_CONF`, left to right with later winning. So
+/// `.cargo/config.toml` sets `JEMALLOC_SYS_WITH_MALLOC_CONF`, which is safe code
+/// and independent of the symbol name, and this symbol covers builds that read no
+/// `.cargo/config.toml` (`cargo install`, or a vendored source tree). An operator
+/// overrides either with `_RJEM_MALLOC_CONF`.
+/// [`log_effective_config`] reports what actually took effect, because both
+/// mechanisms fail *silently*.
+///
+/// # Symbol name
+///
+/// `tikv-jemalloc-sys` sets `cfg(prefixed)` unless the
+/// `unprefixed_malloc_on_supported_platforms` feature is enabled, so the symbol
+/// is `_rjem_malloc_conf`. Enabling that feature would rename it to
+/// `malloc_conf` and silently disable this — no link error. That is what
+/// [`log_effective_config`] guards against.
+#[cfg(all(target_os = "linux", not(target_env = "msvc")))]
+#[used]
+#[unsafe(export_name = "_rjem_malloc_conf")]
+static MALLOC_CONF: &[u8; 10] = b"thp:never\0";
+
+// jemalloc reads the symbol as `const char *`. A *fat* pointer (`&[u8]`,
+// `&CStr`) would make it read the length as part of the address and dereference
+// garbage, silently and severely — so assert the shape is a thin pointer and the
+// string is NUL-terminated. `&[u8; N]` is thin because `[u8; N]` is `Sized`.
+#[cfg(all(target_os = "linux", not(target_env = "msvc")))]
+const _: () = {
+    // Deliberately the size of the *reference*: this asserts that
+    // `MALLOC_CONF`'s own type is one word. Switching it to `&[u8]` or `&CStr`
+    // makes it two and trips this.
+    #[allow(clippy::size_of_ref)]
+    {
+        assert!(size_of_val(&MALLOC_CONF) == size_of::<*const u8>());
+    }
+    assert!(MALLOC_CONF[MALLOC_CONF.len() - 1] == 0);
+};

--- a/crates/alloc/src/stats.rs
+++ b/crates/alloc/src/stats.rs
@@ -1,0 +1,285 @@
+//! Periodic jemalloc arena statistics, published as Prometheus gauges.
+//!
+//! Distinguishes a genuine leak from allocator retention/fragmentation:
+//! `allocated` is live application heap, while `resident` is what the kernel
+//! counts against the container memory limit. A growing `resident` with a flat
+//! `allocated` is retention/fragmentation, not a leak.
+//!
+//! Note that jemalloc's own `resident` can *under-report* actual residency by
+//! hundreds of `MiB`, because it tracks its logical 4 `KiB` view of memory it has
+//! released while the kernel may still hold those pages inside transparent huge
+//! pages. `lakekeeper_process_anon_hugepages_bytes`, read from
+//! `/proc/self/smaps_rollup`, is the ground truth for that case.
+use std::time::Duration;
+
+use tikv_jemalloc_ctl::{arenas, epoch, stats, stats_print};
+
+const METRIC_ALLOCATED: &str = "lakekeeper_jemalloc_allocated_bytes";
+const METRIC_ACTIVE: &str = "lakekeeper_jemalloc_active_bytes";
+const METRIC_METADATA: &str = "lakekeeper_jemalloc_metadata_bytes";
+const METRIC_RESIDENT: &str = "lakekeeper_jemalloc_resident_bytes";
+const METRIC_MAPPED: &str = "lakekeeper_jemalloc_mapped_bytes";
+const METRIC_RETAINED: &str = "lakekeeper_jemalloc_retained_bytes";
+const METRIC_DIRTY: &str = "lakekeeper_jemalloc_dirty_bytes";
+const METRIC_MUZZY: &str = "lakekeeper_jemalloc_muzzy_bytes";
+const METRIC_ARENAS: &str = "lakekeeper_jemalloc_arenas";
+const METRIC_BG_THREADS: &str = "lakekeeper_jemalloc_background_threads_enabled";
+const METRIC_BG_RUNS: &str = "lakekeeper_jemalloc_background_thread_runs";
+/// Ground truth for THP-trapped memory; see [`anon_huge_pages_bytes`].
+const METRIC_ANON_HUGEPAGES: &str = "lakekeeper_process_anon_hugepages_bytes";
+
+/// Merged-arena statistics that `tikv_jemalloc_ctl` does not wrap as typed
+/// keys. Read from `stats_print`'s JSON output, which is a safe API; the crate's
+/// `raw` `mallctl` accessors are `unsafe`.
+#[derive(Debug, Default)]
+struct MergedArenaStats {
+    /// Bytes in freed-but-unpurged pages. Fully resident.
+    dirty: Option<f64>,
+    /// Bytes in `MADV_FREE`d pages. On Linux these stay counted in RSS until
+    /// the kernel reclaims them under pressure.
+    muzzy: Option<f64>,
+    /// Cumulative background purge thread runs. Flat means purging has stalled.
+    background_runs: Option<f64>,
+}
+
+fn merged_arena_stats() -> MergedArenaStats {
+    let mut buf = Vec::new();
+    let mut options = stats_print::Options::default();
+    options.json_format = true;
+    options.skip_per_arena = true;
+    options.skip_bin_size_classes = true;
+    options.skip_large_size_classes = true;
+    options.skip_mutex_statistics = true;
+    if let Err(e) = stats_print::stats_print(&mut buf, options) {
+        tracing::warn!("Could not render jemalloc stats: {e}");
+        return MergedArenaStats::default();
+    }
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(&buf) else {
+        tracing::warn!("Could not parse jemalloc stats as JSON");
+        return MergedArenaStats::default();
+    };
+    let root = &json["jemalloc"];
+    let page = root["arenas"]["page"].as_f64().unwrap_or(4096.0);
+    // jemalloc keys the merged-arena block by the literal string
+    // `"stats.arenas"`, dot included, directly under `jemalloc`. Releases have
+    // also nested it under `stats`, so accept both shapes.
+    let merged = ["stats.arenas", "stats"]
+        .iter()
+        .flat_map(|k| {
+            [
+                &root[*k]["merged"],
+                &root[*k]["stats.arenas"]["merged"],
+                &root[*k]["arenas"]["merged"],
+            ]
+        })
+        .find(|v| !v["pdirty"].is_null());
+    let Some(merged) = merged else {
+        tracing::warn!(
+            "jemalloc stats JSON has no merged-arena block; dirty/muzzy will not be reported"
+        );
+        return MergedArenaStats {
+            background_runs: root["stats"]["background_thread"]["num_runs"].as_f64(),
+            ..MergedArenaStats::default()
+        };
+    };
+    MergedArenaStats {
+        dirty: merged["pdirty"].as_f64().map(|p| p * page),
+        muzzy: merged["pmuzzy"].as_f64().map(|p| p * page),
+        background_runs: root["stats"]["background_thread"]["num_runs"].as_f64(),
+    }
+}
+
+/// Anonymous memory the kernel holds in transparent huge pages, from
+/// `/proc/self/smaps_rollup`.
+///
+/// This is the one number jemalloc cannot report. A 2 `MiB` huge page cannot be
+/// partially freed, so memory jemalloc has correctly released stays resident if
+/// any page inside the same huge page is still live. When that happens
+/// `stats.resident` reads far *below* the process's real anonymous RSS, the gap
+/// only grows, and a restart is the only way to recover it. If this gauge is a
+/// large fraction of RSS, the fix is `thp:never` (see `lakekeeper-alloc`'s
+/// `MALLOC_CONF`), not a hunt for a leak.
+fn anon_huge_pages_bytes() -> Option<f64> {
+    let rollup = std::fs::read_to_string("/proc/self/smaps_rollup").ok()?;
+    for line in rollup.lines() {
+        if let Some(rest) = line.strip_prefix("AnonHugePages:") {
+            let kb: f64 = rest.split_whitespace().next()?.parse().ok()?;
+            return Some(kb * 1024.0);
+        }
+    }
+    None
+}
+
+/// Log the allocator options that actually took effect, and warn if transparent
+/// huge pages are still enabled for our mappings.
+///
+/// Both mechanisms that set `thp:never` fail *silently*: the
+/// `JEMALLOC_SYS_WITH_MALLOC_CONF` build variable is invisible in the source
+/// tree and is lost by any build that does not set it, and the exported
+/// `malloc_conf` symbol is renamed (without a link error) if
+/// `tikv-jemalloc-sys`'s `unprefixed_malloc_on_supported_platforms` feature is
+/// ever enabled. So this reads back jemalloc's own effective `opt.thp`.
+pub fn log_effective_config() {
+    let thp = opt_thp();
+    match thp.as_deref() {
+        Some("never") => tracing::info!(
+            opt_thp = "never",
+            "jemalloc: transparent huge pages disabled for allocator mappings"
+        ),
+        Some(other) => tracing::warn!(
+            opt_thp = other,
+            "jemalloc is allowed to use transparent huge pages. On a host with THP enabled, \
+             freed memory can stay resident indefinitely (a 2 MiB huge page cannot be partially \
+             freed), so container memory ratchets upward and only a restart recovers it. Expected \
+             `never`; set _RJEM_MALLOC_CONF=thp:never or build with \
+             JEMALLOC_SYS_WITH_MALLOC_CONF=thp:never."
+        ),
+        None => {
+            tracing::warn!("Could not read jemalloc opt.thp; cannot confirm huge-page handling");
+        }
+    }
+}
+
+fn opt_thp() -> Option<String> {
+    let mut buf = Vec::new();
+    let mut options = stats_print::Options::default();
+    options.json_format = true;
+    options.skip_per_arena = true;
+    options.skip_bin_size_classes = true;
+    options.skip_large_size_classes = true;
+    options.skip_mutex_statistics = true;
+    stats_print::stats_print(&mut buf, options).ok()?;
+    let json = serde_json::from_slice::<serde_json::Value>(&buf).ok()?;
+    json["jemalloc"]["opt"]["thp"]
+        .as_str()
+        .map(ToOwned::to_owned)
+}
+
+/// Sample jemalloc's own accounting every `interval` and publish it as gauges.
+///
+/// Runs for the lifetime of the process.
+pub async fn run(interval: Duration) {
+    use axum_prometheus::metrics;
+
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        ticker.tick().await;
+
+        // Re-issued every tick. The global metrics recorder is installed while
+        // the server starts, after this task is spawned, and a `describe_gauge!`
+        // issued before that is dropped and never replayed. Registration is
+        // idempotent, so describing on each tick is what gets `# HELP` onto
+        // `/metrics` regardless of which side of startup wins the race.
+        metrics::describe_gauge!(
+            METRIC_ALLOCATED,
+            "Bytes allocated by the application (live heap)"
+        );
+        metrics::describe_gauge!(METRIC_ACTIVE, "Bytes in active pages");
+        metrics::describe_gauge!(METRIC_METADATA, "Bytes used by allocator metadata");
+        metrics::describe_gauge!(METRIC_RESIDENT, "Bytes in physically resident pages");
+        metrics::describe_gauge!(METRIC_MAPPED, "Bytes in mapped extents");
+        metrics::describe_gauge!(
+            METRIC_RETAINED,
+            "Bytes retained (mapped but unused) by the allocator"
+        );
+        metrics::describe_gauge!(
+            METRIC_DIRTY,
+            "Bytes in freed-but-unpurged pages (fully resident)"
+        );
+        metrics::describe_gauge!(
+            METRIC_MUZZY,
+            "Bytes in MADV_FREE'd pages (still counted in RSS)"
+        );
+        metrics::describe_gauge!(
+            METRIC_ARENAS,
+            "Number of arenas (4 x the node's core count by default)"
+        );
+        metrics::describe_gauge!(
+            METRIC_BG_THREADS,
+            "1 if jemalloc background purge threads are running"
+        );
+        metrics::describe_gauge!(METRIC_BG_RUNS, "Cumulative background purge thread runs");
+        metrics::describe_gauge!(
+            METRIC_ANON_HUGEPAGES,
+            "Anonymous bytes held in transparent huge pages (may include memory the allocator freed)"
+        );
+
+        // `epoch::advance` refreshes the cached statistics; without it every
+        // read returns the values from process start.
+        if let Err(e) = epoch::advance() {
+            tracing::warn!("Could not advance jemalloc stats epoch: {e}");
+            continue;
+        }
+        #[allow(clippy::cast_precision_loss)] // byte counts; f64 is exact to 2^53
+        let read = |name: &str, f: fn() -> Result<usize, tikv_jemalloc_ctl::Error>| match f() {
+            Ok(v) => Some(v as f64),
+            Err(e) => {
+                tracing::warn!("Could not read jemalloc stat {name}: {e}");
+                None
+            }
+        };
+        // Pages jemalloc has freed but not yet returned to the kernel. Dirty
+        // pages are still fully resident; muzzy pages have been `MADV_FREE`d,
+        // which on Linux leaves them counted in RSS until the kernel reclaims
+        // them under pressure. Both therefore show up in
+        // `container_memory_working_set_bytes` while being invisible to
+        // `allocated` — so a container can look like it is leaking while the
+        // application heap is flat. If these two climb, the fix is decay/purge
+        // tuning (`dirty_decay_ms`, `muzzy_decay_ms`, `background_thread`),
+        // not a hunt for a retained object.
+        let merged = merged_arena_stats();
+        let (dirty, muzzy, bg_runs) = (merged.dirty, merged.muzzy, merged.background_runs);
+        // Arena count is `4 * ncpus` by default, and `ncpus` is the *node's*
+        // core count: a CFS CPU limit does not reduce it. Each arena keeps its
+        // own dirty/muzzy pools, so a small CPU limit on a large node multiplies
+        // the resident-but-free memory above.
+        let narenas = arenas::narenas::read().ok().map(f64::from);
+        let bg_enabled = tikv_jemalloc_ctl::background_thread::read()
+            .ok()
+            .map(|on| f64::from(u8::from(on)));
+
+        let allocated = read("allocated", stats::allocated::read);
+        let active = read("active", stats::active::read);
+        let metadata = read("metadata", stats::metadata::read);
+        let resident = read("resident", stats::resident::read);
+        let mapped = read("mapped", stats::mapped::read);
+        let retained = read("retained", stats::retained::read);
+
+        for (name, value) in [
+            (METRIC_ALLOCATED, allocated),
+            (METRIC_ACTIVE, active),
+            (METRIC_METADATA, metadata),
+            (METRIC_RESIDENT, resident),
+            (METRIC_MAPPED, mapped),
+            (METRIC_RETAINED, retained),
+            (METRIC_DIRTY, dirty),
+            (METRIC_MUZZY, muzzy),
+            (METRIC_ARENAS, narenas),
+            (METRIC_BG_THREADS, bg_enabled),
+            (METRIC_BG_RUNS, bg_runs),
+            (METRIC_ANON_HUGEPAGES, anon_huge_pages_bytes()),
+        ] {
+            if let Some(v) = value {
+                metrics::gauge!(name).set(v);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Both mechanisms that set `thp:never` fail silently, so assert the
+    /// outcome. Catches a renamed export symbol, a dropped
+    /// `JEMALLOC_SYS_WITH_MALLOC_CONF`, or a `.cargo/config.toml` that stopped
+    /// being read — none of which produce a build error.
+    #[test]
+    fn transparent_huge_pages_are_disabled_for_allocator_mappings() {
+        assert_eq!(
+            super::opt_thp().as_deref(),
+            Some("never"),
+            "jemalloc opt.thp is not `never`; see crates/alloc/src/lib.rs"
+        );
+    }
+}

--- a/crates/lakekeeper-bin/Cargo.toml
+++ b/crates/lakekeeper-bin/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "^4.5", features = ["derive"] }
 figment = { workspace = true }
 http = { workspace = true }
 lakekeeper = { path = "../lakekeeper", features = ["s3-signer", "router"] }
+lakekeeper-alloc = { path = "../alloc" }
 lakekeeper-authz-openfga = { path = "../authz-openfga" }
 lakekeeper-console = { git = "https://github.com/lakekeeper/console", rev = "v0.19.0", optional = true }
 lakekeeper-events-kafka = { path = "../lakekeeper-events-kafka" }
@@ -45,7 +46,8 @@ tikv-jemallocator = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tikv-jemallocator = { workspace = true, features = ["background_threads"] }
+# "stats" backs the jemalloc gauges published by `lakekeeper-alloc`.
+tikv-jemallocator = { workspace = true, features = ["background_threads", "stats"] }
 
 [dev-dependencies]
 figment = { workspace = true, features = ["test"] }

--- a/crates/lakekeeper-bin/src/main.rs
+++ b/crates/lakekeeper-bin/src/main.rs
@@ -214,6 +214,13 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Commands::Serve { force_start }) => {
             print_info();
+            // Allocator accounting: tells a genuine leak (`allocated` grows)
+            // from allocator retention (`resident` grows while `allocated` is
+            // flat) from THP-trapped pages (both look fine but RSS climbs).
+            // This call also keeps `lakekeeper-alloc` linked, which is what
+            // preserves its exported `malloc_conf` symbol.
+            lakekeeper_alloc::log_effective_config();
+            tokio::spawn(lakekeeper_alloc::run(std::time::Duration::from_secs(30)));
             serve_and_maybe_migrate(force_start).await?;
         }
         Some(Commands::Healthcheck {

--- a/crates/lakekeeper-bin/src/ui.rs
+++ b/crates/lakekeeper-bin/src/ui.rs
@@ -1,14 +1,14 @@
 use std::{default::Default, env::VarError, sync::LazyLock};
 
 use lakekeeper::{
-    AuthZBackend, CONFIG, X_FORWARDED_PREFIX_HEADER, axum,
+    AuthZBackend, CONFIG, axum,
     axum::{
         Router,
         http::{HeaderMap, StatusCode, Uri, header},
         response::{IntoResponse, Response},
         routing::get,
     },
-    determine_base_uri,
+    determine_base_uri, determine_forwarded_prefix,
     request_tracing::{MakeRequestUuid7, RestMakeSpan},
     tower,
     tower_http::{
@@ -122,10 +122,16 @@ pub(crate) async fn static_handler(uri: Uri, headers: HeaderMap) -> impl IntoRes
     ))
 }
 
+/// The forwarded prefix, gated on `use_x_forwarded_headers` and normalized the
+/// same way every other route normalizes it.
+///
+/// This value is part of `FILE_CACHE`'s key, and the cache is bounded by entry
+/// count with no TTL over multi-MB templated assets. Reading the header raw let
+/// any caller mint cache keys (`/lk`, `/lk/`, `//lk`, … are all distinct) even
+/// where x-forwarded handling is disabled, so the key space has to be the
+/// normalized one.
 fn forwarded_prefix(headers: &HeaderMap) -> Option<&str> {
-    headers
-        .get(X_FORWARDED_PREFIX_HEADER)
-        .and_then(|hv| hv.to_str().ok())
+    determine_forwarded_prefix(headers)
 }
 
 fn cache_item_to_response(item: CacheItem) -> Response {
@@ -184,7 +190,7 @@ async fn redirect_to_ui(headers: axum::http::HeaderMap) -> axum::response::Redir
 
 #[cfg(test)]
 mod test {
-    use lakekeeper::tokio;
+    use lakekeeper::{X_FORWARDED_PREFIX_HEADER, tokio};
 
     use super::*;
 
@@ -218,6 +224,12 @@ mod test {
                 .to_vec(),
         )
         .unwrap();
-        assert!(body_str.contains("\"/lakekeeper/ui/assets/"));
+        // `forwarded_prefix` is gated on this, so assert the behaviour the
+        // running configuration actually selects.
+        if CONFIG.use_x_forwarded_headers {
+            assert!(body_str.contains("\"/lakekeeper/ui/assets/"));
+        } else {
+            assert!(body_str.contains("\"/ui/assets/"));
+        }
     }
 }

--- a/crates/lakekeeper/Cargo.toml
+++ b/crates/lakekeeper/Cargo.toml
@@ -19,7 +19,7 @@ ignored = ["cloudevents-sdk", "k8s-openapi"]
 [features]
 all = ["s3-signer", "router", "open-api"]
 s3-signer = ["dep:aws-sigv4"]
-router = ["dep:tower-http", "dep:tower"]
+router = ["dep:tower-http", "dep:tower", "dep:hyper-util", "dep:socket2"]
 default = ["s3-signer", "router"]
 test-utils = ["lakekeeper-io/storage-in-memory"]
 open-api = ["dep:utoipa", "dep:utoipa-swagger-ui", "dep:serde_norway"]
@@ -56,6 +56,7 @@ google-cloud-token = { workspace = true }
 hostname = { workspace = true }
 http = { workspace = true }
 http-body-util = { version = "~0.1" }
+hyper-util = { workspace = true, optional = true }
 iceberg = { workspace = true }
 iceberg-ext = { path = "../iceberg-ext", features = ["axum"] }
 iso8601 = { workspace = true }
@@ -80,6 +81,7 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_norway = { workspace = true, optional = true }
 serde_urlencoded = { workspace = true }
+socket2 = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true, features = ["tls-rustls"] }
 strum = { workspace = true }
 strum_macros = { workspace = true }

--- a/crates/lakekeeper/src/api/router.rs
+++ b/crates/lakekeeper/src/api/router.rs
@@ -1,9 +1,16 @@
 use std::{fmt::Debug, sync::Arc};
 
-use axum::{Json, Router, extract::DefaultBodyLimit, response::IntoResponse, routing::get};
+use axum::{
+    Json, Router, extract::DefaultBodyLimit, response::IntoResponse, routing::get, serve::Listener,
+};
 use axum_extra::{either::Either, middleware::option_layer};
-use axum_prometheus::PrometheusMetricLayer;
+use axum_prometheus::{PrometheusMetricLayer, metrics};
 use http::{HeaderName, HeaderValue, Method, StatusCode, header};
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo, TokioTimer},
+    server::{conn::auto, graceful::GracefulShutdown},
+    service::TowerToHyperService,
+};
 use limes::Authenticator;
 use tower::ServiceBuilder;
 use tower_http::{
@@ -419,24 +426,174 @@ fn maybe_merge_swagger_router<C: CatalogStore, A: Authorizer + Clone, S: SecretS
     }
 }
 
-/// Serve the given router on the given listener
+/// Serve the given router on the given listener until `cancellation_token` is
+/// cancelled, then drain in-flight connections.
 ///
 /// # Errors
-/// Fails if the webserver panics
+/// Returns `Ok` once draining finishes; the error type is kept for callers.
 pub async fn serve(
     listener: tokio::net::TcpListener,
     router: Router,
     cancellation_token: CancellationToken,
 ) -> anyhow::Result<()> {
-    let cancellation_future = async move {
-        cancellation_token.cancelled().await;
-        tracing::info!("HTTP server shutdown requested (cancellation token)");
-    };
-    axum::serve(listener, router)
-        .with_graceful_shutdown(cancellation_future)
-        .await
-        .map_err(|e| anyhow::anyhow!(e).context("error running HTTP server"))
+    // One accept loop of our own, because `axum::serve` exposes no way to reach
+    // hyper's per-connection settings. Three of them matter here, and all three
+    // are per-connection state that lives until the connection closes:
+    //
+    // * `timer` — hyper defaults `header_read_timeout` to 30s but silently
+    //   disables it when no timer is installed, which is what `axum::serve`
+    //   does. Installing one activates it, and because hyper arms it whenever
+    //   the connection is waiting for a request head, it also bounds how long
+    //   an idle kept-alive connection is held.
+    // * `max_buf_size` — hyper's read buffer grows adaptively to 408 KiB and
+    //   keeps that capacity for the connection's lifetime, so one large commit
+    //   permanently inflates the connection that carried it.
+    // * TCP keepalive — lets the kernel retire a connection whose peer vanished
+    //   without FIN or RST, which nothing else here would ever notice.
+    //
+    // `Listener::accept` is axum's, so accept-error backoff (EMFILE and
+    // friends) still comes from upstream.
+    let mut builder = auto::Builder::new(TokioExecutor::new());
+    builder
+        .http1()
+        .timer(TokioTimer::new())
+        .header_read_timeout(CONNECTION_IDLE_TIMEOUT)
+        .max_buf_size(MAX_CONNECTION_BUFFER_SIZE);
+    // CONNECT protocol carries websockets over HTTP/2.
+    builder
+        .http2()
+        .timer(TokioTimer::new())
+        .enable_connect_protocol();
+
+    let keepalive = socket2::TcpKeepalive::new()
+        .with_time(TCP_KEEPALIVE_IDLE)
+        .with_interval(TCP_KEEPALIVE_PROBE_INTERVAL)
+        .with_retries(TCP_KEEPALIVE_PROBE_RETRIES);
+
+    let graceful = GracefulShutdown::new();
+    let mut listener = listener;
+
+    // Separates "many connections open" from "we are leaking tasks":
+    // `tokio_live_tasks_count` counts every task on the runtime, so on its own it
+    // cannot tell one from the other.
+    metrics::describe_gauge!(
+        METRIC_HTTP_CONNECTIONS,
+        "Currently open HTTP connections, one tokio task each"
+    );
+    metrics::gauge!(METRIC_HTTP_CONNECTIONS).set(0.0);
+
+    loop {
+        let (stream, peer) = tokio::select! {
+            biased;
+            () = cancellation_token.cancelled() => {
+                tracing::info!("HTTP server shutdown requested (cancellation token)");
+                break;
+            }
+            accepted = Listener::accept(&mut listener) => accepted,
+        };
+
+        // Nagle would otherwise delay small responses waiting for an ACK.
+        if let Err(e) = stream.set_nodelay(true) {
+            tracing::debug!(%peer, "Failed to set TCP_NODELAY: {e}");
+        }
+        if let Err(e) = socket2::SockRef::from(&stream).set_tcp_keepalive(&keepalive) {
+            tracing::debug!(%peer, "Failed to set TCP keepalive: {e}");
+        }
+
+        let open_connection = OpenConnection::new();
+        let connection = builder
+            .serve_connection_with_upgrades(
+                TokioIo::new(stream),
+                TowerToHyperService::new(router.clone()),
+            )
+            .into_owned();
+        let connection = graceful.watch(connection);
+        tokio::spawn(async move {
+            let _open_connection = open_connection;
+            if let Err(e) = connection.await {
+                tracing::debug!(%peer, "Connection closed with error: {e}");
+            }
+        });
+    }
+
+    // Refuse new connections immediately. Held open, the socket keeps
+    // completing handshakes into the backlog for the whole drain, and those
+    // clients wait for a reply that never comes instead of failing fast.
+    drop(listener);
+
+    let in_flight = graceful.count();
+    tracing::info!(in_flight, "Draining connections");
+    tokio::select! {
+        // `GracefulShutdown::shutdown` signals the connections on its first
+        // poll, so it must be polled before the deadline can win.
+        biased;
+        () = graceful.shutdown() => tracing::info!("All connections drained"),
+        () = tokio::time::sleep(SHUTDOWN_GRACE_PERIOD) => tracing::warn!(
+            "Grace period elapsed; abandoning connections still open"
+        ),
+    }
+    Ok(())
 }
+
+/// Open HTTP connections. Compare against `tokio_live_tasks_count`: a gap that
+/// grows is a task leak somewhere other than the accept loop.
+const METRIC_HTTP_CONNECTIONS: &str = "lakekeeper_http_connections";
+
+/// Holds [`METRIC_HTTP_CONNECTIONS`] up for as long as it is alive.
+///
+/// The decrement happens in `Drop` so that it cannot be skipped. This gauge is
+/// the signal for spotting a task leak, so a path that leaks the gauge itself
+/// would fabricate the very thing it is meant to detect.
+struct OpenConnection;
+
+impl OpenConnection {
+    fn new() -> Self {
+        metrics::gauge!(METRIC_HTTP_CONNECTIONS).increment(1.0);
+        Self
+    }
+}
+
+impl Drop for OpenConnection {
+    fn drop(&mut self) {
+        metrics::gauge!(METRIC_HTTP_CONNECTIONS).decrement(1.0);
+    }
+}
+
+/// How long an HTTP/1 connection may wait for a request head before the server
+/// closes it.
+///
+/// hyper arms this timer whenever the connection is waiting for a request head,
+/// so it covers both a client dribbling headers and a connection sitting idle
+/// between requests. 75s matches nginx's `keepalive_timeout` and sits just above
+/// the 60s idle timeout common to cloud load balancers, which retire a
+/// connection before we do.
+///
+/// Two gaps: hyper has no equivalent for HTTP/2, and the timer is armed only
+/// once `auto` has sniffed the protocol, so a peer that connects and sends
+/// nothing at all is bounded by neither this nor TCP keepalive.
+const CONNECTION_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(75);
+/// Ceiling on hyper's per-connection HTTP/1 read/write buffer.
+///
+/// hyper grows the buffer adaptively and keeps the capacity for the connection's
+/// lifetime, so this is the steady-state cost of a connection that has carried a
+/// large request. hyper's own default is 408 `KiB`. Measured on 4 `MiB` bodies,
+/// 64 `KiB` costs nothing: 1828 req/s here against 1742 at hyper's default.
+///
+/// This also caps the request head, which hyper rejects with `431` once it no
+/// longer fits.
+const MAX_CONNECTION_BUFFER_SIZE: usize = 64 * 1024;
+/// Idle time before the kernel starts TCP keepalive probing.
+///
+/// Covers the states the idle timeout above does not: a peer that disappears
+/// while we are reading a request body or writing a response leaves no
+/// wait-for-head timer armed.
+const TCP_KEEPALIVE_IDLE: std::time::Duration = std::time::Duration::from_mins(1);
+/// Gap between TCP keepalive probes once the idle time has elapsed.
+const TCP_KEEPALIVE_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+/// Unanswered TCP keepalive probes before the kernel drops the connection.
+const TCP_KEEPALIVE_PROBE_RETRIES: u32 = 6;
+/// How long `serve` waits for in-flight connections after cancellation.
+const SHUTDOWN_GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10);
 
 #[cfg(test)]
 mod test {

--- a/crates/lakekeeper/src/metrics.rs
+++ b/crates/lakekeeper/src/metrics.rs
@@ -1,15 +1,55 @@
 use std::{future::Future, pin::Pin};
 
 use axum_prometheus::{
-    AXUM_HTTP_REQUESTS_DURATION_SECONDS, PREFIXED_HTTP_REQUESTS_DURATION_SECONDS,
+    AXUM_HTTP_REQUESTS_DURATION_SECONDS, EndpointLabel, PREFIXED_HTTP_REQUESTS_DURATION_SECONDS,
     PrometheusMetricLayer, PrometheusMetricLayerBuilder, metrics,
-    metrics_exporter_prometheus::{Matcher, PrometheusBuilder},
+    metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle},
     utils,
 };
 
 use crate::CONFIG;
 
 pub type ExporterFuture = Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send + 'static>>;
+
+/// `endpoint` label used for requests that matched no route. A single shared
+/// label keeps the metric registry's cardinality bounded by the route table
+/// rather than by whatever paths clients happen to ask for.
+pub const UNMATCHED_ENDPOINT_LABEL: &str = "unmatched";
+
+/// The `endpoint` label policy applied to every HTTP metric.
+///
+/// Requests that match no route reach the router's fallback, which never gets a
+/// [`axum::extract::MatchedPath`] extension. `axum-prometheus`' default
+/// [`EndpointLabel::MatchedPath`] then falls back to the *raw* URI, so every
+/// distinct unknown path becomes 16 permanent series (a counter, a pending gauge
+/// and an 11-bucket histogram). `PrometheusBuilder` sets no `idle_timeout`, so
+/// nothing is ever reclaimed — measured at ~1.9 `KiB` of live heap retained for
+/// the process's remaining life, per distinct path. Because the auth middleware
+/// also wraps the fallback, unauthenticated probing counts: ~9 junk paths per
+/// second grows a replica by ~60 `MiB`/h, and a client that malforms a table URL
+/// (missing route prefix, trailing slash, doubled slash) leaks one series per
+/// table forever.
+///
+/// Collapsing every unmatched path onto [`UNMATCHED_ENDPOINT_LABEL`] bounds the
+/// registry by the route table. The requested paths are still recorded by the
+/// request-tracing layer, so nothing observable is lost.
+#[must_use]
+pub fn endpoint_label_policy() -> EndpointLabel {
+    EndpointLabel::MatchedPathWithFallbackFn(|_| UNMATCHED_ENDPOINT_LABEL.to_string())
+}
+
+/// Builds the HTTP metric layer with the [`endpoint_label_policy`] applied.
+///
+/// Production and `tests/metrics_endpoint_cardinality.rs` both go through here,
+/// so the test exercises the real wiring and not a copy of it.
+#[must_use]
+pub fn build_metric_layer(handle: PrometheusHandle) -> PrometheusMetricLayer<'static> {
+    let (layer, _) = PrometheusMetricLayerBuilder::new()
+        .with_metrics_from_fn(move || handle)
+        .with_endpoint_label_type(endpoint_label_policy())
+        .build_pair();
+    layer
+}
 
 /// Creates `PrometheusRecorder` and installs it as the global metrics recorder. Also creates a
 /// `PrometheusMetricLayer` (which captures axum requests), a Tokio Runtime Metrics recorder (which captures tokio runtime metrics),
@@ -42,9 +82,7 @@ pub fn get_axum_layer_and_install_recorder(
             .describe_and_run(),
     );
 
-    let (layer, _) = PrometheusMetricLayerBuilder::new()
-        .with_metrics_from_fn(|| handle)
-        .build_pair();
+    let layer = build_metric_layer(handle);
 
     Ok((
         layer,

--- a/crates/lakekeeper/src/serve.rs
+++ b/crates/lakekeeper/src/serve.rs
@@ -143,7 +143,10 @@ pub struct ServeConfiguration<
     #[builder(default)]
     /// A function to modify the router before serving
     pub modify_router_fn: Option<fn(axum::Router) -> axum::Router>,
-    /// Cloud events sinks / publishers
+    /// Cloud events sinks / publishers.
+    ///
+    /// The cloud-event publisher is registered only when this is non-empty.
+    /// Listeners added through `event_dispatcher` are unaffected.
     #[builder(default)]
     pub cloud_event_sinks: Vec<Arc<dyn CloudEventBackend + Send + Sync + 'static>>,
     /// Enable built-in queue workers
@@ -389,6 +392,7 @@ async fn serve_inner<
     );
 
     // Cloud events publisher setup
+    let has_cloud_event_sinks = !cloud_event_sinks.is_empty();
     let cloud_events_background_task = CloudEventsPublisherBackgroundTask {
         source: cloud_events_rx,
         sinks: cloud_event_sinks,
@@ -416,9 +420,21 @@ async fn serve_inner<
 
     // Event system setup
     let dispatcher = additional_event_dispatcher.unwrap_or(EventDispatcher::new(vec![]));
-    dispatcher
-        .append(Arc::new(CloudEventsPublisher::new(cloud_events_tx.clone())))
-        .await;
+    // Registering the publisher with no sinks configured is pure waste that is
+    // paid per commit: the listener runs `serde_json::to_value` over the whole
+    // commit request (megabytes, once `max_request_body_size` is raised), queues
+    // it, and the background task then builds a full `CloudEvent` from it —
+    // only to drop it because there is nowhere to send it. Skip the listener
+    // entirely instead; nothing observable changes.
+    if has_cloud_event_sinks {
+        dispatcher
+            .append(Arc::new(CloudEventsPublisher::new(cloud_events_tx.clone())))
+            .await;
+    } else {
+        tracing::info!(
+            "No cloud-event sinks configured, not registering the cloud-events publisher"
+        );
+    }
     if CONFIG.cache.warehouse.enabled {
         tracing::info!("Warehouse cache is enabled, registering warehouse cache event listener");
         dispatcher

--- a/crates/lakekeeper/tests/metrics_endpoint_cardinality.rs
+++ b/crates/lakekeeper/tests/metrics_endpoint_cardinality.rs
@@ -1,0 +1,107 @@
+//! Regression test for unbounded Prometheus cardinality on unmatched routes.
+//!
+//! `metrics::set_global_recorder` can only succeed once per process, so this
+//! lives in its own integration-test binary.
+
+use axum::{Router, routing::get};
+use axum_prometheus::{metrics, metrics_exporter_prometheus::PrometheusBuilder};
+use lakekeeper::metrics::{UNMATCHED_ENDPOINT_LABEL, build_metric_layer};
+use tower::ServiceExt;
+
+/// Build a router shaped like the real one: nested sub-routers plus a top-level
+/// route, with the metric layer applied last.
+fn app(layer: axum_prometheus::PrometheusMetricLayer<'static>) -> Router {
+    let catalog = Router::new().route(
+        "/{prefix}/namespaces/{namespace}/tables/{table}",
+        get(|| async { "ok" }),
+    );
+    Router::new()
+        .nest("/catalog/v1", catalog)
+        .route("/health", get(|| async { "ok" }))
+        .layer(layer)
+}
+
+async fn call(app: &Router, uri: &str) {
+    let request = http::Request::builder()
+        .uri(uri)
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let _ = app.clone().oneshot(request).await.unwrap();
+}
+
+fn endpoint_labels(rendered: &str) -> Vec<String> {
+    rendered
+        .lines()
+        .filter(|line| line.starts_with("axum_http_requests_total"))
+        .filter_map(|line| {
+            let start = line.find("endpoint=\"")? + "endpoint=\"".len();
+            let rest = &line[start..];
+            Some(rest[..rest.find('"')?].to_string())
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn unmatched_paths_share_one_endpoint_label() {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let handle = recorder.handle();
+    let scrape = handle.clone();
+    metrics::set_global_recorder(recorder).expect("no other recorder in this test binary");
+
+    // Deliberately the production constructor: building an equivalent layer
+    // here would leave this test green if the real one stopped applying the
+    // policy.
+    let app = app(build_metric_layer(handle));
+
+    // Matched routes must keep their templated label — the whole point of the
+    // metric is per-route latency, and collapsing those would be a regression.
+    call(&app, "/catalog/v1/wh/namespaces/ns/tables/orders").await;
+    call(&app, "/catalog/v1/wh/namespaces/other/tables/customers").await;
+    call(&app, "/health").await;
+
+    // Every shape a client can malform a URL into, plus outright junk. Each of
+    // these used to mint 16 permanent series carrying the table name.
+    for i in 0..200 {
+        call(&app, &format!("/v1/wh/namespaces/ns/tables/table_{i}")).await;
+        call(
+            &app,
+            &format!("/catalog/v1/wh/namespaces/ns/tables/table_{i}/"),
+        )
+        .await;
+        call(
+            &app,
+            &format!("/catalog/v1//wh/namespaces/ns/tables/table_{i}"),
+        )
+        .await;
+        call(&app, &format!("/junk/{i}")).await;
+    }
+
+    let rendered = scrape.render();
+    let labels = endpoint_labels(&rendered);
+
+    let template = "/catalog/v1/{prefix}/namespaces/{namespace}/tables/{table}";
+    assert!(
+        labels.iter().any(|l| l == template),
+        "matched routes must stay templated, got {labels:?}"
+    );
+    assert!(labels.iter().any(|l| l == "/health"));
+    assert!(
+        labels.iter().any(|l| l == UNMATCHED_ENDPOINT_LABEL),
+        "unmatched requests must be recorded under `{UNMATCHED_ENDPOINT_LABEL}`, got {labels:?}"
+    );
+
+    // 800 distinct unmatched paths must not add 800 labels.
+    let unexpected: Vec<_> = labels
+        .iter()
+        .filter(|l| l.contains("table_") || l.contains("/junk/"))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "raw request paths leaked into the `endpoint` label: {unexpected:?}"
+    );
+    assert!(
+        labels.len() <= 4,
+        "endpoint label cardinality must be bounded by the route table, got {} labels: {labels:?}",
+        labels.len()
+    );
+}

--- a/release-please/release-please-config.json
+++ b/release-please/release-please-config.json
@@ -34,6 +34,11 @@
         {
             "type": "toml",
             "path": "Cargo.lock",
+            "jsonpath": "$.package[?(@.name.value == \"lakekeeper-alloc\")].version"
+        },
+        {
+            "type": "toml",
+            "path": "Cargo.lock",
             "jsonpath": "$.package[?(@.name.value == \"lakekeeper-authz-openfga\")].version"
         },
         {


### PR DESCRIPTION
Backport of #1990.

Four independent causes of RSS growing until restart:

- Transparent huge pages defeat jemalloc's page release: it frees at 4 KiB
  granularity, but a 2 MiB huge page cannot be partially freed, so one live
  page keeps all 2 MiB resident. Forces thp:never via both the build variable
  and an exported malloc_conf symbol, since either can be lost silently.
  AnonHugePages 286 MiB -> 0, settled RSS -68%, throughput +1.9%.

- axum::serve rebuilt the whole route table per accepted connection
  (Router::with_state), holding the copy for the connection's lifetime:
  ~1 KiB of live heap per route per connection, ~370 KiB here before any
  request. into_make_service drops it to ~3.6 KiB at equal throughput.

- hyper's per-connection read buffer grows to 408 KiB and never shrinks, and
  nothing set TCP keepalive or a header-read timer, so connections whose peer
  vanished were held for the life of the process. Per-connection cost after a
  1 MiB request: ~464 KiB -> ~86 KiB.

- Unmatched request paths became permanent Prometheus series (~1.9 KiB of
  live heap each, never reclaimed) because axum-prometheus falls back to the
  raw URI when there is no MatchedPath.

Adds two metrics for telling these apart in future: jemalloc gauges, which
separate a real leak (allocated grows) from allocator retention (resident
grows, allocated flat) from THP-trapped pages (both look fine, RSS climbs);
and lakekeeper_http_connections, since tokio_live_tasks_count counts every
task on the runtime and cannot distinguish open connections from a task leak
elsewhere — live_tasks minus http_connections is the leak signal.

Also normalizes the forwarded prefix in the UI asset cache key, and skips the
cloud-event publisher when no sinks are configured.

Behaviour changes:
- Idle HTTP/1 connections close after 75s (nginx's keepalive_timeout). A
  client taking a pooled connection at the boundary must retry.
- The 64 KiB buffer ceiling also caps the request head; larger heads get 431.
- Shutdown drains for at most 10s.
- The idle timeout and buffer cap are HTTP/1 only.
- Unmatched paths now report endpoint="unmatched"; dashboards grouping by raw
  path lose that data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added allocator health and memory metrics, including huge-page residency and background activity.
  * Improved HTTP server connection handling with configurable timeouts, keepalive behavior, graceful shutdown, and connection tracking.
  * Added support for HTTP/2 CONNECT requests.
* **Bug Fixes**
  * Prevented unmatched request paths from creating unbounded Prometheus metric labels.
  * Improved forwarded-prefix handling when proxy headers are disabled or malformed.
  * Avoided starting cloud-event publisher listeners when no sinks are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->