### PR TITLE
chore: Implement post-migration hook for tables with divergent casing and tests

### DIFF
--- a/.sqlx/query-e7b0631eb7280cb76634658f775475adfe588f6334f253a6738811e3e29b82f8.json
+++ b/.sqlx/query-e7b0631eb7280cb76634658f775475adfe588f6334f253a6738811e3e29b82f8.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE tabular t\n        SET tabular_namespace_name = n.namespace_name\n        FROM namespace n\n        WHERE n.warehouse_id = t.warehouse_id\n            AND n.namespace_id = t.namespace_id\n            AND (t.tabular_namespace_name::text) COLLATE \"C\"\n                <> (n.namespace_name::text) COLLATE \"C\"\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "e7b0631eb7280cb76634658f775475adfe588f6334f253a6738811e3e29b82f8"
+}

--- a/crates/lakekeeper-integration-tests/tests/service_post_migration_hooks.rs
+++ b/crates/lakekeeper-integration-tests/tests/service_post_migration_hooks.rs
@@ -286,11 +286,67 @@ async fn test_casing_repair_hook_runs_only_when_its_gate_is_open(pool: PgPool) {
     .await
     .unwrap();
 
+    // A tabular in `a.B`, whose own path needs no repair, so only the tabular statement can fix
+    // the denormalised copy. Accepted by the foreign key because the collation ignores the case.
+    let namespace_id = lakekeeper_storage_postgres::namespace::tests::initialize_namespace(
+        state.clone(),
+        warehouse_id,
+        &NamespaceIdent::from_vec(vec!["a".to_string(), "B".to_string(), "d".to_string()]).unwrap(),
+        None,
+    )
+    .await
+    .namespace_id();
+    let plant_tabular = |namespace_id: NamespaceId, name: &'static str, path: Vec<String>| {
+        let pool = pool.clone();
+        async move {
+            let tabular_id = uuid::Uuid::now_v7();
+            sqlx::query(
+                "INSERT INTO tabular (warehouse_id, tabular_id, namespace_id, name, typ,
+                                      fs_protocol, fs_location, tabular_namespace_name)
+                 VALUES ($1, $2, $3, $4, 'table', 's3', $5, $6)",
+            )
+            .bind(*warehouse_id)
+            .bind(tabular_id)
+            .bind(*namespace_id)
+            .bind(name)
+            .bind(format!("bucket/{name}"))
+            .bind(path)
+            .execute(&pool)
+            .await
+            .unwrap();
+            tabular_id
+        }
+    };
+
+    let tabular_id = plant_tabular(
+        namespace_id,
+        "tbl",
+        vec!["a".to_string(), "b".to_string(), "d".to_string()],
+    )
+    .await;
+    // A tabular whose copy *and* whose namespace need repairing. Its end state depends on the two
+    // statements composing: the copy must not keep a spelling the namespace no longer has.
+    let in_drifted_id = plant_tabular(
+        drifted,
+        "drifted_tbl",
+        vec!["A".to_string(), "b".to_string(), "c".to_string()],
+    )
+    .await;
+
     let stored = |pool: PgPool| async move {
         sqlx::query_scalar::<_, Vec<String>>(
             "SELECT namespace_name FROM namespace WHERE namespace_id = $1",
         )
         .bind(*drifted)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+    };
