### PR TITLE
chore(deps): bump iceberg to lakekeeper-main-2026-08-26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.10.0"
-source = "git+https://github.com/lakekeeper/iceberg-rust.git?rev=2056f3e4d53129039f2229f3b326aa538289be27#2056f3e4d53129039f2229f3b326aa538289be27"
+source = "git+https://github.com/lakekeeper/iceberg-rust.git?rev=aa04094683f84db8fa82daed716efc0f78d1936d#aa04094683f84db8fa82daed716efc0f78d1936d"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ hyper-util = { version = "0.1.20", features = [
     "service",
     "tokio",
 ] }
-iceberg = { git = "https://github.com/lakekeeper/iceberg-rust.git", rev = "2056f3e4d53129039f2229f3b326aa538289be27" }
+iceberg = { git = "https://github.com/lakekeeper/iceberg-rust.git", rev = "aa04094683f84db8fa82daed716efc0f78d1936d" }
 iso8601 = "0.6.2"
 itertools = "0.14.0"
 # `limes` pulls k8s-openapi transitively without picking a Kubernetes version.


### PR DESCRIPTION
## What

Bumps the `iceberg` pin from the `lakekeeper-main-2026-07-16` snapshot (`2056f3e4`) to `lakekeeper-main-2026-08-26` (`aa040946`).

## Why

The new snapshot adds a backward-compatible **`Storage::as_any`** downcast hook to `iceberg::io::Storage` (default impl returning a non-downcastable ref; existing backends need no change). This is the iceberg-side prerequisite for an upcoming `object_store` bridge change, but is landed **on its own** here so the dependency move is independently reviewable and provably safe.

## Change is minimal & additive

- `Cargo.toml`: one line (the pinned rev).
- `Cargo.lock`: one line (the git source rev) — **no transitive dependency changes**, so `aa040946` resolves an identical dependency tree to `2056f3e4`.

## Verification

- `cargo check --workspace --all-targets` — entire workspace + all test targets compile against the new rev.
- Unit tests pass locally: `lakekeeper-io` (47) and `iceberg-ext` (22).
- Full DB/object-store integration suite left to CI (requires live backends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency revision to incorporate the latest upstream changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->