### PR TITLE
feat(authn)!: gate admission on required token claims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,6 +3839,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
+ "aws-lc-rs",
  "aws-sdk-s3",
  "aws-sdk-sts",
  "aws-sigv4",
@@ -3868,6 +3869,7 @@ dependencies = [
  "iceberg-ext",
  "iso8601",
  "itertools 0.14.0",
+ "jsonwebtoken 11.0.0",
  "k8s-openapi",
  "lakekeeper",
  "lakekeeper-io",
@@ -4332,8 +4334,8 @@ dependencies = [
 
 [[package]]
 name = "limes"
-version = "0.5.0"
-source = "git+https://github.com/vakamo-labs/limes-rs.git?tag=v0.5.0#657d4653c078af010749afd8dca916c77303bba3"
+version = "0.6.0"
+source = "git+https://github.com/vakamo-labs/limes-rs.git?rev=641c81961b423c5e72239655e8a0cff7a8bd5790#641c81961b423c5e72239655e8a0cff7a8bd5790"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ azure_storage_datalake = { git = "https://github.com/lakekeeper/azure-sdk-for-ru
     "enable_reqwest",
     "enable_reqwest_rustls",
 ] }
+aws-lc-rs = "1"
 base64 = "0.22.1"
 bytes = "1.10"
 chrono = "^0.4"
@@ -123,10 +124,12 @@ itertools = "0.14.0"
 # `limes` pulls k8s-openapi transitively without picking a Kubernetes version.
 # The version feature (`v1_XX`) is selected by the `lakekeeper` crate, not in
 # this workspace table.
+jsonwebtoken = { version = "11.0", features = ["aws_lc_rs"] }
 k8s-openapi = { version = "0.28" }
 lazy-regex = { version = "3.2.0", features = ["lite"] }
 lazy_static = "^1.4"
-limes = { git = "https://github.com/vakamo-labs/limes-rs.git", tag = "v0.5.0", features = [
+# TEMPORARY: pinned to main. Move to `tag = "v0.7.0"` once that release is published.
+limes = { git = "https://github.com/vakamo-labs/limes-rs.git", rev = "641c81961b423c5e72239655e8a0cff7a8bd5790", features = [
     "kubernetes",
     "axum",
     "rustls-tls",

--- a/crates/lakekeeper/Cargo.toml
+++ b/crates/lakekeeper/Cargo.toml
@@ -115,10 +115,12 @@ xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }
+aws-lc-rs = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 bytes = { workspace = true }
 figment = { workspace = true, features = ["test"] }
 http-body-util = { workspace = true }
+jsonwebtoken = { workspace = true }
 lakekeeper = { path = ".", features = ["test-utils"] }
 lakekeeper-io = { path = "../io", features = ["storage-in-memory"] }
 maplit = { workspace = true }

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -23,7 +23,7 @@ use crate::{
     WarehouseId,
     service::{
         ArcProjectId, ProjectId, UserId,
-        authn::{K8S_IDP_ID, OIDC_IDP_ID, OidcProviderConfig},
+        authn::{ClaimRuleConfig, K8S_IDP_ID, OIDC_IDP_ID, OidcProviderConfig},
     },
 };
 
@@ -44,7 +44,11 @@ fn resolve_default_project_id(config: &DynAppConfig) -> Option<ArcProjectId> {
     })
 }
 
-fn get_config() -> DynAppConfig {
+/// Load and validate configuration from the environment.
+///
+/// `pub(crate)` so tests can drive the whole seam from environment variables through to
+/// enforcement — a rule that never reaches a field is invisible to config-level tests.
+pub(crate) fn get_config() -> DynAppConfig {
     let defaults = figment::providers::Serialized::defaults(DynAppConfig::default());
 
     #[cfg(not(test))]
@@ -73,11 +77,14 @@ fn get_config() -> DynAppConfig {
         config = config.merge(env);
     }
 
+    // `Display` renders figment's "for key ... in LAKEKEEPER__ environment variable(s)"
+    // pointer; `Debug` (what `expect` prints) loses it.
     let mut config = config
         .extract::<DynAppConfig>()
-        .expect("Valid Configuration");
+        .unwrap_or_else(|e| panic!("Invalid configuration: {e}"));
 
     validate_openid_provider_ids(&config);
+    validate_required_claims(&config);
 
     if !config.openid_providers.is_empty() && config.openid_provider_uri.is_none() {
         tracing::warn!(
@@ -208,6 +215,95 @@ fn validate_openid_provider_ids(config: &DynAppConfig) {
             idp_id != OIDC_IDP_ID,
             "Invalid OIDC provider '{idp_id}': IdP ID '{OIDC_IDP_ID}' is reserved"
         );
+    }
+}
+
+fn validate_required_claims(config: &DynAppConfig) {
+    assert!(
+        config.openid_required_claims.is_empty() || config.openid_provider_uri.is_some(),
+        "`openid_required_claims` is set but `openid_provider_uri` is not; the rules would \
+         never apply. Configure the provider, or move the rules under \
+         `openid_providers.<idp_id>.required_claims`."
+    );
+    assert!(
+        config.openid_scope.is_none() || config.openid_provider_uri.is_some(),
+        "`openid_scope` is set but `openid_provider_uri` is not; the scope would never be \
+         enforced. Configure the provider, or move the scope under \
+         `openid_providers.<idp_id>.scope`."
+    );
+    let scopes = std::iter::once((OIDC_IDP_ID, &config.openid_scope)).chain(
+        config
+            .openid_providers
+            .iter()
+            .map(|(id, p)| (id.as_str(), &p.scope)),
+    );
+    for (idp_id, scope) in scopes {
+        if let Some(scope) = scope {
+            assert!(
+                !scope.is_empty() && !scope.contains(char::is_whitespace),
+                "Invalid `scope` for OIDC provider '{idp_id}': a single non-empty scope \
+                 without whitespace is required; no token could ever satisfy '{scope}'. An \
+                 empty value does not mean `no scope` — unset the variable entirely."
+            );
+        }
+    }
+    // The Kubernetes authenticator is configured with no issuers, so without an audience it
+    // accepts every JWT. It sits last in the chain, which means it takes exactly the tokens a
+    // guarded OIDC provider declined on audience — and admits them with no rules at all.
+    let any_guarded = !config.openid_required_claims.is_empty()
+        || config.openid_scope.is_some()
+        || config
+            .openid_providers
+            .values()
+            .any(OidcProviderConfig::is_guarded);
+    assert!(
+        !(any_guarded
+            && config.enable_kubernetes_authentication
+            && config
+                .kubernetes_authentication_audience
+                .as_ref()
+                .is_none_or(Vec::is_empty)),
+        "An OIDC provider enforces a scope or required claims while Kubernetes \
+         authentication is enabled without `KUBERNETES_AUTHENTICATION_AUDIENCE`. The \
+         Kubernetes authenticator then accepts any token the OIDC providers decline, \
+         admitting them without those rules. Set the audience, or disable Kubernetes \
+         authentication."
+    );
+    for (idp_id, provider) in &config.openid_providers {
+        let guarded = provider.is_guarded();
+        assert!(
+            !guarded || provider.require_connected_on_startup,
+            "OIDC provider '{idp_id}' enforces a scope or required claims but sets \
+             `require_connected_on_startup=false`. A provider skipped at boot enforces \
+             nothing, and another provider publishing the same issuer would admit its \
+             tokens unchecked. Set `require_connected_on_startup=true`."
+        );
+    }
+    let providers = std::iter::once((OIDC_IDP_ID, &config.openid_required_claims)).chain(
+        config
+            .openid_providers
+            .iter()
+            .map(|(id, p)| (id.as_str(), &p.required_claims)),
+    );
+    for (idp_id, rules) in providers {
+        for (name, rule) in rules {
+            assert!(
+                !name.is_empty()
+                    && name
+                        .chars()
+                        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "Invalid required claim rule '{name}' for OIDC provider '{idp_id}': rule name \
+                 must match `[a-z0-9-]+`; write `tenant-filter`, not `tenant_filter`"
+            );
+            assert!(
+                !(rule.exists.is_some() && rule.separator.is_some()),
+                "Invalid required claim rule '{name}' for OIDC provider '{idp_id}': `separator` \
+                 has no effect on `exists`; remove one of them"
+            );
+            if let Err(e) = rule.to_rule() {
+                panic!("Invalid required claim rule '{name}' for OIDC provider '{idp_id}': {e}");
+            }
+        }
     }
 }
 
@@ -450,6 +546,11 @@ pub struct DynAppConfig {
     pub openid_additional_issuers: Option<Vec<String>>,
     /// A scope that must be present in provided tokens
     pub openid_scope: Option<String>,
+    /// Rules a verified token must satisfy; see
+    /// [`OidcProviderConfig::required_claims`](crate::service::authn::OidcProviderConfig).
+    /// Applies to the single-provider `openid_provider_uri` setup.
+    #[serde(default)]
+    pub openid_required_claims: HashMap<String, ClaimRuleConfig>,
     pub enable_kubernetes_authentication: bool,
     /// Audience expected in provided JWT tokens.
     #[serde(
@@ -715,6 +816,38 @@ where
             .ok_or_else(|| serde::de::Error::custom("Expected a string"))
     })
     .transpose()
+}
+
+/// A list of strings from a figment bracket list (`[a, b]`).
+///
+/// figment types a bare `[0644]` as a number, and rendering it back to a string would not
+/// reproduce what was written (`644`), so a rule would silently compare against a value the
+/// operator never configured. Numbers and booleans must therefore be quoted.
+pub(crate) fn deserialize_string_list<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(values) = Option::<Vec<serde_json::Value>>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    values
+        .into_iter()
+        .map(|v| match v {
+            serde_json::Value::String(s) => Ok(s),
+            other @ (serde_json::Value::Number(_) | serde_json::Value::Bool(_)) => {
+                Err(serde::de::Error::custom(format!(
+                    "expected a string, found {other}; quote values that look like numbers or \
+                     booleans so they reach the rule exactly as written, e.g. [\"0644\"]"
+                )))
+            }
+            other => Err(serde::de::Error::custom(format!(
+                "expected a string, found {other}"
+            ))),
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
 }
 
 pub(crate) fn serialize_comma_separated<S>(
@@ -1193,6 +1326,7 @@ impl Default for DynAppConfig {
             openid_audience: None,
             openid_additional_issuers: None,
             openid_scope: None,
+            openid_required_claims: HashMap::new(),
             enable_kubernetes_authentication: false,
             kubernetes_authentication_audience: None,
             kubernetes_authentication_accept_legacy_serviceaccount: false,
@@ -2007,7 +2141,7 @@ mod test {
             );
             jail.set_env(
                 "LAKEKEEPER_TEST__OPENID_PROVIDERS__OKTA__REQUIRE_CONNECTED_ON_STARTUP",
-                "false",
+                "true",
             );
 
             let config = get_config();
@@ -2030,7 +2164,170 @@ mod test {
                 provider.roles_claim,
                 Some("resource_access.lakekeeper.roles".to_string())
             );
+            assert!(provider.require_connected_on_startup);
+            Ok(())
+        });
+    }
+
+    /// Build the rule a provider's config describes, so the mapping from wire field to
+    /// operator is observed rather than assumed.
+    fn rule_from_env(kv: &[(&str, &str)]) -> limes::ClaimRule {
+        let mut built = None;
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(jail, X, "ORG", kv);
+            built = Some(
+                get_config().openid_providers["x"].required_claims["org"]
+                    .to_rule()
+                    .unwrap(),
+            );
+            Ok(())
+        });
+        built.unwrap()
+    }
+
+    /// The `exists` flag must reach the matcher with the polarity that was configured.
+    /// Inverted, `EXISTS=false` admits exactly the tokens it was written to reject — and
+    /// asserting only the parsed config field cannot see that.
+    #[test]
+    fn test_exists_reaches_the_matcher_with_both_polarities() {
+        let present = serde_json::json!({ "grp": ["x"] });
+        let absent = serde_json::json!({ "other": "y" });
+
+        let must_exist = rule_from_env(&[("CLAIM", "grp"), ("EXISTS", "true")]);
+        assert!(must_exist.matches(&present));
+        assert!(!must_exist.matches(&absent));
+
+        let must_be_absent = rule_from_env(&[("CLAIM", "grp"), ("EXISTS", "false")]);
+        assert!(!must_be_absent.matches(&present));
+        assert!(must_be_absent.matches(&absent));
+    }
+
+    /// A one-value list cannot tell `ANY_OF` from `ALL_OF`, so the two are pinned with a list
+    /// the token only partly satisfies. Wiring `ALL_OF` to `any_of` is a fail-open.
+    #[test]
+    fn test_any_of_and_all_of_are_not_interchangeable() {
+        let any = rule_from_env(&[("CLAIM", "grp"), ("ANY_OF", "[a, b]")]);
+        let all = rule_from_env(&[("CLAIM", "grp"), ("ALL_OF", "[a, b]")]);
+
+        let partial = serde_json::json!({ "grp": ["b"] });
+        assert!(any.matches(&partial), "any_of holds on one of two");
+        assert!(!all.matches(&partial), "all_of must not hold on one of two");
+
+        let complete = serde_json::json!({ "grp": ["a", "b"] });
+        assert!(any.matches(&complete));
+        assert!(all.matches(&complete));
+
+        let neither = serde_json::json!({ "grp": ["c"] });
+        assert!(!any.matches(&neither));
+        assert!(!all.matches(&neither));
+    }
+
+    /// `NONE_OF` denies on any listed value, not only the first.
+    #[test]
+    fn test_none_of_denies_every_listed_value() {
+        let deny = rule_from_env(&[("CLAIM", "grp"), ("NONE_OF", "[a, b]")]);
+        assert!(!deny.matches(&serde_json::json!({ "grp": ["a"] })));
+        assert!(!deny.matches(&serde_json::json!({ "grp": ["b"] })));
+        assert!(deny.matches(&serde_json::json!({ "grp": ["c"] })));
+    }
+
+    /// `whitespace` reaches the separator that splits on any whitespace; every other value is
+    /// matched byte-exactly, so a deny split on a space is blind to a tab.
+    #[test]
+    fn test_separator_whitespace_sentinel() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(
+                jail,
+                X,
+                "ORG",
+                &[
+                    ("CLAIM", "scope"),
+                    ("NONE_OF", "[admin]"),
+                    ("SEPARATOR", "whitespace"),
+                ],
+            );
+            let config = get_config();
+            let rule = config.openid_providers["x"].required_claims["org"]
+                .to_rule()
+                .unwrap();
+            // A tab, a newline and a non-breaking space all delimit.
+            for delimiter in [" ", "\t", "\n", "\u{00a0}"] {
+                let claims = serde_json::json!({ "scope": format!("openid{delimiter}admin") });
+                assert!(!rule.matches(&claims), "{delimiter:?} must delimit");
+            }
+            assert!(rule.matches(&serde_json::json!({ "scope": "openid superadmin" })));
+            Ok(())
+        });
+    }
+
+    /// A literal separator stays literal, so the same rule written with a space is byte-exact.
+    #[test]
+    fn test_literal_separator_is_byte_exact() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(
+                jail,
+                X,
+                "ORG",
+                &[
+                    ("CLAIM", "scope"),
+                    ("NONE_OF", "[admin]"),
+                    ("SEPARATOR", "\" \""),
+                ],
+            );
+            let config = get_config();
+            let rule = config.openid_providers["x"].required_claims["org"]
+                .to_rule()
+                .unwrap();
+            assert!(!rule.matches(&serde_json::json!({ "scope": "openid admin" })));
+            assert!(rule.matches(&serde_json::json!({ "scope": "openid\tadmin" })));
+            Ok(())
+        });
+    }
+
+    /// A provider that enforces nothing may be absent at boot without weakening anything.
+    #[test]
+    fn test_require_connected_on_startup_false_is_allowed_when_unguarded() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            jail.set_env(format!("{X}__REQUIRE_CONNECTED_ON_STARTUP"), "false");
+            let config = get_config();
+            let provider = config.openid_providers.get("x").unwrap();
             assert!(!provider.require_connected_on_startup);