+    let stored_tabular = |pool: PgPool, tabular_id: uuid::Uuid| async move {
+        sqlx::query_scalar::<_, Vec<String>>(
+            "SELECT tabular_namespace_name FROM tabular WHERE tabular_id = $1",
+        )
+        .bind(tabular_id)
         .fetch_one(&pool)
         .await
         .unwrap()
@@ -312,6 +368,11 @@ async fn test_casing_repair_hook_runs_only_when_its_gate_is_open(pool: PgPool) {
         vec!["a".to_string(), "b".to_string(), "c".to_string()],
         "with its gate closed the repair must not run"
     );
+    assert_eq!(
+        stored_tabular(pool.clone(), tabular_id).await,
+        vec!["a".to_string(), "b".to_string(), "d".to_string()],
+        "with its gate closed the repair must not run"
+    );
 
     // Gate open — what the break-glass flag sets, even though the pinned migration is long applied.
     run_post_migration_hooks::<PostgresBackend>(
@@ -325,8 +386,18 @@ async fn test_casing_repair_hook_runs_only_when_its_gate_is_open(pool: PgPool) {
     .await
     .unwrap();
     assert_eq!(
-        stored(pool).await,
+        stored(pool.clone()).await,
         vec!["a".to_string(), "B".to_string(), "c".to_string()],
         "with its gate open the repair adopts the parent's stored casing"
+    );
+    assert_eq!(
+        stored_tabular(pool.clone(), tabular_id).await,
+        vec!["a".to_string(), "B".to_string(), "d".to_string()],
+        "with its gate open the repair adopts the namespace's stored casing"
+    );
+    assert_eq!(
+        stored_tabular(pool, in_drifted_id).await,
+        vec!["a".to_string(), "B".to_string(), "c".to_string()],
+        "a copy inside a repaired namespace must end on the repaired path"
     );
 }

--- a/crates/lakekeeper-storage-postgres/src/catalog.rs
+++ b/crates/lakekeeper-storage-postgres/src/catalog.rs
@@ -110,7 +110,8 @@ use crate::{
     tabular::{
         clear_tabular_deleted_at, drop_tabular, get_tabular_infos_by_idents,
         get_tabular_infos_by_ids, get_tabular_infos_by_s3_location, list_tabulars,
-        mark_tabular_as_deleted, rename_tabular, search_tabular, set_tabular_protected,
+        mark_tabular_as_deleted, rename_tabular, repair_tabular_namespace_path_casing,
+        search_tabular, set_tabular_protected,
         table::{commit_table_transaction, create_table},
         view::{commit_existing_view, create_view, load_view},
     },
@@ -1143,6 +1144,12 @@ impl CatalogStore for super::PostgresBackend {
         transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'_>,
     ) -> std::result::Result<u64, CatalogBackendError> {
         repair_namespace_path_casing(transaction).await
+    }
+
+    async fn repair_tabular_namespace_path_casing_impl(
+        transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'_>,
+    ) -> std::result::Result<u64, CatalogBackendError> {
+        repair_tabular_namespace_path_casing(transaction).await
     }
 
     async fn set_warehouse_protected_impl(

--- a/crates/lakekeeper-storage-postgres/src/tabular/mod.rs
+++ b/crates/lakekeeper-storage-postgres/src/tabular/mod.rs
@@ -11,9 +11,9 @@ use lakekeeper::{
     CONFIG, WarehouseId,
     api::iceberg::v1::{PaginatedMapping, PaginationQuery},
     service::{
-        CatalogSearchTabularInfo, CatalogSearchTabularResponse, ClearTabularDeletedAtError,
-        ConcurrentUpdateError, CreateTabularError, DropTabularError, ExpirationTaskInfo,
-        GenericTableDeletionInfo, GenericTabularInfo, GetTabularInfoError,
+        CatalogBackendError, CatalogSearchTabularInfo, CatalogSearchTabularResponse,
+        ClearTabularDeletedAtError, ConcurrentUpdateError, CreateTabularError, DropTabularError,
+        ExpirationTaskInfo, GenericTableDeletionInfo, GenericTabularInfo, GetTabularInfoError,
         InternalParseLocationError, InvalidNamespaceIdentifier, ListTabularsError,
         LocationAlreadyTaken, MarkTabularAsDeletedError, NamespaceId,
         ProtectedTabularDeletionWithoutForce, RenameTabularError, SearchTabularError,
@@ -1343,6 +1343,37 @@ impl From<FromTabularRowError> for RenameTabularError {
             FromTabularRowError::InternalParseLocationError(e) => e.into(),
         }
     }
+}
+
+/// Rewrite `tabular.tabular_namespace_name` where it disagrees with the namespace row it points
+/// at, returning the number of rows changed.
+///
+/// The column is a denormalised copy of the containing namespace's path. It is matched under a
+/// case-insensitive collation, so a copy that differs only in case satisfies the foreign key and
+/// survives unnoticed.
+///
+/// Takes `namespace.namespace_name` as authoritative, so run this after the namespace paths
+/// themselves have been repaired.
+///
+/// Includes soft-deleted rows: an undropped tabular would otherwise bring the old spelling back.
+pub(crate) async fn repair_tabular_namespace_path_casing(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> std::result::Result<u64, CatalogBackendError> {
+    Ok(sqlx::query!(
+        r#"
+        UPDATE tabular t
+        SET tabular_namespace_name = n.namespace_name
+        FROM namespace n
+        WHERE n.warehouse_id = t.warehouse_id
+            AND n.namespace_id = t.namespace_id
+            AND (t.tabular_namespace_name::text) COLLATE "C"
+                <> (n.namespace_name::text) COLLATE "C"
+        "#,
+    )
+    .execute(&mut **transaction)
+    .await
+    .map_err(|e| e.into_catalog_backend_error())?
+    .rows_affected())
 }
 
 /// Map a failed rename onto its error.
@@ -2890,5 +2921,63 @@ mod tests {
                 "a task in an unrelated queue must not be reported as a pending deletion"
             );
         }
+    }
+
+    /// A copy that differs from its namespace row only in case satisfies the foreign key, so the
+    /// repair has to find it byte-wise. Soft-deleted rows count: undropping one would otherwise
+    /// restore the old spelling.
+    #[sqlx::test]
+    async fn test_repair_tabular_namespace_path_casing(pool: sqlx::PgPool) {
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
+        let (_, warehouse_id) = initialize_warehouse(state.clone(), None, None, None, true).await;
+        let ident = iceberg_ext::NamespaceIdent::from_vec(vec!["Repair_NS".to_string()]).unwrap();
+        let namespace_id = *initialize_namespace(state.clone(), warehouse_id, &ident, None)
+            .await
+            .namespace_id();
+
+        let live = plant_tabular(&pool, *warehouse_id, namespace_id, "s3://bucket/live").await;
+        let deleted =
+            plant_tabular(&pool, *warehouse_id, namespace_id, "s3://bucket/deleted").await;
+        sqlx::query("UPDATE tabular SET deleted_at = now() WHERE tabular_id = $1")
+            .bind(deleted)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let diverge = |id: Uuid| {
+            sqlx::query(
+                "UPDATE tabular SET tabular_namespace_name = ARRAY['repair_ns'] \
+                 WHERE tabular_id = $1",
+            )
+            .bind(id)
+            .execute(&pool)
+        };
+        diverge(live).await.unwrap();
+        diverge(deleted).await.unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        let repaired = repair_tabular_namespace_path_casing(&mut transaction)
+            .await
+            .unwrap();
+        transaction.commit().await.unwrap();
+        assert_eq!(repaired, 2);
+
+        for id in [live, deleted] {
+            let stored: Vec<String> = sqlx::query_scalar(
+                "SELECT tabular_namespace_name FROM tabular WHERE tabular_id = $1",
+            )
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(stored, vec!["Repair_NS".to_string()]);
+        }
+
+        let mut transaction = pool.begin().await.unwrap();
+        let repaired = repair_tabular_namespace_path_casing(&mut transaction)
+            .await
+            .unwrap();
+        transaction.commit().await.unwrap();
+        assert_eq!(repaired, 0, "the repair must be idempotent");
     }
 }

--- a/crates/lakekeeper-storage-postgres/src/tabular/table/mod.rs
+++ b/crates/lakekeeper-storage-postgres/src/tabular/table/mod.rs
@@ -1971,6 +1971,71 @@ pub mod tests {
         );
     }
 
+    /// A move must store the destination namespace's own spelling, not the caller's. The
+    /// destination is matched under a case-insensitive collation, so the two can differ, and the
+    /// denormalised path would then disagree with the namespace row it points at.
+    #[sqlx::test]
+    async fn test_rename_across_namespaces_stores_the_namespace_spelling(pool: sqlx::PgPool) {
+        let state = CatalogState::from_pools(pool.clone(), pool.clone());
+
+        let (_, warehouse_id) = initialize_warehouse(state.clone(), None, None, None, true).await;
+        let source = NamespaceIdent::from_vec(vec!["source_ns".to_string()]).unwrap();
+        let source_id = initialize_namespace(state.clone(), warehouse_id, &source, None)
+            .await
+            .namespace_id();
+        let table = initialize_table(
+            warehouse_id,
+            state.clone(),
+            false,
+            Some(source.clone()),
+            None,
+            Some("tbl".to_string()),
+        )
+        .await;
+
+        let destination = NamespaceIdent::from_vec(vec!["Dest_NS".to_string()]).unwrap();
+        let destination_id = initialize_namespace(state.clone(), warehouse_id, &destination, None)
+            .await
+            .namespace_id();
+        let spelled_by_caller = NamespaceIdent::from_vec(vec!["dest_ns".to_string()]).unwrap();
+
+        let mut transaction = pool.begin().await.unwrap();
+        let renamed = rename_tabular(
+            warehouse_id,
+            table.table_id.into(),
+            source_id,
+            destination_id,
+            &table.table_ident,
+            &TableIdent {
+                namespace: spelled_by_caller,
+                name: "moved".to_string(),
+            },
+            &mut transaction,
+        )
+        .await
+        .unwrap();
+        transaction.commit().await.unwrap();
+
+        assert_eq!(renamed.namespace_id(), destination_id);
+        assert_eq!(
+            renamed.tabular_ident().namespace,
+            destination,
+            "the reported path must use the destination namespace's spelling"
+        );
+
+        let stored: Vec<String> =
+            sqlx::query_scalar("SELECT tabular_namespace_name FROM tabular WHERE tabular_id = $1")
+                .bind(*table.table_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            stored,
+            vec!["Dest_NS".to_string()],
+            "the stored path must match the namespace row it points at"
+        );
+    }
+
     /// The destination id is random because the namespace was never created: an id no row
     /// carries is what the caller would have to pass for a namespace that does not exist.
     #[sqlx::test]

--- a/crates/lakekeeper/src/service/catalog_store.rs
+++ b/crates/lakekeeper/src/service/catalog_store.rs
@@ -615,6 +615,19 @@ where
     ) -> std::result::Result<u64, CatalogBackendError>;
 
     // ---------------- Tabular Management ----------------
