### PR TITLE
feat(api): expose the provider-managed role namespaces on ServerInfo

### DIFF
--- a/crates/lakekeeper-storage-postgres/src/idempotency.rs
+++ b/crates/lakekeeper-storage-postgres/src/idempotency.rs
@@ -14,15 +14,24 @@ use super::{PostgresBackend, dbutils::DBErrorHandler as _};
 /// (task killed/aborted) and we take over.
 static CLEANUP_STARTED_AT: AtomicU64 = AtomicU64::new(0);
 
-fn current_epoch_secs() -> u64 {
+/// Wall-clock seconds since the epoch, or `None` if the clock reads at or
+/// before it.
+///
+/// Never `0`, because that is [`CLEANUP_STARTED_AT`]'s idle sentinel. Folding a
+/// bad clock into it would make the claim below compare-exchange `0` for `0` —
+/// which succeeds for every caller at once, against a slot whose value never
+/// changes, so the claim would stop excluding anyone.
+fn current_epoch_secs() -> Option<u64> {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs())
+        .ok()
+        .map(|d| d.as_secs())
+        .filter(|&secs| secs != 0)
 }
 
 /// Try to claim the cleanup slot. Returns the claimed timestamp if we won.
 fn try_claim_cleanup() -> Option<u64> {
-    let now = current_epoch_secs();
+    let now = current_epoch_secs()?;
     let prev = CLEANUP_STARTED_AT.load(Ordering::Relaxed);
     let timeout_secs = lakekeeper::CONFIG.idempotency.cleanup_timeout.as_secs();
     // Slot is free (0) or previous run timed out
@@ -89,19 +98,29 @@ impl PostgresBackend {
         if fastrand::f32() < 0.01 {
             let pool = state.write_pool();
             tokio::spawn(async move {
+                // Unreachable: `lifetime` and `grace_period` parse from ISO-8601
+                // with years and months refused, so each is at most `u32::MAX`
+                // weeks and their sum stays under chrono's i64-millisecond
+                // ceiling. Skipping this run is nonetheless the right failure —
+                // retention has no upper bound to violate, whereas a shorter
+                // substitute would delete records inside their advertised
+                // lifetime, and a retry that finds its record gone re-executes
+                // the mutation. Computed before the claim so it cannot leak the
+                // slot.
+                let max_age = lakekeeper::CONFIG.idempotency.total_retention();
+                let Ok(max_age) = chrono::Duration::from_std(max_age) else {
+                    tracing::error!(
+                        max_age_secs = max_age.as_secs(),
+                        "Idempotency retention exceeds the representable range; skipping cleanup"
+                    );
+                    return;
+                };
+
                 let Some(claimed_at) = try_claim_cleanup() else {
                     return; // Another cleanup is already running
                 };
 
-                let max_age = lakekeeper::CONFIG.idempotency.total_retention();
-                let cutoff = chrono::Utc::now()
-                    - chrono::Duration::from_std(max_age).unwrap_or_else(|_| {
-                        tracing::warn!(
-                            max_age_secs = max_age.as_secs(),
-                            "Failed to convert max_age to chrono::Duration, using 1 hour fallback"
-                        );
-                        chrono::Duration::hours(1)
-                    });
+                let cutoff = chrono::Utc::now() - max_age;
                 match sqlx::query!(
                     r#"
                     DELETE FROM ONLY idempotency_record
@@ -196,5 +215,42 @@ impl PostgresBackend {
         })?;
 
         Ok(result.is_some())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The claim protocol, end to end. Deliberately **one** test: it drives a
+    /// process-global static, and `cargo test` shares one process across a
+    /// crate's tests, so a second test touching the slot would race this one.
+    #[test]
+    fn the_cleanup_slot_admits_one_holder_until_released() {
+        CLEANUP_STARTED_AT.store(0, Ordering::Relaxed);
+
+        let claimed = try_claim_cleanup().expect("an idle slot is claimable");
+        assert_ne!(claimed, 0, "a claim must never store the idle sentinel");
+        assert!(
+            try_claim_cleanup().is_none(),
+            "a held slot must exclude a second claimant"
+        );
+
+        // Releasing someone else's claim is a no-op, so a run that overran its
+        // timeout cannot clear the claim that took over from it.
+        release_cleanup(claimed - 1);
+        assert!(
+            try_claim_cleanup().is_none(),
+            "the slot was released by a stale holder"
+        );
+
+        release_cleanup(claimed);
+        assert_eq!(CLEANUP_STARTED_AT.load(Ordering::Relaxed), 0);
+        assert!(
+            try_claim_cleanup().is_some(),
+            "a released slot is claimable again"
+        );
+
+        CLEANUP_STARTED_AT.store(0, Ordering::Relaxed);
     }
 }

--- a/crates/lakekeeper/src/api/management/v1/server.rs
+++ b/crates/lakekeeper/src/api/management/v1/server.rs
@@ -177,8 +177,48 @@ pub struct ServerInfo {
     pub gcp_system_identities_enabled: bool,
     /// List of queues that are registered for the server.
     pub queues: Vec<String>,
+    /// Role-provider namespaces whose roles are maintained by a configured role
+    /// provider (LDAP/Entra/Okta/token), sorted. Roles whose `provider-id`
+    /// appears here are the provider's to maintain: creating one, or renaming,
+    /// re-describing, rebinding, or deleting an existing one, is rejected with
+    /// `ManagedRoleImmutable` so provider sync cannot be clobbered.
+    ///
+    /// This is live server configuration, not a property of the namespace
+    /// string. A provider removed from config drops out of the list, and the
+    /// roles it left behind become renamable and deletable again so they can be
+    /// cleaned up.
+    ///
+    /// Empty when no role provider is configured. Two namespaces never appear,
+    /// and a client gating on this list must handle both itself: `lakekeeper`,
+    /// which is always writable, and the reserved `system`, whose roles reject
+    /// the same mutations with `SystemRoleImmutable`.
+    ///
+    /// **Membership is gated differently — do not derive it from this list.**
+    /// Adding or removing a role's members requires the `lakekeeper` namespace
+    /// (or `system`, for an instance admin); every other namespace is refused
+    /// with `RoleNotManuallyAssignable` whether or not it appears here. So an
+    /// orphaned role from a since-removed provider is renamable and deletable
+    /// but still not assignable — gate member editing on
+    /// `provider-id == "lakekeeper"`, not on absence from this list.
+    pub managed_role_providers: Vec<String>,
     /// License status information
     pub license_status: LicenseStatus,
+}
+
+/// The authorizer's provider-managed namespaces as a sorted list, for
+/// [`ServerInfo::managed_role_providers`].
+///
+/// Sorted because the source is a `HashSet` with no inherent order: without this
+/// the same server would emit different orderings across restarts and replicas,
+/// which reads as a configuration change to any client diffing the response.
+fn managed_role_providers_sorted<A: Authorizer>(authorizer: &A) -> Vec<String> {
+    let mut ids: Vec<String> = authorizer
+        .managed_role_provider_ids()
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    ids.sort_unstable();
+    ids
 }
 
 impl<C: CatalogStore, A: Authorizer, S: SecretStore> Service<C, A, S> for ApiServer<C, A, S> {}
@@ -377,7 +417,40 @@ pub trait Service<C: CatalogStore, A: Authorizer, S: SecretStore> {
                 names.sort_unstable();
                 names.into_iter().map(ToString::to_string).collect()
             },
+            managed_role_providers: managed_role_providers_sorted(&state.v1_state.authz),
             license_status: state.v1_state.license_status.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::managed_role_providers_sorted;
+    use crate::service::{RoleProviderId, authz::tests::HidingAuthorizer};
+
+    /// The list must mirror the authorizer's deny-set, sorted. A client gates its
+    /// role-editing affordances on this, so a drift between the two would offer
+    /// writes the management API then rejects.
+    #[test]
+    fn managed_role_providers_mirror_the_authorizer_sorted() {
+        let pid = |s: &str| RoleProviderId::try_new(s).expect("valid provider id");
+
+        // No role providers — the shape every OSS authorizer produces.
+        assert!(managed_role_providers_sorted(&HidingAuthorizer::new()).is_empty());
+
+        // Non-empty: inserted out of order, reported in order.
+        let authorizer = HidingAuthorizer::new().with_managed_role_providers([
+            pid("okta"),
+            pid("corporate-ldap"),
+            pid("entra"),
+        ]);
+        assert_eq!(
+            managed_role_providers_sorted(&authorizer),
+            vec![
+                "corporate-ldap".to_string(),
+                "entra".to_string(),
+                "okta".to_string()
+            ],
+        );
     }
 }

--- a/crates/lakekeeper/src/service/authz/mod.rs
+++ b/crates/lakekeeper/src/service/authz/mod.rs
@@ -3119,6 +3119,11 @@ pub mod tests {
         /// Which grant directions this authorizer has authority over. Empty by default,
         /// which answers every grant-authority question with the trait's deny.
         grant_ops: &'static [GrantOp],
+        /// Namespaces to report from [`Authorizer::managed_role_provider_ids`]. Empty
+        /// by default, matching every real OSS authorizer; a test sets it to exercise
+        /// the non-empty path, which OSS otherwise cannot reach (no role providers
+        /// ship here, so the production set is always empty).
+        managed_role_providers: HashSet<RoleProviderId>,
     }
 
     impl Default for HidingAuthorizer {
@@ -3137,7 +3142,19 @@ pub mod tests {
                 server_id: ServerId::new_random(),
                 bootstrap: &[],
                 grant_ops: &[],
+                managed_role_providers: HashSet::new(),
             }
+        }
+
+        /// Report `providers` as provider-managed, so a test can exercise the
+        /// non-empty deny-set that no OSS authorizer produces on its own.
+        #[must_use]
+        pub fn with_managed_role_providers(
+            mut self,
+            providers: impl IntoIterator<Item = RoleProviderId>,
+        ) -> Self {
+            self.managed_role_providers = providers.into_iter().collect();
+            self
         }
 
         /// Give this authorizer authority over `ops` and nothing else, so a test can tell
@@ -3262,6 +3279,10 @@ pub mod tests {
 
         fn server_id(&self) -> ServerId {
             self.server_id
+        }
+
+        fn managed_role_provider_ids(&self) -> &HashSet<RoleProviderId> {
+            &self.managed_role_providers
         }
 
         fn bootstrap_grants(&self, resource_type: ResourceType) -> &[&str] {

--- a/docs/docs/api/management-open-api.yaml
+++ b/docs/docs/api/management-open-api.yaml
@@ -14135,6 +14135,7 @@ components:
         - azure-system-identities-enabled
         - gcp-system-identities-enabled
         - queues
+        - managed-role-providers
         - license-status
       properties:
         authz-backend:
@@ -14189,6 +14190,34 @@ components:
         license-status:
           $ref: '#/components/schemas/LicenseStatus'
           description: License status information
+        managed-role-providers:
+          type: array
+          items:
+            type: string
+          description: |-
+            Role-provider namespaces whose roles are maintained by a configured role
+            provider (LDAP/Entra/Okta/token), sorted. Roles whose `provider-id`
+            appears here are the provider's to maintain: creating one, or renaming,
+            re-describing, rebinding, or deleting an existing one, is rejected with
+            `ManagedRoleImmutable` so provider sync cannot be clobbered.
+
+            This is live server configuration, not a property of the namespace
+            string. A provider removed from config drops out of the list, and the
+            roles it left behind become renamable and deletable again so they can be
+            cleaned up.
+
+            Empty when no role provider is configured. Two namespaces never appear,
+            and a client gating on this list must handle both itself: `lakekeeper`,
+            which is always writable, and the reserved `system`, whose roles reject
+            the same mutations with `SystemRoleImmutable`.
+
+            **Membership is gated differently — do not derive it from this list.**
+            Adding or removing a role's members requires the `lakekeeper` namespace
+            (or `system`, for an instance admin); every other namespace is refused
+            with `RoleNotManuallyAssignable` whether or not it appears here. So an
+            orphaned role from a since-removed provider is renamable and deletable
+            but still not assignable — gate member editing on
+            `provider-id == "lakekeeper"`, not on absence from this list.
         queues:
           type: array
           items:

--- a/docs/docs/logging.md
+++ b/docs/docs/logging.md
@@ -401,7 +401,7 @@ These records also carry the top-level `action`, `entity`, `privilege_source` an
 
 **A replay record does not establish that its actor was ever authorized for that entity.** The replay is served before authorization runs, so any authenticated caller holding the key can produce one — including one with no grants in that warehouse. The key cannot cause a mutation: a replay executes nothing.
 
-**Audit records carry live idempotency keys**, on authorization records as well as these, for as long as `idempotency-key-lifetime` plus the grace period. A reader of the audit log can replay those keys to a 204 and mint further records; treat audit-log access accordingly.
+**Audit records carry live idempotency keys**, on authorization records as well as these. A reader of the audit log can replay those keys to a 204 and mint further records; treat audit-log access accordingly. `idempotency-key-lifetime` sets the earliest a record becomes eligible for deletion; keyed traffic decides when that deletion runs, because cleanup rides on a small fraction of keyed requests. A record stays replayable until then, so a quiet deployment keeps its keys live until traffic resumes.
 
 **Seven endpoints emit this marker**, and no others: `dropTable`, `dropView`, `dropNamespace` (recorded as `action_name = "delete"`), `dropGenericTable`, `renameTable`, `renameView`, `renameGenericTable`. They answer 204 and serve the replay before authorizing, so no `decision` is recorded — the mutation already happened, and denying the retry would report a failure for a completed operation.
 


### PR DESCRIPTION
Roles in a role provider's namespace are maintained by provider sync; the management API rejects create, rename, re-describe, rebind and delete there with `ManagedRoleImmutable`. Clients had no way to discover which namespaces those are.

Add `managed-role-providers` to `GET /management/v1/info`, sorted, from `Authorizer::managed_role_provider_ids()` — the set the write guard consults. It tracks live configuration: a provider removed from config drops out and its leftover roles become writable again.

`lakekeeper` and `system` never appear; the field documents how each behaves. Member editing is gated on `provider-id == "lakekeeper"`.

`HidingAuthorizer::with_managed_role_providers` makes the non-empty path testable; OSS ships no role providers.

## Release notes

`GET /management/v1/info` now returns `managed-role-providers`: the role provider namespaces (LDAP, Entra, Okta, OIDC token claims) whose roles are maintained by provider sync and cannot be modified through the role-management API. Use it to present provider-owned roles as read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Management API server information now reports the sorted namespaces managed by configured role providers.

* **Bug Fixes**
  * Improved cleanup handling when system time or retention-duration conversion is invalid.
  * Clarified idempotency record retention and cleanup behavior.

* **Documentation**
  * Updated the Management API specification with role-provider namespace behavior.
  * Updated logging documentation to explain when idempotency records become eligible for deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->