+            Ok(())
+        });
+    }
+
+    /// A guarded provider skipped at boot enforces nothing, and whether another provider
+    /// would then admit its tokens is only knowable by connecting — so the pair is refused.
+    #[test]
+    #[should_panic(expected = "`require_connected_on_startup=false`")]
+    fn test_guarded_provider_must_be_connected_on_startup() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            jail.set_env(format!("{X}__REQUIRE_CONNECTED_ON_STARTUP"), "false");
+            set_required_claims_env(
+                jail,
+                X,
+                "ORG",
+                &[("CLAIM", "organizations"), ("ANY_OF", "[tenant-a]")],
+            );
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    /// The same holds when the guard is a scope rather than a rule.
+    #[test]
+    #[should_panic(expected = "`require_connected_on_startup=false`")]
+    fn test_scoped_provider_must_be_connected_on_startup() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            jail.set_env(format!("{X}__SCOPE"), "catalog");
+            jail.set_env(format!("{X}__REQUIRE_CONNECTED_ON_STARTUP"), "false");
+            let _config = get_config();
             Ok(())
         });
     }
@@ -2045,6 +2342,275 @@ mod test {
             let config = get_config();
             let provider = config.openid_providers.get("okta").unwrap();
             assert!(provider.require_connected_on_startup);
+            Ok(())
+        });
+    }
+
+    fn set_required_claims_env(
+        jail: &mut figment::Jail,
+        prefix: &str,
+        rule: &str,
+        kv: &[(&str, &str)],
+    ) {
+        for (k, v) in kv {
+            jail.set_env(format!("{prefix}__REQUIRED_CLAIMS__{rule}__{k}"), v);
+        }
+    }
+
+    const X: &str = "LAKEKEEPER_TEST__OPENID_PROVIDERS__X";
+
+    #[test]
+    fn test_required_claims_structured_env() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(
+                jail,
+                X,
+                "ORG",
+                &[("CLAIM", "organizations"), ("ANY_OF", "[f648, \"a,b\"]")],
+            );
+            set_required_claims_env(
+                jail,
+                X,
+                "SCOPES",
+                &[
+                    ("CLAIM", "scope"),
+                    ("SEPARATOR", "\" \""),
+                    ("ALL_OF", "[openid]"),
+                ],
+            );
+            set_required_claims_env(
+                jail,
+                X,
+                "NOGRP",
+                &[("CLAIM", "groups"), ("EXISTS", "false")],
+            );
+            // Flat provider.
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDER_URI",
+                "https://other.example.com",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_REQUIRED_CLAIMS__BLOCK__CLAIM",
+                "amr",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_REQUIRED_CLAIMS__BLOCK__NONE_OF",
+                "[pwd]",
+            );
+
+            let config = get_config();
+            let rules = &config.openid_providers.get("x").unwrap().required_claims;
+            assert_eq!(rules.len(), 3);
+            assert_eq!(
+                rules["org"],
+                ClaimRuleConfig {
+                    claim: "organizations".to_string(),
+                    separator: None,
+                    any_of: Some(vec!["f648".to_string(), "a,b".to_string()]),
+                    all_of: None,
+                    none_of: None,
+                    exists: None,
+                }
+            );
+            assert_eq!(rules["scopes"].separator, Some(" ".to_string()));
+            assert_eq!(rules["scopes"].all_of, Some(vec!["openid".to_string()]));
+            assert_eq!(rules["nogrp"].exists, Some(false));
+            assert_eq!(
+                config.openid_required_claims["block"].none_of,
+                Some(vec!["pwd".to_string()])
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "`separator` has no effect on `exists`")]
+    fn test_required_claims_rejects_separator_on_exists() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(
+                jail,
+                X,
+                "G",
+                &[("CLAIM", "groups"), ("EXISTS", "true"), ("SEPARATOR", ",")],
+            );
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    /// A typo in the container key silently produced zero rules before
+    /// `deny_unknown_fields` was set on the provider.
+    #[test]
+    #[should_panic(expected = "unknown field: found `requiredclaims`")]
+    fn test_provider_rejects_unknown_container_key() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            jail.set_env(format!("{X}__REQUIREDCLAIMS__ORG__CLAIM"), "organizations");
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "no token could ever satisfy 'read write'")]
+    fn test_multi_word_scope_is_rejected_at_startup() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            jail.set_env(format!("{X}__SCOPE"), "read write");
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "the rules would never apply")]
+    fn test_required_claims_without_primary_provider_are_rejected() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_REQUIRED_CLAIMS__ORG__CLAIM",
+                "organizations",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_REQUIRED_CLAIMS__ORG__ANY_OF",
+                "[a]",
+            );
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    /// figment types a bare `[0644]` as a number, so rendering it back would not reproduce
+    /// what was written. Such values must be quoted rather than silently renormalized.
+    #[test]
+    #[should_panic(expected = "expected a string, found 644")]
+    fn test_required_claims_rejects_unquoted_numeric_value() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(jail, X, "T", &[("CLAIM", "tenant"), ("ANY_OF", "[0644]")]);
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_required_claims_accepts_quoted_numeric_value() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(
+                jail,
+                X,
+                "T",
+                &[("CLAIM", "tenant"), ("ANY_OF", "[\"0644\", \"true\"]")],
+            );
+            let config = get_config();
+            assert_eq!(
+                config.openid_providers["x"].required_claims["t"].any_of,
+                Some(vec!["0644".to_string(), "true".to_string()])
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid type: found string \"a\", expected a sequence")]
+    fn test_required_claims_rejects_unbracketed_list() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(jail, X, "ORG", &[("CLAIM", "org"), ("ANY_OF", "a")]);
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown field: found `anyof`")]
+    fn test_required_claims_rejects_unknown_field() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(jail, X, "ORG", &[("CLAIM", "org"), ("ANYOF", "[a]")]);
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "exactly one of `any_of`, `all_of`, `none_of`, `exists`")]
+    fn test_required_claims_rejects_two_operators() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(
+                jail,
+                X,
+                "ORG",
+                &[("CLAIM", "org"), ("ANY_OF", "[a]"), ("NONE_OF", "[b]")],
+            );
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "exactly one of `any_of`, `all_of`, `none_of`, `exists`")]
+    fn test_required_claims_rejects_no_operator() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(jail, X, "ORG", &[("CLAIM", "org")]);
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "any_of must not be empty")]
+    fn test_required_claims_rejects_empty_list() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(jail, X, "ORG", &[("CLAIM", "org"), ("ANY_OF", "[]")]);
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "SEPARATOR='\" \"'")]
+    fn test_required_claims_rejects_trimmed_separator_with_hint() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(
+                jail,
+                X,
+                "S",
+                &[
+                    ("CLAIM", "scope"),
+                    ("SEPARATOR", " "),
+                    ("ALL_OF", "[openid]"),
+                ],
+            );
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "claim path")]
+    fn test_required_claims_rejects_empty_path_segment() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(jail, X, "ORG", &[("CLAIM", "a..b"), ("ANY_OF", "[a]")]);
+            let _config = get_config();
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "rule name must match `[a-z0-9-]+`")]
+    fn test_required_claims_rejects_rule_name_with_underscore() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env(format!("{X}__URI"), "https://idp.example.com");
+            set_required_claims_env(jail, X, "MY_RULE", &[("CLAIM", "org"), ("ANY_OF", "[a]")]);
+            let _config = get_config();
             Ok(())
         });
     }

