### PR TITLE
fix(alloc): allow clippy::unused_async on the non-Linux allocator stub

### DIFF
--- a/crates/alloc/src/lib.rs
+++ b/crates/alloc/src/lib.rs
@@ -24,6 +24,8 @@ pub fn log_effective_config() {}
 
 /// See [`log_effective_config`].
 #[cfg(not(all(target_os = "linux", not(target_env = "msvc"))))]
+// Stays `async` to match the Linux signature; callers `tokio::spawn` it.
+#[allow(clippy::unused_async)]
 pub async fn run(_interval: std::time::Duration) {}
 
 /// jemalloc run-time options, compiled into the binary.


### PR DESCRIPTION
The non-Linux `run` is a no-op with no await points, but keeps its `async` signature to match `stats::run` on Linux so callers can `tokio::spawn` it. Clippy's `unused_async` fires on it under `-D warnings`, and only off Linux where the stub is compiled in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform compatibility for asynchronous task handling on non-Linux and non-MSVC systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->