+    /// Rewrite any denormalised tabular copy of a namespace path that disagrees with the namespace
+    /// row it points at, and report how many rows were changed.
+    ///
+    /// Maintenance, not part of any request path: run from the post-migration hooks, after
+    /// [`CatalogStore::repair_namespace_path_casing_impl`], so that the copies adopt already
+    /// corrected namespace paths.
+    ///
+    /// Implementations must be idempotent and safe to retry, for the reasons given on
+    /// [`CatalogStore::repair_namespace_path_casing_impl`].
+    async fn repair_tabular_namespace_path_casing_impl(
+        transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'_>,
+    ) -> std::result::Result<u64, CatalogBackendError>;
+
     async fn list_tabulars_impl(
         warehouse_id: WarehouseId,
         namespace_id: Option<NamespaceId>, // Filter by namespace

--- a/crates/lakekeeper/src/service/catalog_store/tabular.rs
+++ b/crates/lakekeeper/src/service/catalog_store/tabular.rs
@@ -1970,6 +1970,16 @@ where
         )?;
         Ok(tables)
     }
+
+    /// Repair denormalised tabular copies of namespace paths stored with the wrong casing,
+    /// returning the number of rows changed. See
+    /// [`CatalogStore::repair_tabular_namespace_path_casing_impl`]. Maintenance only — called from
+    /// the post-migration hooks, never from a request path.
+    async fn repair_tabular_namespace_path_casing(
+        transaction: <Self::Transaction as Transaction<Self::State>>::Transaction<'_>,
+    ) -> Result<u64, CatalogBackendError> {
+        Self::repair_tabular_namespace_path_casing_impl(transaction).await
+    }
 }
 
 impl<T> CatalogTabularOps for T where T: CatalogStore {}