--- a/crates/lakekeeper/src/config.rs
+++ b/crates/lakekeeper/src/config.rs
@@ -295,6 +295,20 @@ fn validate_required_claims(config: &DynAppConfig) {
                 "Invalid required claim rule '{name}' for OIDC provider '{idp_id}': rule name \
                  must match `[a-z0-9-]+`; write `tenant-filter`, not `tenant_filter`"
             );
+            // For a deny, splitting on any whitespace finds everything a whitespace literal
+            // finds and the values it misses, so the literal form is dominated — and its one
+            // distinguishing behaviour is to admit a token it was written to reject.
+            assert!(
+                !(rule.none_of.is_some()
+                    && rule
+                        .separator
+                        .as_deref()
+                        .is_some_and(|s| { !s.is_empty() && s.chars().all(char::is_whitespace) })),
+                "Invalid required claim rule '{name}' for OIDC provider '{idp_id}': a \
+                 whitespace `separator` on `none_of` reads only that exact character, so a \
+                 value delimited by any other whitespace is admitted. Write \
+                 `SEPARATOR=whitespace`."
+            );
             assert!(
                 !(rule.exists.is_some() && rule.separator.is_some()),
                 "Invalid required claim rule '{name}' for OIDC provider '{idp_id}': `separator` \
@@ -2265,6 +2279,25 @@ mod test {
     /// A literal separator stays literal, so the same rule written with a space is byte-exact.
     #[test]
     fn test_literal_separator_is_byte_exact() {
+        // A grant may still be byte-exact: narrowing it rejects, which is the safe direction.
+        let rule = rule_from_env(&[
+            ("CLAIM", "scope"),
+            ("ALL_OF", "[admin]"),
+            ("SEPARATOR", "\" \""),
+        ]);
+        assert!(rule.matches(&serde_json::json!({ "scope": "openid admin" })));
+        assert!(!rule.matches(&serde_json::json!({ "scope": "openid\tadmin" })));
+        // A non-whitespace literal is exact in both directions.
+        let deny = rule_from_env(&[("CLAIM", "g"), ("NONE_OF", "[admin]"), ("SEPARATOR", ",")]);
+        assert!(!deny.matches(&serde_json::json!({ "g": "finance,admin" })));
+        assert!(deny.matches(&serde_json::json!({ "g": "finance;admin" })));
+    }
+
+    /// A deny split on one whitespace character admits a value delimited by any other, so the
+    /// dominated spelling is refused in favour of `SEPARATOR=whitespace`.
+    #[test]
+    #[should_panic(expected = "Write `SEPARATOR=whitespace`")]
+    fn test_whitespace_literal_separator_is_rejected_on_a_deny() {
         figment::Jail::expect_with(|jail| {
             jail.set_env(format!("{X}__URI"), "https://idp.example.com");
             set_required_claims_env(
@@ -2277,12 +2310,7 @@ mod test {
                     ("SEPARATOR", "\" \""),
                 ],
             );
-            let config = get_config();
-            let rule = config.openid_providers["x"].required_claims["org"]
-                .to_rule()
-                .unwrap();
-            assert!(!rule.matches(&serde_json::json!({ "scope": "openid admin" })));
-            assert!(rule.matches(&serde_json::json!({ "scope": "openid\tadmin" })));
+            let _config = get_config();
             Ok(())
         });
     }

--- a/crates/lakekeeper/src/service/authn.rs
+++ b/crates/lakekeeper/src/service/authn.rs
@@ -1,6 +1,6 @@
-use std::fmt::Debug;
 #[cfg(feature = "router")]
 use std::sync::Arc;
+use std::{collections::HashMap, fmt::Debug};
 
 #[cfg(feature = "router")]
 use axum::{
@@ -89,6 +89,8 @@ pub(crate) const K8S_IDP_ID: &str = "kubernetes";
 /// `oid` is preferred so Entra-ID gets the stable per-tenant identifier
 /// out-of-the-box; everything else falls through to `sub`.
 const DEFAULT_SUBJECT_CLAIMS: &[&str] = &["oid", "sub"];
+/// The `separator` value that means "any whitespace" rather than a literal to match.
+pub(crate) const WHITESPACE_SEPARATOR: &str = "whitespace";
 
 /// Configuration for a single OIDC provider in multi-provider mode.
 ///
@@ -107,6 +109,7 @@ const DEFAULT_SUBJECT_CLAIMS: &[&str] = &["oid", "sub"];
 /// LAKEKEEPER__OPENID_PROVIDERS__OKTA__SUBJECT_CLAIMS=sub
 /// ```
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct OidcProviderConfig {
     /// The OIDC provider URI (must expose .well-known/openid-configuration)
     pub uri: url::Url,
@@ -128,7 +131,8 @@ pub struct OidcProviderConfig {
     /// A scope that must be present in tokens from this provider.
     #[serde(default)]
     pub scope: Option<String>,
-    /// Claims to use as the subject (user ID), in order of preference.
+    /// Claim paths to use as the subject (user ID), in order of preference.
+    /// Supports nested claims using dot notation, as for `roles_claim`.
     /// Defaults to `oid`, then `sub` if not specified.
     #[serde(
         default,
@@ -155,6 +159,122 @@ pub struct OidcProviderConfig {
     /// If true, fail startup when this provider's OIDC/JWKS configuration cannot be loaded.
     #[serde(default = "default_true")]
     pub require_connected_on_startup: bool,
+    /// Rules a verified token must satisfy, keyed by rule name (`[a-z0-9-]+`). All rules must
+    /// hold; a missing claim fails. Rejected tokens get a generic 401.
+    ///
+    /// ```bash
+    /// LAKEKEEPER__OPENID_PROVIDERS__OKTA__REQUIRED_CLAIMS__ORG__CLAIM=organizations
+    /// LAKEKEEPER__OPENID_PROVIDERS__OKTA__REQUIRED_CLAIMS__ORG__ANY_OF=[tenant-a, tenant-b]
+    /// ```
+    #[serde(default)]
+    pub required_claims: HashMap<String, ClaimRuleConfig>,
+}
+
+/// One required-claim rule as written in configuration; see
+/// [`OidcProviderConfig::required_claims`]. Exactly one of `any_of`, `all_of`, `none_of`,
+/// `exists` must be set; converted to a validated [`limes::ClaimRule`] at startup.
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ClaimRuleConfig {
+    /// Dotted claim path, e.g. `organizations` or `realm_access.roles`.
+    pub claim: String,
+    /// Split a string claim on this literal before matching. Env values are trimmed, so a
+    /// space must be quoted: `SEPARATOR='" "'`.
+    #[serde(default)]
+    pub separator: Option<String>,
+    /// At least one claim value is in the list.
+    #[serde(default, deserialize_with = "crate::config::deserialize_string_list")]
+    pub any_of: Option<Vec<String>>,
+    /// Every listed value is a claim value.
+    #[serde(default, deserialize_with = "crate::config::deserialize_string_list")]
+    pub all_of: Option<Vec<String>>,
+    /// No claim value is in the list; a missing claim fails.
+    #[serde(default, deserialize_with = "crate::config::deserialize_string_list")]
+    pub none_of: Option<Vec<String>>,
+    /// `true`: the claim is populated — it holds a value that is not blank, or, for an
+    /// object, a member; `false`: absent or `null`. These are not opposites: a claim that is
+    /// present but empty (`[]`, `""`, `"   "`, `{}`) satisfies neither.
+    #[serde(default)]
+    pub exists: Option<bool>,
+}
+
+impl OidcProviderConfig {
+    /// Whether this provider rejects tokens a bare signature check would admit.
+    ///
+    /// The one definition, shared by startup validation and the routing check, so a third
+    /// kind of guard cannot be added to one and forgotten in the other.
+    pub(crate) fn is_guarded(&self) -> bool {
+        !self.required_claims.is_empty() || self.scope.is_some()
+    }
+}
+
+impl ClaimRuleConfig {
+    /// Build the validated rule.
+    ///
+    /// # Errors
+    /// If not exactly one operator is set, or the rule is structurally invalid.
+    pub fn to_rule(&self) -> anyhow::Result<limes::ClaimRule> {
+        type Build = fn(&str, &[String]) -> Result<limes::ClaimRule, limes::ClaimRuleError>;
+        let list: [(&Option<Vec<String>>, Build); 3] = [
+            (&self.any_of, |c, v| limes::ClaimRule::any_of(c, v)),
+            (&self.all_of, |c, v| limes::ClaimRule::all_of(c, v)),
+            (&self.none_of, |c, v| limes::ClaimRule::none_of(c, v)),
+        ];
+        let mut builders: Vec<_> = list
+            .into_iter()
+            .filter_map(|(values, build)| values.as_ref().map(|v| (v, build)))
+            .map(|(values, build)| build(&self.claim, values))
+            .collect();
+        if let Some(exists) = self.exists {
+            builders.push(limes::ClaimRule::exists(&self.claim, exists));
+        }
+        let [rule] = <[_; 1]>::try_from(builders).map_err(|found| {
+            anyhow::anyhow!(
+                "exactly one of `any_of`, `all_of`, `none_of`, `exists` must be set, found {}",
+                found.len()
+            )
+        })?;
+        let mut rule = rule?;
+        if let Some(separator) = &self.separator {
+            // A literal separator is byte-exact, so a deny written for space-delimited scopes
+            // is blind to a tab. `whitespace` reaches the separator that splits on any of them.
+            let separator = if separator.eq_ignore_ascii_case(WHITESPACE_SEPARATOR) {
+                limes::Separator::Whitespace
+            } else {
+                limes::Separator::Literal(separator.clone())
+            };
+            rule = rule.with_separator(separator).map_err(|e| match e {
+                limes::ClaimRuleError::EmptySeparator => anyhow::anyhow!(
+                    "{e}; environment values are trimmed, quote a space as SEPARATOR='\" \"'"
+                ),
+                e => anyhow::anyhow!("{e}"),
+            })?;
+        }
+        Ok(rule)
+    }
+}
+
+/// Validated rules for one provider, in deterministic (name) order.
+///
+/// Rules are named `<idp_id>/<rule>` so a rejection identifies the provider as well as the
+/// rule; rule names are only unique within a provider.
+fn required_claim_rules(
+    idp_id: &str,
+    rules: &HashMap<String, ClaimRuleConfig>,
+) -> anyhow::Result<Vec<(String, limes::ClaimRule)>> {
+    let mut names: Vec<&String> = rules.keys().collect();
+    names.sort();
+    names
+        .into_iter()
+        .map(|name| {
+            let rule = rules[name].to_rule().map_err(|e| {
+                anyhow::anyhow!(
+                    "invalid required claim rule `{name}` for OIDC provider `{idp_id}`: {e}"
+                )
+            })?;
+            Ok((format!("{idp_id}/{name}"), rule))
+        })
+        .collect()
 }
 
 const fn default_true() -> bool {
@@ -311,6 +431,7 @@ fn oidc_provider_configs_from_config(
                 roles_claim: config.openid_roles_claim.clone(),
                 display_name_template: config.openid_display_name_template.clone(),
                 require_connected_on_startup: true,
+                required_claims: config.openid_required_claims.clone(),
             },
         ));
     }
@@ -353,19 +474,31 @@ async fn build_oidc_authenticators(
             .map_err(|e| {
                 anyhow::anyhow!("invalid `display_name_template` for OIDC provider `{idp_id}`: {e}")
             })?;
-        validated.push((idp_id, provider, display_name_template));
+        let required_claims = required_claim_rules(&idp_id, &provider.required_claims)?;
+        validated.push((idp_id, provider, display_name_template, required_claims));
     }
 
     let mut authenticators = Vec::new();
-    for (idp_id, provider, display_name_template) in validated {
+    let mut routing = Vec::new();
+    for (idp_id, provider, display_name_template, required_claims) in validated {
         tracing::info!(
             "Creating OIDC authenticator for {} ({})",
             idp_id,
             provider.uri
         );
 
-        match build_oidc_authenticator(&idp_id, &provider, display_name_template).await {
+        match build_oidc_authenticator(&idp_id, &provider, display_name_template, required_claims)
+            .await
+        {
             Ok(authenticator) => {
+                routing.push(AuthenticatorRouting {
+                    idp_id: idp_id.clone(),
+                    // The first issuer is the one published by the provider's discovery
+                    // document, which is not derivable from configuration.
+                    issuers: authenticator.issuers().to_vec(),
+                    audiences: authenticator.audiences().to_vec(),
+                    guarded: provider.is_guarded(),
+                });
                 authenticators.push(AuthenticatorEnum::from(authenticator));
                 tracing::info!("Successfully added OIDC authenticator: {}", idp_id);
             }
@@ -386,13 +519,81 @@ async fn build_oidc_authenticators(
         }
     }
 
+    validate_authenticator_routing(&routing)?;
+
     Ok(authenticators)
+}
+
+/// How a built authenticator is selected for a token.
+#[derive(Debug)]
+struct AuthenticatorRouting {
+    idp_id: String,
+    issuers: Vec<String>,
+    audiences: Vec<String>,
+    /// The provider enforces a scope or required-claim rules, so it matters that its own
+    /// tokens actually reach it.
+    guarded: bool,
+}
+
+/// Reject provider combinations whose tokens cannot be routed as configured.
+///
+/// A token goes to the first authenticator whose issuer set contains its `iss` and whose
+/// audience set intersects its `aud` (an empty audience set matches anything); there is no
+/// fallthrough. Two providers publishing the same issuer therefore compete, and a token
+/// naming both audiences reaches only the first — which is why disjoint audiences are not
+/// enough to protect a provider that enforces a scope or required claims.
+///
+/// This runs on the issuers each provider actually published, so it also catches one identity
+/// provider reached through two URLs (an in-cluster and a public hostname, say).
+fn validate_authenticator_routing(providers: &[AuthenticatorRouting]) -> anyhow::Result<()> {
+    for (i, a) in providers.iter().enumerate() {
+        for b in &providers[i + 1..] {
+            if !a.issuers.iter().any(|issuer| b.issuers.contains(issuer)) {
+                continue;
+            }
+            let (first, second) = (&a.idp_id, &b.idp_id);
+            // Disjoint audience lists do not separate the providers: one token may name both
+            // audiences, and it reaches `{first}` alone. Only the second provider loses its
+            // rules — when `{first}` is the guarded one it still enforces them on everything
+            // it takes, which is strict rather than permissive.
+            anyhow::ensure!(
+                !b.guarded,
+                "OIDC providers `{first}` and `{second}` publish the same issuer, and \
+                 `{second}` enforces a scope or required claims. A token naming both \
+                 audiences reaches only `{first}`, so the rules of `{second}` would not be \
+                 enforced. Configure the same rules on `{first}`, or serve them from separate \
+                 issuers."
+            );
+            if a.audiences.is_empty()
+                || b.audiences.is_empty()
+                || a.audiences.iter().any(|aud| b.audiences.contains(aud))
+            {
+                tracing::warn!(
+                    "OIDC providers `{first}` and `{second}` publish the same issuer and accept \
+                     overlapping audiences. Tokens matching both reach only `{first}`, so the \
+                     settings of `{second}` may never apply."
+                );
+            } else if a.guarded {
+                // Disjoint audiences do not make this safe: `{first}` enforces its rules only
+                // on tokens it takes, and the issuer's other tokens reach `{second}`, which
+                // enforces nothing.
+                tracing::warn!(
+                    "OIDC provider `{first}` publishes the same issuer as `{second}` and \
+                     enforces a scope or required claims, but `{second}` does not. Tokens of \
+                     that issuer carrying only `{second}`'s audience are admitted without \
+                     `{first}`'s rules."
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 async fn build_oidc_authenticator(
     idp_id: &str,
     provider: &OidcProviderConfig,
     display_name_template: Option<limes::jwks::DisplayNameTemplate>,
+    required_claims: Vec<(String, limes::ClaimRule)>,
 ) -> anyhow::Result<limes::jwks::JWKSWebAuthenticator> {
     let mut authenticator = limes::jwks::JWKSWebAuthenticator::new(
         provider.uri.as_ref(),
@@ -413,7 +614,11 @@ async fn build_oidc_authenticator(
 
     if let Some(scope) = &provider.scope {
         tracing::debug!("Setting scope for {idp_id}: {scope}");
-        authenticator = authenticator.set_scope(scope.clone());
+        // Unreachable when config validation ran (`validate_required_claims`); kept as a
+        // guard for programmatic configs.
+        authenticator = authenticator
+            .set_scope(scope.clone())
+            .map_err(|e| anyhow::anyhow!("invalid `scope` for OIDC provider `{idp_id}`: {e}"))?;
     }
 
     if let Some(claims) = &provider.subject_claims {
@@ -443,7 +648,32 @@ async fn build_oidc_authenticator(
         authenticator = authenticator.with_display_name_template(template);
     }
 
+    // At info, and unconditionally: an operator needs boot-time confirmation that the rules
+    // they configured are active, and a count of zero is how a misspelled `REQUIRED_CLAIMS`
+    // container shows up — the spelling that reaches no field is silently dropped, so the
+    // line that would be missing is exactly the one worth reading. Names only, never values.
+    let names: Vec<&str> = required_claims.iter().map(|(n, _)| n.as_str()).collect();
+    tracing::info!(
+        "Requiring {} claim rule(s) for OIDC provider {idp_id}: {names:?}",
+        names.len()
+    );
+    if !required_claims.is_empty() {
+        authenticator = authenticator.with_required_claims(required_claims);
+    }
+
     Ok(authenticator)
+}
+
+/// The 401 for a token the authenticator did not accept. The cause is attached for
+/// server-side logging only; the body never names a rule, claim or expected value.
+#[cfg(feature = "router")]
+fn authentication_failed_response(cause: limes::error::Error) -> Response {
+    ErrorModel::unauthorized(
+        "Authentication failed",
+        "AuthenticationFailed",
+        Some(Box::new(cause)),
+    )
+    .into_response()
 }
 
 #[cfg(feature = "router")]
@@ -480,14 +710,7 @@ pub(crate) async fn auth_middleware_fn<
     let introspection = limes::introspect::introspect(token);
     let authentication = match authenticator.authenticate(token, &introspection).await {
         Ok(principal) => principal,
-        Err(e) => {
-            return ErrorModel::unauthorized(
-                "Authentication failed",
-                "AuthenticationFailed",
-                Some(Box::new(e)),
-            )
-            .into_response();
-        }
+        Err(e) => return authentication_failed_response(e),
     };
     let user_id = match UserId::try_new(authentication.subject().clone()) {
         Ok(user_id) => user_id,
@@ -917,6 +1140,8 @@ impl From<limes::AuthenticatorChain<AuthenticatorEnum>> for BuiltInAuthenticator
 }
 
 #[cfg(test)]
+// `figment::Jail::expect_with` closures return `Result<(), figment::Error>`.
+#[allow(clippy::result_large_err)]
 mod tests {
     use std::time::Duration;
 
@@ -931,6 +1156,12 @@ mod tests {
     use crate::{config::DynAppConfig, service::RoleId};
 
     async fn spawn_oidc_test_server() -> (Url, Url, JoinHandle<()>) {
+        spawn_oidc_test_server_with_keys(json!({ "keys": [] })).await
+    }
+
+    async fn spawn_oidc_test_server_with_keys(
+        jwks: serde_json::Value,
+    ) -> (Url, Url, JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind oidc test server");
@@ -946,7 +1177,6 @@ mod tests {
         let bad_config = json!({
             "issuer": bad_base.as_str(),
         });
-        let jwks = json!({ "keys": [] });
 
         let app = Router::new()
             .route(
@@ -980,6 +1210,524 @@ mod tests {
         (good_base, bad_base, handle)
     }
 
+    fn any_of_rule(claim: &str, values: &[&str]) -> ClaimRuleConfig {
+        ClaimRuleConfig {
+            claim: claim.to_string(),
+            separator: None,
+            any_of: Some(values.iter().map(ToString::to_string).collect()),
+            all_of: None,
+            none_of: None,
+            exists: None,
+        }
+    }
+
+    fn provider(
+        uri: &Url,
+        required_claims: HashMap<String, ClaimRuleConfig>,
+    ) -> OidcProviderConfig {
+        OidcProviderConfig {
+            uri: uri.clone(),
+            audience: Some(vec![TEST_AUD.to_string()]),
+            additional_issuers: None,
+            scope: None,
+            subject_claims: None,
+            roles_claim: None,
+            display_name_template: None,
+            require_connected_on_startup: true,
+            required_claims,
+        }
+    }
+
+    const TEST_AUD: &str = "lakekeeper";
+
+    struct Signer {
+        key: jsonwebtoken::EncodingKey,
+        jwks: serde_json::Value,
+    }
+
+    impl Signer {
+        fn ed25519() -> Self {
+            use base64::Engine as _;
+            let key_pair = aws_lc_rs::signature::Ed25519KeyPair::generate().unwrap();
+            let pkcs8 = key_pair.to_pkcs8().unwrap();
+            let x = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(aws_lc_rs::signature::KeyPair::public_key(&key_pair).as_ref());
+            Self {
+                key: jsonwebtoken::EncodingKey::from_ed_der(pkcs8.as_ref()),
+                jwks: json!({ "keys": [
+                    { "kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "kid": "k1", "x": x }
+                ]}),
+            }
+        }
+
+        fn sign(&self, issuer: &Url, mut claims: serde_json::Value) -> String {
+            let exp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + 3600;
+            claims["exp"] = json!(exp);
+            claims["iss"] = json!(issuer.as_str());
+            claims["aud"] = json!(TEST_AUD);
+            let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::EdDSA);
+            header.kid = Some("k1".to_string());
+            jsonwebtoken::encode(&header, &claims, &self.key).unwrap()
+        }
+    }
+
+    async fn authenticate(
+        chain: &BuiltInAuthenticators,
+        token: &str,
+    ) -> Result<limes::Authentication, limes::error::Error> {
+        let introspection = limes::introspect::introspect(token);
+        match chain {
+            BuiltInAuthenticators::Single(auth) => auth.authenticate(token, &introspection).await,
+            BuiltInAuthenticators::Chain(chain) => chain.authenticate(token, &introspection).await,
+        }
+    }
+
+    fn routing(
+        idp_id: &str,
+        issuers: &[&str],
+        audiences: &[&str],
+        guarded: bool,
+    ) -> AuthenticatorRouting {
+        AuthenticatorRouting {
+            idp_id: idp_id.to_string(),
+            issuers: issuers.iter().map(ToString::to_string).collect(),
+            audiences: audiences.iter().map(ToString::to_string).collect(),
+            guarded,
+        }
+    }
+
+    /// One identity provider reached through two URLs publishes one issuer, which no
+    /// configuration-time check can see. Disjoint audiences do not rescue it: a token naming
+    /// both reaches only the first provider.
+    #[test]
+    fn shared_published_issuer_is_rejected_when_the_shadowed_provider_is_guarded() {
+        let err = validate_authenticator_routing(&[
+            routing(
+                "oidc",
+                &["https://sso.example.com/realms/x"],
+                &["internal"],
+                false,
+            ),
+            routing(
+                "corp",
+                &["https://sso.example.com/realms/x"],
+                &["lakekeeper"],
+                true,
+            ),
+        ])
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("publish the same issuer"), "{msg}");
+        assert!(msg.contains("`oidc`") && msg.contains("`corp`"), "{msg}");
+    }
+
+    #[test]
+    fn shared_published_issuer_is_allowed_when_no_provider_is_guarded() {
+        validate_authenticator_routing(&[
+            routing("oidc", &["https://idp.example.com"], &["a"], false),
+            routing("corp", &["https://idp.example.com"], &["b"], false),
+        ])
+        .unwrap();
+    }
+
+    /// The provider that wins routing enforces its own rules on everything it takes, so
+    /// guarding it and not the one it shadows leaves nothing under-enforced.
+    #[test]
+    fn shared_published_issuer_is_allowed_when_only_the_first_provider_is_guarded() {
+        validate_authenticator_routing(&[
+            routing("oidc", &["https://idp.example.com"], &["a"], true),
+            routing("corp", &["https://idp.example.com"], &["b"], false),
+        ])
+        .unwrap();
+    }
+
+    /// Only a shared issuer creates competition; different issuers never do, whatever the
+    /// audiences are.
+    #[test]
+    fn distinct_issuers_never_compete() {
+        validate_authenticator_routing(&[
+            routing("oidc", &["https://a.example.com"], &["lakekeeper"], true),
+            routing("corp", &["https://b.example.com"], &["lakekeeper"], true),
+        ])
+        .unwrap();
+    }
+
+    /// An issuer shared through `additional_issuers` competes just as much as a primary one.
+    #[test]
+    fn additional_issuers_are_compared_too() {
+        let err = validate_authenticator_routing(&[
+            routing(
+                "oidc",
+                &["https://a.example.com", "https://sts.example.com"],
+                &["a"],
+                false,
+            ),
+            routing(
+                "corp",
+                &["https://b.example.com", "https://sts.example.com"],
+                &["b"],
+                true,
+            ),
+        ])
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("publish the same issuer"));
+    }
+
+    /// The routing check is unit-tested; what feeds it is not. A hardcoded `guarded: false`
+    /// would make the check dead in production while every routing test stayed green.
+    #[tokio::test]
+    async fn routing_inputs_are_wired_from_the_built_authenticators() {
+        let signer = Signer::ed25519();
+        let (issuer, _bad, server) = spawn_oidc_test_server_with_keys(signer.jwks.clone()).await;
+        let mut config = DynAppConfig::default();
+        // Alphabetical order puts the unguarded provider first, so the guarded one is shadowed.
+        config
+            .openid_providers
+            .insert("aaa".to_string(), provider(&issuer, HashMap::new()));
+        config.openid_providers.insert(
+            "bbb".to_string(),
+            provider(
+                &issuer,
+                HashMap::from([(
+                    "org".to_string(),
+                    any_of_rule("organizations", &["tenant-a"]),
+                )]),
+            ),
+        );
+        let err = assemble_authenticator_chain(&config, None, None)
+            .await
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("publish the same issuer"), "{msg}");
+        assert!(msg.contains("`bbb`"), "{msg}");
+        server.abort();
+    }
+
+    /// Every rule of a provider must hold, and the alphabetically first failure is reported.
+    #[tokio::test]
+    async fn all_rules_of_a_provider_are_enforced_in_name_order() {
+        let signer = Signer::ed25519();
+        let (issuer, _bad, server) = spawn_oidc_test_server_with_keys(signer.jwks.clone()).await;
+        let mut config = DynAppConfig::default();
+        config.openid_providers.insert(
+            "x".to_string(),
+            provider(
+                &issuer,
+                HashMap::from([
+                    (
+                        "aaa".to_string(),
+                        any_of_rule("organizations", &["tenant-a"]),
+                    ),
+                    ("zzz".to_string(), any_of_rule("department", &["eng"])),
+                ]),
+            ),
+        );
+        let chain = assemble_authenticator_chain(&config, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let both = json!({ "sub": "u", "organizations": ["tenant-a"], "department": "eng" });
+        assert!(
+            authenticate(&chain, &signer.sign(&issuer, both))
+                .await
+                .is_ok()
+        );
+
+        // Satisfying only the first rule is not enough: the second is reported.
+        let only_first = json!({ "sub": "u", "organizations": ["tenant-a"] });
+        assert_eq!(
+            authenticate(&chain, &signer.sign(&issuer, only_first))
+                .await
+                .unwrap_err()
+                .rejection(),
+            Some(&limes::RejectionReason::ClaimRuleFailed {
+                rule: "x/zzz".to_string(),
+            })
+        );
+        // Failing both names the alphabetically first one only.
+        let neither = json!({ "sub": "u" });
+        assert_eq!(
+            authenticate(&chain, &signer.sign(&issuer, neither))
+                .await
+                .unwrap_err()
+                .rejection(),
+            Some(&limes::RejectionReason::ClaimRuleFailed {
+                rule: "x/aaa".to_string(),
+            })
+        );
+        server.abort();
+    }
+
+    /// Environment variables through to a signed token, the seam config tests and
+    /// token tests each stop short of.
+    #[tokio::test]
+    async fn env_configured_required_claims_are_enforced() {
+        let signer = Signer::ed25519();
+        let (issuer, _bad, server) = spawn_oidc_test_server_with_keys(signer.jwks.clone()).await;
+        let mut captured = None;
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("LAKEKEEPER_TEST__OPENID_PROVIDERS__X__URI", &issuer);
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__X__REQUIRED_CLAIMS__ORG__CLAIM",
+                "organizations",
+            );
+            jail.set_env(
+                "LAKEKEEPER_TEST__OPENID_PROVIDERS__X__REQUIRED_CLAIMS__ORG__ANY_OF",
+                "[tenant-a]",
+            );
+            captured = Some(crate::config::get_config());
+            Ok(())
+        });
+        let config = captured.unwrap();
+        assert_eq!(config.openid_providers["x"].required_claims.len(), 1);
+
+        let chain = assemble_authenticator_chain(&config, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        let ok = signer.sign(
+            &issuer,
+            json!({ "sub": "u", "organizations": ["tenant-a"] }),
+        );
+        assert_eq!(
+            authenticate(&chain, &ok)
+                .await
+                .unwrap()
+                .subject()
+                .subject_in_idp(),
+            "u"
+        );
+        let wrong = signer.sign(
+            &issuer,
+            json!({ "sub": "u", "organizations": ["tenant-b"] }),
+        );
+        assert_eq!(
+            authenticate(&chain, &wrong).await.unwrap_err().rejection(),
+            Some(&limes::RejectionReason::ClaimRuleFailed {
+                rule: "x/org".to_string(),
+            })
+        );
+        server.abort();
+    }
+
+    /// The flat container takes any spelling the environment offers, so a misspelt one reaches
+    /// no field and the rules simply vanish — every token from that provider is then admitted.
+    /// Nothing at parse time can catch it, which is why the rule count is logged at boot even
+    /// when it is zero: the missing confirmation is the only signal an operator gets.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn a_misspelt_required_claims_container_leaves_no_rules() {
+        let signer = Signer::ed25519();
+        let (issuer, _bad, server) = spawn_oidc_test_server_with_keys(signer.jwks.clone()).await;
+        let load = |key: &str| {
+            let mut captured = None;
+            let (issuer, key) = (issuer.clone(), key.to_string());
+            figment::Jail::expect_with(|jail| {
+                jail.set_env("LAKEKEEPER_TEST__OPENID_PROVIDER_URI", &issuer);
+                jail.set_env(
+                    format!("LAKEKEEPER_TEST__{key}__ORG__CLAIM"),
+                    "organizations",
+                );
+                jail.set_env(format!("LAKEKEEPER_TEST__{key}__ORG__ANY_OF"), "[tenant-a]");
+                captured = Some(crate::config::get_config());
+                Ok(())
+            });
+            captured.unwrap()
+        };
+        assert_eq!(
+            load("OPENID_REQUIRED_CLAIMS").openid_required_claims.len(),
+            1
+        );
+        // Singular, and transposed: both are silently dropped.
+        for misspelt in ["OPENID_REQUIRED_CLAIM", "OPENID_REQUIRED_CLAMIS"] {
+            let config = load(misspelt);
+            assert!(
+                config.openid_required_claims.is_empty(),
+                "{misspelt} must reach no field"
+            );
+            let chain = assemble_authenticator_chain(&config, None, None)
+                .await
+                .unwrap()
+                .unwrap();
+            let unwanted = signer.sign(
+                &issuer,
+                json!({ "sub": "u", "organizations": ["tenant-b"] }),
+            );
+            assert!(
+                authenticate(&chain, &unwanted).await.is_ok(),
+                "{misspelt}: no rule is enforced"
+            );
+            // The zero count is the operator's only signal that the rules never arrived, so
+            // it must be logged rather than skipped as uninteresting.
+            assert!(
+                logs_contain("Requiring 0 claim rule(s) for OIDC provider oidc: []"),
+                "{misspelt}: the zero rule count must be logged"
+            );
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn required_claims_admit_and_reject_signed_tokens() {
+        let signer = Signer::ed25519();
+        let (issuer, _bad, server) = spawn_oidc_test_server_with_keys(signer.jwks.clone()).await;
+        let mut config = DynAppConfig::default();
+        config.openid_providers.insert(
+            "x".to_string(),
+            provider(
+                &issuer,
+                HashMap::from([(
+                    "org".to_string(),
+                    any_of_rule("organizations", &["tenant-a"]),
+                )]),
+            ),
+        );
+        let chain = assemble_authenticator_chain(&config, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let ok = signer.sign(
+            &issuer,
+            json!({ "sub": "u", "organizations": ["tenant-a"] }),
+        );
+        let auth = authenticate(&chain, &ok).await.unwrap();
+        assert_eq!(auth.subject().subject_in_idp(), "u");
+
+        let wrong = signer.sign(
+            &issuer,
+            json!({ "sub": "u", "organizations": ["tenant-b"] }),
+        );
+        let err = authenticate(&chain, &wrong).await.unwrap_err();
+        assert_eq!(
+            err.rejection(),
+            Some(&limes::RejectionReason::ClaimRuleFailed {
+                // Rules are reported as `<idp_id>/<rule>`.
+                rule: "x/org".to_string(),
+            })
+        );
+        let rendered = format!("{err} {err:?}");
+        assert!(!rendered.contains("tenant-"), "{rendered}");
+
+        let missing = signer.sign(&issuer, json!({ "sub": "u" }));
+        assert_eq!(
+            authenticate(&chain, &missing)
+                .await
+                .unwrap_err()
+                .rejection(),
+            Some(&limes::RejectionReason::ClaimRuleFailed {
+                rule: "x/org".to_string(),
+            })
+        );
+
+        server.abort();
+    }
+
+    /// `SCOPE=x` and an explicit whitespace-separated `all_of` rule on `scope` reject the
+    /// same token the same way.
+    #[tokio::test]
+    async fn scope_sugar_is_equivalent_to_explicit_scope_rule() {
+        let signer = Signer::ed25519();
+        let (issuer, _bad, server) = spawn_oidc_test_server_with_keys(signer.jwks.clone()).await;
+
+        let mut sugar = DynAppConfig::default();
+        let mut p = provider(&issuer, HashMap::new());
+        p.scope = Some("admin".to_string());
+        sugar.openid_providers.insert("x".to_string(), p);
+
+        let mut explicit = DynAppConfig::default();
+        let rule = ClaimRuleConfig {
+            claim: "scope".to_string(),
+            separator: Some(" ".to_string()),
+            any_of: None,
+            all_of: Some(vec!["admin".to_string()]),
+            none_of: None,
+            exists: None,
+        };
+        explicit.openid_providers.insert(
+            "x".to_string(),
+            provider(&issuer, HashMap::from([("scopes".to_string(), rule)])),
+        );
+
+        let token_ok = signer.sign(&issuer, json!({ "sub": "u", "scope": "openid admin" }));
+        let token_bad = signer.sign(&issuer, json!({ "sub": "u", "scope": "openid" }));
+        // Where the two intentionally diverge: the sugar splits on any whitespace and falls
+        // back to `scp`; an explicit rule splits only on its literal separator and reads
+        // only the named claim.
+        let token_tab = signer.sign(&issuer, json!({ "sub": "u", "scope": "openid\tadmin" }));
+        let token_scp = signer.sign(&issuer, json!({ "sub": "u", "scp": ["admin"] }));
+        for (config, rejection) in [
+            (sugar, limes::RejectionReason::ScopeMissing),
+            (
+                explicit,
+                limes::RejectionReason::ClaimRuleFailed {
+                    rule: "x/scopes".to_string(),
+                },
+            ),
+        ] {
+            let chain = assemble_authenticator_chain(&config, None, None)
+                .await
+                .unwrap()
+                .unwrap();
+            authenticate(&chain, &token_ok).await.unwrap();
+            let err = authenticate(&chain, &token_bad).await.unwrap_err();
+            assert_eq!(err.rejection(), Some(&rejection));
+
+            let tab = authenticate(&chain, &token_tab).await;
+            let scp = authenticate(&chain, &token_scp).await;
+            if rejection == limes::RejectionReason::ScopeMissing {
+                tab.unwrap();
+                scp.unwrap();
+            } else {
+                assert_eq!(tab.unwrap_err().rejection(), Some(&rejection));
+                assert_eq!(scp.unwrap_err().rejection(), Some(&rejection));
+            }
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn rejected_token_response_is_a_generic_401() {
+        use http_body_util::BodyExt as _;
+        let cause = limes::error::Error::rejected(limes::RejectionReason::ClaimRuleFailed {
+            rule: "org".to_string(),
+        });
+        let response = authentication_failed_response(cause);
+        assert_eq!(response.status(), http::StatusCode::UNAUTHORIZED);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"]["type"], "AuthenticationFailed");
+        assert_eq!(body["error"]["message"], "Authentication failed");
+        assert_eq!(body["error"]["code"], 401);
+        let stack = body["error"]["stack"].as_array().unwrap();
+        assert_eq!(stack.len(), 1);
+        assert!(stack[0].as_str().unwrap().starts_with("Error ID: "));
+        let text = body.to_string();
+        assert!(!text.contains("org"), "{text}");
+        assert!(!text.contains("rule"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn invalid_required_claim_fails_startup_before_network() {
+        let (_good, bad_base, server) = spawn_oidc_test_server().await;
+        let mut rule = any_of_rule("org", &[]);
+        rule.any_of = Some(vec![]);
+        let providers = vec![(
+            "acme".to_string(),
+            provider(&bad_base, HashMap::from([("org".to_string(), rule)])),
+        )];
+        let err = build_oidc_authenticators(providers).await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("required claim rule `org`"), "{msg}");
+        assert!(msg.contains("acme"), "{msg}");
+        server.abort();
+    }
+
     #[test]
     fn oidc_provider_configs_from_config_uses_legacy_provider_id_and_roles_claim() {
         let mut config = DynAppConfig::default();
@@ -990,11 +1738,19 @@ mod tests {
         config.openid_subject_claim = Some(vec!["sub".to_string()]);
         config.openid_roles_claim = Some("roles".to_string());
         config.openid_display_name_template = Some("Service Account {email}".to_string());
+        config.openid_required_claims.insert(
+            "org".to_string(),
+            any_of_rule("organizations", &["tenant-a"]),
+        );
 
         let providers = oidc_provider_configs_from_config(&config);
 
         assert_eq!(providers.len(), 1);
         assert_eq!(providers[0].0, OIDC_IDP_ID);
+        assert_eq!(
+            providers[0].1.required_claims,
+            config.openid_required_claims
+        );
         assert_eq!(
             providers[0].1.audience,
             Some(vec!["lakekeeper".to_string()])
@@ -1028,6 +1784,7 @@ mod tests {
                 roles_claim: Some("groups".to_string()),
                 display_name_template: None,
                 require_connected_on_startup: false,
+                required_claims: HashMap::new(),
             },
         );
 
@@ -1065,6 +1822,7 @@ mod tests {
                     roles_claim: None,
                     display_name_template: None,
                     require_connected_on_startup: true,
+                    required_claims: HashMap::new(),
                 },
             );
         }
@@ -1088,6 +1846,7 @@ mod tests {
                 roles_claim: None,
                 display_name_template: template.map(str::to_string),
                 require_connected_on_startup: true,
+                required_claims: HashMap::new(),
             },
         )
     }
@@ -1121,6 +1880,7 @@ mod tests {
                 roles_claim: None,
                 display_name_template: None,
                 require_connected_on_startup: true,
+                required_claims: HashMap::new(),
             },
         );
 
@@ -1178,6 +1938,7 @@ mod tests {
                 roles_claim: None,
                 display_name_template: None,
                 require_connected_on_startup: false,
+                required_claims: HashMap::new(),
             },
         );
 
@@ -1219,6 +1980,7 @@ mod tests {
                 roles_claim: None,
                 display_name_template: None,
                 require_connected_on_startup: true,
+                required_claims: HashMap::new(),
             },
         );
 
@@ -1247,6 +2009,7 @@ mod tests {
                 roles_claim: None,
                 display_name_template: None,
                 require_connected_on_startup: false,
+                required_claims: HashMap::new(),
             },
         );
 
@@ -1283,6 +2046,7 @@ mod tests {
                 roles_claim: None,
                 display_name_template: None,
                 require_connected_on_startup: true,
+                required_claims: HashMap::new(),
             },
         );
 

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -14,7 +14,7 @@ Lakekeeper does not issue API-Keys or Client-Credentials itself. Instead, it rel
 
 Lakekeeper can be configured to integrate with all common identity providers. For best performance, tokens are validated locally against the server keys (`jwks_uri`). This requires all incoming tokens to be JWT tokens. If you require support for opaque tokens, please upvote the corresponding [GitHub Issue](https://github.com/lakekeeper/lakekeeper/issues/620).
 
-If `LAKEKEEPER__OPENID_PROVIDER_URI` is specified, Lakekeeper will  verify access tokens against this provider. The provider must provide the `.well-known/openid-configuration` endpoint and the openid-configuration needs to have `jwks_uri` and `issuer` defined. Optionally, if `LAKEKEEPER__OPENID_AUDIENCE` is specified, Lakekeeper validates the `aud` field of the provided token. Multiple audiences can be provided as a comma-separated list, and a token is accepted if its `aud` claim contains any one of them (OR). We recommend to specify the audience in all deployments, so that tokens leaked for other applications in the same IdP cannot be used to access data in Lakekeeper.
+If `LAKEKEEPER__OPENID_PROVIDER_URI` is specified, Lakekeeper will  verify access tokens against this provider. The provider must provide the `.well-known/openid-configuration` endpoint and the openid-configuration needs to have `jwks_uri` and `issuer` defined. Optionally, if `LAKEKEEPER__OPENID_AUDIENCE` is specified, Lakekeeper validates the `aud` field of the provided token. Multiple audiences can be provided as a comma-separated list, and a token is accepted if its `aud` claim contains any one of them (OR). We recommend to specify the audience in all deployments, so that tokens leaked for other applications in the same IdP cannot be used to access data in Lakekeeper. Where the IdP is shared by several organizations, the audience alone does not identify your tenant; add [required-claim rules](./configuration.md#required-claims) (e.g. on an `organizations` claim) to restrict which of the IdP's tokens Lakekeeper admits.
 
 Users are automatically added to Lakekeeper after successful Authentication (user provides a valid token with the correct issuer and audience). If a User does not yet exist in Lakekeeper's Database, the provided JWT token is parsed. The following fields are parsed:
 
@@ -475,6 +475,8 @@ For scenarios where you need to authenticate tokens from multiple identity provi
 When multiple providers are configured, each provider fetches its own JWKS keys independently. Incoming tokens are checked against each provider in order until one successfully validates the token.
 
 ### Configuration
+
+Each provider can additionally restrict which of its tokens are accepted with [required-claim rules](./configuration.md#required-claims) — for example to admit only members of one organization from an identity provider that serves many.
 
 Configure each provider under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__`. These providers are added in addition to the single-provider `LAKEKEEPER__OPENID_PROVIDER_URI`, which remains the primary provider (`idp_id = "oidc"`).
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -242,8 +242,9 @@ Please check the [Authentication Guide](./authentication.md) for more details.
 | `LAKEKEEPER__OPENID_PROVIDER_URI` | `https://keycloak.local/realms/{your-realm}` | `None` | OpenID Provider URL. Lakekeeper expects to find `<LAKEKEEPER__OPENID_PROVIDER_URI>/.well-known/openid-configuration` and load JWKS tokens from there. Do not include the `/.well-known/openid-configuration` in the provided URL. |
 | `LAKEKEEPER__OPENID_AUDIENCE` | `the-client-id-of-my-app` | `None` | Strongly recommended. If set, the token's `aud` claim must contain at least one of the configured audiences. Multiple audiences can be provided as a comma-separated list; a token is accepted if its `aud` matches any one of them (OR). If unset, audience validation is **skipped** — tokens for any audience are accepted as long as signature and issuer validate. Set this in production. |
 | `LAKEKEEPER__OPENID_ADDITIONAL_ISSUERS` | `https://sts.windows.net/<Tenant>/` | `None` | A comma separated list of additional issuers to trust. The issuer defined in the `issuer` field of the `.well-known/openid-configuration` is always trusted. `LAKEKEEPER__OPENID_ADDITIONAL_ISSUERS` has no effect if `LAKEKEEPER__OPENID_PROVIDER_URI` is not set. |
-| `LAKEKEEPER__OPENID_SCOPE` | `lakekeeper` | `None` | Specify a scope that must be present in provided tokens received from the openid provider. |
-| `LAKEKEEPER__OPENID_SUBJECT_CLAIM` | `sub` or `oid,sub` | `None` | Specify the claim(s) in the user's JWT used to identify a User. Accepts a single claim name or a comma-separated list of claim names; the first claim present in the token is used. By default Lakekeeper tries `oid` first, then falls back to `sub`. We strongly recommend setting this configuration explicitly in production deployments. Entra-ID users want to use `oid`; users from all other IdPs most likely want to use `sub`. |
+| `LAKEKEEPER__OPENID_SCOPE` | `lakekeeper` | `None` | A single scope that must be present in provided tokens — one word, no whitespace (startup fails otherwise). Read from the `scope` claim, or `scp` if `scope` is absent or carries no scopes; both a whitespace-delimited string and an array of strings are accepted; values must be strings. A [required-claim rule](#required-claims) on `scope` can require several scopes, but splits only on the `SEPARATOR` you set (`SEPARATOR=whitespace` gives the same splitting) and reads only the one named claim, with no `scp` fallback. |
+| `LAKEKEEPER__OPENID_REQUIRED_CLAIMS__<RULE>__CLAIM` <br> `…__ANY_OF` / `…__ALL_OF` / `…__NONE_OF` / `…__EXISTS` <br> `…__SEPARATOR` | `…__ORG__CLAIM=organizations` <br> `…__ORG__ANY_OF='[tenant-a, tenant-b]'` | `None` | Rules a verified token must satisfy, keyed by rule name. See [Required Claims](#required-claims). |
+| `LAKEKEEPER__OPENID_SUBJECT_CLAIM` | `sub` or `oid,sub` | `None` | Specify the claim(s) in the user's JWT used to identify a User. Accepts a single claim path or a comma-separated list of them; the first one that resolves to a non-blank string is used. A path nests on every dot (`resource_access.account.id`) or, when it contains `/` or `:`, names one claim outright — the same grammar as `OPENID_ROLES_CLAIM` and required-claim rules. By default Lakekeeper tries `oid` first, then falls back to `sub`. We strongly recommend setting this configuration explicitly in production deployments. Entra-ID users want to use `oid`; users from all other IdPs most likely want to use `sub`. |
 | `LAKEKEEPER__OPENID_ROLES_CLAIM` | `resource_access.lakekeeper.roles` | `None` | Specify the claim to use in provided JWT tokens to extract roles. The field should contain an array of strings or a single string. Supports nested claims using dot notation, e.g., "resource_access.account.roles". Used by authorizers that consume token roles, including Cedar and custom implementations. The default OpenFGA implementation does not use token roles. Requires a project ID to be set via the `x-project-id` header or `LAKEKEEPER__DEFAULT_PROJECT_ID`. |
 | `LAKEKEEPER__OPENID_DISPLAY_NAME_TEMPLATE` | `Service Account {email}` | `None` | Fallback display name for tokens that carry no name claim (typically machine / service-account tokens). Placeholders `{claim.path}` are substituted from the token's claims using dot notation; write a literal brace by doubling it (`{{`/`}}`). A real name claim always takes precedence; if a referenced claim is absent or not a string the template is skipped and the user keeps the `Nameless App with ID <user-id>` placeholder. A structurally malformed template (unbalanced or empty braces) aborts startup. Applies to the single-provider `LAKEKEEPER__OPENID_PROVIDER_URI` setup. |
 | `LAKEKEEPER__ENABLE_KUBERNETES_AUTHENTICATION` | true | `false` | If true, kubernetes service accounts can authenticate to Lakekeeper. This option is compatible with `LAKEKEEPER__OPENID_PROVIDER_URI` - multiple IdPs (OIDC and Kubernetes) can be enabled simultaneously. |
@@ -260,7 +261,7 @@ The `<IDP_ID>` key is the identity-provider ID used in user IDs like `<idp_id>~<
 
 **Chain order.** Tokens are tried against authenticators in this order: the primary provider from `LAKEKEEPER__OPENID_PROVIDER_URI` (if set), then providers from `LAKEKEEPER__OPENID_PROVIDERS` in **alphabetical order of `idp_id`**, then Kubernetes (if enabled).
 
-A token is routed to the **first** authenticator whose `iss` set contains the token's `iss` claim **and** whose `aud` set intersects the token's `aud` claim (an unset issuer or audience matches everything). Once routed, that authenticator performs full signature + issuer + audience validation; if validation fails the request is rejected — the chain does **not** fall through to the next link. As a consequence, if two providers' (issuer, audience) criteria overlap, the first chain link owns the overlap. Make `iss` × `aud` pairs disjoint across providers to avoid surprises.
+A token is routed to the **first** authenticator whose `iss` set contains the token's `iss` claim **and** whose `aud` set intersects the token's `aud` claim (an unset issuer or audience matches everything). Once routed, that authenticator performs full signature + issuer + audience + required-claim validation; if validation fails the request is rejected — the chain does **not** fall through to the next link. As a consequence, if two providers' (issuer, audience) criteria overlap, the first chain link owns the overlap and the later provider's settings (scope, required claims, roles claim, …) never apply. Disjoint `AUDIENCE` lists do not separate them, since one token may name both audiences. Lakekeeper therefore **refuses to start** when two providers share a **published** issuer (the one in their discovery document, plus any `ADDITIONAL_ISSUERS` — not the configured `URI`) and the **later** one enforces a scope or required claims — its rules would never run. Guarding only the earlier provider is allowed: it enforces its rules on everything it takes.
 
 **Provider Fields:**
 
@@ -269,8 +270,9 @@ A token is routed to the **first** authenticator whose `iss` set contains the to
 | `__URI` | Yes | `https://company.okta.com` | OIDC provider URI (must expose `.well-known/openid-configuration`). |
 | `__AUDIENCE` | No (strongly recommended) | `lakekeeper,warehouse` | Expected audience(s) for tokens. If set, the token's `aud` must contain at least one of the configured audiences; provide multiple as a comma-separated list and a token is accepted if its `aud` matches any one of them (OR). If unset, audience validation is **skipped** — tokens for any audience are accepted as long as signature and issuer validate. Set this in production. |
 | `__ADDITIONAL_ISSUERS` | No | `https://sts.windows.net/tenant/` | Additional issuers to trust (comma-separated). |
-| `__SCOPE` | No | `lakekeeper` | Scope that must be present in tokens. |
-| `__SUBJECT_CLAIMS` | No | `sub` or `oid,sub` | Claims to use as user ID (comma-separated, in order of preference). Defaults to `oid,sub`. |
+| `__SCOPE` | No | `lakekeeper` | Scope that must be present in tokens (`scope` claim, or `scp` if absent; string or array). |
+| `__REQUIRED_CLAIMS__<RULE>__…` | No | `__REQUIRED_CLAIMS__ORG__CLAIM=organizations` <br> `__REQUIRED_CLAIMS__ORG__ANY_OF='[tenant-a]'` | Rules a verified token must satisfy for this provider. See [Required Claims](#required-claims). |
+| `__SUBJECT_CLAIMS` | No | `sub` or `oid,sub` | Claim paths to use as user ID (comma-separated, in order of preference). Dot notation nests, as for `ROLES_CLAIM`. Defaults to `oid,sub`. |
 | `__ROLES_CLAIM` | No | `resource_access.lakekeeper.roles` | Claim to use in provided JWT tokens to extract roles. |
 | `__DISPLAY_NAME_TEMPLATE` | No | `Service Account {email}` | Fallback display name for this provider's tokens that carry no name claim. Same syntax and precedence as `LAKEKEEPER__OPENID_DISPLAY_NAME_TEMPLATE` in the OpenID table above (dot-notation `{claim.path}` placeholders, `{{`/`}}` for literal braces, a real name claim wins, malformed templates abort startup). |
 | `__REQUIRE_CONNECTED_ON_STARTUP` | No | `true` | When `true` (default), Lakekeeper refuses to start if this provider's OIDC/JWKS configuration cannot be loaded. Set to `false` to skip this provider while continuing startup. |
@@ -291,6 +293,76 @@ LAKEKEEPER__OPENID_PROVIDERS__EKSPROD__REQUIRE_CONNECTED_ON_STARTUP=false
 
 !!! note
     Providers fail startup by default if their OIDC endpoint cannot be loaded. Set `REQUIRE_CONNECTED_ON_STARTUP=false` for providers that should be skipped while Lakekeeper continues starting.
+
+#### Required Claims
+
+Audience validation proves a token was issued *for* Lakekeeper, not that the caller belongs to your tenant — a shared identity provider mints the right `aud` for every user it knows. Required-claim rules add a check Lakekeeper enforces itself: after signature, issuer and audience are verified, every rule must hold, or the request gets a generic `401 AuthenticationFailed` that reveals nothing about the rule.
+
+```bash
+# Only tokens of one organization, carrying the `catalog` scope.
+LAKEKEEPER__OPENID_PROVIDERS__CORP__URI=https://accounts.example.com
+LAKEKEEPER__OPENID_PROVIDERS__CORP__AUDIENCE=lakekeeper
+LAKEKEEPER__OPENID_PROVIDERS__CORP__REQUIRED_CLAIMS__ORG__CLAIM=organizations
+LAKEKEEPER__OPENID_PROVIDERS__CORP__REQUIRED_CLAIMS__ORG__ANY_OF='[f6481c2e-0000-0000-0000-000000000000]'
+LAKEKEEPER__OPENID_PROVIDERS__CORP__REQUIRED_CLAIMS__SCOPES__CLAIM=scope
+LAKEKEEPER__OPENID_PROVIDERS__CORP__REQUIRED_CLAIMS__SCOPES__SEPARATOR=whitespace
+LAKEKEEPER__OPENID_PROVIDERS__CORP__REQUIRED_CLAIMS__SCOPES__ALL_OF='[catalog]'
+```
+
+For the primary provider use `LAKEKEEPER__OPENID_REQUIRED_CLAIMS__<RULE>__…`. `<RULE>` is your own name matching `[a-z0-9-]+`; it appears in logs as `<idp_id>/<rule>` and nowhere else.
+
+| Suffix | Description |
+|---|---|
+| `__CLAIM` | Required. Nests on every dot (`realm_access.roles`), or names one claim whole when it contains `/` or `:` (`https://myapp.example.com/org`). No array indexing. |
+| `__ANY_OF=[a, b]` | At least one claim value is listed. |
+| `__ALL_OF=[a, b]` | Every listed value is a claim value. |
+| `__NONE_OF=[a, b]` | No claim value is listed. |
+| `__EXISTS=true` / `false` | The claim carries something / is absent or `null`. |
+| `__SEPARATOR` | Optional. Read the claim as a delimited list: a literal (`,`, `::`), or `whitespace` for any whitespace. |
+
+Exactly one operator per rule, and `EXISTS` takes no `SEPARATOR`. All rules of a provider must hold. Matching is byte-exact and case-sensitive; rules run in alphabetical order and the first failure is the one logged.
+
+**How values are read.** A string, number or boolean is one value; an array of them is a set of values. A missing, `null`, object or mixed-array claim fails every rule except `EXISTS=false`. The two `EXISTS` polarities are not opposites — `[]`, `""`, `"   "` and `{}` satisfy neither. With a `SEPARATOR`, `ANY_OF`/`ALL_OF` split a lone string but leave array elements whole, so `["x,admin"]` never grants `admin`; `NONE_OF` instead looks for a banned value at every delimited position in every element, so no way of joining values hides one from it.
+
+**Lists** use brackets even for one value and separate on unquoted commas. Quote the whole assignment — `ANY_OF='[a, b]'` — since a space ends the shell word and `[a]` is a glob. Quote any value containing a comma, or looking like a number or boolean: `["a,b", "42", "0644"]`. An unquoted `[0644]` becomes the number `644` and aborts startup rather than matching something you did not write.
+
+!!! warning "Two ways a rule can fail open"
+    `EXISTS=false` asks for a claim to be **absent**, so a misspelled path is satisfied by every token, and no startup check can tell a typo from a claim your provider genuinely never sends. Prefer `ANY_OF` where you can.
+
+    A `NONE_OF` whose `SEPARATOR` does not match the claim's real format finds nothing — a deny split on `" "` never sees a value delimited by a tab. Use `SEPARATOR=whitespace` for scope-shaped claims. A missing comma does the same: `[a b]` is the single value `a b`, which nothing matches.
+
+    Always confirm a new deny actually rejects a token that should fail it.
+
+**Startup refuses** a malformed rule (no or several operators, an empty list, a blank value, an empty separator, a grant value containing the separator, an unknown field), and any configuration that cannot enforce what it appears to:
+
+- rules or a scope naming no provider;
+- a provider that enforces something while `REQUIRE_CONNECTED_ON_STARTUP=false` — one skipped at boot enforces nothing;
+- two providers publishing the same issuer where the later one enforces something, since a token naming both audiences reaches only the first (checked against published issuers, so one provider reached through two URLs is caught);
+- Kubernetes authentication without `KUBERNETES_AUTHENTICATION_AUDIENCE` beside a provider that enforces something, since it accepts every token the OIDC providers decline.
+
+Rules apply to every token the provider accepts, trusted engines and instance admins included, but not to Kubernetes service-account tokens. Changing a rule requires a restart.
+
+!!! tip "Binding tokens to one client"
+    Audience validation accepts a token whose `aud` merely intersects the configured list. To require one client, add a rule on the authorized party: `__REQUIRED_CLAIMS__AZP__CLAIM=azp`, `__REQUIRED_CLAIMS__AZP__ANY_OF='[<client-id>]'`.
+
+**In Helm**, a YAML value is not shell-quoted:
+
+```yaml
+extraEnv:
+  - name: LAKEKEEPER__OPENID_PROVIDERS__CORP__REQUIRED_CLAIMS__ORG__ANY_OF
+    value: "[f6481c2e-0000-0000-0000-000000000000]"   # a string, not a YAML list
+  - name: LAKEKEEPER__OPENID_PROVIDERS__CORP__REQUIRED_CLAIMS__SCOPES__SEPARATOR
+    value: '" "'                                       # the quotes are part of the value
+```
+
+**Debugging a rejection.** The 401 body says nothing beyond an `Error ID`. The server log carries the reason at `INFO`, tagged `event_source="error_response"`, with the failing rule in the error source chain and the same error id the client received (abbreviated here — the emitted line is JSON):
+
+```
+error.type="AuthenticationFailed"  error.error_id=<uuid>
+error.source=["Token rejected: required-claim rule `corp/org` failed", ...]
+```
+
+Rule evaluation logs rule names only, never the claim values it compared. Each provider also logs its rule count at startup — `Requiring 2 claim rule(s) for OIDC provider corp: ["corp/org", "corp/scopes"]` — so check that line first if rules appear not to apply. A count of zero is how a misspelled primary-provider container shows up: `LAKEKEEPER__OPENID_REQUIRED_CLAMIS__…` reaches no field and is dropped silently, while the same typo under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__` aborts startup. `RUST_LOG=limes=debug` adds the configured audiences and issuers.
 
 ### Authorization
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -318,7 +318,7 @@ For the primary provider use `LAKEKEEPER__OPENID_REQUIRED_CLAIMS__<RULE>__…`. 
 | `__ALL_OF=[a, b]` | Every listed value is a claim value. |
 | `__NONE_OF=[a, b]` | No claim value is listed. |
 | `__EXISTS=true` / `false` | The claim carries something / is absent or `null`. |
-| `__SEPARATOR` | Optional. Read the claim as a delimited list: a literal (`,`, `::`), or `whitespace` for any whitespace. |
+| `__SEPARATOR` | Optional. Read the claim as a delimited list: a literal (`,`, `::`), or `whitespace` for any whitespace. Environment values are trimmed, so a literal space is written `SEPARATOR='" "'`; quoted values also decode escapes, so `SEPARATOR='"\t"'` is a real tab. A literal matches byte for byte, so `NONE_OF` with a whitespace literal is refused — write `whitespace`. |
 
 Exactly one operator per rule, and `EXISTS` takes no `SEPARATOR`. All rules of a provider must hold. Matching is byte-exact and case-sensitive; rules run in alphabetical order and the first failure is the one logged.
 
@@ -329,7 +329,7 @@ Exactly one operator per rule, and `EXISTS` takes no `SEPARATOR`. All rules of a
 !!! warning "Two ways a rule can fail open"
     `EXISTS=false` asks for a claim to be **absent**, so a misspelled path is satisfied by every token, and no startup check can tell a typo from a claim your provider genuinely never sends. Prefer `ANY_OF` where you can.
 
-    A `NONE_OF` whose `SEPARATOR` does not match the claim's real format finds nothing — a deny split on `" "` never sees a value delimited by a tab. Use `SEPARATOR=whitespace` for scope-shaped claims. A missing comma does the same: `[a b]` is the single value `a b`, which nothing matches.
+    A `NONE_OF` whose `SEPARATOR` does not match the claim's real format finds nothing. Startup refuses the whitespace case, since `whitespace` finds everything a space literal finds and more — but it cannot check the rest: a deny split on `,` does not see `"finance, admin"`, because the value it compares is `" admin"`. A missing comma does the same: `[a b]` is the single value `a b`, which nothing matches.
 
     Always confirm a new deny actually rejects a token that should fail it.
 
@@ -357,7 +357,7 @@ extraEnv:
 
 **Debugging a rejection.** The 401 body says nothing beyond an `Error ID`. The server log carries the reason at `INFO`, tagged `event_source="error_response"`, with the failing rule in the error source chain and the same error id the client received (abbreviated here — the emitted line is JSON):
 
-```
+```text
 error.type="AuthenticationFailed"  error.error_id=<uuid>
 error.source=["Token rejected: required-claim rule `corp/org` failed", ...]
 ```


### PR DESCRIPTION
An OIDC provider accepts a token only when every rule configured for it holds. A rule names one claim and one of `ANY_OF`, `ALL_OF`, `NONE_OF` or `EXISTS`, with an optional `SEPARATOR` that reads the claim as a list — a literal, or `whitespace` for any of them. Claim paths nest on every dot, and name one claim outright when they contain `/` or `:`, so claims namespaced as URIs are addressable.

    LAKEKEEPER__OPENID_REQUIRED_CLAIMS__ORG__CLAIM=organizations
    LAKEKEEPER__OPENID_REQUIRED_CLAIMS__ORG__ANY_OF='[tenant-a]'
    LAKEKEEPER__OPENID_PROVIDERS__CORP__REQUIRED_CLAIMS__ORG__ANY_OF='[tenant-b]'

Rules run after the signature, issuer, audience and lifetime are verified. They apply to every token the provider accepts, trusted engines and instance admins included. A token that fails one is answered with the same 401 as any other authentication failure; the rule that failed reaches the log, never the response. Each provider logs how many rules it enforces at startup, including none, so a container name that reached no field is visible.

Configuration that cannot enforce what it appears to is refused at startup: a rule or scope naming no provider, a provider that enforces something while allowed to be absent at boot, two providers publishing one issuer where the shadowed one enforces something, and Kubernetes authentication without an audience beside a provider that enforces something.

BREAKING CHANGE: `LAKEKEEPER__OPENID_SCOPE` is a single word and requires `LAKEKEEPER__OPENID_PROVIDER_URI`; an empty value is not "no scope". An unknown key under `LAKEKEEPER__OPENID_PROVIDERS__<IDP_ID>__` aborts startup. A provider that enforces a scope or required claims requires
`REQUIRE_CONNECTED_ON_STARTUP=true`, and Kubernetes authentication alongside one requires `KUBERNETES_AUTHENTICATION_AUDIENCE`. The scope is read from `scp` when `scope` carries none, and an array-shaped scope claim is accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added required-claim rules for OpenID Connect authentication.
  * Supports `any_of`, `all_of`, `none_of`, and existence checks.
  * Added safeguards for provider routing and shared identity providers.
  * Improved authentication failure responses and configuration validation.

* **Bug Fixes**
  * Prevents ambiguous provider configurations and invalid guarded-provider setups.

* **Documentation**
  * Expanded authentication and configuration guidance for required claims and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->