--- a/crates/lakekeeper/src/service/post_migration_hooks.rs
+++ b/crates/lakekeeper/src/service/post_migration_hooks.rs
@@ -6,8 +6,9 @@ use crate::{
     CONFIG,
     api::management::v1::tasks::{ListTasksRequest, TaskStatus},
     service::{
-        CatalogNamespaceOps, CatalogRoleOps, CatalogStore, CatalogTaskOps, SystemRoleSeederCap,
-        SystemRoleSpec, Transaction, install_system_role_registry, registered_system_roles,
+        CatalogNamespaceOps, CatalogRoleOps, CatalogStore, CatalogTabularOps, CatalogTaskOps,
+        SystemRoleSeederCap, SystemRoleSpec, Transaction, install_system_role_registry,
+        registered_system_roles,
         tasks::{
             ScheduleTaskMetadata, TaskEntity, TaskFilter,
             task_log_cleanup_queue::{self, TaskLogCleanupPayload, TaskLogCleanupTask},
@@ -27,7 +28,8 @@ use crate::{
 /// from an earlier failure. A hook that cannot be re-run does not belong behind one of these flags.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PostMigrationHookOptions {
-    /// Repair namespace path prefixes stored with the caller's casing instead of the parent's.
+    /// Repair stored namespace paths that carry the caller's casing instead of the referenced
+    /// row's: namespace path prefixes and `tabular`'s denormalised copy of its namespace path.
     /// Set when the migration the repair is pinned to was applied by this run — see
     /// `lakekeeper-storage-postgres`'s `NAMESPACE_PATH_CASING_REPAIR_AFTER`.
     pub repair_namespace_path_casing: bool,
@@ -84,17 +86,22 @@ pub async fn run_post_migration_hooks<C: CatalogStore>(
     Ok(())
 }
 
-/// Bring namespace path prefixes in line with their parent rows' spelling.
+/// Bring stored namespace paths in line with the row they reference.
 ///
-/// A namespace's path prefix references its parent, so it must carry the parent's stored spelling.
-/// `create_namespace` used to store the caller's spelling instead, which left the row — and its whole
-/// subtree — permanently unservable from the namespace cache. The write paths no longer allow it;
-/// this repairs rows that predate the fix.
+/// Two places hold a namespace path that is not the namespace's own name: a namespace's path prefix,
+/// which must carry its parent's stored spelling, and `tabular`'s denormalised copy of its
+/// containing namespace's path. `create_namespace` and `rename_tabular` used to store the caller's
+/// spelling instead. A wrong prefix leaves the namespace — and its whole subtree — permanently
+/// unservable from the namespace cache; a wrong tabular copy makes the tabular report a path that
+/// disagrees with the namespace it sits in. The write paths no longer allow either; this repairs
+/// rows that predate the fixes.
+///
+/// Namespaces are repaired first, so that the tabular copies adopt already corrected paths.
 ///
 /// Gated by the caller on the migration it is pinned to having just been applied, so it runs once per
 /// upgrade rather than on every startup. Still written to be idempotent and to derive what needs
 /// repairing from the data, because that is what makes re-pinning it to a later migration enough to
-/// re-run it if another write path is ever found to store a caller-cased prefix.
+/// re-run it if another write path is ever found to store a caller-cased path.
 async fn repair_namespace_path_casing<C: CatalogStore>(state: C::State) -> anyhow::Result<()> {
     let mut t = C::Transaction::begin_write(state)
         .await
@@ -102,6 +109,11 @@ async fn repair_namespace_path_casing<C: CatalogStore>(state: C::State) -> anyho
     let repaired = C::repair_namespace_path_casing(t.transaction())
         .await
         .map_err(|e| anyhow::anyhow!(e).context("Failed to repair namespace path prefix casing"))?;
+    let repaired_tabulars = C::repair_tabular_namespace_path_casing(t.transaction())
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(e).context("Failed to repair tabular namespace path casing")
+        })?;
     t.commit()
         .await
         .map_err(|e| anyhow::anyhow!(e).context("Failed to commit namespace path casing repair"))?;
@@ -109,6 +121,12 @@ async fn repair_namespace_path_casing<C: CatalogStore>(state: C::State) -> anyho
         tracing::info!(
             "Post-migration hook: repaired the stored path of {repaired} namespace(s) whose prefix \
              casing disagreed with their parent"
+        );
+    }
+    if repaired_tabulars > 0 {
+        tracing::info!(
+            "Post-migration hook: repaired the stored namespace path of {repaired_tabulars} \
+             tabular(s) whose casing disagreed with their namespace"
         );
     }
     Ok(())


### PR DESCRIPTION
Adds a migration to the post-migrations that fixes divergent casing for renamed tabulars' namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Post-migration repairs now synchronize tabular namespace paths with the authoritative namespace casing.
  - Repairs include both active and soft-deleted tabular records and can be safely run repeatedly.
  - Renaming a table across namespaces now preserves the destination namespace’s correct spelling in stored and displayed paths.
  - Namespace repairs are completed before related tabular path repairs, improving migration consistency and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->